### PR TITLE
Use 'is not null' in some System.Windows.Forms files

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.EnumVariantObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.EnumVariantObject.cs
@@ -18,13 +18,13 @@ namespace System.Windows.Forms
 
             public EnumVariantObject(AccessibleObject owner)
             {
-                Debug.Assert(owner != null, "Cannot create EnumVariantObject with a null owner");
+                Debug.Assert(owner is not null, "Cannot create EnumVariantObject with a null owner");
                 this.owner = owner;
             }
 
             public EnumVariantObject(AccessibleObject owner, uint currentChild)
             {
-                Debug.Assert(owner != null, "Cannot create EnumVariantObject with a null owner");
+                Debug.Assert(owner is not null, "Cannot create EnumVariantObject with a null owner");
                 this.owner = owner;
                 this.currentChild = currentChild;
             }
@@ -83,7 +83,7 @@ namespace System.Windows.Forms
                     {
                         NextEmpty(celt, rgVar, pCeltFetched);
                     }
-                    else if ((newOrder = owner.GetSysChildOrder()) != null)
+                    else if ((newOrder = owner.GetSysChildOrder()) is not null)
                     {
                         NextFromSystemReordered(celt, rgVar, pCeltFetched, newOrder);
                     }
@@ -118,7 +118,7 @@ namespace System.Windows.Forms
             private unsafe void NextFromSystem(uint celt, IntPtr rgVar, uint* pCeltFetched)
             {
                 owner.systemIEnumVariant?.Next(celt, rgVar, pCeltFetched);
-                if (pCeltFetched != null)
+                if (pCeltFetched is not null)
                 {
                     currentChild += *pCeltFetched;
                 }
@@ -162,7 +162,7 @@ namespace System.Windows.Forms
                     Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "AccessibleObject.IEV.Next: adding sys child " + currentChild + " of " + newOrder.Length);
                 }
 
-                if (pCeltFetched != null)
+                if (pCeltFetched is not null)
                 {
                     *pCeltFetched = i;
                 }
@@ -186,7 +186,7 @@ namespace System.Windows.Forms
                     Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "AccessibleObject.IEV.Next: adding own child " + currentChild + " of " + childCount);
                 }
 
-                if (pCeltFetched != null)
+                if (pCeltFetched is not null)
                 {
                     *pCeltFetched = i;
                 }
@@ -199,7 +199,7 @@ namespace System.Windows.Forms
             /// </summary>
             private unsafe void NextEmpty(uint celt, IntPtr rgvar, uint* pCeltFetched)
             {
-                if (pCeltFetched != null)
+                if (pCeltFetched is not null)
                 {
                     *pCeltFetched = 0;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.SystemIAccessibleWrapper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.SystemIAccessibleWrapper.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
             public SystemIAccessibleWrapper(IAccessible? systemIAccessible)
             {
                 _systemIAccessible = systemIAccessible;
-                IsIAccessibleCreated = systemIAccessible != null;
+                IsIAccessibleCreated = systemIAccessible is not null;
             }
 
             internal IAccessible? SystemIAccessibleInternal => _systemIAccessible;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -146,7 +146,7 @@ namespace System.Windows.Forms
             get
             {
                 var accRole = systemIAccessible.get_accRole(NativeMethods.CHILDID_SELF);
-                return accRole != null
+                return accRole is not null
                     ? (AccessibleRole)accRole
                     : AccessibleRole.None;
             }
@@ -160,7 +160,7 @@ namespace System.Windows.Forms
             get
             {
                 var accState = systemIAccessible.get_accState(NativeMethods.CHILDID_SELF);
-                return accState != null
+                return accState is not null
                     ? (AccessibleStates)accState
                     : AccessibleStates.None;
             }
@@ -241,8 +241,8 @@ namespace System.Windows.Forms
                 for (int index = 0; index < count; ++index)
                 {
                     AccessibleObject? child = GetChild(index);
-                    Debug.Assert(child != null, "GetChild(" + index.ToString(CultureInfo.InvariantCulture) + ") returned null!");
-                    if (child != null && ((child.State & AccessibleStates.Focused) != 0))
+                    Debug.Assert(child is not null, "GetChild(" + index.ToString(CultureInfo.InvariantCulture) + ") returned null!");
+                    if (child is not null && ((child.State & AccessibleStates.Focused) != 0))
                     {
                         return child;
                     }
@@ -278,8 +278,8 @@ namespace System.Windows.Forms
                 for (int index = 0; index < count; ++index)
                 {
                     AccessibleObject? child = GetChild(index);
-                    Debug.Assert(child != null, "GetChild(" + index.ToString(CultureInfo.InvariantCulture) + ") returned null!");
-                    if (child != null && ((child.State & AccessibleStates.Selected) != 0))
+                    Debug.Assert(child is not null, "GetChild(" + index.ToString(CultureInfo.InvariantCulture) + ") returned null!");
+                    if (child is not null && ((child.State & AccessibleStates.Selected) != 0))
                     {
                         return child;
                     }
@@ -308,8 +308,8 @@ namespace System.Windows.Forms
                 for (int index = 0; index < count; ++index)
                 {
                     AccessibleObject? child = GetChild(index);
-                    Debug.Assert(child != null, "GetChild(" + index.ToString(CultureInfo.InvariantCulture) + ") returned null!");
-                    if (child != null && child.Bounds.Contains(x, y))
+                    Debug.Assert(child is not null, "GetChild(" + index.ToString(CultureInfo.InvariantCulture) + ") returned null!");
+                    if (child is not null && child.Bounds.Contains(x, y))
                     {
                         return child;
                     }
@@ -792,7 +792,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     child.DoDefaultAction();
                     return;
@@ -813,7 +813,7 @@ namespace System.Windows.Forms
                     ToString());
 
                 AccessibleObject? obj = HitTest(xLeft, yTop);
-                if (obj != null)
+                if (obj is not null)
                 {
                     return AsVariant(obj);
                 }
@@ -861,7 +861,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     Rectangle bounds = child.Bounds;
                     pxLeft = bounds.X;
@@ -895,7 +895,7 @@ namespace System.Windows.Forms
                 if (childID.Equals(NativeMethods.CHILDID_SELF))
                 {
                     AccessibleObject? newObject = Navigate((AccessibleNavigation)navDir);
-                    if (newObject != null)
+                    if (newObject is not null)
                     {
                         return AsVariant(newObject);
                     }
@@ -903,7 +903,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     return AsVariant(child.Navigate((AccessibleNavigation)navDir));
                 }
@@ -938,7 +938,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     child.Select((AccessibleSelection)flagsSelect);
                     return;
@@ -977,7 +977,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     // Make sure we're not returning ourselves as our own child
                     Debug.Assert(child != this, "An accessible object is returning itself as its own child. This can cause Accessibility client applications to stop responding.");
@@ -1041,7 +1041,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     return child.DefaultAction;
                 }
@@ -1067,7 +1067,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     return child.Description;
                 }
@@ -1107,7 +1107,7 @@ namespace System.Windows.Forms
                         ToString());
 
                     AccessibleObject? obj = GetFocused();
-                    if (obj != null)
+                    if (obj is not null)
                     {
                         return AsVariant(obj);
                     }
@@ -1133,7 +1133,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     return child.Help;
                 }
@@ -1158,7 +1158,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     return child.GetHelpTopic(out pszHelpFile);
                 }
@@ -1188,7 +1188,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     return child.KeyboardShortcut;
                 }
@@ -1222,7 +1222,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     return child.Name;
                 }
@@ -1251,7 +1251,7 @@ namespace System.Windows.Forms
             {
                 Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "AccessibleObject.accParent: this = " + ToString());
                 AccessibleObject? parent = Parent;
-                if (parent != null)
+                if (parent is not null)
                 {
                     // Some debugging related tests
                     Debug.Assert(parent != this, "An accessible object is returning itself as its own parent. This can cause accessibility clients to stop responding.");
@@ -1284,7 +1284,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     return (int)child.Role;
                 }
@@ -1311,7 +1311,7 @@ namespace System.Windows.Forms
                         ToString());
 
                     AccessibleObject? obj = GetSelected();
-                    if (obj != null)
+                    if (obj is not null)
                     {
                         return AsVariant(obj);
                     }
@@ -1341,7 +1341,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     return (int)child.State;
                 }
@@ -1367,7 +1367,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     return child.Value;
                 }
@@ -1395,7 +1395,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     child.Name = newName;
                     return;
@@ -1424,7 +1424,7 @@ namespace System.Windows.Forms
 
                 // If we have an accessible object collection, get the appropriate child
                 AccessibleObject? child = GetAccessibleChild(childID);
-                if (child != null)
+                if (child is not null)
                 {
                     child.Value = newValue;
                     return;
@@ -1452,7 +1452,7 @@ namespace System.Windows.Forms
         unsafe HRESULT Ole32.IOleWindow.GetWindow(IntPtr* phwnd)
         {
             // See if we have an inner object that can provide the window handle
-            if (systemIOleWindow != null)
+            if (systemIOleWindow is not null)
             {
                 return systemIOleWindow.GetWindow(phwnd);
             }
@@ -1480,7 +1480,7 @@ namespace System.Windows.Forms
         HRESULT Ole32.IOleWindow.ContextSensitiveHelp(BOOL fEnterMode)
         {
             // See if we have an inner object that can provide help
-            if (systemIOleWindow != null)
+            if (systemIOleWindow is not null)
             {
                 return systemIOleWindow.ContextSensitiveHelp(fEnterMode);
             }
@@ -1585,7 +1585,7 @@ namespace System.Windows.Forms
 
         private IAccessible? AsIAccessible(AccessibleObject? obj)
         {
-            if (obj != null && obj.systemWrapper)
+            if (obj is not null && obj.systemWrapper)
             {
                 return obj.systemIAccessible.SystemIAccessibleInternal;
             }
@@ -1649,7 +1649,7 @@ namespace System.Windows.Forms
                         ref IID_IEnumVariant,
                         ref en);
 
-            if (acc != null || en != null)
+            if (acc is not null || en is not null)
             {
                 systemIAccessible = new SystemIAccessibleWrapper((IAccessible?)acc);
                 systemIEnumVariant = (Oleaut32.IEnumVariant?)en;
@@ -1834,10 +1834,10 @@ namespace System.Windows.Forms
             if (args?.Length == 0)
             {
                 MemberInfo[] member = typeof(IAccessible).GetMember(name);
-                if (member != null && member.Length > 0 && member[0] is PropertyInfo)
+                if (member is not null && member.Length > 0 && member[0] is PropertyInfo)
                 {
                     MethodInfo? getMethod = ((PropertyInfo)member[0]).GetGetMethod();
-                    if (getMethod != null && getMethod.GetParameters().Length > 0)
+                    if (getMethod is not null && getMethod.GetParameters().Length > 0)
                     {
                         args = new object[getMethod.GetParameters().Length];
                         for (int i = 0; i < args.Length; i++)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ComponentManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ComponentManager.cs
@@ -60,7 +60,7 @@ namespace System.Windows.Forms
                 Guid* iid,
                 void** ppvObj)
             {
-                if (ppvObj != null)
+                if (ppvObj is not null)
                 {
                     *ppvObj = null;
                 }
@@ -358,7 +358,7 @@ namespace System.Windows.Forms
                             // Nothing is on the message queue. Perform idle processing and then do a WaitMessage.
                             bool continueIdle = false;
 
-                            if (OleComponents != null)
+                            if (OleComponents is not null)
                             {
                                 IEnumerator enumerator = OleComponents.Values.GetEnumerator();
 
@@ -422,7 +422,7 @@ namespace System.Windows.Forms
                 void** ppvObj)
             {
                 // We do not support sub component managers.
-                if (ppvObj != null)
+                if (ppvObj is not null)
                 {
                     *ppvObj = null;
                 }
@@ -433,7 +433,7 @@ namespace System.Windows.Forms
             BOOL IMsoComponentManager.FGetParentComponentManager(void** ppicm)
             {
                 // We have no parent.
-                if (ppicm != null)
+                if (ppicm is not null)
                 {
                     *ppicm = null;
                 }
@@ -458,7 +458,7 @@ namespace System.Windows.Forms
                 if (component is null)
                     return BOOL.FALSE;
 
-                if (pcrinfo != null)
+                if (pcrinfo is not null)
                 {
                     if (pcrinfo->cbSize < sizeof(MSOCRINFO))
                     {
@@ -475,7 +475,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (ppic != null)
+                if (ppic is not null)
                 {
                     // This will addref the interface
                     *ppic = (void*)Marshal.GetComInterfaceForObject<IMsoComponent, IMsoComponent>(component);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ModalApplicationContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ModalApplicationContext.cs
@@ -28,19 +28,19 @@ namespace System.Windows.Forms
                 // Get ahold of the parent HWND -- if it's a different thread we need to do the disable
                 // over there too.  Note we only do this if we're parented by a Windows Forms parent.
 
-                if (MainForm != null && MainForm.IsHandleCreated)
+                if (MainForm is not null && MainForm.IsHandleCreated)
                 {
                     // Get ahold of the parenting control
                     IntPtr parentHandle = Interop.User32.GetWindowLong(new HandleRef(this, MainForm.Handle), User32.GWL.HWNDPARENT);
 
                     parentControl = Control.FromHandle(parentHandle);
 
-                    _parentWindowContext = parentControl != null && parentControl.InvokeRequired
+                    _parentWindowContext = parentControl is not null && parentControl.InvokeRequired
                         ? GetContextForHandle(new HandleRef(this, parentHandle)) : null;
                 }
 
                 // If we got a thread context, that means our parent is in a different thread, make the call on that thread.
-                if (_parentWindowContext != null)
+                if (_parentWindowContext is not null)
                 {
                     // In case we've already torn down, ask the context for this.
                     if (parentControl is null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -126,7 +126,7 @@ namespace System.Windows.Forms
                 {
                     Debug.WriteLineIf(CompModSwitches.MSOComponentManager.TraceInfo, "Application.ComponentManager.Get:");
 
-                    if (_componentManager != null || _fetchingComponentManager)
+                    if (_componentManager is not null || _fetchingComponentManager)
                     {
                         return _componentManager;
                     }
@@ -145,7 +145,7 @@ namespace System.Windows.Forms
                     {
                         // Attempt to obtain the Host Application MSOComponentManager
                         _componentManager = GetExternalComponentManager();
-                        if (_componentManager != null)
+                        if (_componentManager is not null)
                         {
                             _externalComponentManager = true;
                             Debug.WriteLineIf(
@@ -160,7 +160,7 @@ namespace System.Windows.Forms
                                 "Using our own component manager");
                         }
 
-                        if (_componentManager != null)
+                        if (_componentManager is not null)
                         {
                             RegisterComponentManager();
                         }
@@ -262,7 +262,7 @@ namespace System.Windows.Forms
             }
 
             internal bool CustomThreadExceptionHandlerAttached
-                => _threadExceptionHandler != null;
+                => _threadExceptionHandler is not null;
 
             /// <summary>
             ///  Retrieves the actual parking form.  This will demand create the parking window
@@ -333,7 +333,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if ((_activatingControlRef != null) && (_activatingControlRef.IsAlive))
+                    if ((_activatingControlRef is not null) && (_activatingControlRef.IsAlive))
                     {
                         return _activatingControlRef.Target as Control;
                     }
@@ -341,7 +341,7 @@ namespace System.Windows.Forms
                 }
                 set
                 {
-                    if (value != null)
+                    if (value is not null)
                     {
                         _activatingControlRef = new WeakReference(value);
                     }
@@ -393,7 +393,7 @@ namespace System.Windows.Forms
                 {
                     _messageFilterSnapshot = new List<IMessageFilter>();
                 }
-                if (f != null)
+                if (f is not null)
                 {
                     SetState(STATE_FILTERSNAPSHOTVALID, false);
                     if (_messageFilters.Count > 0 && f is IMessageModifyAndFilter)
@@ -420,7 +420,7 @@ namespace System.Windows.Forms
                 try
                 {
                     IMsoComponentManager cm = ComponentManager;
-                    if (cm != null)
+                    if (cm is not null)
                     {
                         cm.OnComponentEnterState(_componentID, msocstate.Modal, msoccontext.All, 0, null, 0);
                     }
@@ -435,7 +435,7 @@ namespace System.Windows.Forms
 
                 _modalCount++;
 
-                if (_enterModalHandler != null && _modalCount == 1)
+                if (_enterModalHandler is not null && _modalCount == 1)
                 {
                     _enterModalHandler(Thread.CurrentThread, EventArgs.Empty);
                 }
@@ -488,7 +488,7 @@ namespace System.Windows.Forms
                                     if (ourThread)
                                     {
                                         // If we had a component manager, detach from it.
-                                        if (_componentManager != null)
+                                        if (_componentManager is not null)
                                         {
                                             RevokeComponent();
                                         }
@@ -594,7 +594,7 @@ namespace System.Windows.Forms
                 // cleanup that it may need to do.
                 try
                 {
-                    if (ApplicationContext != null)
+                    if (ApplicationContext is not null)
                     {
                         ApplicationContext.Dispose();
                         ApplicationContext = null;
@@ -618,10 +618,10 @@ namespace System.Windows.Forms
             internal void EnableWindowsForModalLoop(bool onlyWinForms, ApplicationContext context)
             {
                 Debug.WriteLineIf(CompModSwitches.MSOComponentManager.TraceInfo, "ComponentManager : Leaving modal state");
-                if (_threadWindows != null)
+                if (_threadWindows is not null)
                 {
                     _threadWindows.Enable(true);
-                    Debug.Assert(_threadWindows != null, "OnEnterState recursed, but it's not supposed to be reentrant");
+                    Debug.Assert(_threadWindows is not null, "OnEnterState recursed, but it's not supposed to be reentrant");
                     _threadWindows = _threadWindows._previousThreadWindows;
                 }
 
@@ -647,7 +647,7 @@ namespace System.Windows.Forms
                 {
                     // If We started the ModalMessageLoop .. this will call us back on the IMSOComponent.OnStateEnter and not do anything ...
                     IMsoComponentManager cm = ComponentManager;
-                    if (cm != null)
+                    if (cm is not null)
                     {
                         cm.FOnComponentExitState(_componentID, msocstate.Modal, msoccontext.All, 0, null);
                     }
@@ -660,7 +660,7 @@ namespace System.Windows.Forms
 
                 _modalCount--;
 
-                if (_leaveModalHandler != null && _modalCount == 0)
+                if (_leaveModalHandler is not null && _modalCount == 0)
                 {
                     _leaveModalHandler(Thread.CurrentThread, EventArgs.Empty);
                 }
@@ -675,13 +675,13 @@ namespace System.Windows.Forms
             {
                 lock (s_tcInternalSyncObject)
                 {
-                    if (s_contextHash != null)
+                    if (s_contextHash is not null)
                     {
                         ThreadContext[] ctxs = new ThreadContext[s_contextHash.Values.Count];
                         s_contextHash.Values.CopyTo(ctxs, 0);
                         for (int i = 0; i < ctxs.Length; ++i)
                         {
-                            if (ctxs[i].ApplicationContext != null)
+                            if (ctxs[i].ApplicationContext is not null)
                             {
                                 ctxs[i].ApplicationContext.ExitThread();
                             }
@@ -715,7 +715,7 @@ namespace System.Windows.Forms
                 if (activate)
                 {
                     IMsoComponentManager cm = ComponentManager;
-                    if (cm != null && !(cm is ComponentManager))
+                    if (cm is not null && !(cm is ComponentManager))
                     {
                         cm.FOnComponentActivate(_componentID);
                     }
@@ -732,7 +732,7 @@ namespace System.Windows.Forms
                 if (track != GetState(STATE_TRACKINGCOMPONENT))
                 {
                     IMsoComponentManager cm = ComponentManager;
-                    if (cm != null && !(cm is ComponentManager))
+                    if (cm is not null && !(cm is ComponentManager))
                     {
                         cm.FSetTrackingComponent(_componentID, track.ToBOOL());
                         SetState(STATE_TRACKINGCOMPONENT, track);
@@ -796,7 +796,7 @@ namespace System.Windows.Forms
 
                 // Also, access the ComponentManager property to demand create it, and we're also
                 // fine if it is an external manager, because it has already pushed a loop.
-                if (ComponentManager != null && _externalComponentManager)
+                if (ComponentManager is not null && _externalComponentManager)
                 {
                     if (mustBeActive == false)
                     {
@@ -819,7 +819,7 @@ namespace System.Windows.Forms
 
                 // Finally, check if a message loop has been registered
                 MessageLoopCallback callback = _messageLoopCallback;
-                if (callback != null)
+                if (callback is not null)
                 {
                     return callback();
                 }
@@ -874,7 +874,7 @@ namespace System.Windows.Forms
                 SetState(STATE_INTHREADEXCEPTION, true);
                 try
                 {
-                    if (_threadExceptionHandler != null)
+                    if (_threadExceptionHandler is not null)
                     {
                         _threadExceptionHandler(Thread.CurrentThread, new ThreadExceptionEventArgs(t));
                     }
@@ -949,7 +949,7 @@ namespace System.Windows.Forms
             /// </summary>
             internal void RemoveMessageFilter(IMessageFilter f)
             {
-                if (_messageFilters != null)
+                if (_messageFilters is not null)
                 {
                     SetState(STATE_FILTERSNAPSHOTVALID, false);
                     _messageFilters.Remove(f);
@@ -1019,14 +1019,14 @@ namespace System.Windows.Forms
 
                     ApplicationContext.ThreadExit += new EventHandler(OnAppThreadExit);
 
-                    if (ApplicationContext.MainForm != null)
+                    if (ApplicationContext.MainForm is not null)
                     {
                         ApplicationContext.MainForm.Visible = true;
                     }
                 }
 
                 Form oldForm = _currentForm;
-                if (context != null)
+                if (context is not null)
                 {
                     _currentForm = context.MainForm;
                 }
@@ -1050,7 +1050,7 @@ namespace System.Windows.Forms
                     // window back to enabled after disabling everyone else.  This is just a precaution against someone doing the
                     // wrong thing and disabling our dialog.
 
-                    bool modalEnabled = _currentForm != null && _currentForm.Enabled;
+                    bool modalEnabled = _currentForm is not null && _currentForm.Enabled;
 
                     Debug.WriteLineIf(
                         CompModSwitches.MSOComponentManager.TraceInfo,
@@ -1077,7 +1077,7 @@ namespace System.Windows.Forms
 
                     // The second half of the the modalEnabled flag above.  Here, if we were previously
                     // enabled, make sure that's still the case.
-                    if (_currentForm != null && _currentForm.IsHandleCreated && User32.IsWindowEnabled(_currentForm).IsTrue() != modalEnabled)
+                    if (_currentForm is not null && _currentForm.IsHandleCreated && User32.IsWindowEnabled(_currentForm).IsTrue() != modalEnabled)
                     {
                         User32.EnableWindow(new HandleRef(_currentForm, _currentForm.Handle), modalEnabled.ToBOOL());
                     }
@@ -1101,7 +1101,7 @@ namespace System.Windows.Forms
                     }
 
                     // Need to do this in a try/finally.  Also good to do after we installed the synch context.
-                    if (fullModal && _currentForm != null)
+                    if (fullModal && _currentForm is not null)
                     {
                         _currentForm.Visible = true;
                     }
@@ -1156,7 +1156,7 @@ namespace System.Windows.Forms
                     {
                         Dispose(true);
                     }
-                    else if (_messageLoopCount == 0 && _componentManager != null)
+                    else if (_messageLoopCount == 0 && _componentManager is not null)
                     {
                         // If we had a component manager, detach from it.
                         RevokeComponent();
@@ -1213,7 +1213,7 @@ namespace System.Windows.Forms
                                 }
                             }
 
-                            if (form != null)
+                            if (form is not null)
                             {
                                 continueLoop = !form.CheckCloseDialog(false);
                             }
@@ -1247,7 +1247,7 @@ namespace System.Windows.Forms
                 // If message filter is added or removed inside the user-provided PreFilterMessage function,
                 // and user code pumps messages, we might re-enter ProcessFilter on the same stack, we
                 // should not update the snapshot until the next message.
-                if (_messageFilters != null && !GetState(STATE_FILTERSNAPSHOTVALID) && _inProcessFilters == 0)
+                if (_messageFilters is not null && !GetState(STATE_FILTERSNAPSHOTVALID) && _inProcessFilters == 0)
                 {
                     _messageFilterSnapshot.Clear();
                     if (_messageFilters.Count > 0)
@@ -1260,7 +1260,7 @@ namespace System.Windows.Forms
                 _inProcessFilters++;
                 try
                 {
-                    if (_messageFilterSnapshot != null && _messageFilterSnapshot.Count != 0)
+                    if (_messageFilterSnapshot is not null && _messageFilterSnapshot.Count != 0)
                     {
                         IMessageFilter f;
                         int count = _messageFilterSnapshot.Count;
@@ -1334,7 +1334,7 @@ namespace System.Windows.Forms
 
                     Message m = Message.Create(msg.hwnd, msg.message, msg.wParam, msg.lParam);
 
-                    if (target != null)
+                    if (target is not null)
                     {
                         if (NativeWindow.WndProcShouldBeDebuggable)
                         {
@@ -1394,7 +1394,7 @@ namespace System.Windows.Forms
             /// </summary>
             private unsafe void RevokeComponent()
             {
-                if (_componentManager != null && _componentID != s_invalidId)
+                if (_componentManager is not null && _componentID != s_invalidId)
                 {
                     IMsoComponentManager msocm = _componentManager;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
@@ -78,7 +78,7 @@ namespace System.Windows.Forms
                     if (User32.IsWindow(hWnd).IsTrue())
                     {
                         Control c = Control.FromHandle(hWnd);
-                        if (c != null)
+                        if (c is not null)
                         {
                             c.Dispose();
                         }
@@ -93,7 +93,7 @@ namespace System.Windows.Forms
                 {
                     _activeHwnd = User32.GetActiveWindow();
                     Control activatingControl = ThreadContext.FromCurrent().ActivatingControl;
-                    if (activatingControl != null)
+                    if (activatingControl is not null)
                     {
                         _focusedHwnd = activatingControl.Handle;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -154,12 +154,12 @@ namespace System.Windows.Forms
                         // We need access to be able to read from the registry here.  We're not creating a
                         // registry key, nor are we returning information from the registry to the user.
                         RegistryKey key = Registry.LocalMachine.OpenSubKey(CommonAppDataRegistryKeyName);
-                        if (key != null)
+                        if (key is not null)
                         {
                             object value = key.GetValue(EverettThreadAffinityValue);
                             key.Close();
 
-                            if (value != null && (int)value != 0)
+                            if (value is not null && (int)value != 0)
                             {
                                 s_useEverettThreadAffinity = true;
                             }
@@ -201,10 +201,10 @@ namespace System.Windows.Forms
                     {
                         // Custom attribute
                         Assembly entryAssembly = Assembly.GetEntryAssembly();
-                        if (entryAssembly != null)
+                        if (entryAssembly is not null)
                         {
                             object[] attrs = entryAssembly.GetCustomAttributes(typeof(AssemblyCompanyAttribute), false);
-                            if (attrs != null && attrs.Length > 0)
+                            if (attrs is not null && attrs.Length > 0)
                             {
                                 s_companyName = ((AssemblyCompanyAttribute)attrs[0]).Company;
                             }
@@ -214,7 +214,7 @@ namespace System.Windows.Forms
                         if (s_companyName is null || s_companyName.Length == 0)
                         {
                             s_companyName = GetAppFileVersionInfo().CompanyName;
-                            if (s_companyName != null)
+                            if (s_companyName is not null)
                             {
                                 s_companyName = s_companyName.Trim();
                             }
@@ -226,7 +226,7 @@ namespace System.Windows.Forms
                         {
                             Type t = GetAppMainType();
 
-                            if (t != null)
+                            if (t is not null)
                             {
                                 string ns = t.Namespace;
 
@@ -344,10 +344,10 @@ namespace System.Windows.Forms
                     {
                         // Custom attribute
                         Assembly entryAssembly = Assembly.GetEntryAssembly();
-                        if (entryAssembly != null)
+                        if (entryAssembly is not null)
                         {
                             object[] attrs = entryAssembly.GetCustomAttributes(typeof(AssemblyProductAttribute), false);
-                            if (attrs != null && attrs.Length > 0)
+                            if (attrs is not null && attrs.Length > 0)
                             {
                                 s_productName = ((AssemblyProductAttribute)attrs[0]).Product;
                             }
@@ -357,7 +357,7 @@ namespace System.Windows.Forms
                         if (s_productName is null || s_productName.Length == 0)
                         {
                             s_productName = GetAppFileVersionInfo().ProductName;
-                            if (s_productName != null)
+                            if (s_productName is not null)
                             {
                                 s_productName = s_productName.Trim();
                             }
@@ -369,7 +369,7 @@ namespace System.Windows.Forms
                         {
                             Type t = GetAppMainType();
 
-                            if (t != null)
+                            if (t is not null)
                             {
                                 string ns = t.Namespace;
 
@@ -412,10 +412,10 @@ namespace System.Windows.Forms
                     {
                         // Custom attribute
                         Assembly entryAssembly = Assembly.GetEntryAssembly();
-                        if (entryAssembly != null)
+                        if (entryAssembly is not null)
                         {
                             object[] attrs = entryAssembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
-                            if (attrs != null && attrs.Length > 0)
+                            if (attrs is not null && attrs.Length > 0)
                             {
                                 s_productVersion = ((AssemblyInformationalVersionAttribute)attrs[0]).InformationalVersion;
                             }
@@ -425,7 +425,7 @@ namespace System.Windows.Forms
                         if (s_productVersion is null || s_productVersion.Length == 0)
                         {
                             s_productVersion = GetAppFileVersionInfo().ProductVersion;
-                            if (s_productVersion != null)
+                            if (s_productVersion is not null)
                             {
                                 s_productVersion = s_productVersion.Trim();
                             }
@@ -868,7 +868,7 @@ namespace System.Windows.Forms
                 if (s_exiting)
                 {
                     // Recursive call to Exit
-                    if (e != null)
+                    if (e is not null)
                     {
                         e.Cancel = false;
                     }
@@ -879,14 +879,14 @@ namespace System.Windows.Forms
                 try
                 {
                     // Raise the FormClosing and FormClosed events for each open form
-                    if (s_forms != null)
+                    if (s_forms is not null)
                     {
                         foreach (Form f in s_forms)
                         {
                             if (f.RaiseFormClosingOnAppExit())
                             {
                                 // A form refused to close
-                                if (e != null)
+                                if (e is not null)
                                 {
                                     e.Cancel = true;
                                 }
@@ -902,7 +902,7 @@ namespace System.Windows.Forms
                     }
 
                     ThreadContext.ExitApplication();
-                    if (e != null)
+                    if (e is not null)
                     {
                         e.Cancel = false;
                     }
@@ -920,7 +920,7 @@ namespace System.Windows.Forms
         public static void ExitThread()
         {
             ThreadContext context = ThreadContext.FromCurrent();
-            if (context.ApplicationContext != null)
+            if (context.ApplicationContext is not null)
             {
                 context.ApplicationContext.ExitThread();
             }
@@ -953,7 +953,7 @@ namespace System.Windows.Forms
                 if (s_appFileVersion is null)
                 {
                     Type t = GetAppMainType();
-                    if (t != null)
+                    if (t is not null)
                     {
                         s_appFileVersion = FileVersionInfo.GetVersionInfo(t.Module.FullyQualifiedName);
                     }
@@ -980,7 +980,7 @@ namespace System.Windows.Forms
 
                     // Get Main type...This doesn't work in MC++ because Main is a global function and not
                     // a class static method (it doesn't belong to a Type).
-                    if (exe != null)
+                    if (exe is not null)
                     {
                         s_mainType = exe.EntryPoint.ReflectedType;
                     }
@@ -997,7 +997,7 @@ namespace System.Windows.Forms
         {
             ThreadContext cxt = ThreadContext.FromId(User32.GetWindowThreadProcessId(handle.Handle, out _));
             Debug.Assert(
-                cxt != null,
+                cxt is not null,
                 "No thread context for handle.  This is expected if you saw a previous assert about the handle being invalid.");
 
             GC.KeepAlive(handle.Wrapper);
@@ -1027,10 +1027,10 @@ namespace System.Windows.Forms
         /// </summary>
         private static void RaiseExit()
         {
-            if (s_eventHandlers != null)
+            if (s_eventHandlers is not null)
             {
                 Delegate exit = s_eventHandlers[s_eventApplicationExit];
-                if (exit != null)
+                if (exit is not null)
                 {
                     ((EventHandler)exit)(null, EventArgs.Empty);
                 }
@@ -1042,10 +1042,10 @@ namespace System.Windows.Forms
         /// </summary>
         private static void RaiseThreadExit()
         {
-            if (s_eventHandlers != null)
+            if (s_eventHandlers is not null)
             {
                 Delegate exit = s_eventHandlers[s_eventThreadExit];
-                if (exit != null)
+                if (exit is not null)
                 {
                     ((EventHandler)exit)(null, EventArgs.Empty);
                 }
@@ -1064,7 +1064,7 @@ namespace System.Windows.Forms
             Debug.Assert(((int)User32.GetWindowLong(handle, User32.GWL.STYLE) & (int)User32.WS.CHILD) != 0, "Only WS_CHILD windows should be parked.");
 
             ThreadContext cxt = GetContextForHandle(handle);
-            if (cxt != null)
+            if (cxt is not null)
             {
                 cxt.GetParkingWindow(dpiAwarenessContext).ParkHandle(handle);
             }
@@ -1080,7 +1080,7 @@ namespace System.Windows.Forms
         internal static void ParkHandle(CreateParams cp, IntPtr dpiAwarenessContext)
         {
             ThreadContext cxt = ThreadContext.FromCurrent();
-            if (cxt != null)
+            if (cxt is not null)
             {
                 cp.Parent = cxt.GetParkingWindow(dpiAwarenessContext).Handle;
             }
@@ -1105,7 +1105,7 @@ namespace System.Windows.Forms
         internal static void UnparkHandle(HandleRef handle, IntPtr context)
         {
             ThreadContext cxt = GetContextForHandle(handle);
-            if (cxt != null)
+            if (cxt is not null)
             {
                 cxt.GetParkingWindow(context).UnparkHandle(handle);
             }
@@ -1137,7 +1137,7 @@ namespace System.Windows.Forms
             bool hrefExeCase = false;
 
             Process process = Process.GetCurrentProcess();
-            Debug.Assert(process != null);
+            Debug.Assert(process is not null);
             if (string.Equals(process.MainModule.ModuleName, IEEXEC, StringComparison.OrdinalIgnoreCase))
             {
                 string clrPath = Path.GetDirectoryName(typeof(object).Module.FullyQualifiedName);
@@ -1158,7 +1158,7 @@ namespace System.Windows.Forms
             {
                 // Regular app case
                 string[] arguments = Environment.GetCommandLineArgs();
-                Debug.Assert(arguments != null && arguments.Length > 0);
+                Debug.Assert(arguments is not null && arguments.Length > 0);
                 StringBuilder sb = new StringBuilder((arguments.Length - 1) * 16);
                 for (int argumentIndex = 1; argumentIndex < arguments.Length - 1; argumentIndex++)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ApplicationContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ApplicationContext.cs
@@ -49,14 +49,14 @@ namespace System.Windows.Forms
             set
             {
                 EventHandler onClose = OnMainFormDestroy;
-                if (_mainForm != null)
+                if (_mainForm is not null)
                 {
                     _mainForm.HandleDestroyed -= onClose;
                 }
 
                 _mainForm = value;
 
-                if (_mainForm != null)
+                if (_mainForm is not null)
                 {
                     _mainForm.HandleDestroyed += onClose;
                 }
@@ -92,7 +92,7 @@ namespace System.Windows.Forms
         {
             if (disposing)
             {
-                if (_mainForm != null)
+                if (_mainForm is not null)
                 {
                     if (!_mainForm.IsDisposed)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ArrangedElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ArrangedElement.cs
@@ -141,7 +141,7 @@ namespace System.Windows.Forms
                 if (state[stateVisible] != value)
                 {
                     state[stateVisible] = value;
-                    if (Parent != null)
+                    if (Parent is not null)
                     {
                         LayoutTransaction.DoLayout(Parent, this, PropertyNames.Visible);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ArraySubsetEnumerator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ArraySubsetEnumerator.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Forms
 
         public ArraySubsetEnumerator(object[] array, int count)
         {
-            Debug.Assert(count == 0 || array != null, "if array is null, count should be 0");
+            Debug.Assert(count == 0 || array is not null, "if array is null, count should be 0");
             Debug.Assert(array is null || count <= array.Length, "Trying to enumerate more than the array contains");
             _array = array;
             _total = count;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -135,7 +135,7 @@ namespace System.Windows.Forms
                     {
                         Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "!parent || !belongs NYI");
                         AxContainer c = FindContainerForControl(ctl);
-                        if (c != null)
+                        if (c is not null)
                         {
                             rval = new ExtenderProxy(ctl, c);
                         }
@@ -157,7 +157,7 @@ namespace System.Windows.Forms
 
             internal string GetNameForControl(Control ctl)
             {
-                string name = (ctl.Site != null) ? ctl.Site.Name : ctl.Name;
+                string name = (ctl.Site is not null) ? ctl.Site.Name : ctl.Name;
                 return name ?? "";
             }
 
@@ -176,11 +176,11 @@ namespace System.Windows.Forms
                     if (assocContainer is null)
                     {
                         ISite site = ctl.Site;
-                        if (site != null)
+                        if (site is not null)
                         {
                             assocContainer = site.Container;
                             IComponentChangeService ccs = (IComponentChangeService)site.GetService(typeof(IComponentChangeService));
-                            if (ccs != null)
+                            if (ccs is not null)
                             {
                                 ccs.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
                             }
@@ -190,7 +190,7 @@ namespace System.Windows.Forms
                     {
 #if DEBUG
                         ISite site = ctl.Site;
-                        if (site != null && assocContainer != site.Container)
+                        if (site is not null && assocContainer != site.Container)
                         {
                             Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "mismatch between assoc container & added control");
                         }
@@ -267,7 +267,7 @@ namespace System.Windows.Forms
                             break;
                         case GC_WCH.SIBLING:
                             Control p = ctl.ParentInternal;
-                            if (p != null)
+                            if (p is not null)
                             {
                                 ctls = p.GetChildControlsInTabOrder(false);
                                 if (onlyPrev)
@@ -288,10 +288,10 @@ namespace System.Windows.Forms
                         case GC_WCH.CONTAINER:
                             l = new ArrayList();
                             MaybeAdd(l, ctl, selected, dwOleContF, false);
-                            while (ctl != null)
+                            while (ctl is not null)
                             {
                                 AxContainer cont = FindContainerForControl(ctl);
-                                if (cont != null)
+                                if (cont is not null)
                                 {
                                     MaybeAdd(l, cont.parent, selected, dwOleContF, true);
                                     ctl = cont.parent;
@@ -312,12 +312,12 @@ namespace System.Windows.Forms
                     if (l is null)
                     {
                         l = new ArrayList();
-                        if (last == -1 && ctls != null)
+                        if (last == -1 && ctls is not null)
                         {
                             last = ctls.Length;
                         }
 
-                        if (ctl != null)
+                        if (ctl is not null)
                         {
                             MaybeAdd(l, ctl, selected, dwOleContF, false);
                         }
@@ -368,7 +368,7 @@ namespace System.Windows.Forms
                 else if ((dwOleContF & OLECONTF.OTHERS) != 0)
                 {
                     object item = GetProxyForControl(ctl);
-                    if (item != null)
+                    if (item is not null)
                     {
                         l.Add(item);
                     }
@@ -377,15 +377,15 @@ namespace System.Windows.Forms
 
             private void FillComponentsTable(IContainer container)
             {
-                if (container != null)
+                if (container is not null)
                 {
                     ComponentCollection comps = container.Components;
-                    if (comps != null)
+                    if (comps is not null)
                     {
                         components = new Hashtable();
                         foreach (IComponent comp in comps)
                         {
-                            if (comp is Control && comp != parent && comp.Site != null)
+                            if (comp is Control && comp != parent && comp.Site is not null)
                             {
                                 components.Add(comp, comp);
                             }
@@ -400,7 +400,7 @@ namespace System.Windows.Forms
                 bool checkHashTable = true;
                 Control[] ctls = new Control[containerCache.Values.Count];
                 containerCache.Values.CopyTo(ctls, 0);
-                if (ctls != null)
+                if (ctls is not null)
                 {
                     if (ctls.Length > 0 && components is null)
                     {
@@ -459,13 +459,13 @@ namespace System.Windows.Forms
             private bool GetControlBelongs(Control ctl)
             {
                 Hashtable comps = GetComponents();
-                return comps[ctl] != null;
+                return comps[ctl] is not null;
             }
 
             private IContainer GetParentIsDesigned()
             {
                 ISite site = parent.Site;
-                if (site != null && site.DesignMode)
+                if (site is not null && site.DesignMode)
                 {
                     return site.Container;
                 }
@@ -484,12 +484,12 @@ namespace System.Windows.Forms
             private bool RegisterControl(AxHost ctl)
             {
                 ISite site = ctl.Site;
-                if (site != null)
+                if (site is not null)
                 {
                     IContainer cont = site.Container;
-                    if (cont != null)
+                    if (cont is not null)
                     {
-                        if (assocContainer != null)
+                        if (assocContainer is not null)
                         {
                             return cont == assocContainer;
                         }
@@ -497,7 +497,7 @@ namespace System.Windows.Forms
                         {
                             assocContainer = cont;
                             IComponentChangeService ccs = (IComponentChangeService)site.GetService(typeof(IComponentChangeService));
-                            if (ccs != null)
+                            if (ccs is not null)
                             {
                                 ccs.ComponentRemoved += new ComponentEventHandler(OnComponentRemoved);
                             }
@@ -520,13 +520,13 @@ namespace System.Windows.Forms
             {
                 if (ctl is AxHost axctl)
                 {
-                    if (axctl.container != null)
+                    if (axctl.container is not null)
                     {
                         return axctl.container;
                     }
 
                     ContainerControl f = axctl.ContainingControl;
-                    if (f != null)
+                    if (f is not null)
                     {
                         AxContainer container = f.CreateAxContainer();
                         if (container.RegisterControl(axctl))
@@ -576,7 +576,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                if (siteUIActive != null && siteUIActive != site)
+                if (siteUIActive is not null && siteUIActive != site)
                 {
                     AxHost tempSite = siteUIActive;
                     bool ownDisposing = tempSite.GetAxState(AxHost.ownDisposing);
@@ -595,7 +595,7 @@ namespace System.Windows.Forms
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "active Object is now " + site.ToString());
                 siteUIActive = site;
                 ContainerControl f = site.ContainingControl;
-                if (f != null)
+                if (f is not null)
                 {
                     f.ActiveControl = site;
                 }
@@ -611,7 +611,7 @@ namespace System.Windows.Forms
 
                 Control[] ctls = new Control[components.Keys.Count];
                 components.Keys.CopyTo(ctls, 0);
-                if (ctls != null)
+                if (ctls is not null)
                 {
                     for (int i = 0; i < ctls.Length; i++)
                     {
@@ -674,7 +674,7 @@ namespace System.Windows.Forms
             unsafe HRESULT IOleContainer.ParseDisplayName(IntPtr pbc, string pszDisplayName, uint *pchEaten, IntPtr* ppmkOut)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in ParseDisplayName");
-                if (ppmkOut != null)
+                if (ppmkOut is not null)
                 {
                     *ppmkOut = IntPtr.Zero;
                 }
@@ -688,7 +688,7 @@ namespace System.Windows.Forms
                 ppenum = null;
                 if ((grfFlags & OLECONTF.EMBEDDINGS) != 0)
                 {
-                    Debug.Assert(parent != null, "gotta have it...");
+                    Debug.Assert(parent is not null, "gotta have it...");
                     ArrayList list = new ArrayList();
                     ListAxControls(list, true);
                     if (list.Count > 0)
@@ -761,11 +761,11 @@ namespace System.Windows.Forms
             HRESULT IOleInPlaceFrame.SetActiveObject(IOleInPlaceActiveObject pActiveObject, string pszObjName)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in SetActiveObject " + (pszObjName ?? "<null>"));
-                if (siteUIActive != null)
+                if (siteUIActive is not null)
                 {
                     if (siteUIActive.iOleInPlaceActiveObjectExternal != pActiveObject)
                     {
-                        if (siteUIActive.iOleInPlaceActiveObjectExternal != null)
+                        if (siteUIActive.iOleInPlaceActiveObjectExternal is not null)
                         {
                             Marshal.ReleaseComObject(siteUIActive.iOleInPlaceActiveObjectExternal);
                         }
@@ -774,7 +774,7 @@ namespace System.Windows.Forms
                 }
                 if (pActiveObject is null)
                 {
-                    if (ctlInEditMode != null)
+                    if (ctlInEditMode is not null)
                     {
                         ctlInEditMode.editMode = EDITM_NONE;
                         ctlInEditMode = null;
@@ -791,7 +791,7 @@ namespace System.Windows.Forms
                         ctl = ((OleInterfaces)(clientSite)).GetAxHost();
                     }
 
-                    if (ctlInEditMode != null)
+                    if (ctlInEditMode is not null)
                     {
                         Debug.Fail("control " + ctlInEditMode.ToString() + " did not reset its edit mode to null");
                         ctlInEditMode.SetSelectionStyle(1);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPerPropertyBrowsingEnum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPerPropertyBrowsingEnum.cs
@@ -79,7 +79,7 @@ namespace System.Windows.Forms
                     Oleaut32.IPerPropertyBrowsing ppb = (Oleaut32.IPerPropertyBrowsing)owner.GetPerPropertyBrowsing();
                     int itemCount = 0;
 
-                    Debug.Assert(cookieItems != null && nameItems != null, "An item array is null");
+                    Debug.Assert(cookieItems is not null && nameItems is not null, "An item array is null");
 
                     if (nameItems.Length > 0)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Forms
                 // Get the category for this dispid.
                 //
                 dispid = (DispIdAttribute)baseProp.Attributes[typeof(DispIdAttribute)];
-                if (dispid != null)
+                if (dispid is not null)
                 {
                     // Look to see if this property has a property page.
                     // If it does, then it needs to be Browsable(true).
@@ -59,7 +59,7 @@ namespace System.Windows.Forms
 
                     // Use the CategoryAttribute provided by the OCX.
                     CategoryAttribute cat = owner.GetCategoryForDispid((Ole32.DispatchID)dispid.Value);
-                    if (cat != null)
+                    if (cat is not null)
                     {
                         AddAttribute(cat);
                     }
@@ -86,7 +86,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (dispid != null)
+                    if (dispid is not null)
                     {
                         UpdateTypeConverterAndTypeEditorInternal(false, Dispid);
                     }
@@ -99,7 +99,7 @@ namespace System.Windows.Forms
                 get
                 {
                     DispIdAttribute dispid = (DispIdAttribute)baseProp.Attributes[typeof(DispIdAttribute)];
-                    if (dispid != null)
+                    if (dispid is not null)
                     {
                         return (Ole32.DispatchID)dispid.Value;
                     }
@@ -149,12 +149,12 @@ namespace System.Windows.Forms
                     throw new ArgumentNullException(nameof(editorBaseType));
                 }
 
-                if (dispid != null)
+                if (dispid is not null)
                 {
                     UpdateTypeConverterAndTypeEditorInternal(false, (Ole32.DispatchID)dispid.Value);
                 }
 
-                if (editorBaseType.Equals(typeof(UITypeEditor)) && editor != null)
+                if (editorBaseType.Equals(typeof(UITypeEditor)) && editor is not null)
                 {
                     return editor;
                 }
@@ -260,7 +260,7 @@ namespace System.Windows.Forms
                 try
                 {
                     SetFlag(FlagSettingValue, true);
-                    if (PropertyType.IsEnum && value != null && value.GetType() != PropertyType)
+                    if (PropertyType.IsEnum && value is not null && value.GetType() != PropertyType)
                     {
                         baseProp.SetValue(component, Enum.ToObject(PropertyType, value));
                     }
@@ -345,7 +345,7 @@ namespace System.Windows.Forms
                 {
                     Oleaut32.IPerPropertyBrowsing ppb = owner.GetPerPropertyBrowsing();
 
-                    if (ppb != null)
+                    if (ppb is not null)
                     {
                         bool hasStrings = false;
 
@@ -472,10 +472,10 @@ namespace System.Windows.Forms
                 }
                 catch (Exception ex1)
                 {
-                    if (provider != null)
+                    if (provider is not null)
                     {
                         IUIService uiSvc = (IUIService)provider.GetService(typeof(IUIService));
-                        if (uiSvc != null)
+                        if (uiSvc is not null)
                         {
                             uiSvc.ShowError(ex1, SR.ErrorTypeConverterFailed);
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.ConnectionPointCookie.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.ConnectionPointCookie.cs
@@ -93,7 +93,7 @@ namespace System.Windows.Forms
 
                 if (connectionPoint is null || cookie == 0)
                 {
-                    if (connectionPoint != null)
+                    if (connectionPoint is not null)
                     {
                         Marshal.ReleaseComObject(connectionPoint);
                     }
@@ -114,7 +114,7 @@ namespace System.Windows.Forms
             /// </summary>
             public void Disconnect()
             {
-                if (connectionPoint != null && cookie != 0)
+                if (connectionPoint is not null && cookie != 0)
                 {
                     try
                     {
@@ -144,7 +144,7 @@ namespace System.Windows.Forms
 
             ~ConnectionPointCookie()
             {
-                if (connectionPoint != null && cookie != 0)
+                if (connectionPoint is not null && cookie != 0)
                 {
                     if (!AppDomain.CurrentDomain.IsFinalizingForUnload())
                     {
@@ -170,7 +170,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    return connectionPoint != null && cookie != 0;
+                    return connectionPoint is not null && cookie != 0;
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.EnumUnknown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.EnumUnknown.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms
 
             unsafe HRESULT Ole32.IEnumUnknown.Next(uint celt, IntPtr rgelt, uint* pceltFetched)
             {
-                if (pceltFetched != null)
+                if (pceltFetched is not null)
                 {
                     *pceltFetched = 0;
                 }
@@ -51,7 +51,7 @@ namespace System.Windows.Forms
                 {
                     for (; loc < size && fetched < celt; ++loc)
                     {
-                        if (arr[loc] != null)
+                        if (arr[loc] is not null)
                         {
                             Marshal.WriteIntPtr(rgelt, Marshal.GetIUnknownForObject(arr[loc]));
                             rgelt = (IntPtr)((long)rgelt + (long)sizeof(IntPtr));
@@ -60,7 +60,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (pceltFetched != null)
+                if (pceltFetched is not null)
                 {
                     *pceltFetched = fetched;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
@@ -79,7 +79,7 @@ namespace System.Windows.Forms
 
             internal void StartEvents()
             {
-                if (connectionPoint != null)
+                if (connectionPoint is not null)
                 {
                     return;
                 }
@@ -114,7 +114,7 @@ namespace System.Windows.Forms
 
             internal void StopEvents()
             {
-                if (connectionPoint != null)
+                if (connectionPoint is not null)
                 {
                     connectionPoint.Disconnect();
                     connectionPoint = null;
@@ -220,7 +220,7 @@ namespace System.Windows.Forms
                     int endIndex = name.IndexOf(']');
                     DispatchID dispid = (DispatchID)int.Parse(name.Substring(8, endIndex - 8), CultureInfo.InvariantCulture);
                     object ambient = host.GetAmbientProperty(dispid);
-                    if (ambient != null)
+                    if (ambient is not null)
                     {
                         return ambient;
                     }
@@ -456,7 +456,7 @@ namespace System.Windows.Forms
 
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in GetWindow");
                 Control parent = host.ParentInternal;
-                *phwnd = parent != null ? parent.Handle : IntPtr.Zero;
+                *phwnd = parent is not null ? parent.Handle : IntPtr.Zero;
                 return HRESULT.S_OK;
             }
 
@@ -506,7 +506,7 @@ namespace System.Windows.Forms
 
                 *lprcPosRect = host.Bounds;
                 *lprcClipRect = WebBrowserHelper.GetClipRect();
-                if (lpFrameInfo != null)
+                if (lpFrameInfo is not null)
                 {
                     lpFrameInfo->cb = (uint)Marshal.SizeOf<OLEINPLACEFRAMEINFO>();
                     lpFrameInfo->fMDIApp = BOOL.FALSE;
@@ -612,7 +612,7 @@ namespace System.Windows.Forms
                     if (dispid != DispatchID.UNKNOWN)
                     {
                         prop = host.GetPropertyDescriptorFromDispid(dispid);
-                        if (prop != null)
+                        if (prop is not null)
                         {
                             prop.OnValueChanged(host);
                             if (!prop.SettingValue)
@@ -628,7 +628,7 @@ namespace System.Windows.Forms
                         foreach (PropertyDescriptor p in props)
                         {
                             prop = p as AxPropertyDescriptor;
-                            if (prop != null && !prop.SettingValue)
+                            if (prop is not null && !prop.SettingValue)
                             {
                                 prop.UpdateTypeConverterAndTypeEditor(true);
                             }
@@ -636,11 +636,11 @@ namespace System.Windows.Forms
                     }
 
                     ISite site = host.Site;
-                    if (site != null)
+                    if (site is not null)
                     {
                         IComponentChangeService changeService = (IComponentChangeService)site.GetService(typeof(IComponentChangeService));
 
-                        if (changeService != null)
+                        if (changeService is not null)
                         {
                             try
                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.PropertyBagStream.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms
             HRESULT Oleaut32.IPropertyBag.Write(string pszPropName, ref object pVar)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Writing property " + pszPropName + " [" + pVar + "] into OCXState propertybag.");
-                if (pVar != null && !pVar.GetType().IsSerializable)
+                if (pVar is not null && !pVar.GetType().IsSerializable)
                 {
                     Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "\t " + pVar.GetType().FullName + " is not serializable.");
                     return HRESULT.S_OK;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -99,7 +99,7 @@ namespace System.Windows.Forms
                         try
                         {
                             byte[] dat = (byte[])sie.Value;
-                            if (dat != null)
+                            if (dat is not null)
                             {
                                 using var datMemoryStream = new MemoryStream(dat);
                                 InitializeFromStream(datMemoryStream);
@@ -116,7 +116,7 @@ namespace System.Windows.Forms
                         {
                             Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Loading up property bag from stream...");
                             byte[] dat = (byte[])sie.Value;
-                            if (dat != null)
+                            if (dat is not null)
                             {
                                 PropertyBagBinary = new PropertyBagStream();
                                 using var datMemoryStream = new MemoryStream(dat);
@@ -157,7 +157,7 @@ namespace System.Windows.Forms
             {
                 Debug.Assert(storage is null, "but we already have a storage!!!");
                 IntPtr hglobal = IntPtr.Zero;
-                if (buffer != null)
+                if (buffer is not null)
                 {
                     hglobal = Kernel32.GlobalAlloc(Kernel32.GMEM.MOVEABLE, (uint)length);
                     IntPtr pointer = Kernel32.GlobalLock(hglobal);
@@ -228,7 +228,7 @@ namespace System.Windows.Forms
             {
                 if (ms is null)
                 {
-                    Debug.Assert(buffer != null, "gotta have the buffer already...");
+                    Debug.Assert(buffer is not null, "gotta have the buffer already...");
                     if (buffer is null)
                     {
                         return null;
@@ -281,8 +281,8 @@ namespace System.Windows.Forms
 
             internal State RefreshStorage(Ole32.IPersistStorage iPersistStorage)
             {
-                Debug.Assert(storage != null, "how can we not have a storage object?");
-                Debug.Assert(iLockBytes != null, "how can we have a storage w/o ILockBytes?");
+                Debug.Assert(storage is not null, "how can we not have a storage object?");
+                Debug.Assert(iLockBytes is not null, "how can we have a storage w/o ILockBytes?");
                 if (storage is null || iLockBytes is null)
                 {
                     return null;
@@ -331,7 +331,7 @@ namespace System.Windows.Forms
                 bw.Write(type);
                 bw.Write(VERSION);
                 bw.Write(manualUpdate);
-                if (licenseKey != null)
+                if (licenseKey is not null)
                 {
                     bw.Write(licenseKey.Length);
                     bw.Write(licenseKey.ToCharArray());
@@ -342,11 +342,11 @@ namespace System.Windows.Forms
                 }
                 bw.Write((int)0); // skip units
                 bw.Write(length);
-                if (buffer != null)
+                if (buffer is not null)
                 {
                     bw.Write(buffer);
                 }
-                else if (ms != null)
+                else if (ms is not null)
                 {
                     ms.Position = 0;
                     ms.WriteTo(stream);
@@ -367,7 +367,7 @@ namespace System.Windows.Forms
 
                 si.AddValue("Data", stream.ToArray());
 
-                if (PropertyBagBinary != null)
+                if (PropertyBagBinary is not null)
                 {
                     try
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.StateConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.StateConverter.cs
@@ -77,7 +77,7 @@ namespace System.Windows.Forms
 
                 if (destinationType == typeof(byte[]))
                 {
-                    if (value != null)
+                    if (value is not null)
                     {
                         MemoryStream ms = new MemoryStream();
                         State state = (State)value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -482,12 +482,12 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public void EndInit()
         {
-            if (ParentInternal != null)
+            if (ParentInternal is not null)
             {
                 ParentInternal.CreateControl(true);
 
                 ContainerControl f = ContainingControl;
-                if (f != null)
+                if (f is not null)
                 {
                     f.VisibleChanged += onContainerVisibleChanged;
                 }
@@ -497,7 +497,7 @@ namespace System.Windows.Forms
         private void OnContainerVisibleChanged(object sender, EventArgs e)
         {
             ContainerControl f = ContainingControl;
-            if (f != null)
+            if (f is not null)
             {
                 if (f.Visible && Visible && !axState[fOwnWindow])
                 {
@@ -539,7 +539,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return aboutBoxDelegate != null;
+                return aboutBoxDelegate is not null;
             }
         }
 
@@ -905,7 +905,7 @@ namespace System.Windows.Forms
 
         private void AmbientChanged(Ole32.DispatchID dispid)
         {
-            if (GetOcx() != null)
+            if (GetOcx() is not null)
             {
                 try
                 {
@@ -950,7 +950,7 @@ namespace System.Windows.Forms
             }
 
             ISelectionService iss = GetSelectionService();
-            if (iss != null)
+            if (iss is not null)
             {
                 iss.SelectionChanging += selectionChangeHandler;
             }
@@ -981,7 +981,7 @@ namespace System.Windows.Forms
             }
 
             ISelectionService iss = GetSelectionService();
-            if (iss != null)
+            if (iss is not null)
             {
                 iss.SelectionChanging -= selectionChangeHandler;
             }
@@ -997,7 +997,7 @@ namespace System.Windows.Forms
                 //
                 IComponentChangeService changeService = (IComponentChangeService)GetService(typeof(IComponentChangeService));
 
-                if (changeService != null)
+                if (changeService is not null)
                 {
                     if (hook)
                     {
@@ -1045,18 +1045,18 @@ namespace System.Windows.Forms
                     AddSelectionHandler();
                 }
 
-                SyncRenameNotification(value != null);
+                SyncRenameNotification(value is not null);
 
                 // For inherited forms we create the OCX first in User mode
                 // and then we get sited. At that time, we have to re-activate
                 // the OCX by transitioning down to and up to the current state.
                 //
-                if (value != null && !newuMode && olduMode != newuMode && GetOcState() > OC_LOADED)
+                if (value is not null && !newuMode && olduMode != newuMode && GetOcState() > OC_LOADED)
                 {
                     TransitionDownTo(OC_LOADED);
                     TransitionUpTo(OC_INPLACE);
                     ContainerControl f = ContainingControl;
-                    if (f != null && f.Visible && Visible)
+                    if (f is not null && f.Visible && Visible)
                     {
                         MakeVisibleWithShow();
                     }
@@ -1064,7 +1064,7 @@ namespace System.Windows.Forms
 
                 if (olduMode != newuMode && !IsHandleCreated && !axState[disposed])
                 {
-                    if (GetOcx() != null)
+                    if (GetOcx() is not null)
                     {
                         RealizeStyles();
                     }
@@ -1110,7 +1110,7 @@ namespace System.Windows.Forms
             ISelectionService iss = GetSelectionService();
             // What we care about:
             // if we are uiactive and we lose selection, then we need to uideactivate ourselves...
-            if (iss != null)
+            if (iss is not null)
             {
                 if (GetOcState() >= OC_UIACTIVE && !iss.GetComponentSelected(this))
                 {
@@ -1135,7 +1135,7 @@ namespace System.Windows.Forms
                     //
                     PropertyDescriptor prop = TypeDescriptor.GetProperties(this)["SelectionStyle"];
 
-                    if (prop != null && prop.PropertyType == typeof(int))
+                    if (prop is not null && prop.PropertyType == typeof(int))
                     {
                         int curSelectionStyle = (int)prop.GetValue(this);
                         if (curSelectionStyle != selectionStyle)
@@ -1533,7 +1533,7 @@ namespace System.Windows.Forms
                             {
                                 InPlaceActivate();
 
-                                if (!Visible && ContainingControl != null && ContainingControl.Visible)
+                                if (!Visible && ContainingControl is not null && ContainingControl.Visible)
                                 {
                                     HideAxControl();
                                 }
@@ -1614,7 +1614,7 @@ namespace System.Windows.Forms
         {
             axState[ownDisposing] = true;
             ContainerControl f = ContainingControl;
-            if (f != null)
+            if (f is not null)
             {
                 if (f.ActiveControl == this)
                 {
@@ -1669,7 +1669,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            if (ParentInternal != null)
+            if (ParentInternal is not null)
             {    // ==> we are in a valid state
                 Debug.Fail("extremely naughty ctl is refusing to give us an hWnd... giving up...");
                 throw new NotSupportedException(string.Format(SR.AXNohWnd, GetType().Name));
@@ -1681,7 +1681,7 @@ namespace System.Windows.Forms
             if (GetState(States.Visible) != value)
             {
                 bool oldVisible = Visible;
-                if ((IsHandleCreated || value) && ParentInternal != null && ParentInternal.Created)
+                if ((IsHandleCreated || value) && ParentInternal is not null && ParentInternal.Created)
                 {
                     if (!axState[fOwnWindow])
                     {
@@ -1756,7 +1756,7 @@ namespace System.Windows.Forms
 
             EnsureWindowPresent();
             CreateControl(true);
-            if (f != null && f.ActiveControl != ctl)
+            if (f is not null && f.ActiveControl != ctl)
             {
                 f.ActiveControl = ctl;
             }
@@ -1855,7 +1855,7 @@ namespace System.Windows.Forms
                 try
                 {
                     Ole32.IOleInPlaceActiveObject activeObj = GetInPlaceActiveObject();
-                    if (activeObj != null)
+                    if (activeObj is not null)
                     {
                         HRESULT hr = activeObj.TranslateAccelerator(&win32Message);
                         msg.Msg = (int)win32Message.message;
@@ -2017,7 +2017,7 @@ namespace System.Windows.Forms
 
                 ocxState = value;
 
-                if (ocxState != null)
+                if (ocxState is not null)
                 {
                     axState[manualUpdate] = ocxState._GetManualUpdate();
                     licenseKey = ocxState._GetLicenseKey();
@@ -2028,7 +2028,7 @@ namespace System.Windows.Forms
                     licenseKey = null;
                 }
 
-                if (ocxState != null && GetOcState() >= OC_RUNNING)
+                if (ocxState is not null && GetOcState() >= OC_RUNNING)
                 {
                     DepersistControl();
                 }
@@ -2050,7 +2050,7 @@ namespace System.Windows.Forms
                 {
                     PropertyBagStream propBag = null;
 
-                    if (iPersistPropBag != null)
+                    if (iPersistPropBag is not null)
                     {
                         propBag = new PropertyBagStream();
                         iPersistPropBag.Save(propBag, BOOL.TRUE, BOOL.TRUE);
@@ -2072,8 +2072,8 @@ namespace System.Windows.Forms
                             }
                             break;
                         case STG_STORAGE:
-                            Debug.Assert(oldOcxState != null, "we got to have an old state which holds out scribble storage...");
-                            if (oldOcxState != null)
+                            Debug.Assert(oldOcxState is not null, "we got to have an old state which holds out scribble storage...");
+                            if (oldOcxState is not null)
                             {
                                 return oldOcxState.RefreshStorage(iPersistStorage);
                             }
@@ -2083,11 +2083,11 @@ namespace System.Windows.Forms
                             Debug.Fail("unknown storage type.");
                             return null;
                     }
-                    if (ms != null)
+                    if (ms is not null)
                     {
                         return new State(ms, storageType, this, propBag);
                     }
-                    else if (propBag != null)
+                    else if (propBag is not null)
                     {
                         return new State(propBag);
                     }
@@ -2168,10 +2168,10 @@ namespace System.Windows.Forms
 
         private ContainerControl FindContainerControlInternal()
         {
-            if (Site != null)
+            if (Site is not null)
             {
                 IDesignerHost host = (IDesignerHost)Site.GetService(typeof(IDesignerHost));
-                if (host != null)
+                if (host is not null)
                 {
                     if (host.RootComponent is ContainerControl rootControl)
                     {
@@ -2182,7 +2182,7 @@ namespace System.Windows.Forms
 
             ContainerControl cc = null;
             Control control = this;
-            while (control != null)
+            while (control is not null)
             {
                 if (control is ContainerControl tempCC)
                 {
@@ -2272,7 +2272,7 @@ namespace System.Windows.Forms
                     return false;
                 case Ole32.DispatchID.AMBIENT_FONT:
                     Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "asked for font");
-                    if (richParent != null)
+                    if (richParent is not null)
                     {
                         return GetIFontFromFont(richParent.Font);
                     }
@@ -2284,13 +2284,13 @@ namespace System.Windows.Forms
                     Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "asked for showHatching");
                     return false;
                 case Ole32.DispatchID.AMBIENT_BACKCOLOR:
-                    if (richParent != null)
+                    if (richParent is not null)
                     {
                         return GetOleColorFromColor(richParent.BackColor);
                     }
                     return null;
                 case Ole32.DispatchID.AMBIENT_FORECOLOR:
-                    if (richParent != null)
+                    if (richParent is not null)
                     {
                         return GetOleColorFromColor(richParent.ForeColor);
                     }
@@ -2309,7 +2309,7 @@ namespace System.Windows.Forms
                 case Ole32.DispatchID.AMBIENT_RIGHTTOLEFT:
                     Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "asked for right to left");
                     Control ctl = this;
-                    while (ctl != null)
+                    while (ctl is not null)
                     {
                         if (ctl.RightToLeft == System.Windows.Forms.RightToLeft.No)
                         {
@@ -2337,7 +2337,7 @@ namespace System.Windows.Forms
         {
             Control parent = ParentInternal;
             RECT posRect = Bounds;
-            GetOleObject().DoVerb((Ole32.OLEIVERB)verb, null, oleSite, -1, parent != null ? parent.Handle : IntPtr.Zero, &posRect);
+            GetOleObject().DoVerb((Ole32.OLEIVERB)verb, null, oleSite, -1, parent is not null ? parent.Handle : IntPtr.Zero, &posRect);
         }
 
         private bool AwaitingDefreezing()
@@ -2393,7 +2393,7 @@ namespace System.Windows.Forms
 
         private unsafe string GetLicenseKey(Guid clsid)
         {
-            if (licenseKey != null || !axState[needLicenseKey])
+            if (licenseKey is not null || !axState[needLicenseKey])
             {
                 return licenseKey;
             }
@@ -2446,12 +2446,12 @@ namespace System.Windows.Forms
             }
 
             instance = ret;
-            Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "\t" + (instance != null).ToString());
+            Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "\t" + (instance is not null).ToString());
         }
 
         private void CreateWithLicense(string license, Guid clsid)
         {
-            if (license != null)
+            if (license is not null)
             {
                 Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Creating object with license: " + clsid.ToString());
                 HRESULT hr = Ole32.CoGetClassObject(
@@ -2463,7 +2463,7 @@ namespace System.Windows.Forms
                 if (hr.Succeeded())
                 {
                     icf2.CreateInstanceLic(IntPtr.Zero, IntPtr.Zero, ref NativeMethods.ActiveX.IID_IUnknown, license, out instance);
-                    Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "\t" + (instance != null).ToString());
+                    Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "\t" + (instance is not null).ToString());
                 }
             }
 
@@ -2479,7 +2479,7 @@ namespace System.Windows.Forms
             try
             {
                 instance = CreateInstanceCore(clsid);
-                Debug.Assert(instance != null, "w/o an exception being thrown we must have an object...");
+                Debug.Assert(instance is not null, "w/o an exception being thrown we must have an object...");
             }
             catch (ExternalException e)
             {
@@ -2527,22 +2527,22 @@ namespace System.Windows.Forms
             }
 
             int index = -(int)propcat;
-            if (index > 0 && index < categoryNames.Length && categoryNames[index] != null)
+            if (index > 0 && index < categoryNames.Length && categoryNames[index] is not null)
             {
                 return categoryNames[index];
             }
 
-            if (objectDefinedCategoryNames != null)
+            if (objectDefinedCategoryNames is not null)
             {
                 CategoryAttribute rval = (CategoryAttribute)objectDefinedCategoryNames[propcat];
-                if (rval != null)
+                if (rval is not null)
                 {
                     return rval;
                 }
             }
 
             hr = icp.GetCategoryName(propcat, Kernel32.GetThreadLocale(), out string name);
-            if (hr == HRESULT.S_OK && name != null)
+            if (hr == HRESULT.S_OK && name is not null)
             {
                 var rval = new CategoryAttribute(name);
                 objectDefinedCategoryNames ??= new Hashtable();
@@ -2562,12 +2562,12 @@ namespace System.Windows.Forms
 
                 ISelectionService iss = GetSelectionService();
                 this.selectionStyle = selectionStyle;
-                if (iss != null && iss.GetComponentSelected(this))
+                if (iss is not null && iss.GetComponentSelected(this))
                 {
                     // The AX Host designer will offer an extender property called "SelectionStyle"
                     //
                     PropertyDescriptor prop = TypeDescriptor.GetProperties(this)["SelectionStyle"];
-                    if (prop != null && prop.PropertyType == typeof(int))
+                    if (prop is not null && prop.PropertyType == typeof(int))
                     {
                         prop.SetValue(this, selectionStyle);
                     }
@@ -2665,7 +2665,7 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            if (editor != null)
+            if (editor is not null)
             {
                 return editor;
             }
@@ -2728,14 +2728,14 @@ namespace System.Windows.Forms
                 propsStash = null;
                 attribsStash = null;
             }
-            else if (propsStash != null)
+            else if (propsStash is not null)
             {
                 if (attributes is null && attribsStash is null)
                 {
                     Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Returning stashed values for : " + "<null>");
                     return propsStash;
                 }
-                else if (attributes != null && attribsStash != null && attributes.Length == attribsStash.Length)
+                else if (attributes is not null && attribsStash is not null && attributes.Length == attribsStash.Length)
                 {
                     bool attribsEqual = true;
                     int i = 0;
@@ -2776,11 +2776,11 @@ namespace System.Windows.Forms
             }
 
             PropertyDescriptorCollection baseProps = TypeDescriptor.GetProperties(this, null, true);
-            if (baseProps != null)
+            if (baseProps is not null)
             {
                 for (int i = 0; i < baseProps.Count; ++i)
                 {
-                    Debug.Assert(baseProps[i] != null, "Null base prop at location: " + i.ToString(CultureInfo.InvariantCulture));
+                    Debug.Assert(baseProps[i] is not null, "Null base prop at location: " + i.ToString(CultureInfo.InvariantCulture));
 
                     if (baseProps[i].DesignTimeOnly)
                     {
@@ -2793,14 +2793,14 @@ namespace System.Windows.Forms
                     PropertyInfo propInfo = (PropertyInfo)propertyInfos[propName];
 
                     // We do not support "write-only" properties that some activex controls support.
-                    if (propInfo != null && !propInfo.CanRead)
+                    if (propInfo is not null && !propInfo.CanRead)
                     {
                         continue;
                     }
 
                     if (!properties.ContainsKey(propName))
                     {
-                        if (propInfo != null)
+                        if (propInfo is not null)
                         {
                             Debug.WriteLineIf(AxPropTraceSwitch.TraceVerbose, "Added AxPropertyDescriptor for: " + propName);
                             prop = new AxPropertyDescriptor(baseProps[i], this);
@@ -2817,16 +2817,16 @@ namespace System.Windows.Forms
                     else
                     {
                         PropertyDescriptor propDesc = (PropertyDescriptor)properties[propName];
-                        Debug.Assert(propDesc != null, "Cannot find cached entry for: " + propName);
+                        Debug.Assert(propDesc is not null, "Cannot find cached entry for: " + propName);
                         AxPropertyDescriptor axPropDesc = propDesc as AxPropertyDescriptor;
-                        if ((propInfo is null && axPropDesc != null) || (propInfo != null && axPropDesc is null))
+                        if ((propInfo is null && axPropDesc is not null) || (propInfo is not null && axPropDesc is null))
                         {
                             Debug.Fail("Duplicate property with same name: " + propName);
                             Debug.WriteLineIf(AxPropTraceSwitch.TraceVerbose, "Duplicate property with same name: " + propName);
                         }
                         else
                         {
-                            if (axPropDesc != null)
+                            if (axPropDesc is not null)
                             {
                                 axPropDesc.UpdateAttributes();
                             }
@@ -2838,7 +2838,7 @@ namespace System.Windows.Forms
                 // Filter only the Browsable attribute, since that is the only
                 // one we mess with.
                 //
-                if (attributes != null)
+                if (attributes is not null)
                 {
                     Attribute browse = null;
                     foreach (Attribute attr in attributes)
@@ -2849,7 +2849,7 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    if (browse != null)
+                    if (browse is not null)
                     {
                         ArrayList removeList = null;
 
@@ -2858,7 +2858,7 @@ namespace System.Windows.Forms
                             if (prop is AxPropertyDescriptor)
                             {
                                 Attribute attr = prop.Attributes[typeof(BrowsableAttribute)];
-                                if (attr != null && !attr.Equals(browse))
+                                if (attr is not null && !attr.Equals(browse))
                                 {
                                     if (removeList is null)
                                     {
@@ -2869,7 +2869,7 @@ namespace System.Windows.Forms
                             }
                         }
 
-                        if (removeList != null)
+                        if (removeList is not null)
                         {
                             foreach (object prop in removeList)
                             {
@@ -2885,7 +2885,7 @@ namespace System.Windows.Forms
 
             // Update our stashed values.
             //
-            Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Updating stashed values for : " + ((attributes != null) ? attributes.Length.ToString(CultureInfo.InvariantCulture) : "<null>"));
+            Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Updating stashed values for : " + ((attributes is not null) ? attributes.Length.ToString(CultureInfo.InvariantCulture) : "<null>"));
             propsStash = new PropertyDescriptorCollection(temp);
             attribsStash = attributes;
 
@@ -2966,7 +2966,7 @@ namespace System.Windows.Forms
             // storage, we end up not being able to re-create a valid one and this would
             // fail.
             //
-            if (storage != null)
+            if (storage is not null)
             {
                 HRESULT hr = iPersistStorage.Load(storage);
                 if (hr != HRESULT.S_OK)
@@ -3088,7 +3088,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.UnableToInitComponent);
             }
 
-            if (ocxState.GetPropBag() != null)
+            if (ocxState.GetPropBag() is not null)
             {
                 try
                 {
@@ -3201,7 +3201,7 @@ namespace System.Windows.Forms
             }
             finally
             {
-                if (uuids.pElems != null)
+                if (uuids.pElems is not null)
                 {
                     Marshal.FreeCoTaskMem((IntPtr)uuids.pElems);
                 }
@@ -3287,7 +3287,7 @@ namespace System.Windows.Forms
             }
 
             IDesignerHost host = null;
-            if (Site != null)
+            if (Site is not null)
             {
                 host = (IDesignerHost)Site.GetService(typeof(IDesignerHost));
             }
@@ -3295,7 +3295,7 @@ namespace System.Windows.Forms
             DesignerTransaction trans = null;
             try
             {
-                if (host != null)
+                if (host is not null)
                 {
                     trans = host.CreateTransaction(SR.AXEditProperties);
                 }
@@ -3324,17 +3324,17 @@ namespace System.Windows.Forms
             }
             finally
             {
-                if (oleSite != null)
+                if (oleSite is not null)
                 {
                     ((Ole32.IPropertyNotifySink)oleSite).OnChanged(Ole32.DispatchID.UNKNOWN);
                 }
 
-                if (trans != null)
+                if (trans is not null)
                 {
                     trans.Commit();
                 }
 
-                if (uuids.pElems != null)
+                if (uuids.pElems is not null)
                 {
                     Marshal.FreeCoTaskMem((IntPtr)uuids.pElems);
                 }
@@ -3635,7 +3635,7 @@ namespace System.Windows.Forms
 
             Control p = ParentInternal;
 
-            if (p != null)
+            if (p is not null)
             {
                 qaContainer.colorFore = GetOleColorFromColor(p.ForeColor);
                 qaContainer.colorBack = GetOleColorFromColor(p.BackColor);
@@ -3708,12 +3708,12 @@ namespace System.Windows.Forms
             if (disposing)
             {
                 TransitionDownTo(OC_PASSIVE);
-                if (newParent != null)
+                if (newParent is not null)
                 {
                     newParent.Dispose();
                 }
 
-                if (oleSite != null)
+                if (oleSite is not null)
                 {
                     oleSite.Dispose();
                 }
@@ -3728,7 +3728,7 @@ namespace System.Windows.Forms
 
         private void DisposeAxControl()
         {
-            if (GetParentContainer() != null)
+            if (GetParentContainer() is not null)
             {
                 GetParentContainer().RemoveControl(this);
             }
@@ -3752,14 +3752,14 @@ namespace System.Windows.Forms
             NoComponentChangeEvents++;
 
             ContainerControl f = ContainingControl;
-            if (f != null)
+            if (f is not null)
             {
                 f.VisibleChanged -= onContainerVisibleChanged;
             }
 
             try
             {
-                if (instance != null)
+                if (instance is not null)
                 {
                     Marshal.FinalReleaseComObject(instance);
                     instance = null;
@@ -3853,7 +3853,7 @@ namespace System.Windows.Forms
         private Ole32.IOleInPlaceActiveObject GetInPlaceActiveObject()
         {
             // if our AxContainer was set an external active object then use it.
-            if (iOleInPlaceActiveObjectExternal != null)
+            if (iOleInPlaceActiveObjectExternal is not null)
             {
                 return iOleInPlaceActiveObjectExternal;
             }
@@ -3861,7 +3861,7 @@ namespace System.Windows.Forms
             // otherwise use our instance.
             if (iOleInPlaceActiveObject is null)
             {
-                Debug.Assert(instance != null, "must have the ocx");
+                Debug.Assert(instance is not null, "must have the ocx");
                 try
                 {
                     iOleInPlaceActiveObject = (Ole32.IOleInPlaceActiveObject)instance;
@@ -3880,7 +3880,7 @@ namespace System.Windows.Forms
         {
             if (iOleInPlaceObject is null)
             {
-                Debug.Assert(instance != null, "must have the ocx");
+                Debug.Assert(instance is not null, "must have the ocx");
                 iOleInPlaceObject = (Ole32.IOleInPlaceObject)instance;
 
 #if DEBUG
@@ -3895,7 +3895,7 @@ namespace System.Windows.Forms
 
         private VSSDK.ICategorizeProperties GetCategorizeProperties()
         {
-            if (iCategorizeProperties is null && !axState[checkedCP] && instance != null)
+            if (iCategorizeProperties is null && !axState[checkedCP] && instance is not null)
             {
                 axState[checkedCP] = true;
                 if (instance is VSSDK.ICategorizeProperties)
@@ -3908,7 +3908,7 @@ namespace System.Windows.Forms
 
         private Oleaut32.IPerPropertyBrowsing GetPerPropertyBrowsing()
         {
-            if (iPerPropertyBrowsing is null && !axState[checkedIppb] && instance != null)
+            if (iPerPropertyBrowsing is null && !axState[checkedIppb] && instance is not null)
             {
                 axState[checkedIppb] = true;
                 if (instance is Oleaut32.IPerPropertyBrowsing)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Binding.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Binding.cs
@@ -153,7 +153,7 @@ namespace System.Windows.Forms
 
                 // We are essentially doing to the listManager what we were doing to the
                 // BindToObject: bind only when the control is created and it has a BindingContext
-                BindingContext.UpdateBinding((BindableComponent != null && IsComponentCreated(BindableComponent) ? BindableComponent.BindingContext : null), this);
+                BindingContext.UpdateBinding((BindableComponent is not null && IsComponentCreated(BindableComponent) ? BindableComponent.BindingContext : null), this);
                 if (value is Form form)
                 {
                     form.Load += new EventHandler(FormLoaded);
@@ -367,12 +367,12 @@ namespace System.Windows.Forms
             {
                 if (IsBinding)
                 {
-                    if (_propInfo != null && BindableComponent != null)
+                    if (_propInfo is not null && BindableComponent is not null)
                     {
                         EventHandler handler = new EventHandler(Target_PropertyChanged);
                         _propInfo.AddValueChanged(BindableComponent, handler);
                     }
-                    if (_validateInfo != null)
+                    if (_validateInfo is not null)
                     {
                         CancelEventHandler handler = new CancelEventHandler(Target_Validate);
                         _validateInfo.AddEventHandler(BindableComponent, handler);
@@ -381,12 +381,12 @@ namespace System.Windows.Forms
             }
             else
             {
-                if (_propInfo != null && BindableComponent != null)
+                if (_propInfo is not null && BindableComponent is not null)
                 {
                     EventHandler handler = new EventHandler(Target_PropertyChanged);
                     _propInfo.RemoveValueChanged(BindableComponent, handler);
                 }
-                if (_validateInfo != null)
+                if (_validateInfo is not null)
                 {
                     CancelEventHandler handler = new CancelEventHandler(Target_Validate);
                     _validateInfo.RemoveEventHandler(BindableComponent, handler);
@@ -404,7 +404,7 @@ namespace System.Windows.Forms
         {
             _bindToObject.CheckBinding();
 
-            if (BindableComponent != null && !string.IsNullOrEmpty(PropertyName))
+            if (BindableComponent is not null && !string.IsNullOrEmpty(PropertyName))
             {
                 BindableComponent.DataBindings.CheckDuplicates(this);
 
@@ -424,7 +424,7 @@ namespace System.Windows.Forms
                 // inherited controls we don't because an inherited control should
                 // "act" like a runtime control.
                 InheritanceAttribute attr = (InheritanceAttribute)TypeDescriptor.GetAttributes(BindableComponent)[typeof(InheritanceAttribute)];
-                if (attr != null && attr.InheritanceLevel != InheritanceLevel.NotInherited)
+                if (attr is not null && attr.InheritanceLevel != InheritanceLevel.NotInherited)
                 {
                     propInfos = TypeDescriptor.GetProperties(controlClass);
                 }
@@ -438,7 +438,7 @@ namespace System.Windows.Forms
                     if (tempPropInfo is null && string.Equals(propInfos[i].Name, PropertyName, StringComparison.OrdinalIgnoreCase))
                     {
                         tempPropInfo = propInfos[i];
-                        if (tempPropIsNullInfo != null)
+                        if (tempPropIsNullInfo is not null)
                         {
                             break;
                         }
@@ -446,7 +446,7 @@ namespace System.Windows.Forms
                     if (tempPropIsNullInfo is null && string.Equals(propInfos[i].Name, propertyNameIsNull, StringComparison.OrdinalIgnoreCase))
                     {
                         tempPropIsNullInfo = propInfos[i];
-                        if (tempPropInfo != null)
+                        if (tempPropInfo is not null)
                         {
                             break;
                         }
@@ -466,7 +466,7 @@ namespace System.Windows.Forms
                 propType = _propInfo.PropertyType;
                 _propInfoConverter = _propInfo.Converter;
 
-                if (tempPropIsNullInfo != null && tempPropIsNullInfo.PropertyType == typeof(bool) && !tempPropIsNullInfo.IsReadOnly)
+                if (tempPropIsNullInfo is not null && tempPropIsNullInfo.PropertyType == typeof(bool) && !tempPropIsNullInfo.IsReadOnly)
                 {
                     _propIsNullInfo = tempPropIsNullInfo;
                 }
@@ -512,7 +512,7 @@ namespace System.Windows.Forms
 
         private object GetPropValue()
         {
-            if (_propIsNullInfo != null && (bool)_propIsNullInfo.GetValue(BindableComponent))
+            if (_propIsNullInfo is not null && (bool)_propIsNullInfo.GetValue(BindableComponent))
             {
                 return DataSourceNullValue;
             }
@@ -526,7 +526,7 @@ namespace System.Windows.Forms
             string errorText = string.Empty;
             BindingCompleteState state = BindingCompleteState.Success;
 
-            if (ex != null)
+            if (ex is not null)
             {
                 // If an exception was provided, report that
                 errorText = ex.Message;
@@ -563,7 +563,7 @@ namespace System.Windows.Forms
                     // User code should not be throwing exceptions from this event as a way to signal new error conditions (they should use
                     // things like the Format or Parse events for that). Exceptions thrown here can mess up currency manager behavior big time.
                     // For now, eat any non-critical exceptions and instead just cancel the current push/pull operation.
-                    if (e != null)
+                    if (e is not null)
                     {
                         e.Cancel = true;
                     }
@@ -579,9 +579,9 @@ namespace System.Windows.Forms
         {
             _onParse?.Invoke(this, cevent);
 
-            if (!_formattingEnabled && cevent != null)
+            if (!_formattingEnabled && cevent is not null)
             {
-                if (!(cevent.Value is DBNull) && cevent.Value != null && cevent.DesiredType != null && !cevent.DesiredType.IsInstanceOfType(cevent.Value) && (cevent.Value is IConvertible))
+                if (!(cevent.Value is DBNull) && cevent.Value is not null && cevent.DesiredType is not null && !cevent.DesiredType.IsInstanceOfType(cevent.Value) && (cevent.Value is IConvertible))
                 {
                     cevent.Value = Convert.ChangeType(cevent.Value, cevent.DesiredType, CultureInfo.CurrentCulture);
                 }
@@ -592,9 +592,9 @@ namespace System.Windows.Forms
         {
             _onFormat?.Invoke(this, cevent);
 
-            if (!_formattingEnabled && cevent != null)
+            if (!_formattingEnabled && cevent is not null)
             {
-                if (!(cevent.Value is DBNull) && cevent.DesiredType != null && !cevent.DesiredType.IsInstanceOfType(cevent.Value) && (cevent.Value is IConvertible))
+                if (!(cevent.Value is DBNull) && cevent.DesiredType is not null && !cevent.DesiredType.IsInstanceOfType(cevent.Value) && (cevent.Value is IConvertible))
                 {
                     cevent.Value = Convert.ChangeType(cevent.Value, cevent.DesiredType, CultureInfo.CurrentCulture);
                 }
@@ -620,7 +620,7 @@ namespace System.Windows.Forms
                 {
                     // Otherwise parse the formatted value ourselves
                     TypeConverter fieldInfoConverter = null;
-                    if (_bindToObject.FieldInfo != null)
+                    if (_bindToObject.FieldInfo is not null)
                     {
                         fieldInfoConverter = _bindToObject.FieldInfo.Converter;
                     }
@@ -633,14 +633,14 @@ namespace System.Windows.Forms
                 var e = new ConvertEventArgs(value, type);
                 // first try: use the OnParse event
                 OnParse(e);
-                if (e.Value != null && (e.Value.GetType().IsSubclassOf(type) || e.Value.GetType() == type || e.Value is DBNull))
+                if (e.Value is not null && (e.Value.GetType().IsSubclassOf(type) || e.Value.GetType() == type || e.Value is DBNull))
                 {
                     return e.Value;
                 }
 
                 // second try: use the TypeConverter
-                TypeConverter typeConverter = TypeDescriptor.GetConverter(value != null ? value.GetType() : typeof(object));
-                if (typeConverter != null && typeConverter.CanConvertTo(type))
+                TypeConverter typeConverter = TypeDescriptor.GetConverter(value is not null ? value.GetType() : typeof(object));
+                if (typeConverter is not null && typeConverter.CanConvertTo(type))
                 {
                     return typeConverter.ConvertTo(value, type);
                 }
@@ -648,7 +648,7 @@ namespace System.Windows.Forms
                 if (value is IConvertible)
                 {
                     object ret = Convert.ChangeType(value, type, CultureInfo.CurrentCulture);
-                    if (ret != null && (ret.GetType().IsSubclassOf(type) || ret.GetType() == type))
+                    if (ret is not null && (ret.GetType().IsSubclassOf(type) || ret.GetType() == type))
                     {
                         return ret;
                     }
@@ -684,7 +684,7 @@ namespace System.Windows.Forms
                 {
                     // Otherwise format the parsed value ourselves
                     TypeConverter fieldInfoConverter = null;
-                    if (_bindToObject.FieldInfo != null)
+                    if (_bindToObject.FieldInfo is not null)
                     {
                         fieldInfoConverter = _bindToObject.FieldInfo.Converter;
                     }
@@ -706,14 +706,14 @@ namespace System.Windows.Forms
                 }
 
                 // stop now if we have a value of a compatible type
-                if (ret != null && (ret.GetType().IsSubclassOf(type) || ret.GetType() == type))
+                if (ret is not null && (ret.GetType().IsSubclassOf(type) || ret.GetType() == type))
                 {
                     return ret;
                 }
 
                 // second try: use type converter for the desiredType
-                TypeConverter typeConverter = TypeDescriptor.GetConverter(value != null ? value.GetType() : typeof(object));
-                if (typeConverter != null && typeConverter.CanConvertTo(type))
+                TypeConverter typeConverter = TypeDescriptor.GetConverter(value is not null ? value.GetType() : typeof(object));
+                if (typeConverter is not null && typeConverter.CanConvertTo(type))
                 {
                     return typeConverter.ConvertTo(value, type);
                 }
@@ -722,7 +722,7 @@ namespace System.Windows.Forms
                 if (value is IConvertible)
                 {
                     ret = Convert.ChangeType(value, type, CultureInfo.CurrentCulture);
-                    if (ret != null && (ret.GetType().IsSubclassOf(type) || ret.GetType() == type))
+                    if (ret is not null && (ret.GetType().IsSubclassOf(type) || ret.GetType() == type))
                     {
                         return ret;
                     }
@@ -807,7 +807,7 @@ namespace System.Windows.Forms
             {
                 // If parse failed, reset control property value back to original data source value.
                 // An exception always indicates a parsing failure.
-                if (lastException != null || (!FormattingEnabled && parsedValue is null))
+                if (lastException is not null || (!FormattingEnabled && parsedValue is null))
                 {
                     parseFailed = true;
                     parsedValue = _bindToObject.GetValue();
@@ -967,11 +967,11 @@ namespace System.Windows.Forms
                 bool isNull = value is null || Formatter.IsNullData(value, DataSourceNullValue);
                 if (isNull)
                 {
-                    if (_propIsNullInfo != null)
+                    if (_propIsNullInfo is not null)
                     {
                         _propIsNullInfo.SetValue(BindableComponent, true);
                     }
-                    else if (_propInfo != null)
+                    else if (_propInfo is not null)
                     {
                         if (_propInfo.PropertyType == typeof(object))
                         {
@@ -996,7 +996,7 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeFormatString() => !string.IsNullOrEmpty(_formatString);
 
-        private bool ShouldSerializeNullValue() => _nullValue != null;
+        private bool ShouldSerializeNullValue() => _nullValue is not null;
 
         private bool ShouldSerializeDataSourceNullValue()
         {
@@ -1055,8 +1055,8 @@ namespace System.Windows.Forms
         {
             get
             {
-                return (BindableComponent != null && !string.IsNullOrEmpty(PropertyName) &&
-                                DataSource != null && _bindingManagerBase != null);
+                return (BindableComponent is not null && !string.IsNullOrEmpty(PropertyName) &&
+                                DataSource is not null && _bindingManagerBase is not null);
             }
         }
 
@@ -1097,7 +1097,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    Debug.Assert(_owner.DataSource != null, "how can we determine if DataSource is initialized or not if we have no data source?");
+                    Debug.Assert(_owner.DataSource is not null, "how can we determine if DataSource is initialized or not if we have no data source?");
                     if (_dataSourceInitialized)
                     {
                         return true;
@@ -1125,7 +1125,7 @@ namespace System.Windows.Forms
 
             internal BindToObject(Binding owner)
             {
-                Debug.Assert(owner != null);
+                Debug.Assert(owner is not null);
                 _owner = owner;
                 CheckBinding();
             }
@@ -1158,7 +1158,7 @@ namespace System.Windows.Forms
                 }
 
                 // remove notification from the backEnd
-                if (_bindingManager != null && FieldInfo != null && _bindingManager.IsBinding && !(_bindingManager is CurrencyManager))
+                if (_bindingManager is not null && FieldInfo is not null && _bindingManager.IsBinding && !(_bindingManager is CurrencyManager))
                 {
                     FieldInfo.RemoveValueChanged(_bindingManager.Current, new EventHandler(PropValueChanged));
                     FieldInfo = null;
@@ -1207,7 +1207,7 @@ namespace System.Windows.Forms
                 // this as part of the BindingCompleteEventArgs anyway.
                 DataErrorText = GetErrorText(obj);
 
-                if (FieldInfo != null)
+                if (FieldInfo is not null)
                 {
                     obj = FieldInfo.GetValue(obj);
                 }
@@ -1239,7 +1239,7 @@ namespace System.Windows.Forms
             {
                 object obj = null;
 
-                if (FieldInfo != null)
+                if (FieldInfo is not null)
                 {
                     obj = _bindingManager.Current;
                     if (obj is IEditableObject editableObject)
@@ -1269,29 +1269,29 @@ namespace System.Windows.Forms
             internal void CheckBinding()
             {
                 // At design time, don't check anything.
-                if (_owner.BindableComponent != null && _owner.ControlAtDesignTime())
+                if (_owner.BindableComponent is not null && _owner.ControlAtDesignTime())
                 {
                     return;
                 }
 
                 // Remove propertyChangedNotification when this binding is deleted
-                if (_bindingManager != null &&
-                    FieldInfo != null &&
+                if (_bindingManager is not null &&
+                    FieldInfo is not null &&
                     _bindingManager.IsBinding &&
                     !(_bindingManager is CurrencyManager))
                 {
                     FieldInfo.RemoveValueChanged(_bindingManager.Current, new EventHandler(PropValueChanged));
                 }
 
-                if (_bindingManager != null &&
-                    _owner.BindableComponent != null &&
+                if (_bindingManager is not null &&
+                    _owner.BindableComponent is not null &&
                     _owner.ComponentCreated &&
                     IsDataSourceInitialized)
                 {
                     string dataField = _owner.BindingMemberInfo.BindingField;
 
                     FieldInfo = _bindingManager.GetItemProperties().Find(dataField, true);
-                    if (_bindingManager.DataSource != null && FieldInfo is null && dataField.Length > 0)
+                    if (_bindingManager.DataSource is not null && FieldInfo is null && dataField.Length > 0)
                     {
                         throw new ArgumentException(string.Format(SR.ListBindingBindField, dataField), "dataMember");
                     }
@@ -1302,7 +1302,7 @@ namespace System.Windows.Forms
                     // if the binding is of the form (Control, ControlProperty, DataSource, Property1.Property2.Property3)
                     // then we want to get notification from Current.Property1.Property2 and not from DataSource
                     // when we get the backEnd notification we push the new value into the Control's property
-                    if (FieldInfo != null && _bindingManager.IsBinding &&
+                    if (FieldInfo is not null && _bindingManager.IsBinding &&
                         !(_bindingManager is CurrencyManager))
                     {
                         FieldInfo.AddValueChanged(_bindingManager.Current, new EventHandler(PropValueChanged));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
@@ -272,7 +272,7 @@ namespace System.Windows.Forms
             if (dataSource is ICurrencyManagerProvider currencyManagerProvider)
             {
                 bindingManagerBase = currencyManagerProvider.GetRelatedCurrencyManager(dataMember);
-                if (bindingManagerBase != null)
+                if (bindingManagerBase is not null)
                 {
                     return bindingManagerBase;
                 }
@@ -281,11 +281,11 @@ namespace System.Windows.Forms
             // Check for previously created binding manager
             HashKey key = GetKey(dataSource, dataMember);
             WeakReference wRef = _listManagers[key] as WeakReference;
-            if (wRef != null)
+            if (wRef is not null)
             {
                 bindingManagerBase = (BindingManagerBase)wRef.Target;
             }
-            if (bindingManagerBase != null)
+            if (bindingManagerBase is not null)
             {
                 return bindingManagerBase;
             }
@@ -330,7 +330,7 @@ namespace System.Windows.Forms
             }
 
             // if wRef is null, then it is the first time we want this bindingManagerBase: so add it
-            // if wRef != null, then the bindingManagerBase was GC'ed at some point: keep the old wRef and change its target
+            // if wRef is not null, then the bindingManagerBase was GC'ed at some point: keep the old wRef and change its target
             if (wRef is null)
             {
                 _listManagers.Add(key, new WeakReference(bindingManagerBase, false));
@@ -347,10 +347,10 @@ namespace System.Windows.Forms
 
         private static void CheckPropertyBindingCycles(BindingContext newBindingContext, Binding propBinding)
         {
-            Debug.Assert(newBindingContext != null, "Always called with a non-null BindingContext");
-            Debug.Assert(propBinding != null, "Always called with a non-null Binding.");
+            Debug.Assert(newBindingContext is not null, "Always called with a non-null BindingContext");
+            Debug.Assert(propBinding is not null, "Always called with a non-null Binding.");
 
-            if (propBinding.BindableComponent != null && newBindingContext.Contains(propBinding.BindableComponent, string.Empty))
+            if (propBinding.BindableComponent is not null && newBindingContext.Contains(propBinding.BindableComponent, string.Empty))
             {
                 // this way we do not add a bindingManagerBase to the
                 // bindingContext if there isn't one already
@@ -389,7 +389,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (cleanupList != null)
+            if (cleanupList is not null)
             {
                 foreach (object o in cleanupList)
                 {
@@ -411,12 +411,12 @@ namespace System.Windows.Forms
             }
 
             BindingManagerBase oldManager = binding.BindingManagerBase;
-            if (oldManager != null)
+            if (oldManager is not null)
             {
                 oldManager.Bindings.Remove(binding);
             }
 
-            if (newBindingContext != null)
+            if (newBindingContext is not null)
             {
                 // we need to first check for cycles before adding this binding to the collection
                 // of bindings.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingManagerBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingManagerBase.cs
@@ -151,13 +151,13 @@ namespace System.Windows.Forms
                     {
                         list = dataSources[offset - 1] as IList;
                     }
-                    if (list != null && list.Count > 0)
+                    if (list is not null && list.Count > 0)
                     {
                         itemProps = TypeDescriptor.GetProperties(list[0]);
                     }
                 }
 
-                if (itemProps != null)
+                if (itemProps is not null)
                 {
                     for (int j = 0; j < itemProps.Count; j++)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
@@ -265,7 +265,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_moveFirstItem != null && _moveFirstItem.IsDisposed)
+                if (_moveFirstItem is not null && _moveFirstItem.IsDisposed)
                 {
                     _moveFirstItem = null;
                 }
@@ -288,7 +288,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_movePreviousItem != null && _movePreviousItem.IsDisposed)
+                if (_movePreviousItem is not null && _movePreviousItem.IsDisposed)
                 {
                     _movePreviousItem = null;
                 }
@@ -312,7 +312,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_moveNextItem != null && _moveNextItem.IsDisposed)
+                if (_moveNextItem is not null && _moveNextItem.IsDisposed)
                 {
                     _moveNextItem = null;
                 }
@@ -335,7 +335,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_moveLastItem != null && _moveLastItem.IsDisposed)
+                if (_moveLastItem is not null && _moveLastItem.IsDisposed)
                 {
                     _moveLastItem = null;
                 }
@@ -358,7 +358,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_addNewItem != null && _addNewItem.IsDisposed)
+                if (_addNewItem is not null && _addNewItem.IsDisposed)
                 {
                     _addNewItem = null;
                 }
@@ -367,7 +367,7 @@ namespace System.Windows.Forms
 
             set
             {
-                if (_addNewItem != value && value != null)
+                if (_addNewItem != value && value is not null)
                 {
                     value.InternalEnabledChanged += new EventHandler(OnAddNewItemEnabledChanged);
                     _addNewItemUserEnabled = value.Enabled;
@@ -386,7 +386,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_deleteItem != null && _deleteItem.IsDisposed)
+                if (_deleteItem is not null && _deleteItem.IsDisposed)
                 {
                     _deleteItem = null;
                 }
@@ -395,7 +395,7 @@ namespace System.Windows.Forms
 
             set
             {
-                if (_deleteItem != value && value != null)
+                if (_deleteItem != value && value is not null)
                 {
                     value.InternalEnabledChanged += new EventHandler(OnDeleteItemEnabledChanged);
                     _deleteItemUserEnabled = value.Enabled;
@@ -414,7 +414,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_positionItem != null && _positionItem.IsDisposed)
+                if (_positionItem is not null && _positionItem.IsDisposed)
                 {
                     _positionItem = null;
                 }
@@ -437,7 +437,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_countItem != null && _countItem.IsDisposed)
+                if (_countItem is not null && _countItem.IsDisposed)
                 {
                     _countItem = null;
                 }
@@ -512,27 +512,27 @@ namespace System.Windows.Forms
             // Enable or disable items (except when in design mode)
             if (!DesignMode)
             {
-                if (MoveFirstItem != null)
+                if (MoveFirstItem is not null)
                 {
                     _moveFirstItem.Enabled = (position > 1);
                 }
 
-                if (MovePreviousItem != null)
+                if (MovePreviousItem is not null)
                 {
                     _movePreviousItem.Enabled = (position > 1);
                 }
 
-                if (MoveNextItem != null)
+                if (MoveNextItem is not null)
                 {
                     _moveNextItem.Enabled = (position < count);
                 }
 
-                if (MoveLastItem != null)
+                if (MoveLastItem is not null)
                 {
                     _moveLastItem.Enabled = (position < count);
                 }
 
-                if (AddNewItem != null)
+                if (AddNewItem is not null)
                 {
                     EventHandler handler = new EventHandler(OnAddNewItemEnabledChanged);
                     _addNewItem.InternalEnabledChanged -= handler;
@@ -540,7 +540,7 @@ namespace System.Windows.Forms
                     _addNewItem.InternalEnabledChanged += handler;
                 }
 
-                if (DeleteItem != null)
+                if (DeleteItem is not null)
                 {
                     EventHandler handler = new EventHandler(OnDeleteItemEnabledChanged);
                     _deleteItem.InternalEnabledChanged -= handler;
@@ -548,25 +548,25 @@ namespace System.Windows.Forms
                     _deleteItem.InternalEnabledChanged += handler;
                 }
 
-                if (PositionItem != null)
+                if (PositionItem is not null)
                 {
                     _positionItem.Enabled = (position > 0 && count > 0);
                 }
 
-                if (CountItem != null)
+                if (CountItem is not null)
                 {
                     _countItem.Enabled = (count > 0);
                 }
             }
 
             // Update current position indicator
-            if (_positionItem != null)
+            if (_positionItem is not null)
             {
                 _positionItem.Text = position.ToString(CultureInfo.CurrentCulture);
             }
 
             // Update record count indicator
-            if (_countItem != null)
+            if (_countItem is not null)
             {
                 _countItem.Text = DesignMode ? CountItemFormat : string.Format(CultureInfo.CurrentCulture, CountItemFormat, count);
             }
@@ -652,7 +652,7 @@ namespace System.Windows.Forms
         {
             if (Validate())
             {
-                if (_bindingSource != null)
+                if (_bindingSource is not null)
                 {
                     _bindingSource.MoveFirst();
                     RefreshItemsInternal();
@@ -667,7 +667,7 @@ namespace System.Windows.Forms
         {
             if (Validate())
             {
-                if (_bindingSource != null)
+                if (_bindingSource is not null)
                 {
                     _bindingSource.MovePrevious();
                     RefreshItemsInternal();
@@ -682,7 +682,7 @@ namespace System.Windows.Forms
         {
             if (Validate())
             {
-                if (_bindingSource != null)
+                if (_bindingSource is not null)
                 {
                     _bindingSource.MoveNext();
                     RefreshItemsInternal();
@@ -697,7 +697,7 @@ namespace System.Windows.Forms
         {
             if (Validate())
             {
-                if (_bindingSource != null)
+                if (_bindingSource is not null)
                 {
                     _bindingSource.MoveLast();
                     RefreshItemsInternal();
@@ -712,7 +712,7 @@ namespace System.Windows.Forms
         {
             if (Validate())
             {
-                if (_bindingSource != null)
+                if (_bindingSource is not null)
                 {
                     _bindingSource.AddNew();
                     RefreshItemsInternal();
@@ -727,7 +727,7 @@ namespace System.Windows.Forms
         {
             if (Validate())
             {
-                if (_bindingSource != null)
+                if (_bindingSource is not null)
                 {
                     _bindingSource.RemoveCurrent();
                     RefreshItemsInternal();
@@ -802,7 +802,7 @@ namespace System.Windows.Forms
 
         private void OnAddNewItemEnabledChanged(object sender, EventArgs e)
         {
-            if (AddNewItem != null)
+            if (AddNewItem is not null)
             {
                 _addNewItemUserEnabled = _addNewItem.Enabled;
             }
@@ -810,7 +810,7 @@ namespace System.Windows.Forms
 
         private void OnDeleteItemEnabledChanged(object sender, EventArgs e)
         {
-            if (DeleteItem != null)
+            if (DeleteItem is not null)
             {
                 _deleteItemUserEnabled = _deleteItem.Enabled;
             }
@@ -827,12 +827,12 @@ namespace System.Windows.Forms
                 return;
             }
 
-            if (oldButton != null)
+            if (oldButton is not null)
             {
                 oldButton.Click -= clickHandler;
             }
 
-            if (newButton != null)
+            if (newButton is not null)
             {
                 newButton.Click += clickHandler;
             }
@@ -887,7 +887,7 @@ namespace System.Windows.Forms
         {
             if (oldBindingSource != newBindingSource)
             {
-                if (oldBindingSource != null)
+                if (oldBindingSource is not null)
                 {
                     oldBindingSource.PositionChanged -= new EventHandler(OnBindingSourceStateChanged);
                     oldBindingSource.CurrentChanged -= new EventHandler(OnBindingSourceStateChanged);
@@ -897,7 +897,7 @@ namespace System.Windows.Forms
                     oldBindingSource.ListChanged -= new ListChangedEventHandler(OnBindingSourceListChanged);
                 }
 
-                if (newBindingSource != null)
+                if (newBindingSource is not null)
                 {
                     newBindingSource.PositionChanged += new EventHandler(OnBindingSourceStateChanged);
                     newBindingSource.CurrentChanged += new EventHandler(OnBindingSourceStateChanged);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingSource.cs
@@ -142,7 +142,7 @@ namespace System.Windows.Forms
 
         private bool IsListWriteable(bool checkConstructor)
         {
-            return !List.IsReadOnly && !List.IsFixedSize && (!checkConstructor || _itemConstructor != null);
+            return !List.IsReadOnly && !List.IsFixedSize && (!checkConstructor || _itemConstructor is not null);
         }
 
         [Browsable(false)]
@@ -507,7 +507,7 @@ namespace System.Windows.Forms
         {
             BindingSource bindingSource = newDataSource as BindingSource;
 
-            while (bindingSource != null)
+            while (bindingSource is not null)
             {
                 if (bindingSource == this)
                 {
@@ -564,7 +564,7 @@ namespace System.Windows.Forms
                 instanceException = ex; // No default ctor defined
             }
 
-            if (instanceException != null)
+            if (instanceException is not null)
             {
                 throw new NotSupportedException(SR.BindingSourceInstanceError, instanceException);
             }
@@ -739,7 +739,7 @@ namespace System.Windows.Forms
             // See if data member corresponds to a valid property on the specified data source
             PropertyDescriptorCollection dsProps = ListBindingHelper.GetListItemProperties(_dataSource);
             PropertyDescriptor dmProp = dsProps[_dataMember];
-            if (dmProp != null)
+            if (dmProp is not null)
             {
                 return true;
             }
@@ -921,20 +921,20 @@ namespace System.Windows.Forms
                     // If parent list has a current item, get the sub-list from the relevant property on that item
                     PropertyDescriptorCollection dsProps = cm.GetItemProperties();
                     PropertyDescriptor dmProp = dsProps[_dataMember];
-                    if (dmProp != null)
+                    if (dmProp is not null)
                     {
                         currentValue = ListBindingHelper.GetList(dmProp.GetValue(cm.Current));
                         currentList = currentValue as IList;
                     }
                 }
 
-                if (currentList != null)
+                if (currentList is not null)
                 {
                     // Yippeeee, the current item gave us a list to bind to!
                     // [NOTE: Specify applySortAndFilter=TRUE to apply our sort/filter settings to new list]
                     SetList(currentList, false, true);
                 }
-                else if (currentValue != null)
+                else if (currentValue is not null)
                 {
                     // Ok, we didn't get a list, but we did get something, so wrap it in a list
                     // [NOTE: Specify applySortAndFilter=FALSE to stop BindingList<T> from throwing]
@@ -1131,7 +1131,7 @@ namespace System.Windows.Forms
 
                     // GetListFromEnumerable returns null if there are no elements
                     // Don't consider it a list of enumerables in this case
-                    if (bindingList != null)
+                    if (bindingList is not null)
                     {
                         _listExtractedFromEnumerable = true;
                     }
@@ -1139,7 +1139,7 @@ namespace System.Windows.Forms
                 // If it's not an IList, IListSource or IEnumerable
                 if (bindingList is null)
                 {
-                    if (list != null)
+                    if (list is not null)
                     {
                         // If its some random non-list object, just wrap it in a list
                         bindingList = WrapObjectInBindingList(list);
@@ -1231,11 +1231,11 @@ namespace System.Windows.Forms
             // because the sort or filter values were invalid).
             if (applySortAndFilter)
             {
-                if (Sort != null)
+                if (Sort is not null)
                 {
                     InnerListSort = Sort;
                 }
-                if (Filter != null)
+                if (Filter is not null)
                 {
                     InnerListFilter = Filter;
                 }
@@ -1287,7 +1287,7 @@ namespace System.Windows.Forms
 
         private void WireCurrencyManager(CurrencyManager cm)
         {
-            Debug.Assert(cm != null);
+            Debug.Assert(cm is not null);
 
             cm.PositionChanged += new EventHandler(CurrencyManager_PositionChanged);
             cm.CurrentChanged += new EventHandler(CurrencyManager_CurrentChanged);
@@ -1298,7 +1298,7 @@ namespace System.Windows.Forms
 
         private void UnwireCurrencyManager(CurrencyManager cm)
         {
-            Debug.Assert(cm != null);
+            Debug.Assert(cm is not null);
 
             cm.PositionChanged -= new EventHandler(CurrencyManager_PositionChanged);
             cm.CurrentChanged -= new EventHandler(CurrencyManager_CurrentChanged);
@@ -1312,7 +1312,7 @@ namespace System.Windows.Forms
             if (_dataSource is ICurrencyManagerProvider provider)
             {
                 CurrencyManager cm = provider.CurrencyManager;
-                if (cm != null)
+                if (cm is not null)
                 {
                     cm.CurrentItemChanged += new EventHandler(ParentCurrencyManager_CurrentItemChanged);
                     cm.MetaDataChanged += new EventHandler(ParentCurrencyManager_MetaDataChanged);
@@ -1325,7 +1325,7 @@ namespace System.Windows.Forms
             if (_dataSource is ICurrencyManagerProvider provider)
             {
                 CurrencyManager cm = provider.CurrencyManager;
-                if (cm != null)
+                if (cm is not null)
                 {
                     cm.CurrentItemChanged -= new EventHandler(ParentCurrencyManager_CurrentItemChanged);
                     cm.MetaDataChanged -= new EventHandler(ParentCurrencyManager_MetaDataChanged);
@@ -1351,7 +1351,7 @@ namespace System.Windows.Forms
 
         private void WirePropertyChangedEvents(object item)
         {
-            if (item != null && _itemShape != null)
+            if (item is not null && _itemShape is not null)
             {
                 for (int j = 0; j < _itemShape.Count; j++)
                 {
@@ -1362,7 +1362,7 @@ namespace System.Windows.Forms
 
         private void UnwirePropertyChangedEvents(object item)
         {
-            if (item != null && _itemShape != null)
+            if (item is not null && _itemShape is not null)
             {
                 for (int j = 0; j < _itemShape.Count; j++)
                 {
@@ -1494,7 +1494,7 @@ namespace System.Windows.Forms
             }
 
             // Throw if user tries to add items to list that don't match the current item type
-            if (value != null && !_itemType.IsAssignableFrom(value.GetType()))
+            if (value is not null && !_itemType.IsAssignableFrom(value.GetType()))
             {
                 throw new InvalidOperationException(SR.BindingSourceItemTypeMismatchOnAdd);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
                 if (GetAutoSizeMode() != value)
                 {
                     SetAutoSizeMode(value);
-                    if (ParentInternal != null)
+                    if (ParentInternal is not null)
                     {
                         // DefaultLayout does not keep anchor information until it needs to.  When
                         // AutoSize became a common property, we could no longer blindly call into
@@ -239,7 +239,7 @@ namespace System.Windows.Forms
         protected override void OnClick(EventArgs e)
         {
             Form form = FindForm();
-            if (form != null)
+            if (form is not null)
             {
                 form.DialogResult = _dialogResult;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -318,7 +318,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_image is null && _imageList != null)
+                if (_image is null && _imageList is not null)
                 {
                     int actualIndex = _imageIndex.ActualIndex;
 
@@ -350,7 +350,7 @@ namespace System.Windows.Forms
                 StopAnimate();
 
                 _image = value;
-                if (_image != null)
+                if (_image is not null)
                 {
                     ImageIndex = ImageList.Indexer.DefaultIndex;
                     ImageList = null;
@@ -405,7 +405,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_imageIndex.Index != ImageList.Indexer.DefaultIndex && _imageList != null && _imageIndex.Index >= _imageList.Images.Count)
+                if (_imageIndex.Index != ImageList.Indexer.DefaultIndex && _imageList is not null && _imageIndex.Index >= _imageList.Images.Count)
                 {
                     return _imageList.Images.Count - 1;
                 }
@@ -459,7 +459,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                if (value != null)
+                if (value is not null)
                 {
                     // Image.set calls ImageIndex = -1
                     _image = null;
@@ -496,7 +496,7 @@ namespace System.Windows.Forms
 
                 // Detach old event handlers
                 //
-                if (_imageList != null)
+                if (_imageList is not null)
                 {
                     _imageList.RecreateHandle -= recreateHandler;
                     _imageList.Disposed -= disposedHandler;
@@ -504,7 +504,7 @@ namespace System.Windows.Forms
 
                 // Make sure we don't have an Image as well as an ImageList
                 //
-                if (value != null)
+                if (value is not null)
                 {
                     _image = null; // Image.set calls ImageList = null
                 }
@@ -514,7 +514,7 @@ namespace System.Windows.Forms
 
                 // Wire up new event handlers
                 //
-                if (value != null)
+                if (value is not null)
                 {
                     value.RecreateHandle += recreateHandler;
                     value.Disposed += disposedHandler;
@@ -737,7 +737,7 @@ namespace System.Windows.Forms
 
         private void Animate()
         {
-            Animate(!DesignMode && Visible && Enabled && ParentInternal != null);
+            Animate(!DesignMode && Visible && Enabled && ParentInternal is not null);
         }
 
         private void StopAnimate()
@@ -751,7 +751,7 @@ namespace System.Windows.Forms
             {
                 if (animate)
                 {
-                    if (_image != null)
+                    if (_image is not null)
                     {
                         ImageAnimator.Animate(_image, new EventHandler(OnFrameChanged));
                         SetFlag(FlagCurrentlyAnimating, animate);
@@ -759,7 +759,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    if (_image != null)
+                    if (_image is not null)
                     {
                         ImageAnimator.StopAnimate(_image, new EventHandler(OnFrameChanged));
                         SetFlag(FlagCurrentlyAnimating, animate);
@@ -783,12 +783,12 @@ namespace System.Windows.Forms
             if (disposing)
             {
                 StopAnimate();
-                if (_imageList != null)
+                if (_imageList is not null)
                 {
                     _imageList.Disposed -= new EventHandler(DetachImageList);
                 }
                 //Dipose the tooltip if one present..
-                if (_textToolTip != null)
+                if (_textToolTip is not null)
                 {
                     _textToolTip.Dispose();
                     _textToolTip = null;
@@ -840,7 +840,7 @@ namespace System.Windows.Forms
         {
             SetFlag(FlagMouseOver, true);
             Invalidate();
-            if (!DesignMode && AutoEllipsis && ShowToolTip && _textToolTip != null)
+            if (!DesignMode && AutoEllipsis && ShowToolTip && _textToolTip is not null)
             {
                 _textToolTip.Show(WindowsFormsUtils.TextWithoutMnemonics(Text), this);
             }
@@ -855,7 +855,7 @@ namespace System.Windows.Forms
         protected override void OnMouseLeave(EventArgs eventargs)
         {
             SetFlag(FlagMouseOver, false);
-            if (_textToolTip != null)
+            if (_textToolTip is not null)
             {
                 _textToolTip.Hide(this);
             }
@@ -1188,7 +1188,7 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeImage()
         {
-            return _image != null;
+            return _image is not null;
         }
 
         private void UpdateOwnerDraw()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.CheckBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.CheckBoxAccessibleObject.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
                 {
                     string defaultAction = Owner.AccessibleDefaultActionDescription;
 
-                    if (defaultAction != null)
+                    if (defaultAction is not null)
                     {
                         return defaultAction;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -267,7 +267,7 @@ namespace System.Windows.Forms
 
                     // see if we have some items, and only invalidate if we do.
                     ObjectCollection items = (ObjectCollection)Items;
-                    if ((items != null) && (items.Count > 0))
+                    if ((items is not null) && (items.Count > 0))
                     {
                         Invalidate();
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Clipboard.cs
@@ -165,7 +165,7 @@ namespace System.Windows.Forms
             }
             while (hr != 0);
 
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 if (dataObject is IDataObject ido && !Marshal.IsComObject(dataObject))
                 {
@@ -186,7 +186,7 @@ namespace System.Windows.Forms
         public static bool ContainsAudio()
         {
             IDataObject dataObject = Clipboard.GetDataObject();
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 return dataObject.GetDataPresent(DataFormats.WaveAudio, false);
             }
@@ -202,7 +202,7 @@ namespace System.Windows.Forms
             }
 
             IDataObject dataObject = Clipboard.GetDataObject();
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 return dataObject.GetDataPresent(format, false);
             }
@@ -213,7 +213,7 @@ namespace System.Windows.Forms
         public static bool ContainsFileDropList()
         {
             IDataObject dataObject = Clipboard.GetDataObject();
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 return dataObject.GetDataPresent(DataFormats.FileDrop, true);
             }
@@ -224,7 +224,7 @@ namespace System.Windows.Forms
         public static bool ContainsImage()
         {
             IDataObject dataObject = Clipboard.GetDataObject();
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 return dataObject.GetDataPresent(DataFormats.Bitmap, true);
             }
@@ -239,7 +239,7 @@ namespace System.Windows.Forms
             SourceGenerated.EnumValidator.Validate(format, nameof(format));
 
             IDataObject dataObject = Clipboard.GetDataObject();
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 return dataObject.GetDataPresent(ConvertToDataFormats(format), false);
             }
@@ -250,7 +250,7 @@ namespace System.Windows.Forms
         public static Stream GetAudioStream()
         {
             IDataObject dataObject = Clipboard.GetDataObject();
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 return dataObject.GetData(DataFormats.WaveAudio, false) as Stream;
             }
@@ -266,7 +266,7 @@ namespace System.Windows.Forms
             }
 
             IDataObject dataObject = Clipboard.GetDataObject();
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 return dataObject.GetData(format);
             }
@@ -279,7 +279,7 @@ namespace System.Windows.Forms
             IDataObject dataObject = Clipboard.GetDataObject();
             StringCollection retVal = new StringCollection();
 
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 if (dataObject.GetData(DataFormats.FileDrop, true) is string[] strings)
                 {
@@ -293,7 +293,7 @@ namespace System.Windows.Forms
         public static Image GetImage()
         {
             IDataObject dataObject = Clipboard.GetDataObject();
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 return dataObject.GetData(DataFormats.Bitmap, true) as Image;
             }
@@ -308,7 +308,7 @@ namespace System.Windows.Forms
             SourceGenerated.EnumValidator.Validate(format, nameof(format));
 
             IDataObject dataObject = Clipboard.GetDataObject();
-            if (dataObject != null)
+            if (dataObject is not null)
             {
                 if (dataObject.GetData(ConvertToDataFormats(format), false) is string text)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -177,7 +177,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (ListView != null)
+                if (ListView is not null)
                 {
                     return ListView.GetColumnIndex(this);
                 }
@@ -195,7 +195,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_imageIndexer.Index != ImageList.Indexer.DefaultIndex && ImageList != null && _imageIndexer.Index >= ImageList.Images.Count)
+                if (_imageIndexer.Index != ImageList.Indexer.DefaultIndex && ImageList is not null && _imageIndexer.Index >= ImageList.Images.Count)
                 {
                     return ImageList.Images.Count - 1;
                 }
@@ -215,7 +215,7 @@ namespace System.Windows.Forms
 
                 _imageIndexer.Index = value;
 
-                if (ListView != null && ListView.IsHandleCreated)
+                if (ListView is not null && ListView.IsHandleCreated)
                 {
                     ListView.SetColumnInfo(LVCF.IMAGE, this);
                 }
@@ -252,7 +252,7 @@ namespace System.Windows.Forms
 
                 _imageIndexer.Key = value;
 
-                if (ListView != null && ListView.IsHandleCreated)
+                if (ListView is not null && ListView.IsHandleCreated)
                 {
                     ListView.SetColumnInfo(LVCF.IMAGE, this);
                 }
@@ -286,7 +286,7 @@ namespace System.Windows.Forms
                 {
                     _name = value;
                 }
-                if (Site != null)
+                if (Site is not null)
                 {
                     Site.Name = value;
                 }
@@ -314,7 +314,7 @@ namespace System.Windows.Forms
                 {
                     _text = value;
                 }
-                if (ListView != null)
+                if (ListView is not null)
                 {
                     ListView.SetColumnInfo(LVCF.TEXT, this);
                 }
@@ -331,7 +331,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (!_textAlignInitialized && (ListView != null))
+                if (!_textAlignInitialized && (ListView is not null))
                 {
                     _textAlignInitialized = true;
                     // See below for an explanation of (Index != 0)
@@ -356,7 +356,7 @@ namespace System.Windows.Forms
                     _textAlign = HorizontalAlignment.Left;
                 }
 
-                if (ListView != null)
+                if (ListView is not null)
                 {
                     ListView.SetColumnInfo(LVCF.FMT, this);
                     ListView.Invalidate();
@@ -394,7 +394,7 @@ namespace System.Windows.Forms
                 // we don't get notified when the user changes it, we need to get this info
                 // from the underlying control every time we're asked.
                 // The underlying control will only report the correct width if it's in Report view
-                if (ListView != null && ListView.IsHandleCreated && !ListView.Disposing && ListView.View == View.Details)
+                if (ListView is not null && ListView.IsHandleCreated && !ListView.Disposing && ListView.View == View.Details)
                 {
                     // Make sure this column has already been added to the ListView, else just return width
                     IntPtr hwndHdr = User32.SendMessageW(ListView, (User32.WM)LVM.GETHEADER);
@@ -413,7 +413,7 @@ namespace System.Windows.Forms
             set
             {
                 _width = value;
-                if (ListView != null)
+                if (ListView is not null)
                 {
                     ListView.SetColumnWidth(Index, ColumnHeaderAutoResizeStyle.None);
                 }
@@ -427,7 +427,7 @@ namespace System.Windows.Forms
                 throw new InvalidEnumArgumentException(nameof(headerAutoResize), (int)headerAutoResize, typeof(ColumnHeaderAutoResizeStyle));
             }
 
-            if (ListView != null)
+            if (ListView is not null)
             {
                 ListView.AutoResizeColumn(Index, headerAutoResize);
             }
@@ -460,7 +460,7 @@ namespace System.Windows.Forms
         {
             if (disposing)
             {
-                if (ListView != null)
+                if (ListView is not null)
                 {
                     int index = Index;
                     if (index != -1)
@@ -501,7 +501,7 @@ namespace System.Windows.Forms
 
         internal bool ShouldSerializeText()
         {
-            return _text != null;
+            return _text is not null;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeaderConverter.cs
@@ -51,7 +51,7 @@ namespace System.Windows.Forms
                 if (col.ImageIndex != -1)
                 {
                     ctor = t.GetConstructor(new Type[] { typeof(int) });
-                    if (ctor != null)
+                    if (ctor is not null)
                     {
                         id = new InstanceDescriptor(ctor, new object[] { col.ImageIndex }, false);
                     }
@@ -60,7 +60,7 @@ namespace System.Windows.Forms
                 if (id is null && !string.IsNullOrEmpty(col.ImageKey))
                 {
                     ctor = t.GetConstructor(new Type[] { typeof(string) });
-                    if (ctor != null)
+                    if (ctor is not null)
                     {
                         id = new InstanceDescriptor(ctor, new object[] { col.ImageKey }, false);
                     }
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
                 if (id is null)
                 {
                     ctor = t.GetConstructor(Array.Empty<Type>());
-                    if (ctor != null)
+                    if (ctor is not null)
                     {
                         return new InstanceDescriptor(ctor, Array.Empty<object>(), false);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms
 
             internal override bool IsIAccessibleExSupported()
             {
-                if (_owningComboBox != null)
+                if (_owningComboBox is not null)
                 {
                     return true;
                 }
@@ -73,7 +73,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (_owningComboBox != null)
+                    if (_owningComboBox is not null)
                     {
                         // we need to provide a unique ID
                         // others are implementing this in the same manner

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
@@ -205,7 +205,7 @@ namespace System.Windows.Forms
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
                     var accRole = systemIAccessible?.get_accRole(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
-                    return accRole != null
+                    return accRole is not null
                         ? (AccessibleRole)accRole
                         : AccessibleRole.None;
                 }
@@ -241,7 +241,7 @@ namespace System.Windows.Forms
                 {
                     var systemIAccessible = GetSystemIAccessibleInternal();
                     var accState = systemIAccessible?.get_accState(COMBOBOX_DROPDOWN_BUTTON_ACC_ITEM_INDEX);
-                    return accState != null
+                    return accState is not null
                         ? (AccessibleStates)accState
                         : AccessibleStates.None;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms
             internal override UiaCore.IRawElementProviderFragment? ElementProviderFromPoint(double x, double y)
             {
                 var systemIAccessible = GetSystemIAccessibleInternal();
-                if (systemIAccessible != null)
+                if (systemIAccessible is not null)
                 {
                     object result = systemIAccessible.accHitTest((int)x, (int)y);
                     if (result is int childId)
@@ -198,7 +198,7 @@ namespace System.Windows.Forms
 
                 AccessibleObject? itemAccessibleObject = GetChildFragment(selectedIndex);
 
-                if (itemAccessibleObject != null)
+                if (itemAccessibleObject is not null)
                 {
                     return new UiaCore.IRawElementProviderSimple[] {
                         itemAccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -193,7 +193,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var accRole = _systemIAccessible?.get_accRole(GetChildId());
-                    return accRole != null
+                    return accRole is not null
                         ? (AccessibleRole)accRole
                         : AccessibleRole.None;
                 }
@@ -229,7 +229,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var accState = _systemIAccessible?.get_accState(GetChildId());
-                    return accState != null
+                    return accState is not null
                         ? (AccessibleStates)accState
                         : AccessibleStates.None;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.FlatComboAdapter.cs
@@ -194,7 +194,7 @@ namespace System.Windows.Forms
             /// </summary>
             public unsafe void ValidateOwnerDrawRegions(ComboBox comboBox, Rectangle updateRegionBox)
             {
-                if (comboBox != null)
+                if (comboBox is not null)
                 {
                     return;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -231,14 +231,14 @@ namespace System.Windows.Forms
             {
                 if (_autoCompleteCustomSource != value)
                 {
-                    if (_autoCompleteCustomSource != null)
+                    if (_autoCompleteCustomSource is not null)
                     {
                         _autoCompleteCustomSource.CollectionChanged -= new CollectionChangeEventHandler(OnAutoCompleteCustomSourceChanged);
                     }
 
                     _autoCompleteCustomSource = value;
 
-                    if (_autoCompleteCustomSource != null)
+                    if (_autoCompleteCustomSource is not null)
                     {
                         _autoCompleteCustomSource.CollectionChanged += new CollectionChangeEventHandler(OnAutoCompleteCustomSourceChanged);
                     }
@@ -590,7 +590,7 @@ namespace System.Windows.Forms
                 }
 
                 IntPtr focus = GetFocus();
-                return focus != IntPtr.Zero && ((_childEdit != null && focus == _childEdit.Handle) || (_childListBox != null && focus == _childListBox.Handle));
+                return focus != IntPtr.Zero && ((_childEdit is not null && focus == _childEdit.Handle) || (_childListBox is not null && focus == _childListBox.Handle));
             }
         }
 
@@ -733,7 +733,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(PropMatchingText))
+                if (value is not null || Properties.ContainsObject(PropMatchingText))
                 {
                     Properties.SetObject(PropMatchingText, value);
                 }
@@ -992,7 +992,7 @@ namespace System.Windows.Forms
                 if (SelectedIndex != value)
                 {
                     int itemCount = 0;
-                    if (_itemsCollection != null)
+                    if (_itemsCollection is not null)
                     {
                         itemCount = _itemsCollection.Count;
                     }
@@ -1043,10 +1043,10 @@ namespace System.Windows.Forms
             {
                 int x = -1;
 
-                if (_itemsCollection != null)
+                if (_itemsCollection is not null)
                 {
                     //
-                    if (value != null)
+                    if (value is not null)
                     {
                         x = _itemsCollection.IndexOf(value);
                     }
@@ -1090,7 +1090,7 @@ namespace System.Windows.Forms
                     //AccessViolation exception, which is bad
                     string str = (value ?? "");
                     CreateControl();
-                    if (IsHandleCreated && _childEdit != null)
+                    if (IsHandleCreated && _childEdit is not null)
                     {
                         SendMessageW(new HandleRef(this, _childEdit.Handle), (WM)EM.REPLACESEL, (IntPtr)(-1), str);
                     }
@@ -1160,7 +1160,7 @@ namespace System.Windows.Forms
             {
                 if (_sorted != value)
                 {
-                    if (DataSource != null && value)
+                    if (DataSource is not null && value)
                     {
                         throw new ArgumentException(SR.ComboBoxSortWithDataSource);
                     }
@@ -1228,7 +1228,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (SelectedItem != null && !BindingFieldEmpty)
+                if (SelectedItem is not null && !BindingFieldEmpty)
                 {
                     //preserve everett behavior if "formatting enabled == false" -- just return selecteditem text.
                     if (FormattingEnabled)
@@ -1269,7 +1269,7 @@ namespace System.Windows.Forms
                     {
                         SelectedIndex = -1;
                     }
-                    else if (value != null &&
+                    else if (value is not null &&
                         (selectedItem is null || (string.Compare(value, GetItemText(selectedItem), false, CultureInfo.CurrentCulture) != 0)))
                     {
                         int index = FindStringIgnoreCase(value);
@@ -1495,7 +1495,7 @@ namespace System.Windows.Forms
 
         private void CheckNoDataSource()
         {
-            if (DataSource != null)
+            if (DataSource is not null)
             {
                 throw new ArgumentException(SR.DataSourceLocksItems);
             }
@@ -1678,7 +1678,7 @@ namespace System.Windows.Forms
                     if (!HostedInWin32DialogManager)
                     {
                         IContainerControl c = GetContainerControl();
-                        if (c != null)
+                        if (c is not null)
                         {
                             if (c is ContainerControl container)
                             {
@@ -1696,7 +1696,7 @@ namespace System.Windows.Forms
                     // once in the combobox and once here.
                     if (_fireSetFocus)
                     {
-                        if (!DesignMode && _childEdit != null && m.HWnd == _childEdit.Handle)
+                        if (!DesignMode && _childEdit is not null && m.HWnd == _childEdit.Handle)
                         {
                             WmImeSetFocus();
                         }
@@ -1712,7 +1712,7 @@ namespace System.Windows.Forms
 
                 case WM.SETFONT:
                     DefChildWndProc(ref m);
-                    if (_childEdit != null && m.HWnd == _childEdit.Handle)
+                    if (_childEdit is not null && m.HWnd == _childEdit.Handle)
                     {
                         SendMessageW(new HandleRef(this, _childEdit.Handle), (WM)EM.SETMARGINS, (IntPtr)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
                     }
@@ -1838,7 +1838,7 @@ namespace System.Windows.Forms
                     _mousePressed = true;
                     _mouseEvents = true;
 
-                    if (ContextMenuStrip != null)
+                    if (ContextMenuStrip is not null)
                     {
                         // Set the mouse capture as this is the child Wndproc.
                         Capture = true;
@@ -1874,7 +1874,7 @@ namespace System.Windows.Forms
 
                 case WM.CONTEXTMENU:
                     // Forward context menu messages to the parent control
-                    if (ContextMenuStrip != null)
+                    if (ContextMenuStrip is not null)
                     {
                         SendMessageW(this, WM.CONTEXTMENU, m.WParam, m.LParam);
                     }
@@ -1894,7 +1894,7 @@ namespace System.Windows.Forms
                     break;
 
                 case WM.SETCURSOR:
-                    if (Cursor != DefaultCursor && _childEdit != null && m.HWnd == _childEdit.Handle && PARAM.LOWORD(m.LParam) == (int)HT.CLIENT)
+                    if (Cursor != DefaultCursor && _childEdit is not null && m.HWnd == _childEdit.Handle && PARAM.LOWORD(m.LParam) == (int)HT.CLIENT)
                     {
                         Cursor.Current = Cursor;
                     }
@@ -1945,7 +1945,7 @@ namespace System.Windows.Forms
 
         private void DefChildWndProc(ref Message m)
         {
-            if (_childEdit != null)
+            if (_childEdit is not null)
             {
                 NativeWindow childWindow;
                 if (m.HWnd == _childEdit.Handle)
@@ -1964,7 +1964,7 @@ namespace System.Windows.Forms
                 //childwindow could be null if the handle was recreated while within a message handler
                 // and then whoever recreated the handle allowed the message to continue to be processed
                 //we cannot really be sure the new child will properly handle this window message, so we eat it.
-                if (childWindow != null)
+                if (childWindow is not null)
                 {
                     childWindow.DefWndProc(ref m);
                 }
@@ -1975,11 +1975,11 @@ namespace System.Windows.Forms
         {
             if (disposing)
             {
-                if (_autoCompleteCustomSource != null)
+                if (_autoCompleteCustomSource is not null)
                 {
                     _autoCompleteCustomSource.CollectionChanged -= new CollectionChangeEventHandler(OnAutoCompleteCustomSourceChanged);
                 }
-                if (_stringSource != null)
+                if (_stringSource is not null)
                 {
                     _stringSource.ReleaseAutoComplete();
                     _stringSource = null;
@@ -2003,11 +2003,11 @@ namespace System.Windows.Forms
             }
             if (EndUpdateInternal())
             {
-                if (_childEdit != null && _childEdit.Handle != IntPtr.Zero)
+                if (_childEdit is not null && _childEdit.Handle != IntPtr.Zero)
                 {
                     InvalidateRect(new HandleRef(this, _childEdit.Handle), null, BOOL.FALSE);
                 }
-                if (_childListBox != null && _childListBox.Handle != IntPtr.Zero)
+                if (_childListBox is not null && _childListBox.Handle != IntPtr.Zero)
                 {
                     InvalidateRect(new HandleRef(this, _childListBox.Handle), null, BOOL.FALSE);
                 }
@@ -2124,7 +2124,7 @@ namespace System.Windows.Forms
         internal int GetListNativeWindowRuntimeIdPart()
         {
             NativeWindow listNativeWindow = GetListNativeWindow();
-            return listNativeWindow != null ? listNativeWindow.GetHashCode() : 0;
+            return listNativeWindow is not null ? listNativeWindow.GetHashCode() : 0;
         }
 
         internal override Gdi32.HBRUSH InitializeDCForWmCtlColor(Gdi32.HDC dc, User32.WM msg)
@@ -2302,7 +2302,7 @@ namespace System.Windows.Forms
             }
 
             SendMessageW(this, (WM)CB.RESETCONTENT);
-            if (saved != null)
+            if (saved is not null)
             {
                 WindowText = saved;
             }
@@ -2472,7 +2472,7 @@ namespace System.Windows.Forms
                 _fromHandleCreate = false;
             }
 
-            if (_itemsCollection != null)
+            if (_itemsCollection is not null)
             {
                 foreach (object item in _itemsCollection)
                 {
@@ -2507,7 +2507,7 @@ namespace System.Windows.Forms
             {
                 _selectedIndex = SelectedIndex;
             }
-            if (_stringSource != null)
+            if (_stringSource is not null)
             {
                 _stringSource.ReleaseAutoComplete();
                 _stringSource = null;
@@ -2712,7 +2712,7 @@ namespace System.Windows.Forms
             // into the backEnd. We do not need to do that.
             //
             // don't change the position if SelectedIndex is -1 because this indicates a selection not from the list.
-            if (DataManager != null && DataManager.Position != SelectedIndex)
+            if (DataManager is not null && DataManager.Position != SelectedIndex)
             {
                 //read this as "if everett or   (whidbey and selindex is valid)"
                 if (!FormattingEnabled || SelectedIndex != -1)
@@ -2917,7 +2917,7 @@ namespace System.Windows.Forms
         {
             if (Sorted)
             {
-                if (DataSource != null && Created)
+                if (DataSource is not null && Created)
                 {
                     // we will only throw the exception when the control is already on the form.
                     Debug.Assert(DisplayMember.Equals(string.Empty), "if this list is sorted it means that dataSource was null when Sorted first became true. at that point DisplayMember had to be String.Empty");
@@ -3051,7 +3051,7 @@ namespace System.Windows.Forms
             // if we have a dataSource and a DisplayMember, then use it
             // to populate the Items collection
             //
-            if (DataManager != null && DataManager.Count != -1)
+            if (DataManager is not null && DataManager.Count != -1)
             {
                 newItems = new object[DataManager.Count];
                 for (int i = 0; i < newItems.Length; i++)
@@ -3059,7 +3059,7 @@ namespace System.Windows.Forms
                     newItems[i] = DataManager[i];
                 }
             }
-            else if (savedItems != null)
+            else if (savedItems is not null)
             {
                 newItems = new object[savedItems.Count];
                 savedItems.CopyTo(newItems, arrayIndex: 0);
@@ -3075,11 +3075,11 @@ namespace System.Windows.Forms
                 }
                 // Store the current list of items
                 //
-                if (newItems != null)
+                if (newItems is not null)
                 {
                     Items.AddRangeInternal(newItems);
                 }
-                if (DataManager != null)
+                if (DataManager is not null)
                 {
                     // put the selectedIndex in sync w/ the position in the dataManager
                     SelectedIndex = DataManager.Position;
@@ -3109,14 +3109,14 @@ namespace System.Windows.Forms
         /// </summary>
         private void ReleaseChildWindow()
         {
-            if (_childEdit != null)
+            if (_childEdit is not null)
             {
                 // We do not use UI Automation provider for child edit, so do not need to release providers.
                 _childEdit.ReleaseHandle();
                 _childEdit = null;
             }
 
-            if (_childListBox != null)
+            if (_childListBox is not null)
             {
                 // Need to notify UI Automation that it can safely remove all map entries that refer to the specified window.
                 ReleaseUiaProvider(_childListBox.Handle);
@@ -3125,7 +3125,7 @@ namespace System.Windows.Forms
                 _childListBox = null;
             }
 
-            if (_childDropDown != null)
+            if (_childDropDown is not null)
             {
                 // Need to notify UI Automation that it can safely remove all map entries that refer to the specified window.
                 ReleaseUiaProvider(_childDropDown.Handle);
@@ -3188,7 +3188,7 @@ namespace System.Windows.Forms
 
                 if (AutoCompleteSource == AutoCompleteSource.CustomSource)
                 {
-                    if (AutoCompleteCustomSource != null)
+                    if (AutoCompleteCustomSource is not null)
                     {
                         if (AutoCompleteCustomSource.Count == 0)
                         {
@@ -3215,7 +3215,7 @@ namespace System.Windows.Forms
                 {
                     if (DropDownStyle != ComboBoxStyle.DropDownList)
                     {
-                        if (_itemsCollection != null)
+                        if (_itemsCollection is not null)
                         {
                             if (_itemsCollection.Count == 0)
                             {
@@ -3326,7 +3326,7 @@ namespace System.Windows.Forms
             // if the list changed, we want to keep the same selected index
             // CurrencyManager will provide the PositionChanged event
             // it will be provided before changing the list though...
-            if (DataManager != null)
+            if (DataManager is not null)
             {
                 if (DataSource is ICurrencyManagerProvider)
                 {
@@ -3361,7 +3361,7 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeAutoCompleteCustomSource()
         {
-            return _autoCompleteCustomSource != null && _autoCompleteCustomSource.Count > 0;
+            return _autoCompleteCustomSource is not null && _autoCompleteCustomSource.Count > 0;
         }
 
         internal bool ShouldSerializeDropDownWidth()
@@ -3477,7 +3477,7 @@ namespace System.Windows.Forms
             if (SelectedIndex != -1)
             {
                 object item = Items[SelectedIndex];
-                if (item != null)
+                if (item is not null)
                 {
                     s = GetItemText(item);
                 }
@@ -3487,7 +3487,7 @@ namespace System.Windows.Forms
 
             if (DropDownStyle == ComboBoxStyle.DropDown)
             {
-                if (_childEdit != null && _childEdit.Handle != IntPtr.Zero)
+                if (_childEdit is not null && _childEdit.Handle != IntPtr.Zero)
                 {
                     SendMessageW(new HandleRef(this, _childEdit.Handle), WM.SETTEXT, IntPtr.Zero, s);
                 }
@@ -3496,7 +3496,7 @@ namespace System.Windows.Forms
 
         private void WmEraseBkgnd(ref Message m)
         {
-            if ((DropDownStyle == ComboBoxStyle.Simple) && ParentInternal != null)
+            if ((DropDownStyle == ComboBoxStyle.Simple) && ParentInternal is not null)
             {
                 RECT rect = default;
                 GetClientRect(this, ref rect);
@@ -3519,7 +3519,7 @@ namespace System.Windows.Forms
 
                 // By some reason WmParentNotify with WM_DESTROY is not called before recreation.
                 // So release the old references here.
-                if (_childDropDown != null)
+                if (_childDropDown is not null)
                 {
                     // Need to notify UI Automation that it can safely remove all map entries that refer to the specified window.
                     ReleaseUiaProvider(_childDropDown.Handle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CommonDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CommonDialog.cs
@@ -177,7 +177,7 @@ namespace System.Windows.Forms
             DialogResult result = DialogResult.Cancel;
             try
             {
-                if (owner != null)
+                if (owner is not null)
                 {
                     hwndOwner = Control.GetSafeHandle(owner);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -346,7 +346,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (ParentInternal != null)
+                if (ParentInternal is not null)
                 {
                     return ParentInternal.FindForm();
                 }
@@ -381,10 +381,10 @@ namespace System.Windows.Forms
             bool updateContainerActiveControl = false;
             ContainerControl cc = null;
             Control parent = ParentInternal;
-            if (parent != null)
+            if (parent is not null)
             {
                 cc = (parent.GetContainerControl()) as ContainerControl;
-                if (cc != null)
+                if (cc is not null)
                 {
                     updateContainerActiveControl = (cc.ActiveControl != this);
                 }
@@ -419,13 +419,13 @@ namespace System.Windows.Forms
             do
             {
                 ctl = GetNextControl(ctl, true);
-                if (ctl != null && ctl.CanSelect && ctl.TabStop)
+                if (ctl is not null && ctl.CanSelect && ctl.TabStop)
                 {
                     break;
                 }
-            } while (ctl != null);
+            } while (ctl is not null);
 
-            return ctl != null;
+            return ctl is not null;
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
@@ -445,7 +445,7 @@ namespace System.Windows.Forms
         internal virtual void AfterControlRemoved(Control control, Control oldParent)
         {
             ContainerControl cc;
-            Debug.Assert(control != null);
+            Debug.Assert(control is not null);
             Debug.WriteLineIf(s_focusTracing.TraceVerbose, "ContainerControl::AfterControlRemoved(" + control.Name + ") - " + Name);
             if (control == _activeControl || control.Contains(_activeControl))
             {
@@ -465,15 +465,15 @@ namespace System.Windows.Forms
                     SetActiveControl(null);
                 }
             }
-            else if (_activeControl is null && ParentInternal != null)
+            else if (_activeControl is null && ParentInternal is not null)
             {
                 // The last control of an active container was removed. Focus needs to be given to the next
                 // control in the Form.
                 cc = ParentInternal.GetContainerControl() as ContainerControl;
-                if (cc != null && cc.ActiveControl == this)
+                if (cc is not null && cc.ActiveControl == this)
                 {
                     Form f = FindForm();
-                    if (f != null)
+                    if (f is not null)
                     {
                         f.SelectNextControl(this, true, true, true, true);
                     }
@@ -485,7 +485,7 @@ namespace System.Windows.Forms
             // container potentially, but the unvalidatedControl of all its container parents, up the chain, needs to
             // now point to the old parent of the disappearing control.
             cc = this;
-            while (cc != null)
+            while (cc is not null)
             {
                 Control parent = cc.ParentInternal;
                 if (parent is null)
@@ -496,8 +496,8 @@ namespace System.Windows.Forms
                 {
                     cc = parent.GetContainerControl() as ContainerControl;
                 }
-                if (cc != null &&
-                    cc._unvalidatedControl != null &&
+                if (cc is not null &&
+                    cc._unvalidatedControl is not null &&
                     (cc._unvalidatedControl == control || control.Contains(cc._unvalidatedControl)))
                 {
                     cc._unvalidatedControl = oldParent;
@@ -513,9 +513,9 @@ namespace System.Windows.Forms
         private bool AssignActiveControlInternal(Control value)
         {
 #if DEBUG
-            if (value is null || (value != null && value.ParentInternal != null && !value.ParentInternal.IsContainerControl))
+            if (value is null || (value is not null && value.ParentInternal is not null && !value.ParentInternal.IsContainerControl))
             {
-                Debug.Assert(value is null || (value.ParentInternal != null && this == value.ParentInternal.GetContainerControl()));
+                Debug.Assert(value is null || (value.ParentInternal is not null && this == value.ParentInternal.GetContainerControl()));
             }
 #endif
 
@@ -524,7 +524,7 @@ namespace System.Windows.Forms
             {
                 try
                 {
-                    if (value != null)
+                    if (value is not null)
                     {
                         value.BecomingActiveControl = true;
                     }
@@ -534,7 +534,7 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-                    if (value != null)
+                    if (value is not null)
                     {
                         value.BecomingActiveControl = false;
                     }
@@ -543,7 +543,7 @@ namespace System.Windows.Forms
                 if (_activeControl == value)
                 {
                     Form form = FindForm();
-                    if (form != null)
+                    if (form is not null)
                     {
                         form.UpdateDefaultButton();
                     }
@@ -631,13 +631,13 @@ namespace System.Windows.Forms
             Debug.WriteLineIf(s_focusTracing.TraceVerbose, "ContainerControl::FocusActiveControlInternal() - " + Name);
 #if DEBUG
             // Things really get ugly if you try to pop up an assert dialog here
-            if (_activeControl != null && !Contains(_activeControl))
+            if (_activeControl is not null && !Contains(_activeControl))
             {
                 Debug.WriteLine("ActiveControl is not a child of this ContainerControl");
             }
 #endif
 
-            if (_activeControl != null && _activeControl.Visible)
+            if (_activeControl is not null && _activeControl.Visible)
             {
                 // Avoid focus loops, especially with ComboBoxes.
                 IntPtr focusHandle = User32.GetFocus();
@@ -650,10 +650,10 @@ namespace System.Windows.Forms
             {
                 // Determine and focus closest visible parent
                 ContainerControl cc = this;
-                while (cc != null && !cc.Visible)
+                while (cc is not null && !cc.Visible)
                 {
                     Control parent = cc.ParentInternal;
-                    if (parent != null)
+                    if (parent is not null)
                     {
                         cc = parent.GetContainerControl() as ContainerControl;
                     }
@@ -663,7 +663,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (cc != null && cc.Visible)
+                if (cc is not null && cc.Visible)
                 {
                     User32.SetFocus(new HandleRef(cc, cc.Handle));
                 }
@@ -823,7 +823,7 @@ namespace System.Windows.Forms
         {
             base.OnCreateControl();
 
-            if (Properties.GetObject(s_propAxContainer) != null)
+            if (Properties.GetObject(s_propAxContainer) is not null)
             {
                 AxContainerFormCreated();
             }
@@ -1063,7 +1063,7 @@ namespace System.Windows.Forms
                     // scaling occur.
                     SizeF ourExternalContainerFactor = ourExcludedFactor;
 
-                    if (!excludedFactor.IsEmpty && ParentInternal != null)
+                    if (!excludedFactor.IsEmpty && ParentInternal is not null)
                     {
                         ourExternalContainerFactor = SizeF.Empty;
 
@@ -1100,7 +1100,7 @@ namespace System.Windows.Forms
         private bool ProcessArrowKey(bool forward)
         {
             Control group = this;
-            if (_activeControl != null)
+            if (_activeControl is not null)
             {
                 group = _activeControl.ParentInternal;
             }
@@ -1227,7 +1227,7 @@ namespace System.Windows.Forms
                 bool wrapped = false;
 
                 Control ctl = start;
-                Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Check starting at '" + ((start != null) ? start.ToString() : "<null>") + "'");
+                Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Check starting at '" + ((start is not null) ? start.ToString() : "<null>") + "'");
 
                 do
                 {
@@ -1241,7 +1241,7 @@ namespace System.Windows.Forms
 #endif
                     ctl = GetNextControl(ctl, true);
 
-                    if (ctl != null)
+                    if (ctl is not null)
                     {
 #if DEBUG
                         Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "  ...checking for mnemonics on " + ctl.ToString());
@@ -1292,7 +1292,7 @@ namespace System.Windows.Forms
         private ScrollableControl FindScrollableParent(Control ctl)
         {
             Control current = ctl.ParentInternal;
-            while (current != null && !(current is ScrollableControl))
+            while (current is not null && !(current is ScrollableControl))
             {
                 current = current.ParentInternal;
             }
@@ -1303,11 +1303,11 @@ namespace System.Windows.Forms
         private void ScrollActiveControlIntoView()
         {
             Control last = _activeControl;
-            if (last != null)
+            if (last is not null)
             {
                 ScrollableControl scrollParent = FindScrollableParent(last);
 
-                while (scrollParent != null)
+                while (scrollParent is not null)
                 {
                     scrollParent.ScrollControlIntoView(_activeControl);
                     last = scrollParent;
@@ -1319,10 +1319,10 @@ namespace System.Windows.Forms
         protected override void Select(bool directed, bool forward)
         {
             bool correctParentActiveControl = true;
-            if (ParentInternal != null)
+            if (ParentInternal is not null)
             {
                 IContainerControl c = ParentInternal.GetContainerControl();
-                if (c != null)
+                if (c is not null)
                 {
                     c.ActiveControl = this;
                     correctParentActiveControl = (c.ActiveControl == this);
@@ -1341,9 +1341,9 @@ namespace System.Windows.Forms
         {
             Debug.WriteLineIf(s_focusTracing.TraceVerbose, "ContainerControl::SetActiveControl(" + (value is null ? "null" : value.Name) + ") - " + Name);
 
-            if (_activeControl != value || (value != null && !value.Focused))
+            if (_activeControl != value || (value is not null && !value.Focused))
             {
-                if (value != null && !Contains(value))
+                if (value is not null && !Contains(value))
                 {
                     throw new ArgumentException(SR.CannotActivateControl, nameof(value));
                 }
@@ -1351,11 +1351,11 @@ namespace System.Windows.Forms
                 bool ret;
                 ContainerControl cc = this;
 
-                if (value != null)
+                if (value is not null)
                 {
                     cc = (value.ParentInternal.GetContainerControl()) as ContainerControl;
                 }
-                if (cc != null)
+                if (cc is not null)
                 {
                     // Call to the recursive function that corrects the chain of active controls
                     ret = cc.ActivateControl(value, false);
@@ -1365,14 +1365,14 @@ namespace System.Windows.Forms
                     ret = AssignActiveControlInternal(value);
                 }
 
-                if (cc != null && ret)
+                if (cc is not null && ret)
                 {
                     ContainerControl ccAncestor = this;
-                    while (ccAncestor.ParentInternal != null &&
+                    while (ccAncestor.ParentInternal is not null &&
                            ccAncestor.ParentInternal.GetContainerControl() is ContainerControl)
                     {
                         ccAncestor = ccAncestor.ParentInternal.GetContainerControl() as ContainerControl;
-                        Debug.Assert(ccAncestor != null);
+                        Debug.Assert(ccAncestor is not null);
                     }
 
                     if (ccAncestor.ContainsFocus &&
@@ -1482,7 +1482,7 @@ namespace System.Windows.Forms
                     ContainerControl innerMostFCC = InnerMostFocusedContainerControl;
                     Control stopControl = null;
 
-                    if (innerMostFCC._focusedControl != null)
+                    if (innerMostFCC._focusedControl is not null)
                     {
                         pathControl = innerMostFCC._focusedControl;
                         stopControl = innerMostFCC;
@@ -1490,7 +1490,7 @@ namespace System.Windows.Forms
                         if (innerMostFCC != this)
                         {
                             innerMostFCC._focusedControl = null;
-                            if (!(innerMostFCC.ParentInternal != null && innerMostFCC.ParentInternal is MdiClient))
+                            if (!(innerMostFCC.ParentInternal is not null && innerMostFCC.ParentInternal is MdiClient))
                             {
                                 // Don't reset the active control of a MDIChild that loses the focus
                                 innerMostFCC._activeControl = null;
@@ -1501,11 +1501,11 @@ namespace System.Windows.Forms
                     {
                         pathControl = innerMostFCC;
                         // innerMostFCC.ParentInternal can be null when the ActiveControl is deleted.
-                        if (innerMostFCC.ParentInternal != null)
+                        if (innerMostFCC.ParentInternal is not null)
                         {
                             ContainerControl cc = (innerMostFCC.ParentInternal.GetContainerControl()) as ContainerControl;
                             stopControl = cc;
-                            if (cc != null && cc != this)
+                            if (cc is not null && cc != this)
                             {
                                 cc._focusedControl = null;
                                 cc._activeControl = null;
@@ -1517,7 +1517,7 @@ namespace System.Windows.Forms
                     {
                         Control leaveControl = pathControl;
 
-                        if (pathControl != null)
+                        if (pathControl is not null)
                         {
                             pathControl = pathControl.ParentInternal;
                         }
@@ -1527,7 +1527,7 @@ namespace System.Windows.Forms
                             pathControl = null;
                         }
 
-                        if (leaveControl != null)
+                        if (leaveControl is not null)
                         {
                             if (NativeWindow.WndProcShouldBeDebuggable)
                             {
@@ -1546,20 +1546,20 @@ namespace System.Windows.Forms
                             }
                         }
                     }
-                    while (pathControl != null &&
+                    while (pathControl is not null &&
                            pathControl != stopControl &&
                            !pathControl.IsDescendant(_activeControl));
                 }
             }
 
 #if DEBUG
-            if (_activeControl is null || (_activeControl != null && _activeControl.ParentInternal != null && !_activeControl.ParentInternal.IsContainerControl))
+            if (_activeControl is null || (_activeControl is not null && _activeControl.ParentInternal is not null && !_activeControl.ParentInternal.IsContainerControl))
             {
                 Debug.Assert(_activeControl is null || _activeControl.ParentInternal.GetContainerControl() == this);
             }
 #endif
             _focusedControl = _activeControl;
-            if (_activeControl != null)
+            if (_activeControl is not null)
             {
                 EnterValidation(_activeControl);
             }
@@ -1577,7 +1577,7 @@ namespace System.Windows.Forms
             }
 
             // Don't change the existing unvalidated control
-            if (_unvalidatedControl != null)
+            if (_unvalidatedControl is not null)
             {
                 return;
             }
@@ -1604,11 +1604,11 @@ namespace System.Windows.Forms
             {
                 ContainerControl container = _unvalidatedControl as ContainerControl;
 
-                if (container._unvalidatedControl != null && container._unvalidatedControl.ShouldAutoValidate)
+                if (container._unvalidatedControl is not null && container._unvalidatedControl.ShouldAutoValidate)
                 {
                     _unvalidatedControl = container._unvalidatedControl;
                 }
-                else if (container._activeControl != null && container._activeControl.ShouldAutoValidate)
+                else if (container._activeControl is not null && container._activeControl.ShouldAutoValidate)
                 {
                     _unvalidatedControl = container._activeControl;
                 }
@@ -1648,7 +1648,7 @@ namespace System.Windows.Forms
 
             // Find common ancestor of entered control and unvalidated control
             Control commonAncestor = enterControl;
-            while (commonAncestor != null && !commonAncestor.IsDescendant(_unvalidatedControl))
+            while (commonAncestor is not null && !commonAncestor.IsDescendant(_unvalidatedControl))
             {
                 commonAncestor = commonAncestor.ParentInternal;
             }
@@ -1687,7 +1687,7 @@ namespace System.Windows.Forms
             validatedControlAllowsFocusChange = false;
 
             if (AutoValidate == AutoValidate.EnablePreventFocusChange ||
-                (_activeControl != null && _activeControl.CausesValidation))
+                (_activeControl is not null && _activeControl.CausesValidation))
             {
                 if (_unvalidatedControl is null)
                 {
@@ -1710,7 +1710,7 @@ namespace System.Windows.Forms
 
                 Control controlToValidate = _unvalidatedControl ?? _focusedControl;
 
-                if (controlToValidate != null)
+                if (controlToValidate is not null)
                 {
                     // Get the effective AutoValidate mode for unvalidated control (based on its container control)
                     AutoValidate autoValidateMode = Control.GetAutoValidateForControl(controlToValidate);
@@ -1789,7 +1789,7 @@ namespace System.Windows.Forms
 
             Control currentActiveControl = _activeControl;
             Control currentValidatingControl = _unvalidatedControl;
-            if (currentActiveControl != null)
+            if (currentActiveControl is not null)
             {
                 currentActiveControl.ValidationCancelled = false;
                 if (currentActiveControl is ContainerControl currentActiveContainerControl)
@@ -1799,7 +1799,7 @@ namespace System.Windows.Forms
             }
             try
             {
-                while (currentValidatingControl != null && currentValidatingControl != ancestorControl)
+                while (currentValidatingControl is not null && currentValidatingControl != ancestorControl)
                 {
                     try
                     {
@@ -1821,7 +1821,7 @@ namespace System.Windows.Forms
 
                 if (cancel && preventFocusChangeOnError)
                 {
-                    if (_unvalidatedControl is null && currentValidatingControl != null &&
+                    if (_unvalidatedControl is null && currentValidatingControl is not null &&
                         ancestorControl.IsDescendant(currentValidatingControl))
                     {
                         _unvalidatedControl = currentValidatingControl;
@@ -1830,7 +1830,7 @@ namespace System.Windows.Forms
                     // mouse or key events. Otherwise it would still perform its default 'click' action or whatever.
                     if (currentActiveControl == _activeControl)
                     {
-                        if (currentActiveControl != null)
+                        if (currentActiveControl is not null)
                         {
                             CancelEventArgs ev = new CancelEventArgs
                             {
@@ -1840,7 +1840,7 @@ namespace System.Windows.Forms
                             if (currentActiveControl is ContainerControl)
                             {
                                 ContainerControl currentActiveContainerControl = currentActiveControl as ContainerControl;
-                                if (currentActiveContainerControl._focusedControl != null)
+                                if (currentActiveContainerControl._focusedControl is not null)
                                 {
                                     currentActiveContainerControl._focusedControl.ValidationCancelled = true;
                                 }
@@ -1896,7 +1896,7 @@ namespace System.Windows.Forms
             Debug.WriteLineIf(s_focusTracing.TraceVerbose, "ContainerControl::WmSetFocus() - " + Name);
             if (!HostedInWin32DialogManager)
             {
-                if (ActiveControl != null)
+                if (ActiveControl is not null)
                 {
                     WmImeSetFocus();
                     // Do not raise GotFocus event since the focus is given to the visible ActiveControl
@@ -1909,10 +1909,10 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    if (ParentInternal != null)
+                    if (ParentInternal is not null)
                     {
                         IContainerControl c = ParentInternal.GetContainerControl();
-                        if (c != null)
+                        if (c is not null)
                         {
                             bool succeeded = false;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -99,7 +99,7 @@ namespace System.Windows.Forms
                         object obj = null;
                         if (GetAmbientProperty(DispatchID.AMBIENT_BACKCOLOR, ref obj))
                         {
-                            if (obj != null)
+                            if (obj is not null)
                             {
                                 try
                                 {
@@ -150,7 +150,7 @@ namespace System.Windows.Forms
                             try
                             {
                                 Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Object font type=" + obj.GetType().FullName);
-                                Debug.Assert(obj != null, "GetAmbientProperty failed");
+                                Debug.Assert(obj is not null, "GetAmbientProperty failed");
                                 IFont ifont = (IFont)obj;
                                 prop.Value = Font.FromHfont(ifont.hFont);
                             }
@@ -183,7 +183,7 @@ namespace System.Windows.Forms
                         object obj = null;
                         if (GetAmbientProperty(DispatchID.AMBIENT_FORECOLOR, ref obj))
                         {
-                            if (obj != null)
+                            if (obj is not null)
                             {
                                 try
                                 {
@@ -280,7 +280,7 @@ namespace System.Windows.Forms
                      dwSaveOption == OLECLOSE.PROMPTSAVE) &&
                     _activeXState[s_isDirty])
                 {
-                    if (_clientSite != null)
+                    if (_clientSite is not null)
                     {
                         _clientSite.SaveObject();
                     }
@@ -311,7 +311,7 @@ namespace System.Windows.Forms
 
                         // Now that we're active, send the lpmsg to the control if it
                         // is valid.
-                        if (lpmsg != null)
+                        if (lpmsg is not null)
                         {
                             Control target = _control;
 
@@ -330,7 +330,7 @@ namespace System.Windows.Forms
                                 //  control, and if so, map the point into that child's window
                                 //  coordinates
                                 Control realTarget = target.GetChildAtPoint(pt);
-                                if (realTarget != null && realTarget != target)
+                                if (realTarget is not null && realTarget != target)
                                 {
                                     User32.MapWindowPoints(new HandleRef(target, target.Handle), new HandleRef(realTarget, realTarget.Handle), ref pt, 1);
                                     target = realTarget;
@@ -428,7 +428,7 @@ namespace System.Windows.Forms
                 }
 
                 // if they didn't give us a rectangle, just copy over ours
-                if (prcBounds != null)
+                if (prcBounds is not null)
                 {
                     RECT rc = *prcBounds;
 
@@ -462,7 +462,7 @@ namespace System.Windows.Forms
                 finally
                 {
                     // And clean up the DC
-                    if (prcBounds != null)
+                    if (prcBounds is not null)
                     {
                         Gdi32.SetWindowOrgEx(hdc, pW.X, pW.Y, null);
                         Gdi32.SetWindowExtEx(hdc, sWindowExt.Width, sWindowExt.Height, null);
@@ -546,12 +546,12 @@ namespace System.Windows.Forms
             /// </summary>
             internal unsafe HRESULT GetAdvise(DVASPECT* pAspects, ADVF* pAdvf, IAdviseSink[] ppAdvSink)
             {
-                if (pAspects != null)
+                if (pAspects is not null)
                 {
                     *pAspects = DVASPECT.CONTENT;
                 }
 
-                if (pAdvf != null)
+                if (pAdvf is not null)
                 {
                     *pAdvf = 0;
 
@@ -565,7 +565,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (ppAdvSink != null)
+                if (ppAdvSink is not null)
                 {
                     ppAdvSink[0] = _viewAdviseSink;
                 }
@@ -738,7 +738,7 @@ namespace System.Windows.Forms
                 // And recurse for our children.
                 foreach (Control c in control.Controls)
                 {
-                    if (c != null)
+                    if (c is not null)
                     {
                         GetMnemonicList(c, mnemonicList);
                     }
@@ -847,13 +847,13 @@ namespace System.Windows.Forms
                     var posRect = new RECT();
                     var clipRect = new RECT();
 
-                    if (_inPlaceUiWindow != null && Marshal.IsComObject(_inPlaceUiWindow))
+                    if (_inPlaceUiWindow is not null && Marshal.IsComObject(_inPlaceUiWindow))
                     {
                         Marshal.ReleaseComObject(_inPlaceUiWindow);
                         _inPlaceUiWindow = null;
                     }
 
-                    if (_inPlaceFrame != null && Marshal.IsComObject(_inPlaceFrame))
+                    if (_inPlaceFrame is not null && Marshal.IsComObject(_inPlaceFrame))
                     {
                         Marshal.ReleaseComObject(_inPlaceFrame);
                         _inPlaceFrame = null;
@@ -915,9 +915,9 @@ namespace System.Windows.Forms
                     }
 
                     // set ourselves up in the host.
-                    Debug.Assert(_inPlaceFrame != null, "Setting us to visible should have created the in place frame");
+                    Debug.Assert(_inPlaceFrame is not null, "Setting us to visible should have created the in place frame");
                     _inPlaceFrame.SetActiveObject(_control, null);
-                    if (_inPlaceUiWindow != null)
+                    if (_inPlaceUiWindow is not null)
                     {
                         _inPlaceUiWindow.SetActiveObject(_control, null);
                     }
@@ -930,7 +930,7 @@ namespace System.Windows.Forms
                         Marshal.ThrowExceptionForHR((int)hr);
                     }
 
-                    if (_inPlaceUiWindow != null)
+                    if (_inPlaceUiWindow is not null)
                     {
                         hr = _inPlaceFrame.SetBorderSpace(null);
                         if (!hr.Succeeded() && hr != HRESULT.OLE_E_INVALIDRECT &&
@@ -978,13 +978,13 @@ namespace System.Windows.Forms
                 _control.Visible = false;
                 HWNDParent = IntPtr.Zero;
 
-                if (_inPlaceUiWindow != null && Marshal.IsComObject(_inPlaceUiWindow))
+                if (_inPlaceUiWindow is not null && Marshal.IsComObject(_inPlaceUiWindow))
                 {
                     Marshal.ReleaseComObject(_inPlaceUiWindow);
                     _inPlaceUiWindow = null;
                 }
 
-                if (_inPlaceFrame != null && Marshal.IsComObject(_inPlaceFrame))
+                if (_inPlaceFrame is not null && Marshal.IsComObject(_inPlaceFrame))
                 {
                     Marshal.ReleaseComObject(_inPlaceFrame);
                     _inPlaceFrame = null;
@@ -1095,7 +1095,7 @@ namespace System.Windows.Forms
                     {
                         object obj = null;
                         HRESULT hr = pPropBag.Read(props[i].Name, ref obj, pErrorLog);
-                        if (hr.Succeeded() && obj != null)
+                        if (hr.Succeeded() && obj is not null)
                         {
                             Debug.Indent();
                             Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Property was in bag");
@@ -1133,7 +1133,7 @@ namespace System.Windows.Forms
                                     // not check for CanConvertFrom here -- we the conversion fails the type converter will throw,
                                     // and we will log it into the COM error log.
                                     TypeConverter converter = props[i].Converter;
-                                    Debug.Assert(converter != null, "No type converter for property '" + props[i].Name + "' on class " + _control.GetType().FullName);
+                                    Debug.Assert(converter is not null, "No type converter for property '" + props[i].Name + "' on class " + _control.GetType().FullName);
 
                                     // Check to see if the type converter can convert from a string.  If it can,.
                                     // use that as it is the best format for IPropertyBag.  Otherwise, check to see
@@ -1166,10 +1166,10 @@ namespace System.Windows.Forms
                                     errorCode = HRESULT.E_FAIL;
                                 }
                             }
-                            if (errorString != null)
+                            if (errorString is not null)
                             {
                                 Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "Exception converting property: " + errorString);
-                                if (pErrorLog != null)
+                                if (pErrorLog is not null)
                                 {
                                     IntPtr bstrSource = Marshal.StringToBSTR(_control.GetType().FullName);
                                     IntPtr bstrDescription = Marshal.StringToBSTR(errorString);
@@ -1329,7 +1329,7 @@ namespace System.Windows.Forms
             /// </summary>
             internal void OnDocWindowActivate(BOOL fActivate)
             {
-                if (_activeXState[s_uiActive] && fActivate.IsTrue() && _inPlaceFrame != null)
+                if (_activeXState[s_uiActive] && fActivate.IsTrue() && _inPlaceFrame is not null)
                 {
                     // we have to explicitly say we don't wany any border space.
                     HRESULT hr = _inPlaceFrame.SetBorderSpace(null);
@@ -1388,7 +1388,7 @@ namespace System.Windows.Forms
                 prop.Value = ColorTranslator.FromOle(unchecked((int)pQaContainer.colorFore));
 
                 // And our ambient font
-                if (pQaContainer.pFont != null)
+                if (pQaContainer.pFont is not null)
                 {
                     prop = LookupAmbient(DispatchID.AMBIENT_FONT);
 
@@ -1408,7 +1408,7 @@ namespace System.Windows.Forms
 
                 SetClientSite(pQaContainer.pClientSite);
 
-                if (pQaContainer.pAdviseSink != null)
+                if (pQaContainer.pAdviseSink is not null)
                 {
                     SetAdvise(DVASPECT.CONTENT, 0, pQaContainer.pAdviseSink);
                 }
@@ -1426,12 +1426,12 @@ namespace System.Windows.Forms
                 // Note that the AdviseHelper handles some non-standard COM interop that is required in order to access
                 // the events on the CLR-supplied CCW (COM-callable Wrapper.
 
-                if ((pQaContainer.pUnkEventSink != null) && (_control is UserControl))
+                if ((pQaContainer.pUnkEventSink is not null) && (_control is UserControl))
                 {
                     // Check if this control exposes events to COM.
                     Type eventInterface = GetDefaultEventsInterface(_control.GetType());
 
-                    if (eventInterface != null)
+                    if (eventInterface is not null)
                     {
                         try
                         {
@@ -1445,12 +1445,12 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (pQaContainer.pPropertyNotifySink != null && Marshal.IsComObject(pQaContainer.pPropertyNotifySink))
+                if (pQaContainer.pPropertyNotifySink is not null && Marshal.IsComObject(pQaContainer.pPropertyNotifySink))
                 {
                     Marshal.ReleaseComObject(pQaContainer.pPropertyNotifySink);
                 }
 
-                if (pQaContainer.pUnkEventSink != null && Marshal.IsComObject(pQaContainer.pUnkEventSink))
+                if (pQaContainer.pUnkEventSink is not null && Marshal.IsComObject(pQaContainer.pUnkEventSink))
                 {
                     Marshal.ReleaseComObject(pQaContainer.pUnkEventSink);
                 }
@@ -1757,7 +1757,7 @@ namespace System.Windows.Forms
                     STGM.WRITE | STGM.SHARE_EXCLUSIVE | STGM.CREATE,
                     0,
                     0);
-                Debug.Assert(stream != null, "Stream should be non-null, or an exception should have been thrown.");
+                Debug.Assert(stream is not null, "Stream should be non-null, or an exception should have been thrown.");
 
                 Save(stream, BOOL.TRUE);
                 Marshal.ReleaseComObject(stream);
@@ -1814,7 +1814,7 @@ namespace System.Windows.Forms
                         {
                             // Not a resource property.  Persist this using standard type converters.
                             TypeConverter converter = props[i].Converter;
-                            Debug.Assert(converter != null, "No type converter for property '" + props[i].Name + "' on class " + _control.GetType().FullName);
+                            Debug.Assert(converter is not null, "No type converter for property '" + props[i].Name + "' on class " + _control.GetType().FullName);
 
                             if (converter.CanConvertFrom(typeof(string)))
                             {
@@ -1852,7 +1852,7 @@ namespace System.Windows.Forms
                 for (int i = 0; i < cnt; i++)
                 {
                     IAdviseSink s = (IAdviseSink)_adviseList[i];
-                    Debug.Assert(s != null, "NULL in our advise list");
+                    Debug.Assert(s is not null, "NULL in our advise list");
                     s.OnSave();
                 }
             }
@@ -1872,7 +1872,7 @@ namespace System.Windows.Forms
                 _activeXState[s_viewAdvisePrimeFirst] = (advf & ADVF.PRIMEFIRST) != 0;
                 _activeXState[s_viewAdviseOnlyOnce] = (advf & ADVF.ONLYONCE) != 0;
 
-                if (_viewAdviseSink != null && Marshal.IsComObject(_viewAdviseSink))
+                if (_viewAdviseSink is not null && Marshal.IsComObject(_viewAdviseSink))
                 {
                     Marshal.ReleaseComObject(_viewAdviseSink);
                 }
@@ -1893,7 +1893,7 @@ namespace System.Windows.Forms
             /// </summary>
             internal void SetClientSite(IOleClientSite value)
             {
-                if (_clientSite != null)
+                if (_clientSite is not null)
                 {
                     if (Marshal.IsComObject(_clientSite))
                     {
@@ -1903,7 +1903,7 @@ namespace System.Windows.Forms
 
                 _clientSite = value;
 
-                if (_clientSite != null)
+                if (_clientSite is not null)
                 {
                     _control.Site = new AxSourcingSite(_control, _clientSite, "ControlAxSourcingSite");
                 }
@@ -1966,7 +1966,7 @@ namespace System.Windows.Forms
                                 bounds.Height = adjusted.Height;
                                 Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "SetExtent : Announcing to in place site that our rect has changed.");
                                 Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "            Announcing rect = " + bounds);
-                                Debug.Assert(_clientSite != null, "How can we setextent before we are sited??");
+                                Debug.Assert(_clientSite is not null, "How can we setextent before we are sited??");
 
                                 RECT posRect = bounds;
                                 ioleClientSite.OnPosRectChange(&posRect);
@@ -1990,7 +1990,7 @@ namespace System.Windows.Forms
 
                             // We need to call RequestNewObjectLayout
                             // here so we visually display our new extents.
-                            if (!_activeXState[s_inPlaceActive] && _clientSite != null)
+                            if (!_activeXState[s_inPlaceActive] && _clientSite is not null)
                             {
                                 Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "SetExtent : Requesting new Object layout.");
                                 _clientSite.RequestNewObjectLayout();
@@ -2093,7 +2093,7 @@ namespace System.Windows.Forms
                     setRegion = true;
                 }
 
-                if (lprcClipRect != null)
+                if (lprcClipRect is not null)
                 {
                     // The container wants us to clip, so figure out if we really need to.
                     Rectangle clipRect = *lprcClipRect;
@@ -2193,7 +2193,7 @@ namespace System.Windows.Forms
                 if (needPreProcess)
                 {
                     Control target = FromChildHandle(lpmsg->hwnd);
-                    if (target != null && (_control == target || _control.Contains(target)))
+                    if (target is not null && (_control == target || _control.Contains(target)))
                     {
                         PreProcessControlState messageState = PreProcessControlMessageInternal(target, ref msg);
                         switch (messageState)
@@ -2270,7 +2270,7 @@ namespace System.Windows.Forms
                 _inPlaceUiWindow?.SetActiveObject(null, null);
 
                 // May need this for SetActiveObject & OnUIDeactivate, so leave until function return
-                Debug.Assert(_inPlaceFrame != null, "No inplace frame -- how dod we go UI active?");
+                Debug.Assert(_inPlaceFrame is not null, "No inplace frame -- how dod we go UI active?");
                 _inPlaceFrame.SetActiveObject(null, null);
 
                 if (_clientSite is IOleInPlaceSite ioleClientSite)
@@ -2293,7 +2293,7 @@ namespace System.Windows.Forms
 
                 IAdviseSink sink = (IAdviseSink)_adviseList[(int)dwConnection - 1];
                 _adviseList.RemoveAt((int)dwConnection - 1);
-                if (sink != null && Marshal.IsComObject(sink))
+                if (sink is not null && Marshal.IsComObject(sink))
                 {
                     Marshal.ReleaseComObject(sink);
                 }
@@ -2393,7 +2393,7 @@ namespace System.Windows.Forms
                 // Note: Word2000 won't resize components correctly if an OnViewChange notification
                 //       is sent while the component is persisting it's state.  The !m_fSaving check
                 //       is to make sure we don't call OnViewChange in this case.
-                if (_viewAdviseSink != null && !_activeXState[s_saving])
+                if (_viewAdviseSink is not null && !_activeXState[s_saving])
                 {
                     _viewAdviseSink.OnViewChange((int)DVASPECT.CONTENT, -1);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXVerbEnum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXVerbEnum.cs
@@ -47,7 +47,7 @@ namespace System.Windows.Forms
                     fetched++;
                 }
 
-                if (pceltFetched != null)
+                if (pceltFetched is not null)
                 {
                     *pceltFetched = fetched;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -124,7 +124,7 @@ namespace System.Windows.Forms
                         }
                         break;
                     case AccessibleNavigation.Previous:
-                        if (IsNonClientObject && parentControl != null)
+                        if (IsNonClientObject && parentControl is not null)
                         {
                             ctrls = parentControl.GetChildControlsInTabOrder(true);
                             index = Array.IndexOf(ctrls, Owner);
@@ -135,7 +135,7 @@ namespace System.Windows.Forms
                         }
                         break;
                     case AccessibleNavigation.Next:
-                        if (IsNonClientObject && parentControl != null)
+                        if (IsNonClientObject && parentControl is not null)
                         {
                             ctrls = parentControl.GetChildControlsInTabOrder(true);
                             index = Array.IndexOf(ctrls, Owner);
@@ -242,7 +242,7 @@ namespace System.Windows.Forms
                 get
                 {
                     QueryAccessibilityHelpEventHandler? handler = (QueryAccessibilityHelpEventHandler?)Owner.Events[s_queryAccessibilityHelpEvent];
-                    if (handler != null)
+                    if (handler is not null)
                     {
                         QueryAccessibilityHelpEventArgs args = new QueryAccessibilityHelpEventArgs();
                         handler(Owner, args);
@@ -272,7 +272,7 @@ namespace System.Windows.Forms
                     // Note: Any non-null value in AccessibleName overrides the default accessible name logic,
                     // even an empty string (this is the only way to *force* the accessible name to be blank).
                     string? name = Owner.AccessibleName;
-                    if (name != null)
+                    if (name is not null)
                     {
                         return name;
                     }
@@ -313,7 +313,7 @@ namespace System.Windows.Forms
 
                     // Otherwise use the text of the preceding Label control, if there is one
                     Label? previousLabel = PreviousLabel;
-                    if (previousLabel != null)
+                    if (previousLabel is not null)
                     {
                         string text = previousLabel.Text;
                         if (!string.IsNullOrEmpty(text))
@@ -354,7 +354,7 @@ namespace System.Windows.Forms
 
                     // Walk backwards through peer controls...
                     for (Control previous = container.GetNextControl(Owner, false);
-                         previous != null;
+                         previous is not null;
                          previous = container.GetNextControl(previous, false))
                     {
                         // Stop when we hit a Label (whether visible or invisible)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
@@ -73,7 +73,7 @@ namespace System.Windows.Forms
                 }
 
                 // Remove the new control from its old parent (if any)
-                if (value._parent != null)
+                if (value._parent is not null)
                 {
                     value._parent.Controls.Remove(value);
                 }
@@ -391,7 +391,7 @@ namespace System.Windows.Forms
                     }
 
                     Control control = (Control)InnerList[index];
-                    Debug.Assert(control != null, "Why are we returning null controls from a valid index?");
+                    Debug.Assert(control is not null, "Why are we returning null controls from a valid index?");
                     return control;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlNativeWindow.cs
@@ -74,7 +74,7 @@ namespace System.Windows.Forms
             // non-released controls will show what control wasn't released.
             public override string ToString()
             {
-                if (_control != null)
+                if (_control is not null)
                 {
                     return _control.GetType().FullName;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlVersionInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlVersionInfo.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms
                     if (_companyName is null)
                     {
                         object[] attrs = _owner.GetType().Module.Assembly.GetCustomAttributes(typeof(AssemblyCompanyAttribute), false);
-                        if (attrs != null && attrs.Length > 0)
+                        if (attrs is not null && attrs.Length > 0)
                         {
                             _companyName = ((AssemblyCompanyAttribute)attrs[0]).Company;
                         }
@@ -40,7 +40,7 @@ namespace System.Windows.Forms
                         if (_companyName is null || _companyName.Length == 0)
                         {
                             _companyName = GetFileVersionInfo().CompanyName;
-                            if (_companyName != null)
+                            if (_companyName is not null)
                             {
                                 _companyName = _companyName.Trim();
                             }
@@ -80,7 +80,7 @@ namespace System.Windows.Forms
                     if (_productName is null)
                     {
                         object[] attrs = _owner.GetType().Module.Assembly.GetCustomAttributes(typeof(AssemblyProductAttribute), false);
-                        if (attrs != null && attrs.Length > 0)
+                        if (attrs is not null && attrs.Length > 0)
                         {
                             _productName = ((AssemblyProductAttribute)attrs[0]).Product;
                         }
@@ -88,7 +88,7 @@ namespace System.Windows.Forms
                         if (_productName is null || _productName.Length == 0)
                         {
                             _productName = GetFileVersionInfo().ProductName;
-                            if (_productName != null)
+                            if (_productName is not null)
                             {
                                 _productName = _productName.Trim();
                             }
@@ -129,7 +129,7 @@ namespace System.Windows.Forms
                     {
                         // custom attribute
                         object[] attrs = _owner.GetType().Module.Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false);
-                        if (attrs != null && attrs.Length > 0)
+                        if (attrs is not null && attrs.Length > 0)
                         {
                             _productVersion = ((AssemblyInformationalVersionAttribute)attrs[0]).InformationalVersion;
                         }
@@ -138,7 +138,7 @@ namespace System.Windows.Forms
                         if (_productVersion is null || _productVersion.Length == 0)
                         {
                             _productVersion = GetFileVersionInfo().ProductVersion;
-                            if (_productVersion != null)
+                            if (_productVersion is not null)
                             {
                                 _productVersion = _productVersion.Trim();
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -61,7 +61,7 @@ namespace System.Windows.Forms
                 if (cachedImeMode == ImeMode.Inherit)
                 {
                     Control parent = ParentInternal;
-                    if (parent != null)
+                    if (parent is not null)
                     {
                         cachedImeMode = parent.CachedImeMode;
                         Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Verbose, "inherited from parent = " + parent.GetType());
@@ -262,7 +262,7 @@ namespace System.Windows.Forms
                             ctl = FromChildHandle(User32.GetFocus());
                         }
 
-                        if (ctl != null && ctl.CanEnableIme)
+                        if (ctl is not null && ctl.CanEnableIme)
                         {
                             // Block ImeModeChanged since we are checking for it below.
                             DisableImeModeChangedCount++;
@@ -682,7 +682,7 @@ namespace System.Windows.Forms
 
             Form form = FindForm();
 
-            if (form != null)
+            if (form is not null)
             {
                 InputLanguageChangedEventArgs e = InputLanguage.CreateInputLanguageChangedEventArgs(m);
                 Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, "Culture=" + e.Culture);
@@ -706,7 +706,7 @@ namespace System.Windows.Forms
             InputLanguageChangingEventArgs e = InputLanguage.CreateInputLanguageChangingEventArgs(m);
             Form form = FindForm();
 
-            if (form != null)
+            if (form is not null)
             {
                 Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, "Culture=" + e.Culture);
                 form.PerformOnInputLanguageChanging(e);
@@ -1003,7 +1003,7 @@ namespace System.Windows.Forms
             Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Verbose, "ImmGetConversionStatus(" + inputContext + ", conversion, sentence)");
             Imm32.ImmGetConversionStatus(inputContext, out Imm32.IME_CMODE conversion, out Imm32.IME_SMODE sentence);
 
-            Debug.Assert(countryTable != null, "countryTable is null");
+            Debug.Assert(countryTable is not null, "countryTable is null");
 
             if ((conversion & Imm32.IME_CMODE.NATIVE) != 0)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ThreadMethodEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ThreadMethodEntry.cs
@@ -49,7 +49,7 @@ namespace System.Windows.Forms
 
             ~ThreadMethodEntry()
             {
-                if (_resetEvent != null)
+                if (_resetEvent is not null)
                 {
                     _resetEvent.Close();
                 }
@@ -109,7 +109,7 @@ namespace System.Windows.Forms
                 lock (_invokeSyncObject)
                 {
                     IsCompleted = true;
-                    if (_resetEvent != null)
+                    if (_resetEvent is not null)
                     {
                         _resetEvent.Set();
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -494,7 +494,7 @@ namespace System.Windows.Forms
                     Properties.SetObject(s_accessibilityProperty, accessibleObject);
                 }
 
-                Debug.Assert(accessibleObject != null, "Failed to create accessibility object");
+                Debug.Assert(accessibleObject is not null, "Failed to create accessibility object");
                 return accessibleObject;
             }
         }
@@ -514,7 +514,7 @@ namespace System.Windows.Forms
                     Properties.SetObject(s_ncAccessibilityProperty, ncAccessibleObject);
                 }
 
-                Debug.Assert(ncAccessibleObject != null, "Failed to create NON-CLIENT accessibility object");
+                Debug.Assert(ncAccessibleObject is not null, "Failed to create NON-CLIENT accessibility object");
                 return ncAccessibleObject;
             }
         }
@@ -718,7 +718,7 @@ namespace System.Windows.Forms
                 AmbientProperties props = (AmbientProperties)Properties.GetObject(s_ambientPropertiesServiceProperty, out bool contains);
                 if (!contains)
                 {
-                    if (Site != null)
+                    if (Site is not null)
                     {
                         props = Site.GetService(typeof(AmbientProperties)) as AmbientProperties;
                     }
@@ -727,7 +727,7 @@ namespace System.Windows.Forms
                         props = (AmbientProperties)GetService(typeof(AmbientProperties));
                     }
 
-                    if (props != null)
+                    if (props is not null)
                     {
                         Properties.SetObject(s_ambientPropertiesServiceProperty, props);
                     }
@@ -768,7 +768,7 @@ namespace System.Windows.Forms
                 if (value != AutoSize)
                 {
                     CommonProperties.SetAutoSize(this, value);
-                    if (ParentInternal != null)
+                    if (ParentInternal is not null)
                     {
                         // DefaultLayout does not keep anchor information until it needs to.  When
                         // AutoSize became a common property, we could no longer blindly call into
@@ -840,7 +840,7 @@ namespace System.Windows.Forms
             get
             {
                 object customBackBrush = Properties.GetObject(s_backBrushProperty);
-                if (customBackBrush != null)
+                if (customBackBrush is not null)
                 {
                     // We already have a valid brush.  Unbox, and return.
                     return (Gdi32.HBRUSH)customBackBrush;
@@ -851,7 +851,7 @@ namespace System.Windows.Forms
                     // No custom back color.  See if we can get to our parent.
                     // The color check here is to account for parents and children who
                     // override the BackColor property.
-                    if (_parent != null && _parent.BackColor == BackColor)
+                    if (_parent is not null && _parent.BackColor == BackColor)
                     {
                         return _parent.BackColorBrush;
                     }
@@ -898,7 +898,7 @@ namespace System.Windows.Forms
                 }
 
                 Control p = ParentInternal;
-                if (p != null && p.CanAccessProperties)
+                if (p is not null && p.CanAccessProperties)
                 {
                     c = p.BackColor;
                     if (IsValidBackColor(c))
@@ -915,7 +915,7 @@ namespace System.Windows.Forms
                 if (c.IsEmpty)
                 {
                     AmbientProperties ambient = AmbientPropertiesService;
-                    if (ambient != null)
+                    if (ambient is not null)
                     {
                         c = ambient.BackColor;
                     }
@@ -1065,7 +1065,7 @@ namespace System.Windows.Forms
         public void ResetBindings()
         {
             ControlBindingsCollection bindings = (ControlBindingsCollection)Properties.GetObject(s_bindingsProperty);
-            if (bindings != null)
+            if (bindings is not null)
             {
                 bindings.Clear();
             }
@@ -1082,14 +1082,14 @@ namespace System.Windows.Forms
             {
                 // See if we have locally overridden the binding manager.
                 BindingContext context = (BindingContext)Properties.GetObject(s_bindingManagerProperty);
-                if (context != null)
+                if (context is not null)
                 {
                     return context;
                 }
 
                 // Otherwise, see if the parent has one for us.
                 Control p = ParentInternal;
-                if (p != null && p.CanAccessProperties)
+                if (p is not null && p.CanAccessProperties)
                 {
                     return p.BindingContext;
                 }
@@ -1405,14 +1405,14 @@ namespace System.Windows.Forms
                 {
                     EventHandler disposedHandler = new EventHandler(DetachContextMenuStrip);
 
-                    if (oldValue != null)
+                    if (oldValue is not null)
                     {
                         oldValue.Disposed -= disposedHandler;
                     }
 
                     Properties.SetObject(s_contextMenuStripProperty, value);
 
-                    if (value != null)
+                    if (value is not null)
                     {
                         value.Disposed += disposedHandler;
                     }
@@ -1579,7 +1579,7 @@ namespace System.Windows.Forms
             bool valid = true;
             validatedControlAllowsFocusChange = false;
             IContainerControl c = GetContainerControl();
-            if (c != null && CausesValidation)
+            if (c is not null && CausesValidation)
             {
                 if (c is ContainerControl container)
                 {
@@ -1587,10 +1587,10 @@ namespace System.Windows.Forms
                     {
                         ContainerControl cc;
                         Control parent = container.ParentInternal;
-                        if (parent != null)
+                        if (parent is not null)
                         {
                             cc = parent.GetContainerControl() as ContainerControl;
-                            if (cc != null)
+                            if (cc is not null)
                             {
                                 container = cc;
                             }
@@ -1624,7 +1624,7 @@ namespace System.Windows.Forms
                 else
                 {
                     Control parent = ParentInternal;
-                    if (parent != null)
+                    if (parent is not null)
                     {
                         return parent.ValidationCancelled;
                     }
@@ -1681,7 +1681,7 @@ namespace System.Windows.Forms
                 }
 
                 Cursor cursor = (Cursor)Properties.GetObject(s_cursorProperty);
-                if (cursor != null)
+                if (cursor is not null)
                 {
                     return cursor;
                 }
@@ -1695,13 +1695,13 @@ namespace System.Windows.Forms
                 }
 
                 Control p = ParentInternal;
-                if (p != null)
+                if (p is not null)
                 {
                     return p.Cursor;
                 }
 
                 AmbientProperties ambient = AmbientPropertiesService;
-                if (ambient != null && ambient.Cursor != null)
+                if (ambient is not null && ambient.Cursor is not null)
                 {
                     return ambient.Cursor;
                 }
@@ -1793,7 +1793,7 @@ namespace System.Windows.Forms
                 if (s_defaultFont is null)
                 {
                     s_defaultFont = SystemFonts.MessageBoxFont;
-                    Debug.Assert(s_defaultFont != null, "defaultFont wasn't set!");
+                    Debug.Assert(s_defaultFont is not null, "defaultFont wasn't set!");
                 }
 
                 return s_defaultFont;
@@ -2059,13 +2059,13 @@ namespace System.Windows.Forms
             get
             {
                 Font font = (Font)Properties.GetObject(s_fontProperty);
-                if (font != null)
+                if (font is not null)
                 {
                     return font;
                 }
 
                 Font f = GetParentFont();
-                if (f != null)
+                if (f is not null)
                 {
                     return f;
                 }
@@ -2073,14 +2073,14 @@ namespace System.Windows.Forms
                 if (IsActiveX)
                 {
                     f = ActiveXAmbientFont;
-                    if (f != null)
+                    if (f is not null)
                     {
                         return f;
                     }
                 }
 
                 AmbientProperties ambient = AmbientPropertiesService;
-                if (ambient != null && ambient.Font != null)
+                if (ambient is not null && ambient.Font is not null)
                 {
                     return ambient.Font;
                 }
@@ -2096,7 +2096,7 @@ namespace System.Windows.Forms
                 bool localChanged = false;
                 if (value is null)
                 {
-                    if (local != null)
+                    if (local is not null)
                     {
                         localChanged = true;
                     }
@@ -2187,7 +2187,7 @@ namespace System.Windows.Forms
             {
                 Font font = (Font)Properties.GetObject(s_fontProperty);
 
-                if (font != null)
+                if (font is not null)
                 {
                     FontHandleWrapper fontHandle = (FontHandleWrapper)Properties.GetObject(s_fontHandleWrapperProperty);
                     if (fontHandle is null)
@@ -2200,20 +2200,20 @@ namespace System.Windows.Forms
                     return fontHandle.Handle;
                 }
 
-                if (_parent != null)
+                if (_parent is not null)
                 {
                     return _parent.FontHandle;
                 }
 
                 AmbientProperties ambient = AmbientPropertiesService;
 
-                if (ambient != null && ambient.Font != null)
+                if (ambient is not null && ambient.Font is not null)
                 {
                     FontHandleWrapper fontHandle = null;
 
                     Font currentAmbient = (Font)Properties.GetObject(s_currentAmbientFontProperty);
 
-                    if (currentAmbient != null && currentAmbient == ambient.Font)
+                    if (currentAmbient is not null && currentAmbient == ambient.Font)
                     {
                         fontHandle = (FontHandleWrapper)Properties.GetObject(s_fontHandleWrapperProperty);
                     }
@@ -2249,7 +2249,7 @@ namespace System.Windows.Forms
                 else
                 {
                     Font font = (Font)Properties.GetObject(s_fontProperty);
-                    if (font != null)
+                    if (font is not null)
                     {
                         fontHeight = font.Height;
                         Properties.SetInteger(s_fontHeightProperty, fontHeight);
@@ -2260,7 +2260,7 @@ namespace System.Windows.Forms
                 //ask the parent if it has the font height
                 int localFontHeight = -1;
 
-                if (ParentInternal != null && ParentInternal.CanAccessProperties)
+                if (ParentInternal is not null && ParentInternal.CanAccessProperties)
                 {
                     localFontHeight = ParentInternal.FontHeight;
                 }
@@ -2297,7 +2297,7 @@ namespace System.Windows.Forms
                 }
 
                 Control p = ParentInternal;
-                if (p != null && p.CanAccessProperties)
+                if (p is not null && p.CanAccessProperties)
                 {
                     return p.ForeColor;
                 }
@@ -2312,7 +2312,7 @@ namespace System.Windows.Forms
                 if (c.IsEmpty)
                 {
                     AmbientProperties ambient = AmbientPropertiesService;
-                    if (ambient != null)
+                    if (ambient is not null)
                     {
                         c = ambient.ForeColor;
                     }
@@ -2352,7 +2352,7 @@ namespace System.Windows.Forms
 
         private Font GetParentFont()
         {
-            if (ParentInternal != null && ParentInternal.CanAccessProperties)
+            if (ParentInternal is not null && ParentInternal.CanAccessProperties)
             {
                 return ParentInternal.Font;
             }
@@ -2466,7 +2466,7 @@ namespace System.Windows.Forms
             get
             {
                 ControlCollection controls = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-                return controls != null && controls.Count > 0;
+                return controls is not null && controls.Count > 0;
             }
         }
 
@@ -2559,9 +2559,9 @@ namespace System.Windows.Forms
                 RECT temp = new RECT();
                 Region working;
                 Control parent = ParentInternal;
-                if (parent != null)
+                if (parent is not null)
                 {
-                    while (parent.ParentInternal != null)
+                    while (parent.ParentInternal is not null)
                     {
                         parent = parent.ParentInternal;
                     }
@@ -2575,7 +2575,7 @@ namespace System.Windows.Forms
                     IntPtr prev;
                     IntPtr next;
                     IntPtr start;
-                    if (parent != null)
+                    if (parent is not null)
                     {
                         start = parent.Handle;
                     }
@@ -2934,7 +2934,7 @@ namespace System.Windows.Forms
                 string name = (string)Properties.GetObject(s_namePropertyProperty);
                 if (string.IsNullOrEmpty(name))
                 {
-                    if (Site != null)
+                    if (Site is not null)
                     {
                         name = Site.Name;
                     }
@@ -2980,7 +2980,7 @@ namespace System.Windows.Forms
             {
                 if (_parent != value)
                 {
-                    if (value != null)
+                    if (value is not null)
                     {
                         value.Controls.Add(this);
                     }
@@ -3044,7 +3044,7 @@ namespace System.Windows.Forms
             get => _reflectParent;
             set
             {
-                if (value != null)
+                if (value is not null)
                 {
                     value.AddReflectChild();
                 }
@@ -3218,7 +3218,7 @@ namespace System.Windows.Forms
                 if (((RightToLeft)rightToLeft) == RightToLeft.Inherit)
                 {
                     Control parent = ParentInternal;
-                    if (parent != null)
+                    if (parent is not null)
                     {
                         rightToLeft = (int)parent.RightToLeft;
                     }
@@ -3279,7 +3279,7 @@ namespace System.Windows.Forms
                 AmbientProperties oldAmbients = AmbientPropertiesService;
                 AmbientProperties newAmbients = null;
 
-                if (value != null)
+                if (value is not null)
                 {
                     newAmbients = value.GetService(typeof(AmbientProperties)) as AmbientProperties;
                 }
@@ -3490,10 +3490,10 @@ namespace System.Windows.Forms
 
                 if (IsMnemonicsListenerAxSourced)
                 {
-                    for (Control ctl = this; ctl != null; ctl = ctl.ParentInternal)
+                    for (Control ctl = this; ctl is not null; ctl = ctl.ParentInternal)
                     {
                         ActiveXImpl activeXImpl = (ActiveXImpl)ctl.Properties.GetObject(s_activeXImplProperty);
-                        if (activeXImpl != null)
+                        if (activeXImpl is not null)
                         {
                             activeXImpl.UpdateAccelTable();
                             break;
@@ -3542,7 +3542,7 @@ namespace System.Windows.Forms
             get
             {
                 Control control = this;
-                while (control != null && !control.GetTopLevel())
+                while (control is not null && !control.GetTopLevel())
                 {
                     control = control.ParentInternal;
                 }
@@ -3555,7 +3555,7 @@ namespace System.Windows.Forms
             get
             {
                 Control control = this;
-                while (control.ParentInternal != null)
+                while (control.ParentInternal is not null)
                 {
                     control = control.ParentInternal;
                 }
@@ -3702,7 +3702,7 @@ namespace System.Windows.Forms
                     SetState(States.UseWaitCursor, value);
                     ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
 
-                    if (controlsCollection != null)
+                    if (controlsCollection is not null)
                     {
                         // PERFNOTE: This is more efficient than using Foreach.  Foreach
                         // forces the creation of an array subset enum each time we
@@ -3845,7 +3845,7 @@ namespace System.Windows.Forms
                     throw new InvalidAsynchronousStateException(SR.ThreadNoLongerValid);
                 }
 
-                if (IsDisposed && _threadCallbackList != null && _threadCallbackList.Count > 0)
+                if (IsDisposed && _threadCallbackList is not null && _threadCallbackList.Count > 0)
                 {
                     lock (_threadCallbackList)
                     {
@@ -4541,7 +4541,7 @@ namespace System.Windows.Forms
         internal virtual void AssignParent(Control value)
         {
             // Adopt the parent's required scaling bits
-            if (value != null)
+            if (value is not null)
             {
                 RequiredScalingEnabled = value.RequiredScalingEnabled;
             }
@@ -4613,7 +4613,7 @@ namespace System.Windows.Forms
             }
 
             SetState(States.CheckedHost, false);
-            if (ParentInternal != null)
+            if (ParentInternal is not null)
             {
                 ParentInternal.LayoutEngine.InitLayout(this, BoundsSpecified.All);
             }
@@ -4692,7 +4692,7 @@ namespace System.Windows.Forms
         /// </summary>
         public void BringToFront()
         {
-            if (_parent != null)
+            if (_parent is not null)
             {
                 _parent.Controls.SetChildIndex(this, 0);
             }
@@ -4720,7 +4720,7 @@ namespace System.Windows.Forms
                 return false;
             }
 
-            if (_parent != null)
+            if (_parent is not null)
             {
                 return _parent.CanProcessMnemonic();
             }
@@ -4736,7 +4736,7 @@ namespace System.Windows.Forms
                 return false;
             }
 
-            for (Control ctl = this; ctl != null; ctl = ctl._parent)
+            for (Control ctl = this; ctl is not null; ctl = ctl._parent)
             {
                 if (!ctl.Enabled || !ctl.Visible)
                 {
@@ -4756,7 +4756,7 @@ namespace System.Windows.Forms
             Form lastOwner = null;
             Control lastParent = null;
 
-            for (Control ctl = bottom; ctl != null; ctl = ctl.ParentInternal)
+            for (Control ctl = bottom; ctl is not null; ctl = ctl.ParentInternal)
             {
                 lastParent = ctl;
                 if (ctl == toFind)
@@ -4765,11 +4765,11 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (lastParent != null)
+            if (lastParent is not null)
             {
                 if (lastParent is Form f)
                 {
-                    for (Form form = f; form != null; form = form.OwnerInternal)
+                    for (Form form = f; form is not null; form = form.OwnerInternal)
                     {
                         lastOwner = form;
                         if (form == toFind)
@@ -4780,9 +4780,9 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (lastOwner != null)
+            if (lastOwner is not null)
             {
-                if (lastOwner.ParentInternal != null)
+                if (lastOwner.ParentInternal is not null)
                 {
                     CheckParentingCycle(lastOwner.ParentInternal, toFind);
                 }
@@ -4795,7 +4795,7 @@ namespace System.Windows.Forms
             {
                 ActiveXOnFocus(true);
             }
-            if (_parent != null)
+            if (_parent is not null)
             {
                 _parent.ChildGotFocus(child);
             }
@@ -4806,7 +4806,7 @@ namespace System.Windows.Forms
         /// </summary>
         public bool Contains(Control ctl)
         {
-            while (ctl != null)
+            while (ctl is not null)
             {
                 ctl = ctl.ParentInternal;
                 if (ctl is null)
@@ -4898,7 +4898,7 @@ namespace System.Windows.Forms
                 SetState(States.Mirrored, (cp.ExStyle & (int)User32.WS_EX.LAYOUTRTL) != 0);
 
                 // Adjust for scrolling of parent...
-                if (_parent != null)
+                if (_parent is not null)
                 {
                     Rectangle parentClient = _parent.ClientRectangle;
 
@@ -4950,7 +4950,7 @@ namespace System.Windows.Forms
             bool controlIsAlreadyCreated = Created;
             CreateControl(false);
 
-            if (Properties.GetObject(s_bindingManagerProperty) is null && ParentInternal != null && !controlIsAlreadyCreated)
+            if (Properties.GetObject(s_bindingManagerProperty) is null && ParentInternal is not null && !controlIsAlreadyCreated)
             {
                 // We do not want to call our parent's BindingContext property here.
                 // We have no idea if us or any of our children are using data binding,
@@ -4993,7 +4993,7 @@ namespace System.Windows.Forms
                     // z-order updates from Windows may rearrange it!
                     ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
 
-                    if (controlsCollection != null)
+                    if (controlsCollection is not null)
                     {
                         Control[] controlSnapshot = new Control[controlsCollection.Count];
                         controlsCollection.CopyTo(controlSnapshot, 0);
@@ -5040,7 +5040,7 @@ namespace System.Windows.Forms
         {
             if (RecreatingHandle)
             {
-                if (_threadCallbackList != null)
+                if (_threadCallbackList is not null)
                 {
                     // See if we have a thread marshaling request pending.  If so, we will need to
                     // re-post it after recreating the handle.
@@ -5070,7 +5070,7 @@ namespace System.Windows.Forms
             // the thread callback message to the new handle for us.
             if (!RecreatingHandle)
             {
-                if (_threadCallbackList != null)
+                if (_threadCallbackList is not null)
                 {
                     lock (_threadCallbackList)
                     {
@@ -5107,7 +5107,7 @@ namespace System.Windows.Forms
             if (GetState(States.OwnCtlBrush))
             {
                 object backBrush = Properties.GetObject(s_backBrushProperty);
-                if (backBrush != null)
+                if (backBrush is not null)
                 {
                     Gdi32.HBRUSH p = (Gdi32.HBRUSH)backBrush;
                     if (!p.IsNull)
@@ -5148,14 +5148,14 @@ namespace System.Windows.Forms
                         DestroyHandle();
                     }
 
-                    if (_parent != null)
+                    if (_parent is not null)
                     {
                         _parent.Controls.Remove(this);
                     }
 
                     ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
 
-                    if (controlsCollection != null)
+                    if (controlsCollection is not null)
                     {
                         // PERFNOTE: This is more efficient than using Foreach.  Foreach
                         // forces the creation of an array subset enum each time we
@@ -5182,7 +5182,7 @@ namespace System.Windows.Forms
             {
                 // This same post is done in NativeWindow's finalize method, so if you change
                 // it, change it there too.
-                if (_window != null)
+                if (_window is not null)
                 {
                     _window.ForceExitMessageLoop();
                 }
@@ -5195,7 +5195,7 @@ namespace System.Windows.Forms
         {
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
 
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -5332,7 +5332,7 @@ namespace System.Windows.Forms
             }
 
             Debug.Assert(asyncResult.IsCompleted, "Why isn't this asyncResult done yet?");
-            if (entry._exception != null)
+            if (entry._exception is not null)
             {
                 throw entry._exception;
             }
@@ -5373,7 +5373,7 @@ namespace System.Windows.Forms
         public Form FindForm()
         {
             Control cur = this;
-            while (cur != null && !(cur is Form))
+            while (cur is not null && !(cur is Form))
             {
                 cur = cur.ParentInternal;
             }
@@ -5393,7 +5393,7 @@ namespace System.Windows.Forms
             {
                 Control c = this;
 
-                while (c != null && !c.IsHandleCreated)
+                while (c is not null && !c.IsHandleCreated)
                 {
                     Control p = c.ParentInternal;
                     c = p;
@@ -5473,11 +5473,11 @@ namespace System.Windows.Forms
             {
                 User32.SetFocus(new HandleRef(this, Handle));
             }
-            if (Focused && ParentInternal != null)
+            if (Focused && ParentInternal is not null)
             {
                 IContainerControl c = ParentInternal.GetContainerControl();
 
-                if (c != null)
+                if (c is not null)
                 {
                     if (c is ContainerControl)
                     {
@@ -5506,7 +5506,7 @@ namespace System.Windows.Forms
             while (handle != IntPtr.Zero)
             {
                 Control ctl = FromHandle(handle);
-                if (ctl != null)
+                if (ctl is not null)
                 {
                     return ctl;
                 }
@@ -5523,7 +5523,7 @@ namespace System.Windows.Forms
         public static Control FromHandle(IntPtr handle)
         {
             NativeWindow w = NativeWindow.FromHandle(handle);
-            while (w != null && !(w is ControlNativeWindow))
+            while (w is not null && !(w is ControlNativeWindow))
             {
                 w = w.PreviousWindow;
             }
@@ -5608,11 +5608,11 @@ namespace System.Windows.Forms
             Control c = this;
 
             // Refer to IsContainerControl property for more details.
-            if (c != null && IsContainerControl)
+            if (c is not null && IsContainerControl)
             {
                 c = c.ParentInternal;
             }
-            while (c != null && !IsFocusManagingContainerControl(c))
+            while (c is not null && !IsFocusManagingContainerControl(c))
             {
                 c = c.ParentInternal;
             }
@@ -5675,7 +5675,7 @@ namespace System.Windows.Forms
             if (scaleLoc)
             {
                 ISite site = Site;
-                if (site != null && site.DesignMode)
+                if (site is not null && site.DesignMode)
                 {
                     if (site.GetService(typeof(IDesignerHost)) is IDesignerHost host && host.RootComponent == this)
                     {
@@ -5737,7 +5737,7 @@ namespace System.Windows.Forms
         {
             Control up = this;
             bool isDisposing = false;
-            while (up != null)
+            while (up is not null)
             {
                 if (up.Disposing)
                 {
@@ -5816,7 +5816,7 @@ namespace System.Windows.Forms
             ControlCollection ctlControls = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
 
             Control found = null;
-            if (ctlControls != null)
+            if (ctlControls is not null)
             {
                 if (forward)
                 {
@@ -5859,10 +5859,10 @@ namespace System.Windows.Forms
             {
                 ControlCollection ctlControls = (ControlCollection)ctl.Properties.GetObject(s_controlsCollectionProperty);
 
-                if (ctlControls != null && ctlControls.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
+                if (ctlControls is not null && ctlControls.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
                 {
                     Control found = ctl.GetFirstChildControlInTabOrder(/*forward=*/true);
-                    if (found != null)
+                    if (found is not null)
                     {
                         return found;
                     }
@@ -5883,7 +5883,7 @@ namespace System.Windows.Forms
 
                     ControlCollection parentControls = (ControlCollection)p.Properties.GetObject(s_controlsCollectionProperty);
 
-                    if (parentControls != null)
+                    if (parentControls is not null)
                     {
                         parentControlCount = parentControls.Count;
                     }
@@ -5922,7 +5922,7 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    if (found != null)
+                    if (found is not null)
                     {
                         return found;
                     }
@@ -5945,7 +5945,7 @@ namespace System.Windows.Forms
 
                     ControlCollection parentControls = (ControlCollection)p.Properties.GetObject(s_controlsCollectionProperty);
 
-                    if (parentControls != null)
+                    if (parentControls is not null)
                     {
                         parentControlCount = parentControls.Count;
                     }
@@ -5986,7 +5986,7 @@ namespace System.Windows.Forms
 
                     // If we were unable to find a control we should return the control's parent.  However, if that parent is us, return
                     // NULL.
-                    if (found != null)
+                    if (found is not null)
                     {
                         ctl = found;
                     }
@@ -6006,10 +6006,10 @@ namespace System.Windows.Forms
                 // We found a control.  Walk into this control to find the proper sub control within it to select.
                 ControlCollection ctlControls = (ControlCollection)ctl.Properties.GetObject(s_controlsCollectionProperty);
 
-                while (ctlControls != null && ctlControls.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
+                while (ctlControls is not null && ctlControls.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
                 {
                     Control found = ctl.GetFirstChildControlInTabOrder(/*forward=*/false);
-                    if (found != null)
+                    if (found is not null)
                     {
                         ctl = found;
                         ctlControls = (ControlCollection)ctl.Properties.GetObject(s_controlsCollectionProperty);
@@ -6030,7 +6030,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal static IntPtr GetSafeHandle(IWin32Window window)
         {
-            Debug.Assert(window != null, "window is null in Control.GetSafeHandle");
+            Debug.Assert(window is not null, "window is null in Control.GetSafeHandle");
             if (window is Control control)
             {
                 return control.Handle;
@@ -6326,7 +6326,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void InvokeMarshaledCallback(ThreadMethodEntry tme)
         {
-            if (tme._executionContext != null)
+            if (tme._executionContext is not null)
             {
                 if (s_invokeMarshaledCallbackHelperDelegate is null)
                 {
@@ -6355,7 +6355,7 @@ namespace System.Windows.Forms
         {
             ThreadMethodEntry tme = (ThreadMethodEntry)obj;
 
-            if (tme._syncContext != null)
+            if (tme._syncContext is not null)
             {
                 SynchronizationContext oldContext = SynchronizationContext.Current;
 
@@ -6427,9 +6427,9 @@ namespace System.Windows.Forms
             }
 
             // Now invoke on all the queued items.
-            while (current != null)
+            while (current is not null)
             {
-                if (current._method != null)
+                if (current._method is not null)
                 {
                     try
                     {
@@ -6460,7 +6460,7 @@ namespace System.Windows.Forms
                         // do this because the exception would have been handled above.  If we're
                         // not debugging, raise the exception here.
                         if (!NativeWindow.WndProcShouldBeDebuggable &&
-                            current._exception != null && !current._synchronous)
+                            current._exception is not null && !current._synchronous)
                         {
                             Application.OnThreadException(current._exception);
                         }
@@ -6497,7 +6497,7 @@ namespace System.Windows.Forms
         internal bool IsFontSet()
         {
             Font font = (Font)Properties.GetObject(s_fontProperty);
-            if (font != null)
+            if (font is not null)
             {
                 return true;
             }
@@ -6512,7 +6512,7 @@ namespace System.Windows.Forms
         internal bool IsDescendant(Control descendant)
         {
             Control control = descendant;
-            while (control != null)
+            while (control is not null)
             {
                 if (control == this)
                 {
@@ -6635,7 +6635,7 @@ namespace System.Windows.Forms
             {
                 Debug.Write("Control.IsMnemonic(" + charCode.ToString() + ", ");
 
-                if (text != null)
+                if (text is not null)
                 {
                     Debug.Write(text);
                 }
@@ -6654,7 +6654,7 @@ namespace System.Windows.Forms
                 return false;
             }
 
-            if (text != null)
+            if (text is not null)
             {
                 int pos = -1; // start with -1 to handle double &'s
                 char c2 = char.ToUpper(charCode, CultureInfo.CurrentCulture);
@@ -6824,7 +6824,7 @@ namespace System.Windows.Forms
                 {
                     WaitForWaitHandle(tme.AsyncWaitHandle);
                 }
-                if (tme._exception != null)
+                if (tme._exception is not null)
                 {
                     throw tme._exception;
                 }
@@ -6916,7 +6916,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected void InvokeOnClick(Control toInvoke, EventArgs e)
         {
-            if (toInvoke != null)
+            if (toInvoke is not null)
             {
                 toInvoke.OnClick(e);
             }
@@ -6939,7 +6939,7 @@ namespace System.Windows.Forms
             }
 
             object backBrush = Properties.GetObject(s_backBrushProperty);
-            if (backBrush != null)
+            if (backBrush is not null)
             {
                 if (GetState(States.OwnCtlBrush))
                 {
@@ -6960,7 +6960,7 @@ namespace System.Windows.Forms
             }
 
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -6988,7 +6988,7 @@ namespace System.Windows.Forms
             }
 
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -7019,7 +7019,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual void OnBindingContextChanged(EventArgs e)
         {
-            if (Properties.GetObject(s_bindingsProperty) != null)
+            if (Properties.GetObject(s_bindingsProperty) is not null)
             {
                 UpdateBindings();
             }
@@ -7030,7 +7030,7 @@ namespace System.Windows.Forms
             }
 
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -7057,7 +7057,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal virtual void OnChildLayoutResuming(Control child, bool performLayout)
         {
-            if (ParentInternal != null)
+            if (ParentInternal is not null)
             {
                 ParentInternal.OnChildLayoutResuming(child, performLayout);
             }
@@ -7081,7 +7081,7 @@ namespace System.Windows.Forms
             }
 
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -7134,7 +7134,7 @@ namespace System.Windows.Forms
             }
 
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -7183,7 +7183,7 @@ namespace System.Windows.Forms
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
             using (new LayoutTransaction(this, this, PropertyNames.Font, false))
             {
-                if (controlsCollection != null)
+                if (controlsCollection is not null)
                 {
                     // This may have changed the sizes of our children.
                     // PERFNOTE: This is more efficient than using Foreach.  Foreach
@@ -7215,7 +7215,7 @@ namespace System.Windows.Forms
             }
 
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -7247,7 +7247,7 @@ namespace System.Windows.Forms
             }
 
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -7330,7 +7330,7 @@ namespace System.Windows.Forms
             // restore ourselves over to the original control.
             // use SetParent directly so as to not raise ParentChanged events
             Control parent = ParentInternal;
-            if (parent != null)
+            if (parent is not null)
             {
                 if (IsHandleCreated)
                 {
@@ -7408,7 +7408,7 @@ namespace System.Windows.Forms
             {
                 // This control became invisible too - notify its children
                 ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-                if (controlsCollection != null)
+                if (controlsCollection is not null)
                 {
                     for (int i = 0; i < controlsCollection.Count; i++)
                     {
@@ -7497,7 +7497,7 @@ namespace System.Windows.Forms
                 _trackMouseEvent = default;
             }
 
-            if (_parent != null && visible && !Created)
+            if (_parent is not null && visible && !Created)
             {
                 bool isDisposing = GetAnyDisposingInHierarchy();
                 if (!isDisposing)
@@ -7514,7 +7514,7 @@ namespace System.Windows.Forms
             }
 
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -7537,7 +7537,7 @@ namespace System.Windows.Forms
         internal virtual void OnTopMostActiveXParentChanged(EventArgs e)
         {
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -7641,7 +7641,7 @@ namespace System.Windows.Forms
                 SetAcceptDrops(AllowDrop);
 
                 Region region = Region;
-                if (region != null)
+                if (region is not null)
                 {
                     SetRegion(region);
                 }
@@ -7663,7 +7663,7 @@ namespace System.Windows.Forms
                 }
 
                 // Set the window text from the Text property.
-                if (_text != null && _text.Length != 0)
+                if (_text is not null && _text.Length != 0)
                 {
                     User32.SetWindowTextW(new HandleRef(this, Handle), _text);
                 }
@@ -7761,7 +7761,7 @@ namespace System.Windows.Forms
                 if (GetState(States.OwnCtlBrush))
                 {
                     object backBrush = Properties.GetObject(s_backBrushProperty);
-                    if (backBrush != null)
+                    if (backBrush is not null)
                     {
                         Properties.SetObject(s_backBrushProperty, null);
                         Gdi32.HBRUSH p = (Gdi32.HBRUSH)backBrush;
@@ -7784,7 +7784,7 @@ namespace System.Windows.Forms
                 if (!GetAnyDisposingInHierarchy())
                 {
                     _text = Text;
-                    if (_text != null && _text.Length == 0)
+                    if (_text is not null && _text.Length == 0)
                     {
                         _text = null;
                     }
@@ -7881,7 +7881,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected void InvokeGotFocus(Control toInvoke, EventArgs e)
         {
-            if (toInvoke != null)
+            if (toInvoke is not null)
             {
                 toInvoke.OnGotFocus(e);
                 KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(toInvoke);
@@ -7899,7 +7899,7 @@ namespace System.Windows.Forms
                 ActiveXOnFocus(true);
             }
 
-            if (_parent != null)
+            if (_parent is not null)
             {
                 _parent.ChildGotFocus(this);
             }
@@ -7915,19 +7915,19 @@ namespace System.Windows.Forms
         protected virtual void OnHelpRequested(HelpEventArgs hevent)
         {
             HelpEventHandler handler = (HelpEventHandler)Events[s_helpRequestedEvent];
-            if (handler != null)
+            if (handler is not null)
             {
                 handler(this, hevent);
 
                 // Mark the event as handled so that the event isn't raised for the
                 // control's parent.
-                if (hevent != null)
+                if (hevent is not null)
                 {
                     hevent.Handled = true;
                 }
             }
 
-            if (hevent != null && !hevent.Handled)
+            if (hevent is not null && !hevent.Handled)
             {
                 ParentInternal?.OnHelpRequested(hevent);
             }
@@ -7948,7 +7948,7 @@ namespace System.Windows.Forms
 
             // Transparent control support
             ControlCollection controls = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controls != null)
+            if (controls is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -8007,7 +8007,7 @@ namespace System.Windows.Forms
             ((LayoutEventHandler)Events[s_layoutEvent])?.Invoke(this, levent);
 
             bool parentRequiresLayout = LayoutEngine.Layout(this, levent);
-            if (parentRequiresLayout && ParentInternal != null)
+            if (parentRequiresLayout && ParentInternal is not null)
             {
                 // LayoutEngine.Layout can return true to request that our parent resize us because
                 // we did not have enough room for our contents. We can not just call PerformLayout
@@ -8043,7 +8043,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected void InvokeLostFocus(Control toInvoke, EventArgs e)
         {
-            if (toInvoke != null)
+            if (toInvoke is not null)
             {
                 toInvoke.OnLostFocus(e);
                 KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(toInvoke);
@@ -8341,7 +8341,7 @@ namespace System.Windows.Forms
         protected virtual void OnSystemColorsChanged(EventArgs e)
         {
             ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-            if (controlsCollection != null)
+            if (controlsCollection is not null)
             {
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
@@ -8414,7 +8414,7 @@ namespace System.Windows.Forms
             // The rest of this won't do much if BackColor is transparent and there is no BackgroundImage,
             // but we need to call it in the partial alpha case.
 
-            if (BackgroundImage != null && !DisplayInformation.HighContrast && !formRTL)
+            if (BackgroundImage is not null && !DisplayInformation.HighContrast && !formRTL)
             {
                 if (BackgroundImageLayout == ImageLayout.Tile)
                 {
@@ -8537,7 +8537,7 @@ namespace System.Windows.Forms
                 // we use the wrapper in ButtonRenderer - this should do the right thing for all controls,
                 // not just Buttons.
 
-                if (transparentRegion != null)
+                if (transparentRegion is not null)
                 {
                     Graphics g = e.GraphicsInternal;
                     using var saveState = new GraphicsStateScope(g);
@@ -8569,7 +8569,7 @@ namespace System.Windows.Forms
 
             using PaintEventArgs newArgs = new PaintEventArgs(hdc, newClipRect);
 
-            if (transparentRegion != null)
+            if (transparentRegion is not null)
             {
                 using var saveState = new GraphicsStateScope(newArgs.Graphics);
 
@@ -8646,7 +8646,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                for (Control c = ParentInternal; c != null; c = c.ParentInternal)
+                for (Control c = ParentInternal; c is not null; c = c.ParentInternal)
                 {
                     if (c is ContainerControl)
                     {
@@ -8664,7 +8664,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public void PerformLayout()
         {
-            if (_cachedLayoutEventArgs != null)
+            if (_cachedLayoutEventArgs is not null)
             {
                 PerformLayout(_cachedLayoutEventArgs);
                 _cachedLayoutEventArgs = null;
@@ -8691,7 +8691,7 @@ namespace System.Windows.Forms
 
         internal void PerformLayout(LayoutEventArgs args)
         {
-            Debug.Assert(args != null, "This method should never be called with null args.");
+            Debug.Assert(args is not null, "This method should never be called with null args.");
             if (GetAnyDisposingInHierarchy())
             {
                 return;
@@ -8734,7 +8734,7 @@ namespace System.Windows.Forms
                 // LayoutEngine.Layout can return true to request that our parent resize us because
                 // we did not have enough room for our contents.  Now that we are unsuspended,
                 // see if this happened and layout parent if necessary.  (See also OnLayout)
-                if (ParentInternal != null && ParentInternal.GetState(States.LayoutIsDirty))
+                if (ParentInternal is not null && ParentInternal.GetState(States.LayoutIsDirty))
                 {
                     LayoutTransaction.DoLayout(ParentInternal, this, PropertyNames.PreferredSize);
                 }
@@ -9044,7 +9044,7 @@ namespace System.Windows.Forms
         {
             Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Control.ProcessCmdKey " + msg.ToString());
 
-            if (_parent != null)
+            if (_parent is not null)
             {
                 return _parent.ProcessCmdKey(ref msg, keyData);
             }
@@ -9262,7 +9262,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (kpe != null)
+            if (kpe is not null)
             {
                 Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "    processkeyeventarg returning: " + kpe.Handled);
                 m.WParam = newWParam;
@@ -9299,7 +9299,7 @@ namespace System.Windows.Forms
         protected internal virtual bool ProcessKeyMessage(ref Message m)
         {
             Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Control.ProcessKeyMessage " + m.ToString());
-            if (_parent != null && _parent.ProcessKeyPreview(ref m))
+            if (_parent is not null && _parent.ProcessKeyPreview(ref m))
             {
                 return true;
             }
@@ -9589,13 +9589,13 @@ namespace System.Windows.Forms
 
                     //fish out control collection w/o demand creating one.
                     ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-                    if (controlsCollection != null && controlsCollection.Count > 0)
+                    if (controlsCollection is not null && controlsCollection.Count > 0)
                     {
                         controlSnapshot = new Control[controlsCollection.Count];
                         for (int i = 0; i < controlsCollection.Count; i++)
                         {
                             Control childControl = controlsCollection[i];
-                            if (childControl != null && childControl.IsHandleCreated)
+                            if (childControl is not null && childControl.IsHandleCreated)
                             {
                                 // SetParent to parking window
                                 childControl.OnParentHandleRecreating();
@@ -9649,12 +9649,12 @@ namespace System.Windows.Forms
                     // - or -
                     // CreateHandle is successful.
                     //      We will move the child controls to the new parent.
-                    if (controlSnapshot != null && GetState(States.Created))
+                    if (controlSnapshot is not null && GetState(States.Created))
                     {
                         for (int i = 0; i < controlSnapshot.Length; i++)
                         {
                             Control childControl = controlSnapshot[i];
-                            if (childControl != null && childControl.IsHandleCreated)
+                            if (childControl is not null && childControl.IsHandleCreated)
                             {
                                 // Re-parent the control.
                                 // If the control fails to re-parent itself,
@@ -9861,7 +9861,7 @@ namespace System.Windows.Forms
                 // PERFNOTE: This is more efficient than using Foreach.  Foreach
                 // forces the creation of an array subset enum each time we
                 // enumerate
-                if (controlsCollection != null)
+                if (controlsCollection is not null)
                 {
                     for (int i = 0; i < controlsCollection.Count; i++)
                     {
@@ -9968,7 +9968,7 @@ namespace System.Windows.Forms
                 if (ScaleChildren)
                 {
                     ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
-                    if (controlsCollection != null)
+                    if (controlsCollection is not null)
                     {
                         // PERFNOTE: This is more efficient than using Foreach.  Foreach
                         // forces the creation of an array subset enum each time we
@@ -10040,7 +10040,7 @@ namespace System.Windows.Forms
             {
                 ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
 
-                if (controlsCollection != null)
+                if (controlsCollection is not null)
                 {
                     // PERFNOTE: This is more efficient than using Foreach.  Foreach
                     // forces the creation of an array subset enum each time we
@@ -10231,7 +10231,7 @@ namespace System.Windows.Forms
             Size scaledSize = LayoutUtils.IntersectSizes(rawScaledBounds.Size, maximumSize);
             scaledSize = LayoutUtils.UnionSizes(scaledSize, minSize);
 
-            if (DpiHelper.IsScalingRequirementMet && (ParentInternal != null) && (ParentInternal.LayoutEngine == DefaultLayout.Instance))
+            if (DpiHelper.IsScalingRequirementMet && (ParentInternal is not null) && (ParentInternal.LayoutEngine == DefaultLayout.Instance))
             {
                 // We need to scale AnchorInfo to update distances to container edges
                 DefaultLayout.ScaleAnchorInfo((IArrangedElement)this, factor);
@@ -10275,7 +10275,7 @@ namespace System.Windows.Forms
 
                 ControlCollection controlsCollection = (ControlCollection)Properties.GetObject(s_controlsCollectionProperty);
 
-                if (controlsCollection != null)
+                if (controlsCollection is not null)
                 {
                     // PERFNOTE: This is more efficient than using Foreach.  Foreach
                     // forces the creation of an array subset enum each time we
@@ -10325,7 +10325,7 @@ namespace System.Windows.Forms
         {
             IContainerControl c = GetContainerControl();
 
-            if (c != null)
+            if (c is not null)
             {
                 c.ActiveControl = this;
             }
@@ -10337,7 +10337,7 @@ namespace System.Windows.Forms
         public bool SelectNextControl(Control ctl, bool forward, bool tabStopOnly, bool nested, bool wrap)
         {
             Control nextSelectableControl = GetNextSelectableControl(ctl, forward, tabStopOnly, nested, wrap);
-            if (nextSelectableControl != null)
+            if (nextSelectableControl is not null)
             {
                 nextSelectableControl.Select(true, forward);
                 return true;
@@ -10401,11 +10401,11 @@ namespace System.Windows.Forms
             //           We want to move focus away from hidden controls, so this
             //           function was added.
             //
-            if (ContainsFocus && ParentInternal != null)
+            if (ContainsFocus && ParentInternal is not null)
             {
                 IContainerControl c = ParentInternal.GetContainerControl();
 
-                if (c != null)
+                if (c is not null)
                 {
                     ((Control)c).SelectNextControl(this, true, true, true, true);
                 }
@@ -10417,7 +10417,7 @@ namespace System.Windows.Forms
         /// </summary>
         public void SendToBack()
         {
-            if (_parent != null)
+            if (_parent is not null)
             {
                 _parent.Controls.SetChildIndex(this, -1);
             }
@@ -10515,7 +10515,7 @@ namespace System.Windows.Forms
 #if DEBUG
             int suspendCount = -44371;      // Arbitrary negative prime to surface bugs.
 #endif
-            if (ParentInternal != null)
+            if (ParentInternal is not null)
             {
 #if DEBUG
                 suspendCount = ParentInternal.LayoutSuspendCount;
@@ -10582,7 +10582,7 @@ namespace System.Windows.Forms
                 // Initialize the scaling engine.
                 InitScaling(specified);
 
-                if (ParentInternal != null)
+                if (ParentInternal is not null)
                 {
                     // Some layout engines (DefaultLayout) base their PreferredSize on
                     // the bounds of their children.  If we change change the child bounds, we
@@ -10689,7 +10689,7 @@ namespace System.Windows.Forms
                                 throw new Win32Exception(Marshal.GetLastWin32Error(), SR.Win32SetParentFailed);
                             }
 
-                            if (_parent != null)
+                            if (_parent is not null)
                             {
                                 _parent.UpdateChildZOrder(this);
                             }
@@ -10750,7 +10750,7 @@ namespace System.Windows.Forms
         {
             if (GetTopLevel() != value)
             {
-                if (_parent != null)
+                if (_parent is not null)
                 {
                     throw new ArgumentException(SR.TopLevelParentedControl, nameof(value));
                 }
@@ -10885,7 +10885,7 @@ namespace System.Windows.Forms
         internal static AutoValidate GetAutoValidateForControl(Control control)
         {
             ContainerControl parent = control.ParentContainerControl;
-            return (parent != null) ? parent.AutoValidate : AutoValidate.EnablePreventFocusChange;
+            return (parent is not null) ? parent.AutoValidate : AutoValidate.EnablePreventFocusChange;
         }
 
         /// <summary>
@@ -10925,7 +10925,7 @@ namespace System.Windows.Forms
         internal virtual bool ShouldSerializeCursor()
         {
             object cursor = Properties.GetObject(s_cursorProperty, out bool found);
-            return (found && cursor != null);
+            return (found && cursor is not null);
         }
 
         /// <summary>
@@ -10954,7 +10954,7 @@ namespace System.Windows.Forms
         internal virtual bool ShouldSerializeFont()
         {
             object font = Properties.GetObject(s_fontProperty, out bool found);
-            return (found && font != null);
+            return (found && font is not null);
         }
 
         /// <summary>
@@ -11315,7 +11315,7 @@ namespace System.Windows.Forms
             while ((hWnd = User32.GetWindow(hWnd, User32.GW.HWNDPREV)) != IntPtr.Zero)
             {
                 Control c = FromHandle(hWnd);
-                if (c != null)
+                if (c is not null)
                 {
                     newIndex = Controls.GetChildIndex(c, false) + 1;
                     break;
@@ -11358,7 +11358,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected void UpdateZOrder()
         {
-            if (_parent != null)
+            if (_parent is not null)
             {
                 _parent.UpdateChildZOrder(this);
             }
@@ -11487,7 +11487,7 @@ namespace System.Windows.Forms
 
         private void WmClose(ref Message m)
         {
-            if (ParentInternal != null)
+            if (ParentInternal is not null)
             {
                 IntPtr parentHandle = Handle;
                 IntPtr lastParentHandle = parentHandle;
@@ -11557,7 +11557,7 @@ namespace System.Windows.Forms
         internal void WmContextMenu(ref Message m, Control sourceControl)
         {
             var contextMenuStrip = (ContextMenuStrip)Properties.GetObject(s_contextMenuStripProperty);
-            if (contextMenuStrip != null)
+            if (contextMenuStrip is not null)
             {
                 int x = PARAM.SignedLOWORD(m.LParam);
                 int y = PARAM.SignedHIWORD(m.LParam);
@@ -11598,7 +11598,7 @@ namespace System.Windows.Forms
         {
             // We could simply reflect the message, but it's faster to handle it here if possible.
             Control control = FromHandle(m.LParam);
-            if (control != null)
+            if (control is not null)
             {
                 m.Result = (IntPtr)control.InitializeDCForWmCtlColor((Gdi32.HDC)m.WParam, (User32.WM)m.Msg);
                 if (m.Result != IntPtr.Zero)
@@ -11656,7 +11656,7 @@ namespace System.Windows.Forms
         {
             string name;
 
-            if (Site != null)
+            if (Site is not null)
             {
                 name = Site.Name;
             }
@@ -11707,13 +11707,13 @@ namespace System.Windows.Forms
 
             AccessibleObject ctrlAccessibleObject = GetAccessibilityObject(unchecked((int)(long)m.LParam));
 
-            if (ctrlAccessibleObject != null)
+            if (ctrlAccessibleObject is not null)
             {
                 intAccessibleObject = new InternalAccessibleObject(ctrlAccessibleObject);
             }
 
             // See "How to Handle WM_GETOBJECT" in MSDN
-            if (intAccessibleObject != null)
+            if (intAccessibleObject is not null)
             {
                 // Get the IAccessible GUID
                 Guid IID_IAccessible = new Guid(NativeMethods.uuid_IAccessible);
@@ -11776,7 +11776,7 @@ namespace System.Windows.Forms
         {
             // if there's currently a message box open - grab the help info from it.
             HelpInfo hpi = MessageBox.HelpInfo;
-            if (hpi != null)
+            if (hpi is not null)
             {
                 switch (hpi.Option)
                 {
@@ -11812,7 +11812,7 @@ namespace System.Windows.Forms
         {
             DefWndProc(ref m);
 
-            if (_parent != null)
+            if (_parent is not null)
             {
                 _parent.UpdateChildZOrder(this);
             }
@@ -11990,7 +11990,7 @@ namespace System.Windows.Forms
                 {
                     // Checking if font was inherited from parent. Font inherited from parent will receive OnParentFontChanged() events to scale those controls.
                     Font local = (Font)Properties.GetObject(s_fontProperty);
-                    if (local != null)
+                    if (local is not null)
                     {
                         var factor = (float)_deviceDpi / deviceDpiOld;
                         Font = new Font(local.FontFamily, local.Size * factor, local.Style, local.Unit, local.GdiCharSet, local.GdiVerticalFont);
@@ -12198,7 +12198,7 @@ namespace System.Windows.Forms
                 if (handle != IntPtr.Zero)
                 {
                     Control control = FromHandle(handle);
-                    if (control != null)
+                    if (control is not null)
                     {
                         m.Result = User32.SendMessageW(control, User32.WM.REFLECT | (User32.WM)m.Msg, handle, m.LParam);
                         reflectCalled = true;
@@ -12306,7 +12306,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (bufferedGraphics != null)
+            if (bufferedGraphics is not null)
             {
                 bufferedGraphics.Graphics.SetClip(clip);
                 pevent = new PaintEventArgs(
@@ -12460,7 +12460,7 @@ namespace System.Windows.Forms
             if (!HostedInWin32DialogManager)
             {
                 IContainerControl c = GetContainerControl();
-                if (c != null)
+                if (c is not null)
                 {
                     bool activateSucceed;
 
@@ -12532,7 +12532,7 @@ namespace System.Windows.Forms
 
                     // We do not want to update state if we are on the parking window.
                     bool parentVisible = GetTopLevel();
-                    if (ParentInternal != null)
+                    if (ParentInternal is not null)
                     {
                         parentVisible = ParentInternal.Visible;
                     }
@@ -12653,7 +12653,7 @@ namespace System.Windows.Forms
             DefWndProc(ref m);
             // Update new size / position
             UpdateBounds();
-            if (_parent != null && User32.GetParent(new HandleRef(_window, InternalHandle)) == _parent.InternalHandle &&
+            if (_parent is not null && User32.GetParent(new HandleRef(_window, InternalHandle)) == _parent.InternalHandle &&
                 (_state & States.NoZOrder) == 0)
             {
                 User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
@@ -13083,18 +13083,18 @@ namespace System.Windows.Forms
             bool sizeChanged = false;
             bool locationChanged = false;
 
-            if (site != null && site.DesignMode)
+            if (site is not null && site.DesignMode)
             {
                 ccs = (IComponentChangeService)site.GetService(typeof(IComponentChangeService));
-                if (ccs != null)
+                if (ccs is not null)
                 {
                     sizeProperty = TypeDescriptor.GetProperties(this)[PropertyNames.Size];
                     locationProperty = TypeDescriptor.GetProperties(this)[PropertyNames.Location];
-                    Debug.Assert(sizeProperty != null && locationProperty != null, "Error retrieving Size/Location properties on Control.");
+                    Debug.Assert(sizeProperty is not null && locationProperty is not null, "Error retrieving Size/Location properties on Control.");
 
                     try
                     {
-                        if (sizeProperty != null && !sizeProperty.IsReadOnly && (bounds.Width != Width || bounds.Height != Height))
+                        if (sizeProperty is not null && !sizeProperty.IsReadOnly && (bounds.Width != Width || bounds.Height != Height))
                         {
                             if (!(site is INestedSite))
                             {
@@ -13102,7 +13102,7 @@ namespace System.Windows.Forms
                             }
                             sizeChanged = true;
                         }
-                        if (locationProperty != null && !locationProperty.IsReadOnly && (bounds.X != _x || bounds.Y != _y))
+                        if (locationProperty is not null && !locationProperty.IsReadOnly && (bounds.X != _x || bounds.Y != _y))
                         {
                             if (!(site is INestedSite))
                             {
@@ -13122,7 +13122,7 @@ namespace System.Windows.Forms
 
             SetBoundsCore(bounds.X, bounds.Y, bounds.Width, bounds.Height, specified);
 
-            if (site != null && ccs != null)
+            if (site is not null && ccs is not null)
             {
                 try
                 {
@@ -13328,7 +13328,7 @@ namespace System.Windows.Forms
 
         unsafe HRESULT Ole32.IOleInPlaceObject.SetObjectRects(RECT* lprcPosRect, RECT* lprcClipRect)
         {
-            if (lprcClipRect != null)
+            if (lprcClipRect is not null)
             {
                 Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "AxSource:SetObjectRects(" + lprcClipRect->left + ", " + lprcClipRect->top + ", " + lprcClipRect->right + ", " + lprcClipRect->bottom + ")");
             }
@@ -13426,7 +13426,7 @@ namespace System.Windows.Forms
                 Debug.WriteLine("     activeSite: " + pActiveSite);
                 Debug.WriteLine("     index: " + lindex);
                 Debug.WriteLine("     hwndParent: " + hwndParent);
-                Debug.WriteLine("     posRect: " + (lprcPosRect != null ? (*lprcPosRect).ToString() : "null"));
+                Debug.WriteLine("     posRect: " + (lprcPosRect is not null ? (*lprcPosRect).ToString() : "null"));
             }
 #endif
             Debug.Indent();
@@ -13937,7 +13937,7 @@ namespace System.Windows.Forms
         bool IKeyboardToolTip.HasRtlModeEnabled()
         {
             Control topLevelControl = TopLevelControlInternal;
-            return topLevelControl != null && topLevelControl.RightToLeft == RightToLeft.Yes && !IsMirrored;
+            return topLevelControl is not null && topLevelControl.RightToLeft == RightToLeft.Yes && !IsMirrored;
         }
 
         bool IKeyboardToolTip.AllowsToolTip()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlBindingsCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlBindingsCollection.cs
@@ -115,7 +115,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentException(SR.BindingsCollectionAdd1, nameof(dataBinding));
             }
-            if (dataBinding.BindableComponent != null)
+            if (dataBinding.BindableComponent is not null)
             {
                 throw new ArgumentException(SR.BindingsCollectionAdd2, nameof(dataBinding));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -1169,7 +1169,7 @@ namespace System.Windows.Forms
                 bounds = new Rectangle(bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
 
                 Graphics graphics = context.TryGetGraphics(create: true);
-                if (graphics != null)
+                if (graphics is not null)
                 {
                     if (style == ButtonBorderStyle.Solid)
                     {
@@ -1380,7 +1380,7 @@ namespace System.Windows.Forms
             {
                 if (t_checkImage is null || t_checkImage.Width != rectangle.Width || t_checkImage.Height != rectangle.Height)
                 {
-                    if (t_checkImage != null)
+                    if (t_checkImage is not null)
                     {
                         t_checkImage.Dispose();
                         t_checkImage = null;
@@ -1549,7 +1549,7 @@ namespace System.Windows.Forms
             if (t_gridBrush is null || s_gridSize.Width != pixelsBetweenDots.Width
                 || s_gridSize.Height != pixelsBetweenDots.Height || invert != s_gridInvert)
             {
-                if (t_gridBrush != null)
+                if (t_gridBrush is not null)
                 {
                     t_gridBrush.Dispose();
                     t_gridBrush = null;
@@ -1604,7 +1604,7 @@ namespace System.Windows.Forms
         }
 
         internal static bool IsImageTransparent(Image backgroundImage)
-            => backgroundImage != null && (backgroundImage.Flags & (int)ImageFlags.HasAlpha) > 0;
+            => backgroundImage is not null && (backgroundImage.Flags & (int)ImageFlags.HasAlpha) > 0;
 
         // takes an image and replaces all the pixels of oldColor with newColor, drawing the new image into the rectangle on
         // the supplied Graphics object.
@@ -2188,7 +2188,7 @@ namespace System.Windows.Forms
 
             if (t_frameBrushActive is null || !s_frameColorActive.Equals(brushColor))
             {
-                if (t_frameBrushActive != null)
+                if (t_frameBrushActive is not null)
                 {
                     t_frameBrushActive.Dispose();
                     t_frameBrushActive = null;
@@ -2239,7 +2239,7 @@ namespace System.Windows.Forms
                 || (!highContrast && t_focusPenColor.GetBrightness() <= .5 && baseColor.GetBrightness() <= .5)
                 || t_focusPenColor.ToArgb() != baseColor.ToArgb())
             {
-                if (t_focusPen != null)
+                if (t_focusPen is not null)
                 {
                     t_focusPen.Dispose();
                     t_focusPen = null;
@@ -2314,7 +2314,7 @@ namespace System.Windows.Forms
 
             if (t_frameBrushSelected is null || !s_frameColorSelected.Equals(brushColor))
             {
-                if (t_frameBrushSelected != null)
+                if (t_frameBrushSelected is not null)
                 {
                     t_frameBrushSelected.Dispose();
                     t_frameBrushSelected = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CurrencyManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CurrencyManager.cs
@@ -593,12 +593,12 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(key));
             }
 
-            if (property != null && (list is IBindingList) && ((IBindingList)list).SupportsSearching)
+            if (property is not null && (list is IBindingList) && ((IBindingList)list).SupportsSearching)
             {
                 return ((IBindingList)list).Find(property, key);
             }
 
-            if (property != null)
+            if (property is not null)
             {
                 for (int i = 0; i < list.Count; i++)
                 {
@@ -1013,7 +1013,7 @@ namespace System.Windows.Forms
                 {
                     shouldBind = true;
                     // we need to put the listPosition at the beginning of the list if the list is not empty
-                    listposition = (list != null && list.Count != 0) ? 0 : -1;
+                    listposition = (list is not null && list.Count != 0) ? 0 : -1;
                     UpdateIsBinding();
                 }
             }
@@ -1053,8 +1053,8 @@ namespace System.Windows.Forms
 
         private void UpdateIsBinding(bool raiseItemChangedEvent)
         {
-            bool newBound = list != null && list.Count > 0 && shouldBind && listposition != -1;
-            if (list != null)
+            bool newBound = list is not null && list.Count > 0 && shouldBind && listposition != -1;
+            if (list is not null)
             {
                 if (bound != newBound)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -417,7 +417,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void LoadPicture(Ole32.IStream stream, string paramName)
         {
-            Debug.Assert(stream != null, "Stream should be validated before this method is called.");
+            Debug.Assert(stream is not null, "Stream should be validated before this method is called.");
 
             try
             {
@@ -426,7 +426,7 @@ namespace System.Windows.Forms
                 Ole32.IPersistStream ipictureAsIPersist = (Ole32.IPersistStream)picture;
                 ipictureAsIPersist.Load(stream);
 
-                if (picture != null && picture.Type == (short)Ole32.PICTYPE.ICON)
+                if (picture is not null && picture.Type == (short)Ole32.PICTYPE.ICON)
                 {
                     IntPtr cursorHandle = (IntPtr)picture.Handle;
                     Size picSize = GetIconSize(cursorHandle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CursorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CursorConverter.cs
@@ -172,7 +172,7 @@ namespace System.Windows.Forms
                 {
                     PropertyInfo prop = props[i];
                     object[] tempIndex = null;
-                    Debug.Assert(prop.GetValue(null, tempIndex) != null, "Property " + prop.Name + " returned NULL");
+                    Debug.Assert(prop.GetValue(null, tempIndex) is not null, "Property " + prop.Name + " returned NULL");
                     list.Add(prop.GetValue(null, tempIndex));
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -142,7 +142,7 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetFocused()
             {
-                if (_ownerDataGridView.Focused && _ownerDataGridView.CurrentCell != null)
+                if (_ownerDataGridView.Focused && _ownerDataGridView.CurrentCell is not null)
                 {
                     return _ownerDataGridView.CurrentCell.AccessibilityObject;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataConnection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataConnection.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (CurrencyManager != null)
+                    if (CurrencyManager is not null)
                     {
                         // we only allow to add new rows on an IBindingList
                         return (CurrencyManager.List is IBindingList) && CurrencyManager.AllowAdd && ((IBindingList)CurrencyManager.List).SupportsChangeNotification;
@@ -102,7 +102,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (CurrencyManager != null)
+                    if (CurrencyManager is not null)
                     {
                         return CurrencyManager.AllowEdit;
                     }
@@ -117,7 +117,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (CurrencyManager != null)
+                    if (CurrencyManager is not null)
                     {
                         // we only allow deletion on an IBindingList
                         return (CurrencyManager.List is IBindingList) && CurrencyManager.AllowRemove && ((IBindingList)CurrencyManager.List).SupportsChangeNotification;
@@ -167,7 +167,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (CurrencyManager != null)
+                    if (CurrencyManager is not null)
                     {
                         return CurrencyManager.List;
                     }
@@ -225,7 +225,7 @@ namespace System.Windows.Forms
 
             public void AddNew()
             {
-                if (CurrencyManager != null)
+                if (CurrencyManager is not null)
                 {
                     // don't call AddNew on a suspended currency manager.
                     if (!CurrencyManager.ShouldBind)
@@ -344,7 +344,7 @@ namespace System.Windows.Forms
 
             public TypeConverter BoundColumnConverter(int boundColumnIndex)
             {
-                Debug.Assert(_props != null);
+                Debug.Assert(_props is not null);
                 return _props[boundColumnIndex].Converter;
             }
 
@@ -372,8 +372,8 @@ namespace System.Windows.Forms
 
             public SortOrder BoundColumnSortOrder(int boundColumnIndex)
             {
-                IBindingList ibl = CurrencyManager != null ? CurrencyManager.List as IBindingList : null;
-                IBindingListView iblv = ibl != null ? ibl as IBindingListView : null;
+                IBindingList ibl = CurrencyManager is not null ? CurrencyManager.List as IBindingList : null;
+                IBindingListView iblv = ibl is not null ? ibl as IBindingListView : null;
 
                 if (ibl is null || !ibl.SupportsSorting || !ibl.IsSorted)
                 {
@@ -400,7 +400,7 @@ namespace System.Windows.Forms
 
             public Type BoundColumnValueType(int boundColumnIndex)
             {
-                Debug.Assert(_props != null);
+                Debug.Assert(_props is not null);
                 return _props[boundColumnIndex].PropertyType;
             }
 
@@ -682,7 +682,7 @@ namespace System.Windows.Forms
                         case ListChangedType.ItemChanged:
                             Debug.Assert(e.NewIndex != -1, "the item changed event does not cover changes to the entire list");
                             string dataPropertyName = null;
-                            if (e.PropertyDescriptor != null)
+                            if (e.PropertyDescriptor is not null)
                             {
                                 dataPropertyName = ((MemberDescriptor)(e.PropertyDescriptor)).Name;
                             }
@@ -850,14 +850,14 @@ namespace System.Windows.Forms
 
                 // Update the data manager
                 SetDataConnection(DataSource, DataMember);
-                Debug.Assert(CurrencyManager != null);
+                Debug.Assert(CurrencyManager is not null);
                 _owner.RefreshColumnsAndRows();
                 _owner.OnDataBindingComplete(ListChangedType.Reset);
             }
 
             private void DataSourceMetaDataChanged()
             {
-                Debug.Assert(CurrencyManager != null);
+                Debug.Assert(CurrencyManager is not null);
 
                 // get the new meta data
                 _props = CurrencyManager.GetItemProperties();
@@ -1026,8 +1026,8 @@ namespace System.Windows.Forms
 
             private void GetSortingInformationFromBackend(out PropertyDescriptor sortProperty, out SortOrder sortOrder)
             {
-                IBindingList ibl = CurrencyManager != null ? CurrencyManager.List as IBindingList : null;
-                IBindingListView iblv = ibl != null ? ibl as IBindingListView : null;
+                IBindingList ibl = CurrencyManager is not null ? CurrencyManager.List as IBindingList : null;
+                IBindingListView iblv = ibl is not null ? ibl as IBindingListView : null;
 
                 if (ibl is null || !ibl.SupportsSorting || !ibl.IsSorted)
                 {
@@ -1036,20 +1036,20 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                if (ibl.SortProperty != null)
+                if (ibl.SortProperty is not null)
                 {
                     sortProperty = ibl.SortProperty;
                     sortOrder = ibl.SortDirection == ListSortDirection.Ascending ? SortOrder.Ascending : SortOrder.Descending;
                 }
-                else if (iblv != null)
+                else if (iblv is not null)
                 {
                     // Maybe the data view is sorted on multiple columns.
                     // Go thru the IBindingListView which offers the entire list of sorted columns
                     // and pick the first one as the SortedColumn.
                     ListSortDescriptionCollection sorts = iblv.SortDescriptions;
-                    if (sorts != null &&
+                    if (sorts is not null &&
                         sorts.Count > 0 &&
-                        sorts[0].PropertyDescriptor != null)
+                        sorts[0].PropertyDescriptor is not null)
                     {
                         sortProperty = sorts[0].PropertyDescriptor;
                         sortOrder = sorts[0].SortDirection == ListSortDirection.Ascending ? SortOrder.Ascending : SortOrder.Descending;
@@ -1079,7 +1079,7 @@ namespace System.Windows.Forms
                 // Microsoft: I wish there would be a Reset method on BitVector32...
                 _dataConnectionState = new BitVector32(DATACONNECTIONSTATE_finishedAddNew);
 
-                if (CurrencyManager != null)
+                if (CurrencyManager is not null)
                 {
                     _dataConnectionState[DATACONNECTIONSTATE_interestedInRowEvents] = true;
                 }
@@ -1124,10 +1124,10 @@ namespace System.Windows.Forms
                     // unwire the events
                     UnWireEvents();
 
-                    if (this.DataSource != null && _owner.BindingContext != null && !(this.DataSource == Convert.DBNull))
+                    if (this.DataSource is not null && _owner.BindingContext is not null && !(this.DataSource == Convert.DBNull))
                     {
                         dsInit = this.DataSource as ISupportInitializeNotification;
-                        if (dsInit != null && !dsInit.IsInitialized)
+                        if (dsInit is not null && !dsInit.IsInitialized)
                         {
                             if (!_dataConnectionState[DATACONNECTIONSTATE_dataSourceInitializedHookedUp])
                             {
@@ -1148,7 +1148,7 @@ namespace System.Windows.Forms
 
                     // wire the events
                     WireEvents();
-                    if (CurrencyManager != null)
+                    if (CurrencyManager is not null)
                     {
                         _props = CurrencyManager.GetItemProperties();
                     }
@@ -1164,7 +1164,7 @@ namespace System.Windows.Forms
 
                 ResetCachedAllowUserToAddRowsInternal();
 
-                if (CurrencyManager != null)
+                if (CurrencyManager is not null)
                 {
                     _lastListCount = CurrencyManager.Count;
                 }
@@ -1196,7 +1196,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (errInfo != null)
+                if (errInfo is not null)
                 {
                     return errInfo.Error;
                 }
@@ -1230,7 +1230,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (errInfo != null)
+                if (errInfo is not null)
                 {
                     return errInfo[_props[boundColumnIndex].Name];
                 }
@@ -1271,7 +1271,7 @@ namespace System.Windows.Forms
                 {
 #if DEBUG
                     // all the properties in the currency manager should be either Browsable(false) or point to sub lists
-                    if (_props != null)
+                    if (_props is not null)
                     {
                         for (int i = 0; i < _props.Count; i++)
                         {
@@ -1290,7 +1290,7 @@ namespace System.Windows.Forms
                 if (columnIndex == -1)
                 {
                     DataGridViewColumn dataGridViewColumn = _owner.Columns.GetFirstColumn(DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     dataGridViewColumn.Visible = true;
                     columnIndex = dataGridViewColumn.Index;
                 }
@@ -1371,7 +1371,7 @@ namespace System.Windows.Forms
                         editableObject = CurrencyManager.Current as IEditableObject;
                     }
 
-                    if (editableObject != null && currentItem == editableObject)
+                    if (editableObject is not null && currentItem == editableObject)
                     {
                         editableObject.BeginEdit();
                     }
@@ -1536,7 +1536,7 @@ namespace System.Windows.Forms
             {
                 try
                 {
-                    if (value != null)
+                    if (value is not null)
                     {
                         Type valueType = value.GetType();
                         Type columnType = _owner.Columns[columnIndex].ValueType;
@@ -1544,14 +1544,14 @@ namespace System.Windows.Forms
                         {
                             // value needs to be converted before being fed to the back-end.
                             TypeConverter boundColumnConverter = BoundColumnConverter(boundColumnIndex);
-                            if (boundColumnConverter != null && boundColumnConverter.CanConvertFrom(valueType))
+                            if (boundColumnConverter is not null && boundColumnConverter.CanConvertFrom(valueType))
                             {
                                 value = boundColumnConverter.ConvertFrom(value);
                             }
                             else
                             {
                                 TypeConverter valueConverter = _owner.GetCachedTypeConverter(valueType);
-                                if (valueConverter != null && valueConverter.CanConvertTo(columnType))
+                                if (valueConverter is not null && valueConverter.CanConvertTo(columnType))
                                 {
                                     value = valueConverter.ConvertTo(value, columnType);
                                 }
@@ -1601,7 +1601,7 @@ namespace System.Windows.Forms
                 }
 
                 PropertyDescriptorCollection props = cm.GetItemProperties();
-                if (DataMember.Length != 0 && props[DataMember] != null)
+                if (DataMember.Length != 0 && props[DataMember] is not null)
                 {
                     // the data member is valid. Don't change it
                     return false;
@@ -1619,7 +1619,7 @@ namespace System.Windows.Forms
 
             private void UnWireEvents()
             {
-                if (CurrencyManager != null)
+                if (CurrencyManager is not null)
                 {
                     CurrencyManager.PositionChanged -= new EventHandler(currencyManager_PositionChanged);
                     CurrencyManager.ListChanged -= new ListChangedEventHandler(currencyManager_ListChanged);
@@ -1629,7 +1629,7 @@ namespace System.Windows.Forms
 
             private void WireEvents()
             {
-                if (CurrencyManager != null)
+                if (CurrencyManager is not null)
                 {
                     CurrencyManager.PositionChanged += new EventHandler(currencyManager_PositionChanged);
                     CurrencyManager.ListChanged += new ListChangedEventHandler(currencyManager_ListChanged);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
@@ -52,7 +52,7 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.NavigateDirection.Parent:
                         DataGridViewCell currentCell = _ownerDataGridView.CurrentCell;
-                        if (currentCell != null && _ownerDataGridView.IsCurrentCellInEditMode)
+                        if (currentCell is not null && _ownerDataGridView.IsCurrentCellInEditMode)
                         {
                             return currentCell.AccessibilityObject;
                         }
@@ -93,7 +93,7 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return true;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
-                        return _ownerDataGridView.CurrentCell != null;
+                        return _ownerDataGridView.CurrentCell is not null;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _ownerDataGridView.Enabled;
                     case UiaCore.UIA.IsOffscreenPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -298,7 +298,7 @@ namespace System.Windows.Forms
 
         private bool AdjustExpandingColumn(DataGridViewColumn dataGridViewColumn, int rowIndex)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             Debug.Assert(rowIndex > -1);
             Debug.Assert(rowIndex < Rows.Count);
 
@@ -343,7 +343,7 @@ namespace System.Windows.Forms
 
             bool ret = false; // No column autosizes by default
             DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-            while (dataGridViewColumn != null)
+            while (dataGridViewColumn is not null)
             {
                 DataGridViewAutoSizeColumnCriteriaInternal inheritedAutoSizeColumnCriteria = (DataGridViewAutoSizeColumnCriteriaInternal)dataGridViewColumn.InheritedAutoSizeMode;
                 DataGridViewAutoSizeColumnCriteriaInternal autoSizeColumnCriteriaFiltered = (inheritedAutoSizeColumnCriteria & autoSizeColumnCriteriaFilter);
@@ -528,7 +528,7 @@ namespace System.Windows.Forms
 
             try
             {
-                Debug.Assert(dataGridViewColumn != null);
+                Debug.Assert(dataGridViewColumn is not null);
                 Debug.Assert(dataGridViewColumn.Visible);
                 Debug.Assert(!dataGridViewColumn.Frozen);
                 Debug.Assert(dataGridViewColumn.MinimumWidth <= width);
@@ -1123,7 +1123,7 @@ namespace System.Windows.Forms
                                             }
                                         }
                                     }
-                                    if (mostDeservingDataGridViewColumn != null)
+                                    if (mostDeservingDataGridViewColumn is not null)
                                     {
                                         float floatDesiredWidth = (stepDownAvailableWidthForFillColumns * mostDeservingDataGridViewColumn.UsedFillWeight / weightSum) - widthLoss * mostDeservingDataGridViewColumn.UsedFillWeight / mostDeservingDataGridViewColumn.FillWeight / fillWeightRatioSum;
                                         if (floatDesiredWidth < (float)mostDeservingDataGridViewColumn.MinimumWidth)
@@ -1376,7 +1376,7 @@ namespace System.Windows.Forms
                                 dataGridViewRow = Rows[rowIndex]; // unshares this row
 
                                 DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-                                while (dataGridViewColumn != null)
+                                while (dataGridViewColumn is not null)
                                 {
                                     if (!dataGridViewRow.Cells[dataGridViewColumn.Index].Selected)
                                     {
@@ -1401,7 +1401,7 @@ namespace System.Windows.Forms
                         else
                         {
                             DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-                            while (dataGridViewColumn != null)
+                            while (dataGridViewColumn is not null)
                             {
                                 if (!_selectedBandIndexes.Contains(dataGridViewColumn.Index))
                                 {
@@ -1443,7 +1443,7 @@ namespace System.Windows.Forms
                                 {
                                     dataGridViewRow = Rows[rowIndex]; // unshares this row
                                     DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-                                    while (dataGridViewColumn != null)
+                                    while (dataGridViewColumn is not null)
                                     {
                                         if (!dataGridViewRow.Cells[dataGridViewColumn.Index].Selected)
                                         {
@@ -1496,7 +1496,7 @@ namespace System.Windows.Forms
             // We can't do 1. and 2. in the same loop because we need to save the DisplayIndex.
             for (i = 0; i < dataGridViewCols.Count; i++)
             {
-                if (DataSource != null &&
+                if (DataSource is not null &&
                     !string.IsNullOrEmpty(dataGridViewCols[i].DataPropertyName) &&
                     !dataGridViewCols[i].IsDataBound)
                 {
@@ -1506,7 +1506,7 @@ namespace System.Windows.Forms
                 if (dataGridViewCols[i].IsDataBound)
                 {
                     // We only clone columns which are data bound w/ the new DataSource/DataMember combination.
-                    if (DataConnection != null && DataConnection.BoundColumnIndex(dataGridViewCols[i].DataPropertyName) != -1)
+                    if (DataConnection is not null && DataConnection.BoundColumnIndex(dataGridViewCols[i].DataPropertyName) != -1)
                     {
                         clonedColumns[clonedColumnsCount] = (DataGridViewColumn)dataGridViewCols[i].Clone();
                         clonedColumns[clonedColumnsCount].DisplayIndex = dataGridViewCols[i].DisplayIndex;
@@ -1548,18 +1548,18 @@ namespace System.Windows.Forms
             Array.Sort(finalClonedColumns, System.Windows.Forms.DataGridViewColumnCollection.ColumnCollectionOrderComparer);
 
             // 4. Add new columns for the Fields which were not data bound previously ( ie, for fields which do not have a clone ).
-            if (boundColumns != null)
+            if (boundColumns is not null)
             {
                 for (int j = 0; j < boundColumns.Length; j++)
                 {
-                    if (boundColumns[j] != null && boundColumns[j].IsBrowsableInternal)
+                    if (boundColumns[j] is not null && boundColumns[j].IsBrowsableInternal)
                     {
                         bool addNewColumn = true;
                         // Go thru the list of cloned columns and see if there is another column w/ the same data property name.
                         int clonedColIndex = 0;
                         for (; clonedColIndex < clonedColumnsCount; clonedColIndex++)
                         {
-                            if (finalClonedColumns[clonedColIndex] != null &&
+                            if (finalClonedColumns[clonedColIndex] is not null &&
                                 string.Compare(finalClonedColumns[clonedColIndex].DataPropertyName,
                                     boundColumns[j].DataPropertyName,
                                     true /*ignoreCase*/,
@@ -1599,7 +1599,7 @@ namespace System.Windows.Forms
             {
                 for (int k = 0; k < finalClonedColumns.Length; k++)
                 {
-                    if (finalClonedColumns[k] != null)
+                    if (finalClonedColumns[k] is not null)
                     {
                         dataGridViewCols.Add(finalClonedColumns[k]);
                         MapDataGridViewColumnToDataBoundField(finalClonedColumns[k]);
@@ -1616,7 +1616,7 @@ namespace System.Windows.Forms
 
             bool ret = false; // No column autosizes by default
             DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-            while (dataGridViewColumn != null)
+            while (dataGridViewColumn is not null)
             {
                 DataGridViewAutoSizeColumnCriteriaInternal inheritedAutoSizeColumnCriteria = (DataGridViewAutoSizeColumnCriteriaInternal)dataGridViewColumn.InheritedAutoSizeMode;
                 DataGridViewAutoSizeColumnCriteriaInternal autoSizeColumnCriteriaFiltered = (inheritedAutoSizeColumnCriteria & autoSizeColumnCriteriaFilter);
@@ -2569,7 +2569,7 @@ namespace System.Windows.Forms
                 Debug.Assert(!IsCurrentCellInEditMode);
 
                 DataGridViewCell dataGridViewCell = CurrentCellInternal;
-                Debug.Assert(dataGridViewCell != null);
+                Debug.Assert(dataGridViewCell is not null);
 
                 if (IsSharedCellReadOnly(dataGridViewCell, _ptCurrentCell.Y) ||
                     !ColumnEditable(_ptCurrentCell.X))
@@ -2643,7 +2643,7 @@ namespace System.Windows.Forms
                 {
                     throw new InvalidCastException(SR.DataGridView_InvalidEditingControl);
                 }
-                if (_latestEditingControl != null &&
+                if (_latestEditingControl is not null &&
                     editControlType.IsInstanceOfType(_latestEditingControl) &&
                     !_latestEditingControl.GetType().IsSubclassOf(editControlType))
                 {
@@ -2654,17 +2654,17 @@ namespace System.Windows.Forms
                 {
                     Debug.Assert(EditingControl is null);
                     EditingControl = (Control)Activator.CreateInstance(editControlType);
-                    Debug.Assert(EditingControl != null);
+                    Debug.Assert(EditingControl is not null);
 
                     ((IDataGridViewEditingControl)EditingControl).EditingControlDataGridView = this;
-                    if (_latestEditingControl != null)
+                    if (_latestEditingControl is not null)
                     {
                         _latestEditingControl.Dispose();
                         _latestEditingControl = null;
                     }
                 }
 
-                Debug.Assert(EditingControl != null);
+                Debug.Assert(EditingControl is not null);
                 if (string.IsNullOrEmpty(EditingControl.AccessibleName))
                 {
                     EditingControl.AccessibleName = SR.DataGridView_AccEditingControlAccName;
@@ -2677,11 +2677,11 @@ namespace System.Windows.Forms
 
                 WireEditingControlEvents();
 
-                Debug.Assert(EditingControl != null);
-                Debug.Assert(_editingPanel != null);
+                Debug.Assert(EditingControl is not null);
+                Debug.Assert(_editingPanel is not null);
                 DataGridViewEditingControlShowingEventArgs dgvese = new DataGridViewEditingControlShowingEventArgs(EditingControl, dataGridViewCellStyle);
                 OnEditingControlShowing(dgvese);
-                Debug.Assert(dgvese.CellStyle != null);
+                Debug.Assert(dgvese.CellStyle is not null);
                 if (_editingPanel is null || EditingControl is null)
                 {
                     return false;
@@ -2775,22 +2775,22 @@ namespace System.Windows.Forms
 
         private void BuildInheritedColumnHeaderCellStyle(DataGridViewCellStyle inheritedCellStyle, DataGridViewCell cell)
         {
-            Debug.Assert(inheritedCellStyle != null);
+            Debug.Assert(inheritedCellStyle is not null);
 
             DataGridViewCellStyle cellStyle = null;
             if (cell.HasStyle)
             {
                 cellStyle = cell.Style;
-                Debug.Assert(cellStyle != null);
+                Debug.Assert(cellStyle is not null);
             }
 
             DataGridViewCellStyle columnHeadersStyle = ColumnHeadersDefaultCellStyle;
-            Debug.Assert(columnHeadersStyle != null);
+            Debug.Assert(columnHeadersStyle is not null);
 
             DataGridViewCellStyle dataGridViewStyle = DefaultCellStyle;
-            Debug.Assert(dataGridViewStyle != null);
+            Debug.Assert(dataGridViewStyle is not null);
 
-            if (cellStyle != null && !cellStyle.BackColor.IsEmpty)
+            if (cellStyle is not null && !cellStyle.BackColor.IsEmpty)
             {
                 inheritedCellStyle.BackColor = cellStyle.BackColor;
             }
@@ -2803,7 +2803,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.BackColor = dataGridViewStyle.BackColor;
             }
 
-            if (cellStyle != null && !cellStyle.ForeColor.IsEmpty)
+            if (cellStyle is not null && !cellStyle.ForeColor.IsEmpty)
             {
                 inheritedCellStyle.ForeColor = cellStyle.ForeColor;
             }
@@ -2816,7 +2816,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.ForeColor = dataGridViewStyle.ForeColor;
             }
 
-            if (cellStyle != null && !cellStyle.SelectionBackColor.IsEmpty)
+            if (cellStyle is not null && !cellStyle.SelectionBackColor.IsEmpty)
             {
                 inheritedCellStyle.SelectionBackColor = cellStyle.SelectionBackColor;
             }
@@ -2829,7 +2829,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.SelectionBackColor = dataGridViewStyle.SelectionBackColor;
             }
 
-            if (cellStyle != null && !cellStyle.SelectionForeColor.IsEmpty)
+            if (cellStyle is not null && !cellStyle.SelectionForeColor.IsEmpty)
             {
                 inheritedCellStyle.SelectionForeColor = cellStyle.SelectionForeColor;
             }
@@ -2842,11 +2842,11 @@ namespace System.Windows.Forms
                 inheritedCellStyle.SelectionForeColor = dataGridViewStyle.SelectionForeColor;
             }
 
-            if (cellStyle != null && cellStyle.Font != null)
+            if (cellStyle is not null && cellStyle.Font is not null)
             {
                 inheritedCellStyle.Font = cellStyle.Font;
             }
-            else if (columnHeadersStyle.Font != null)
+            else if (columnHeadersStyle.Font is not null)
             {
                 inheritedCellStyle.Font = columnHeadersStyle.Font;
             }
@@ -2855,7 +2855,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.Font = dataGridViewStyle.Font;
             }
 
-            if (cellStyle != null && !cellStyle.IsNullValueDefault)
+            if (cellStyle is not null && !cellStyle.IsNullValueDefault)
             {
                 inheritedCellStyle.NullValue = cellStyle.NullValue;
             }
@@ -2868,7 +2868,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.NullValue = dataGridViewStyle.NullValue;
             }
 
-            if (cellStyle != null && !cellStyle.IsDataSourceNullValueDefault)
+            if (cellStyle is not null && !cellStyle.IsDataSourceNullValueDefault)
             {
                 inheritedCellStyle.DataSourceNullValue = cellStyle.DataSourceNullValue;
             }
@@ -2881,7 +2881,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.DataSourceNullValue = dataGridViewStyle.DataSourceNullValue;
             }
 
-            if (cellStyle != null && cellStyle.Format.Length != 0)
+            if (cellStyle is not null && cellStyle.Format.Length != 0)
             {
                 inheritedCellStyle.Format = cellStyle.Format;
             }
@@ -2894,7 +2894,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.Format = dataGridViewStyle.Format;
             }
 
-            if (cellStyle != null && !cellStyle.IsFormatProviderDefault)
+            if (cellStyle is not null && !cellStyle.IsFormatProviderDefault)
             {
                 inheritedCellStyle.FormatProvider = cellStyle.FormatProvider;
             }
@@ -2907,11 +2907,11 @@ namespace System.Windows.Forms
                 inheritedCellStyle.FormatProvider = dataGridViewStyle.FormatProvider;
             }
 
-            if (cellStyle != null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
+            if (cellStyle is not null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyle.AlignmentInternal = cellStyle.Alignment;
             }
-            else if (columnHeadersStyle != null && columnHeadersStyle.Alignment != DataGridViewContentAlignment.NotSet)
+            else if (columnHeadersStyle is not null && columnHeadersStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyle.AlignmentInternal = columnHeadersStyle.Alignment;
             }
@@ -2921,11 +2921,11 @@ namespace System.Windows.Forms
                 inheritedCellStyle.AlignmentInternal = dataGridViewStyle.Alignment;
             }
 
-            if (cellStyle != null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
+            if (cellStyle is not null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyle.WrapModeInternal = cellStyle.WrapMode;
             }
-            else if (columnHeadersStyle != null && columnHeadersStyle.WrapMode != DataGridViewTriState.NotSet)
+            else if (columnHeadersStyle is not null && columnHeadersStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyle.WrapModeInternal = columnHeadersStyle.WrapMode;
             }
@@ -2935,11 +2935,11 @@ namespace System.Windows.Forms
                 inheritedCellStyle.WrapModeInternal = dataGridViewStyle.WrapMode;
             }
 
-            if (cellStyle != null && cellStyle.Tag != null)
+            if (cellStyle is not null && cellStyle.Tag is not null)
             {
                 inheritedCellStyle.Tag = cellStyle.Tag;
             }
-            else if (columnHeadersStyle.Tag != null)
+            else if (columnHeadersStyle.Tag is not null)
             {
                 inheritedCellStyle.Tag = columnHeadersStyle.Tag;
             }
@@ -2948,7 +2948,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.Tag = dataGridViewStyle.Tag;
             }
 
-            if (cellStyle != null && cellStyle.Padding != Padding.Empty)
+            if (cellStyle is not null && cellStyle.Padding != Padding.Empty)
             {
                 inheritedCellStyle.PaddingInternal = cellStyle.Padding;
             }
@@ -3041,7 +3041,7 @@ namespace System.Windows.Forms
 
                 if (IsCurrentCellInEditMode)
                 {
-                    if (endEdit && EditMode != DataGridViewEditMode.EditOnEnter && EditingControl != null)
+                    if (endEdit && EditMode != DataGridViewEditMode.EditOnEnter && EditingControl is not null)
                     {
                         bool success = EndEdit(DataGridViewDataErrorContexts.Parsing | DataGridViewDataErrorContexts.InitialValueRestoration,
                                                DataGridViewValidateCellInternal.Never /*validateCell*/,
@@ -3062,7 +3062,7 @@ namespace System.Windows.Forms
                         try
                         {
                             _dataGridViewState1[State1_IgnoringEditingChanges] = true;
-                            if (EditingControl != null)
+                            if (EditingControl is not null)
                             {
                                 ((IDataGridViewEditingControl)EditingControl).EditingControlFormattedValue = _uneditedFormattedValue;
                                 ((IDataGridViewEditingControl)EditingControl).EditingControlValueChanged = false;
@@ -3071,7 +3071,7 @@ namespace System.Windows.Forms
                             {
                                 Debug.Assert(_dataGridViewState1[State1_CurrentCellInEditMode]);
                                 dataGridViewEditingCell = CurrentCellInternal as IDataGridViewEditingCell;
-                                Debug.Assert(dataGridViewEditingCell != null);
+                                Debug.Assert(dataGridViewEditingCell is not null);
                                 dataGridViewEditingCell.EditingCellFormattedValue = _uneditedFormattedValue;
                                 dataGridViewEditingCell.EditingCellValueChanged = false;
                             }
@@ -3090,7 +3090,7 @@ namespace System.Windows.Forms
                         {
                             _dataGridViewState1[State1_IgnoringEditingChanges] = false;
                         }
-                        if (dgvdee2 != null)
+                        if (dgvdee2 is not null)
                         {
                             OnDataErrorInternal(dgvdee2);
                             if (dgvdee2.ThrowException)
@@ -3099,13 +3099,13 @@ namespace System.Windows.Forms
                             }
                         }
 
-                        if (EditingControl != null)
+                        if (EditingControl is not null)
                         {
                             ((IDataGridViewEditingControl)EditingControl).PrepareEditingControlForEdit(true /*selectAll*/);
                         }
                         else
                         {
-                            Debug.Assert(dataGridViewEditingCell != null);
+                            Debug.Assert(dataGridViewEditingCell is not null);
                             dataGridViewEditingCell.PrepareEditingCellForEdit(true /*selectAll*/);
                             InvalidateCellPrivate(_ptCurrentCell.X, _ptCurrentCell.Y);
                         }
@@ -3152,7 +3152,7 @@ namespace System.Windows.Forms
                 /* Do not push original value back into the cell
 
 */
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     ((IDataGridViewEditingControl)EditingControl).EditingControlValueChanged = false;
                 }
@@ -3164,7 +3164,7 @@ namespace System.Windows.Forms
                 IsCurrentCellDirtyInternal = false;
             }
 
-            if (DataSource != null || VirtualMode)
+            if (DataSource is not null || VirtualMode)
             {
                 if ((currentRowDirty && !currentCellDirty) ||
                     (_dataGridViewState1[State1_NewRowEdited] &&
@@ -3178,7 +3178,7 @@ namespace System.Windows.Forms
                         OnCancelRowEdit(qe);
                         discardNewRow &= qe.Response;
                     }
-                    if (DataSource != null)
+                    if (DataSource is not null)
                     {
                         int oldCurrentCellX = _ptCurrentCell.X;
                         DataConnection.CancelRowEdit(true /*restoreRow*/, _dataGridViewState1[State1_NewRowEdited]/*addNewFinished*/);
@@ -3218,7 +3218,7 @@ namespace System.Windows.Forms
                         if (IsCurrentCellInEditMode)
                         {
                             DataGridViewCellStyle dataGridViewCellStyle = dataGridViewCell.GetInheritedStyle(null, _ptCurrentCell.Y, true);
-                            if (EditingControl != null)
+                            if (EditingControl is not null)
                             {
                                 InitializeEditingControlValue(ref dataGridViewCellStyle, dataGridViewCell);
                                 if (((IDataGridViewEditingControl)EditingControl).RepositionEditingControlOnValueChange)
@@ -3293,7 +3293,7 @@ namespace System.Windows.Forms
                 return true;
             }
 
-            Debug.Assert(dataGridViewCurrentCell.OwningColumn != null);
+            Debug.Assert(dataGridViewCurrentCell.OwningColumn is not null);
 
             if (!dataGridViewCurrentCell.OwningColumn.IsDataBoundInternal)
             {
@@ -3571,7 +3571,7 @@ namespace System.Windows.Forms
         {
             Debug.Assert(columnIndex >= 0 && columnIndex < Columns.Count, "Invalid columnIndex: " + columnIndex);
             if (Columns[columnIndex].IsDataBound &&
-                DataConnection != null &&
+                DataConnection is not null &&
                 !DataConnection.AllowEdit)
             {
                 return false;
@@ -3581,7 +3581,7 @@ namespace System.Windows.Forms
 
         private bool ColumnNeedsDisplayedState(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
 
             if (!dataGridViewColumn.Visible)
             {
@@ -3591,7 +3591,7 @@ namespace System.Windows.Forms
             if (dataGridViewColumn.Frozen)
             {
                 DataGridViewColumn firstVisibleFrozenColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
-                Debug.Assert(firstVisibleFrozenColumn != null);
+                Debug.Assert(firstVisibleFrozenColumn is not null);
                 if (firstVisibleFrozenColumn.Index == dataGridViewColumn.Index)
                 {
                     return DisplayedBandsInfo.NumDisplayedFrozenCols > 0;
@@ -3645,7 +3645,7 @@ namespace System.Windows.Forms
                         DataGridViewColumn dataGridViewColumnPrev = Columns.GetPreviousColumn(Columns[hti._col],
                                                                                                             DataGridViewElementStates.Visible,
                                                                                                             DataGridViewElementStates.None);
-                        if (dataGridViewColumnPrev != null)
+                        if (dataGridViewColumnPrev is not null)
                         {
                             previousColumnIndex = dataGridViewColumnPrev.Index;
                         }
@@ -3820,7 +3820,7 @@ namespace System.Windows.Forms
 
             Debug.Assert(
                  (
-                  (EditingControl != null && ((IDataGridViewEditingControl)EditingControl).EditingControlValueChanged) ||
+                  (EditingControl is not null && ((IDataGridViewEditingControl)EditingControl).EditingControlValueChanged) ||
                   (_dataGridViewState1[State1_CurrentCellInEditMode] && ((IDataGridViewEditingCell)CurrentCellInternal).EditingCellValueChanged)
                  ) == IsCurrentCellDirty ||
                  _dataGridViewState1[State1_IgnoringEditingChanges]);
@@ -3856,7 +3856,7 @@ namespace System.Windows.Forms
 
                     object formattedValue;
 
-                    if (EditingControl != null)
+                    if (EditingControl is not null)
                     {
                         formattedValue = ((IDataGridViewEditingControl)EditingControl).GetEditingControlFormattedValue(context);
                     }
@@ -3891,7 +3891,7 @@ namespace System.Windows.Forms
                     _uneditedFormattedValue = formattedValue;
                 }
 
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     ((IDataGridViewEditingControl)EditingControl).EditingControlValueChanged = false;
                 }
@@ -4098,7 +4098,7 @@ namespace System.Windows.Forms
 
         internal void CompleteCellsCollection(DataGridViewRow dataGridViewRow)
         {
-            Debug.Assert(dataGridViewRow != null);
+            Debug.Assert(dataGridViewRow is not null);
             int cellsInCollection = dataGridViewRow.Cells.Count;
             if (Columns.Count > cellsInCollection)
             {
@@ -4140,7 +4140,7 @@ namespace System.Windows.Forms
             }
 
             int cx = 0;
-            while (dataGridViewColumn != null)
+            while (dataGridViewColumn is not null)
             {
                 cx += dataGridViewColumn.Thickness;
                 if (cx > _horizontalOffset)
@@ -4485,7 +4485,7 @@ namespace System.Windows.Forms
             }
 
             dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.None);
-            while (dataGridViewColumn != null)
+            while (dataGridViewColumn is not null)
             {
                 if (!dataGridViewColumn.Frozen && dataGridViewColumn.Visible)
                 {
@@ -4534,7 +4534,7 @@ namespace System.Windows.Forms
                 }
 
                 cx -= FirstDisplayedScrollingColumnHiddenWidth;
-                while (cx < displayWidth && dataGridViewColumn != null)
+                while (cx < displayWidth && dataGridViewColumn is not null)
                 {
                     cx += dataGridViewColumn.Thickness;
                     visibleScrollingColumnsTmp++;
@@ -4573,7 +4573,7 @@ namespace System.Windows.Forms
                         dataGridViewColumn = Columns.GetPreviousColumn((Columns[firstDisplayedScrollingCol]),
                             DataGridViewElementStates.Visible,
                             DataGridViewElementStates.Frozen);
-                        while (dataGridViewColumn != null && cx + dataGridViewColumn.Thickness <= displayWidth)
+                        while (dataGridViewColumn is not null && cx + dataGridViewColumn.Thickness <= displayWidth)
                         {
                             cx += dataGridViewColumn.Thickness;
                             visibleScrollingColumnsTmp++;
@@ -4592,7 +4592,7 @@ namespace System.Windows.Forms
                         dataGridViewColumn = Columns.GetPreviousColumn((Columns[firstDisplayedScrollingCol]),
                                                                             DataGridViewElementStates.Visible,
                                                                             DataGridViewElementStates.Frozen);
-                        Debug.Assert(dataGridViewColumn != null);
+                        Debug.Assert(dataGridViewColumn is not null);
                         Debug.Assert(dataGridViewColumn.Thickness > displayWidth - cx);
                         firstDisplayedScrollingCol = dataGridViewColumn.Index;
                         FirstDisplayedScrollingColumnHiddenWidth = dataGridViewColumn.Thickness - displayWidth + cx;
@@ -4635,7 +4635,7 @@ namespace System.Windows.Forms
                         dataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn,
                             DataGridViewElementStates.Visible,
                             DataGridViewElementStates.None);
-                        Debug.Assert(dataGridViewColumn != null);
+                        Debug.Assert(dataGridViewColumn is not null);
                     }
                     DisplayedBandsInfo.LastTotallyDisplayedScrollingCol = dataGridViewColumn.Index;
                 }
@@ -4846,7 +4846,7 @@ namespace System.Windows.Forms
             // Column indexes have already been adjusted.
             // This column has already been detached and has retained its old Index and DisplayIndex
 
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             Debug.Assert(dataGridViewColumn.DataGridView is null);
             Debug.Assert(dataGridViewColumn.Index >= 0);
             Debug.Assert(dataGridViewColumn.DisplayIndex >= 0);
@@ -4880,7 +4880,7 @@ namespace System.Windows.Forms
 
         private void CorrectColumnDisplayIndexesAfterInsertion(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             Debug.Assert(dataGridViewColumn.DataGridView == this);
             // dataGridViewColumn.DisplayIndex has been set already.
             Debug.Assert(dataGridViewColumn.DisplayIndex >= 0);
@@ -4914,7 +4914,7 @@ namespace System.Windows.Forms
 
         private void CorrectColumnFrozenState(DataGridViewColumn dataGridViewColumn, int anticipatedColumnIndex)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             Debug.Assert(anticipatedColumnIndex >= 0 && anticipatedColumnIndex <= Columns.Count);
 
             int anticipatedColumnDisplayIndex;
@@ -4936,7 +4936,7 @@ namespace System.Windows.Forms
                 displayIndex--;
             }
             while (displayIndex >= 0 && (dataGridViewColumnPrev is null || !dataGridViewColumnPrev.Visible));
-            if (dataGridViewColumnPrev != null && !dataGridViewColumnPrev.Frozen && dataGridViewColumn.Frozen)
+            if (dataGridViewColumnPrev is not null && !dataGridViewColumnPrev.Frozen && dataGridViewColumn.Frozen)
             {
                 throw new InvalidOperationException(SR.DataGridView_CannotAddFrozenColumn);
             }
@@ -4950,7 +4950,7 @@ namespace System.Windows.Forms
                     displayIndex++;
                 }
                 while (displayIndex < Columns.Count && (dataGridViewColumnNext is null || !dataGridViewColumnNext.Visible));
-                if (dataGridViewColumnNext != null && dataGridViewColumnNext.Frozen && !dataGridViewColumn.Frozen)
+                if (dataGridViewColumnNext is not null && dataGridViewColumnNext.Frozen && !dataGridViewColumn.Frozen)
                 {
                     throw new InvalidOperationException(SR.DataGridView_CannotAddNonFrozenColumn);
                 }
@@ -4978,7 +4978,7 @@ namespace System.Windows.Forms
 
         private void CorrectColumnFrozenStates(DataGridViewColumn dataGridViewColumn, bool frozenStateChanging)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             DataGridViewColumn dataGridViewColumnTmp;
             if ((dataGridViewColumn.Frozen && !frozenStateChanging) ||
                 (!dataGridViewColumn.Frozen && frozenStateChanging))
@@ -4995,7 +4995,7 @@ namespace System.Windows.Forms
                         dataGridViewColumnTmp = dataGridViewColumnFirst;
                     }
                 }
-                while (dataGridViewColumnTmp != null && Columns.DisplayInOrder(dataGridViewColumnTmp.Index, dataGridViewColumn.Index))
+                while (dataGridViewColumnTmp is not null && Columns.DisplayInOrder(dataGridViewColumnTmp.Index, dataGridViewColumn.Index))
                 {
                     dataGridViewColumnTmp.Frozen = true;
                     dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp,
@@ -5017,18 +5017,18 @@ namespace System.Windows.Forms
                         dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnLast,
                             DataGridViewElementStates.Visible,
                             DataGridViewElementStates.None);
-                        if (dataGridViewColumnTmp != null)
+                        if (dataGridViewColumnTmp is not null)
                         {
                             dataGridViewColumnLast = dataGridViewColumnTmp;
                         }
                     }
-                    while (dataGridViewColumnTmp != null);
+                    while (dataGridViewColumnTmp is not null);
                     if (dataGridViewColumnLast != dataGridViewColumn)
                     {
                         dataGridViewColumnTmp = dataGridViewColumnLast;
                     }
                 }
-                while (dataGridViewColumnTmp != null && Columns.DisplayInOrder(dataGridViewColumn.Index, dataGridViewColumnTmp.Index))
+                while (dataGridViewColumnTmp is not null && Columns.DisplayInOrder(dataGridViewColumn.Index, dataGridViewColumnTmp.Index))
                 {
                     dataGridViewColumnTmp.Frozen = false;
                     dataGridViewColumnTmp = Columns.GetPreviousColumn(dataGridViewColumnTmp,
@@ -5040,7 +5040,7 @@ namespace System.Windows.Forms
 
         private void CorrectColumnFrozenStatesForMove(DataGridViewColumn dataGridViewColumn, int newDisplayIndex)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             Debug.Assert(newDisplayIndex != dataGridViewColumn.DisplayIndex);
             Debug.Assert(!_dataGridViewOper[OperationInDisplayIndexAdjustments]);
 
@@ -5072,7 +5072,7 @@ namespace System.Windows.Forms
                 }
                 while (displayIndex < colCount && (dataGridViewColumnNext is null || dataGridViewColumnNext == dataGridViewColumn || !dataGridViewColumnNext.Visible));
 
-                if (dataGridViewColumnNext != null && dataGridViewColumnNext.Frozen)
+                if (dataGridViewColumnNext is not null && dataGridViewColumnNext.Frozen)
                 {
                     throw new InvalidOperationException(SR.DataGridView_CannotMoveNonFrozenColumn);
                 }
@@ -5091,7 +5091,7 @@ namespace System.Windows.Forms
                 }
                 while (displayIndex >= 0 && (dataGridViewColumnPrev is null || !dataGridViewColumnPrev.Visible));
 
-                if (dataGridViewColumnPrev != null && !dataGridViewColumnPrev.Frozen)
+                if (dataGridViewColumnPrev is not null && !dataGridViewColumnPrev.Frozen)
                 {
                     throw new InvalidOperationException(SR.DataGridView_CannotMoveFrozenColumn);
                 }
@@ -5100,7 +5100,7 @@ namespace System.Windows.Forms
 
         private void CorrectColumnIndexesAfterDeletion(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             for (int columnIndex = dataGridViewColumn.Index; columnIndex < Columns.Count; columnIndex++)
             {
                 Columns[columnIndex].Index = Columns[columnIndex].Index - 1;
@@ -5110,7 +5110,7 @@ namespace System.Windows.Forms
 
         private void CorrectColumnIndexesAfterInsertion(DataGridViewColumn dataGridViewColumn, int insertionCount)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             Debug.Assert(insertionCount > 0);
             for (int columnIndex = dataGridViewColumn.Index + insertionCount; columnIndex < Columns.Count; columnIndex++)
             {
@@ -5120,16 +5120,16 @@ namespace System.Windows.Forms
 
         private void CorrectFocus(bool onlyIfGridHasFocus)
         {
-            if ((!onlyIfGridHasFocus || Focused) && EditingControl != null)
+            if ((!onlyIfGridHasFocus || Focused) && EditingControl is not null)
             {
-                Debug.Assert(CurrentCellInternal != null);
+                Debug.Assert(CurrentCellInternal is not null);
                 EditingControl.Focus();
             }
         }
 
         private void CorrectRowFrozenState(DataGridViewRow dataGridViewRow, DataGridViewElementStates rowState, int anticipatedRowIndex)
         {
-            Debug.Assert(dataGridViewRow != null);
+            Debug.Assert(dataGridViewRow is not null);
             Debug.Assert(anticipatedRowIndex >= 0 && anticipatedRowIndex <= Rows.Count);
 
             int previousRowIndex = Rows.GetPreviousRow(anticipatedRowIndex,
@@ -5194,7 +5194,7 @@ namespace System.Windows.Forms
 
         private void CorrectRowFrozenStates(DataGridViewRow dataGridViewRow, int rowIndex, bool frozenStateChanging)
         {
-            Debug.Assert(dataGridViewRow != null);
+            Debug.Assert(dataGridViewRow is not null);
             int rowIndexTmp;
             if (((Rows.GetRowState(rowIndex) & DataGridViewElementStates.Frozen) != 0 && !frozenStateChanging) ||
                 ((Rows.GetRowState(rowIndex) & DataGridViewElementStates.Frozen) == 0 && frozenStateChanging))
@@ -5330,7 +5330,7 @@ namespace System.Windows.Forms
 
         private RECT[] CreateScrollableRegion(Rectangle scroll)
         {
-            if (_cachedScrollableRegion != null)
+            if (_cachedScrollableRegion is not null)
             {
                 return _cachedScrollableRegion;
             }
@@ -5426,7 +5426,7 @@ namespace System.Windows.Forms
             int cxMax = _layout.Data.Width, cx = 0;
             int completeColumns = 0, partialColumns = 0;
             DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
-            while (dataGridViewColumn != null && cx < cxMax)
+            while (dataGridViewColumn is not null && cx < cxMax)
             {
                 partialColumns++;
                 cx += dataGridViewColumn.Thickness;
@@ -5449,7 +5449,7 @@ namespace System.Windows.Forms
                 dataGridViewColumn = (DataGridViewColumn)Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol];
                 Debug.Assert(dataGridViewColumn.Visible && !dataGridViewColumn.Frozen);
 
-                while (dataGridViewColumn != null && cx < cxMax)
+                while (dataGridViewColumn is not null && cx < cxMax)
                 {
                     partialColumns++;
                     cx += dataGridViewColumn.Thickness;
@@ -5868,7 +5868,7 @@ namespace System.Windows.Forms
             Debug.Assert(sender == EditingControl || sender == _editingPanel);
             if (sender == _editingPanel)
             {
-                Debug.Assert(EditingControl != null);
+                Debug.Assert(EditingControl is not null);
                 Debug.Assert(!_dataGridViewState1[State1_CustomCursorSet]);
                 _dataGridViewState1[State1_CustomCursorSet] = true;
                 _oldCursor = Cursor;
@@ -5888,7 +5888,7 @@ namespace System.Windows.Forms
             Debug.Assert(sender == EditingControl || sender == _editingPanel);
             if (sender == _editingPanel)
             {
-                Debug.Assert(EditingControl != null);
+                Debug.Assert(EditingControl is not null);
                 if (_dataGridViewState1[State1_CustomCursorSet])
                 {
                     _dataGridViewState1[State1_CustomCursorSet] = false;
@@ -6059,7 +6059,7 @@ namespace System.Windows.Forms
                 DataGridViewCell dataGridViewCurrentCell = CurrentCellInternal;
                 DataGridViewDataErrorEventArgs dgvdee = CommitEdit(ref dataGridViewCurrentCell, context, validateCell,
                     fireCellLeave, fireCellEnter, fireRowLeave, fireRowEnter, fireLeave);
-                if (dgvdee != null)
+                if (dgvdee is not null)
                 {
                     if (dgvdee.ThrowException)
                     {
@@ -6095,7 +6095,7 @@ namespace System.Windows.Forms
                     return true;
                 }
 
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     UnwireEditingControlEvents();
                     _dataGridViewState2[State2_MouseOverRemovedEditingCtrl] = MouseOverEditingControl;
@@ -6499,7 +6499,7 @@ namespace System.Windows.Forms
                         dataGridViewColumnTmp = Columns[columnIndexTmp];
                         while (numDisplayedScrollingCols > 0)
                         {
-                            Debug.Assert(dataGridViewColumnTmp != null);
+                            Debug.Assert(dataGridViewColumnTmp is not null);
                             if (!dataGridViewColumnTmp.Displayed)
                             {
                                 dataGridViewColumnTmp.Displayed = true;
@@ -6513,7 +6513,7 @@ namespace System.Windows.Forms
                         // Make sure all scrolling columns before FirstDisplayedScrollingCol have their Displayed state set to false
                         Debug.Assert(DisplayedBandsInfo.FirstDisplayedScrollingCol != -1);
                         dataGridViewColumnTmp = Columns.GetPreviousColumn(Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol], DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
-                        while (dataGridViewColumnTmp != null && dataGridViewColumnTmp.Displayed)
+                        while (dataGridViewColumnTmp is not null && dataGridViewColumnTmp.Displayed)
                         {
                             dataGridViewColumnTmp.Displayed = false;
                             dataGridViewColumnTmp = Columns.GetPreviousColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
@@ -6527,7 +6527,7 @@ namespace System.Windows.Forms
                         // No displayed scrolling columns. Make sure all non-frozen columns have their Displayed state set to false (next loop)
                         dataGridViewColumnTmp = Columns.GetFirstColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
                     }
-                    while (dataGridViewColumnTmp != null && dataGridViewColumnTmp.Displayed)
+                    while (dataGridViewColumnTmp is not null && dataGridViewColumnTmp.Displayed)
                     {
                         dataGridViewColumnTmp.Displayed = false;
                         dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
@@ -6538,7 +6538,7 @@ namespace System.Windows.Forms
                     dataGridViewColumnTmp = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
                     while (numDisplayedFrozenCols > 0)
                     {
-                        Debug.Assert(dataGridViewColumnTmp != null);
+                        Debug.Assert(dataGridViewColumnTmp is not null);
                         if (!dataGridViewColumnTmp.Displayed)
                         {
                             dataGridViewColumnTmp.Displayed = true;
@@ -6548,7 +6548,7 @@ namespace System.Windows.Forms
                     }
 
                     // Make sure all non-displayed frozen columns have their Displayed state set to false
-                    while (dataGridViewColumnTmp != null && dataGridViewColumnTmp.Displayed)
+                    while (dataGridViewColumnTmp is not null && dataGridViewColumnTmp.Displayed)
                     {
                         dataGridViewColumnTmp.Displayed = false;
                         dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp, DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen, DataGridViewElementStates.None);
@@ -6584,7 +6584,7 @@ namespace System.Windows.Forms
                         !ColumnNeedsDisplayedState(Columns[columnIndexTmp]))
                     {
                         dataGridViewColumnTmp = Columns[columnIndexTmp];
-                        while (dataGridViewColumnTmp != null)
+                        while (dataGridViewColumnTmp is not null)
                         {
                             if (!dataGridViewColumnTmp.Displayed)
                             {
@@ -6601,7 +6601,7 @@ namespace System.Windows.Forms
                     if (DisplayedBandsInfo.ColumnInsertionOccurred)
                     {
                         dataGridViewColumnTmp = Columns[Columns.Count - 1];
-                        while (dataGridViewColumnTmp != null && !ColumnNeedsDisplayedState(dataGridViewColumnTmp))
+                        while (dataGridViewColumnTmp is not null && !ColumnNeedsDisplayedState(dataGridViewColumnTmp))
                         {
                             if (dataGridViewColumnTmp.Displayed)
                             {
@@ -6823,7 +6823,7 @@ namespace System.Windows.Forms
                                                bool readOnlyRequired,
                                                bool visibleRequired)
         {
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             Debug.Assert(rowIndex >= 0);
             DataGridViewElementStates rowState = Rows.GetRowState(rowIndex);
             if (displayedRequired)
@@ -6967,7 +6967,7 @@ namespace System.Windows.Forms
             if (rowIndex >= 0)
             {
                 DataGridViewRow dataGridViewRow = Rows.SharedRow(rowIndex);
-                Debug.Assert(dataGridViewRow != null);
+                Debug.Assert(dataGridViewRow is not null);
                 if (columnIndex >= 0)
                 {
                     return dataGridViewRow.Cells[columnIndex];
@@ -7047,7 +7047,7 @@ namespace System.Windows.Forms
                             {
                                 // Cycle through the visible columns in their reverse display order
                                 dataGridViewColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                                if (dataGridViewColumn != null)
+                                if (dataGridViewColumn is not null)
                                 {
                                     prevDataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
                                     cellContent = dataGridViewColumn.HeaderCell.GetClipboardContentInternal(-1,
@@ -7056,11 +7056,11 @@ namespace System.Windows.Forms
                                                                                                             true /*inFirstRow*/,
                                                                                                             false /*inLastRow*/,
                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
-                                    while (prevDataGridViewColumn != null)
+                                    while (prevDataGridViewColumn is not null)
                                     {
                                         dataGridViewColumn = prevDataGridViewColumn;
                                         prevDataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
@@ -7070,7 +7070,7 @@ namespace System.Windows.Forms
                                                                                                                 true /*inFirstRow*/,
                                                                                                                 false /*inLastRow*/,
                                                                                                                 format) as string;
-                                        if (cellContent != null)
+                                        if (cellContent is not null)
                                         {
                                             sbContent.Append(cellContent);
                                         }
@@ -7084,7 +7084,7 @@ namespace System.Windows.Forms
                                                                                                      true /*inFirstRow*/,
                                                                                                      false /*inLastRow*/,
                                                                                                      format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7100,14 +7100,14 @@ namespace System.Windows.Forms
                                                                                                      true /*inFirstRow*/,
                                                                                                      false /*inLastRow*/,
                                                                                                      format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
                                 }
                                 // Cycle through the visible columns in their display order
                                 dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-                                if (dataGridViewColumn != null)
+                                if (dataGridViewColumn is not null)
                                 {
                                     nextDataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
                                     cellContent = dataGridViewColumn.HeaderCell.GetClipboardContentInternal(-1,
@@ -7116,11 +7116,11 @@ namespace System.Windows.Forms
                                                                                                             true /*inFirstRow*/,
                                                                                                             false /*inLastRow*/,
                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
-                                    while (nextDataGridViewColumn != null)
+                                    while (nextDataGridViewColumn is not null)
                                     {
                                         dataGridViewColumn = nextDataGridViewColumn;
                                         nextDataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
@@ -7130,7 +7130,7 @@ namespace System.Windows.Forms
                                                                                                                 true /*inFirstRow*/,
                                                                                                                 false /*inLastRow*/,
                                                                                                                 format) as string;
-                                        if (cellContent != null)
+                                        if (cellContent is not null)
                                         {
                                             sbContent.Append(cellContent);
                                         }
@@ -7150,7 +7150,7 @@ namespace System.Windows.Forms
                                 dataGridViewColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.None);
 
                                 // Cycle through the visible columns in their reverse display order
-                                if (dataGridViewColumn != null)
+                                if (dataGridViewColumn is not null)
                                 {
                                     prevDataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
                                     cellContent = Rows.SharedRow(rowIndex).Cells[dataGridViewColumn.Index].GetClipboardContentInternal(rowIndex,
@@ -7159,11 +7159,11 @@ namespace System.Windows.Forms
                                                                                                                                             !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                                             nextRowIndex == -1 /*inLastRow*/,
                                                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
-                                    while (prevDataGridViewColumn != null)
+                                    while (prevDataGridViewColumn is not null)
                                     {
                                         dataGridViewColumn = prevDataGridViewColumn;
                                         prevDataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
@@ -7173,7 +7173,7 @@ namespace System.Windows.Forms
                                                                                                                                                 !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                                                 nextRowIndex == -1 /*inLastRow*/,
                                                                                                                                                 format) as string;
-                                        if (cellContent != null)
+                                        if (cellContent is not null)
                                         {
                                             sbContent.Append(cellContent);
                                         }
@@ -7189,7 +7189,7 @@ namespace System.Windows.Forms
                                                                                                                        !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                        nextRowIndex == -1 /*inLastRow*/,
                                                                                                                        format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7208,14 +7208,14 @@ namespace System.Windows.Forms
                                                                                                                        !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                        nextRowIndex == -1 /*inLastRow*/,
                                                                                                                        format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
                                 }
 
                                 // Cycle through the visible columns in their display order
-                                if (dataGridViewColumn != null)
+                                if (dataGridViewColumn is not null)
                                 {
                                     nextDataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
                                     cellContent = Rows.SharedRow(rowIndex).Cells[dataGridViewColumn.Index].GetClipboardContentInternal(rowIndex,
@@ -7224,11 +7224,11 @@ namespace System.Windows.Forms
                                                                                                                                             !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                                             nextRowIndex == -1 /*inLastRow*/,
                                                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
-                                    while (nextDataGridViewColumn != null)
+                                    while (nextDataGridViewColumn is not null)
                                     {
                                         dataGridViewColumn = nextDataGridViewColumn;
                                         nextDataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
@@ -7238,7 +7238,7 @@ namespace System.Windows.Forms
                                                                                                                                                 !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                                                 nextRowIndex == -1 /*inLastRow*/,
                                                                                                                                                 format) as string;
-                                        if (cellContent != null)
+                                        if (cellContent is not null)
                                         {
                                             sbContent.Append(cellContent);
                                         }
@@ -7303,8 +7303,8 @@ namespace System.Windows.Forms
                                 // Cycle through the visible & selected columns in their display order
                                 DataGridViewColumn lastDataGridViewColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
                                 dataGridViewColumn = lastDataGridViewColumn;
-                                Debug.Assert(dataGridViewColumn != null);
-                                if (dataGridViewColumn != null)
+                                Debug.Assert(dataGridViewColumn is not null);
+                                if (dataGridViewColumn is not null)
                                 {
                                     prevDataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn, DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
                                     cellContent = dataGridViewColumn.HeaderCell.GetClipboardContentInternal(-1,
@@ -7313,11 +7313,11 @@ namespace System.Windows.Forms
                                                                                                             true /*inFirstRow*/,
                                                                                                             firstVisibleRowIndex == -1 /*inLastRow*/,
                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
-                                    while (prevDataGridViewColumn != null)
+                                    while (prevDataGridViewColumn is not null)
                                     {
                                         dataGridViewColumn = prevDataGridViewColumn;
                                         prevDataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn, DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
@@ -7327,7 +7327,7 @@ namespace System.Windows.Forms
                                                                                                                 true /*inFirstRow*/,
                                                                                                                 firstVisibleRowIndex == -1 /*inLastRow*/,
                                                                                                                 format) as string;
-                                        if (cellContent != null)
+                                        if (cellContent is not null)
                                         {
                                             sbContent.Append(cellContent);
                                         }
@@ -7341,7 +7341,7 @@ namespace System.Windows.Forms
                                                                                                      true /*inFirstRow*/,
                                                                                                      firstVisibleRowIndex == -1 /*inLastRow*/,
                                                                                                      format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7359,14 +7359,14 @@ namespace System.Windows.Forms
                                                                                                      true /*inFirstRow*/,
                                                                                                      firstVisibleRowIndex == -1 /*inLastRow*/,
                                                                                                      format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
                                 }
                                 // Cycle through the visible & selected columns in their display order
-                                Debug.Assert(dataGridViewColumn != null);
-                                if (dataGridViewColumn != null)
+                                Debug.Assert(dataGridViewColumn is not null);
+                                if (dataGridViewColumn is not null)
                                 {
                                     nextDataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
                                     cellContent = dataGridViewColumn.HeaderCell.GetClipboardContentInternal(-1,
@@ -7375,11 +7375,11 @@ namespace System.Windows.Forms
                                                                                                             true /*inFirstRow*/,
                                                                                                             firstVisibleRowIndex == -1 /*inLastRow*/,
                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
-                                    while (nextDataGridViewColumn != null)
+                                    while (nextDataGridViewColumn is not null)
                                     {
                                         dataGridViewColumn = nextDataGridViewColumn;
                                         nextDataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
@@ -7389,7 +7389,7 @@ namespace System.Windows.Forms
                                                                                                                 true /*inFirstRow*/,
                                                                                                                 firstVisibleRowIndex == -1 /*inLastRow*/,
                                                                                                                 format) as string;
-                                        if (cellContent != null)
+                                        if (cellContent is not null)
                                         {
                                             sbContent.Append(cellContent);
                                         }
@@ -7413,7 +7413,7 @@ namespace System.Windows.Forms
 
                                 // Cycle through the visible & selected columns in their reverse display order
                                 dataGridViewColumn = lastDataGridViewColumn;
-                                if (dataGridViewColumn != null)
+                                if (dataGridViewColumn is not null)
                                 {
                                     prevDataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn, DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
                                     cellContent = Rows.SharedRow(rowIndex).Cells[dataGridViewColumn.Index].GetClipboardContentInternal(rowIndex,
@@ -7422,11 +7422,11 @@ namespace System.Windows.Forms
                                                                                                                                             !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                                             nextRowIndex == -1 /*inLastRow*/,
                                                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
-                                    while (prevDataGridViewColumn != null)
+                                    while (prevDataGridViewColumn is not null)
                                     {
                                         dataGridViewColumn = prevDataGridViewColumn;
                                         prevDataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn, DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
@@ -7436,7 +7436,7 @@ namespace System.Windows.Forms
                                                                                                                                                 !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                                                 nextRowIndex == -1 /*inLastRow*/,
                                                                                                                                                 format) as string;
-                                        if (cellContent != null)
+                                        if (cellContent is not null)
                                         {
                                             sbContent.Append(cellContent);
                                         }
@@ -7452,7 +7452,7 @@ namespace System.Windows.Forms
                                                                                                                        !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                        nextRowIndex == -1 /*inLastRow*/,
                                                                                                                        format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7471,14 +7471,14 @@ namespace System.Windows.Forms
                                                                                                                        !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                        nextRowIndex == -1 /*inLastRow*/,
                                                                                                                        format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
                                 }
 
                                 // Cycle through the visible & selected columns in their display order
-                                if (dataGridViewColumn != null)
+                                if (dataGridViewColumn is not null)
                                 {
                                     nextDataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
                                     cellContent = Rows.SharedRow(rowIndex).Cells[dataGridViewColumn.Index].GetClipboardContentInternal(rowIndex,
@@ -7487,11 +7487,11 @@ namespace System.Windows.Forms
                                                                                                                                             !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                                             nextRowIndex == -1 /*inLastRow*/,
                                                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
-                                    while (nextDataGridViewColumn != null)
+                                    while (nextDataGridViewColumn is not null)
                                     {
                                         dataGridViewColumn = nextDataGridViewColumn;
                                         nextDataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible | DataGridViewElementStates.Selected, DataGridViewElementStates.None);
@@ -7501,7 +7501,7 @@ namespace System.Windows.Forms
                                                                                                                                                 !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                                                 nextRowIndex == -1 /*inLastRow*/,
                                                                                                                                                 format) as string;
-                                        if (cellContent != null)
+                                        if (cellContent is not null)
                                         {
                                             sbContent.Append(cellContent);
                                         }
@@ -7610,8 +7610,8 @@ namespace System.Windows.Forms
                         DataGridViewColumn firstVisibleColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
                         DataGridViewColumn lastVisibleColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.None);
 
-                        Debug.Assert(firstVisibleColumn != null);
-                        Debug.Assert(lastVisibleColumn != null);
+                        Debug.Assert(firstVisibleColumn is not null);
+                        Debug.Assert(lastVisibleColumn is not null);
                         foreach (int rowIndex in _selectedBandIndexes)
                         {
                             if ((Rows.GetRowState(rowIndex) & DataGridViewElementStates.Visible) != 0)
@@ -7679,8 +7679,8 @@ namespace System.Windows.Forms
 
                     Debug.Assert(lRowIndex != -1);
                     Debug.Assert(uRowIndex != -1);
-                    Debug.Assert(lColumn != null);
-                    Debug.Assert(uColumn != null);
+                    Debug.Assert(lColumn is not null);
+                    Debug.Assert(uColumn is not null);
                     Debug.Assert(lColumn.Index == uColumn.Index || Columns.DisplayInOrder(lColumn.Index, uColumn.Index));
                     Debug.Assert(lRowIndex <= uRowIndex);
 
@@ -7701,13 +7701,13 @@ namespace System.Windows.Forms
                             {
                                 // Cycle through the visible columns from uColumn to lColumn
                                 dataGridViewColumn = uColumn;
-                                Debug.Assert(dataGridViewColumn != null);
-                                while (dataGridViewColumn != null)
+                                Debug.Assert(dataGridViewColumn is not null);
+                                while (dataGridViewColumn is not null)
                                 {
                                     if (dataGridViewColumn != lColumn)
                                     {
                                         prevDataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                                        Debug.Assert(prevDataGridViewColumn != null);
+                                        Debug.Assert(prevDataGridViewColumn is not null);
                                     }
                                     else
                                     {
@@ -7719,7 +7719,7 @@ namespace System.Windows.Forms
                                                                                                             true /*inFirstRow*/,
                                                                                                             false /*inLastRow*/,
                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7733,7 +7733,7 @@ namespace System.Windows.Forms
                                                                                                      true  /*inFirstRow*/,
                                                                                                      false /*inLastRow*/,
                                                                                                      format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7749,20 +7749,20 @@ namespace System.Windows.Forms
                                                                                                      true  /*inFirstRow*/,
                                                                                                      false /*inLastRow*/,
                                                                                                      format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
                                 }
                                 // Cycle through the visible columns from lColumn to uColumn
                                 dataGridViewColumn = lColumn;
-                                Debug.Assert(dataGridViewColumn != null);
-                                while (dataGridViewColumn != null)
+                                Debug.Assert(dataGridViewColumn is not null);
+                                while (dataGridViewColumn is not null)
                                 {
                                     if (dataGridViewColumn != uColumn)
                                     {
                                         nextDataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                                        Debug.Assert(nextDataGridViewColumn != null);
+                                        Debug.Assert(nextDataGridViewColumn is not null);
                                     }
                                     else
                                     {
@@ -7774,7 +7774,7 @@ namespace System.Windows.Forms
                                                                                                             true /*inFirstRow*/,
                                                                                                             false /*inLastRow*/,
                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7803,13 +7803,13 @@ namespace System.Windows.Forms
                             {
                                 // Cycle through the visible columns from uColumn to lColumn
                                 dataGridViewColumn = uColumn;
-                                Debug.Assert(dataGridViewColumn != null);
-                                while (dataGridViewColumn != null)
+                                Debug.Assert(dataGridViewColumn is not null);
+                                while (dataGridViewColumn is not null)
                                 {
                                     if (dataGridViewColumn != lColumn)
                                     {
                                         prevDataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                                        Debug.Assert(prevDataGridViewColumn != null);
+                                        Debug.Assert(prevDataGridViewColumn is not null);
                                     }
                                     else
                                     {
@@ -7822,7 +7822,7 @@ namespace System.Windows.Forms
                                                                                                                                             !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                                             nextRowIndex == -1 /*inLastRow*/,
                                                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7838,7 +7838,7 @@ namespace System.Windows.Forms
                                                                                                                        !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                        nextRowIndex == -1 /*inLastRow*/,
                                                                                                                        format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7855,7 +7855,7 @@ namespace System.Windows.Forms
                                                                                                                        !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                        nextRowIndex == -1 /*inLastRow*/,
                                                                                                                        format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7863,13 +7863,13 @@ namespace System.Windows.Forms
 
                                 // Cycle through the visible columns from lColumn to uColumn
                                 dataGridViewColumn = lColumn;
-                                Debug.Assert(dataGridViewColumn != null);
-                                while (dataGridViewColumn != null)
+                                Debug.Assert(dataGridViewColumn is not null);
+                                while (dataGridViewColumn is not null)
                                 {
                                     if (dataGridViewColumn != uColumn)
                                     {
                                         nextDataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                                        Debug.Assert(nextDataGridViewColumn != null);
+                                        Debug.Assert(nextDataGridViewColumn is not null);
                                     }
                                     else
                                     {
@@ -7882,7 +7882,7 @@ namespace System.Windows.Forms
                                                                                                                                             !includeColumnHeaders && firstRowIndex /*inFirstRow*/,
                                                                                                                                             nextRowIndex == -1 /*inLastRow*/,
                                                                                                                                             format) as string;
-                                    if (cellContent != null)
+                                    if (cellContent is not null)
                                     {
                                         sbContent.Append(cellContent);
                                     }
@@ -7965,7 +7965,7 @@ namespace System.Windows.Forms
                 cx = data.X;
             }
             for (dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
-                dataGridViewColumn != null && !columnFound;
+                dataGridViewColumn is not null && !columnFound;
                 )
             {
                 if ((RightToLeftInternal && cx < data.X) ||
@@ -7996,7 +7996,7 @@ namespace System.Windows.Forms
             if (!columnFound && DisplayedBandsInfo.FirstDisplayedScrollingCol >= 0)
             {
                 for (dataGridViewColumn = Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol];
-                    dataGridViewColumn != null && !columnFound;
+                    dataGridViewColumn is not null && !columnFound;
                     )
                 {
                     if ((RightToLeftInternal && cx < data.X) ||
@@ -8038,7 +8038,7 @@ namespace System.Windows.Forms
 
             if (columnFound)
             {
-                Debug.Assert(dataGridViewColumn != null);
+                Debug.Assert(dataGridViewColumn is not null);
                 int displayWidth, viewedColumnWidth = dataGridViewColumn.Thickness;
                 if (dataGridViewColumn.Index == DisplayedBandsInfo.FirstDisplayedScrollingCol)
                 {
@@ -8111,7 +8111,7 @@ namespace System.Windows.Forms
 
             // first try to match x against a frozen column
             DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
-            while (dataGridViewColumn != null &&
+            while (dataGridViewColumn is not null &&
                    ((!RightToLeftInternal && cx < data.Right) || (RightToLeftInternal && cx >= data.X)))
             {
                 if (RightToLeftInternal)
@@ -8150,7 +8150,7 @@ namespace System.Windows.Forms
             if (DisplayedBandsInfo.FirstDisplayedScrollingCol >= 0)
             {
                 dataGridViewColumn = Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol];
-                while (dataGridViewColumn != null &&
+                while (dataGridViewColumn is not null &&
                        ((!RightToLeftInternal && cx < data.Right) || (RightToLeftInternal && cx >= data.X)))
                 {
                     Debug.Assert(dataGridViewColumn.Visible && !dataGridViewColumn.Frozen);
@@ -8229,7 +8229,7 @@ namespace System.Windows.Forms
             }
 
             DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
-            while (dataGridViewColumn != null)
+            while (dataGridViewColumn is not null)
             {
                 if (index == dataGridViewColumn.Index)
                 {
@@ -8269,7 +8269,7 @@ namespace System.Windows.Forms
             }
             Debug.Assert(dataGridViewColumn.Visible && !dataGridViewColumn.Frozen);
 
-            while (dataGridViewColumn != null)
+            while (dataGridViewColumn is not null)
             {
                 if (index == dataGridViewColumn.Index)
                 {
@@ -8294,7 +8294,7 @@ namespace System.Windows.Forms
             dataGridViewColumn = Columns.GetPreviousColumn(dataGridViewColumn,
                 DataGridViewElementStates.Visible,
                 DataGridViewElementStates.Frozen);
-            while (dataGridViewColumn != null)
+            while (dataGridViewColumn is not null)
             {
                 if (RightToLeftInternal)
                 {
@@ -8320,7 +8320,7 @@ namespace System.Windows.Forms
         private int GetNegOffsetFromHorizontalOffset(int horizontalOffset)
         {
             DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen);
-            while (dataGridViewColumn != null && dataGridViewColumn.Thickness <= horizontalOffset)
+            while (dataGridViewColumn is not null && dataGridViewColumn.Thickness <= horizontalOffset)
             {
                 horizontalOffset -= dataGridViewColumn.Thickness;
                 dataGridViewColumn = Columns.GetNextColumn(dataGridViewColumn, DataGridViewElementStates.Visible, DataGridViewElementStates.None);
@@ -8495,7 +8495,7 @@ namespace System.Windows.Forms
                          (_trackColumnEdge != -1 && !Columns[_trackColumnEdge].Frozen)) &&
                         DisplayedBandsInfo.FirstDisplayedScrollingCol >= 0 &&
                         (FirstDisplayedScrollingColumnHiddenWidth > 0 ||
-                         Columns.GetPreviousColumn(Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol], DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen) != null))
+                         Columns.GetPreviousColumn(Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol], DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen) is not null))
                     {
                         // xOffset strictly negative
                         if (RightToLeftInternal)
@@ -8641,7 +8641,7 @@ namespace System.Windows.Forms
                         &&
                         DisplayedBandsInfo.FirstDisplayedScrollingCol >= 0 &&
                         (FirstDisplayedScrollingColumnHiddenWidth > 0 ||
-                         Columns.GetPreviousColumn(Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol], DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen) != null)
+                         Columns.GetPreviousColumn(Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol], DataGridViewElementStates.Visible, DataGridViewElementStates.Frozen) is not null)
                        )
                     {
                         // xOffset strictly negative
@@ -8677,7 +8677,7 @@ namespace System.Windows.Forms
                     // Mouse's X is on the right of scrolling bands (LTR)
                     if (DisplayedBandsInfo.FirstDisplayedScrollingCol >= 0 &&
                         (DisplayedBandsInfo.LastTotallyDisplayedScrollingCol == -1 ||
-                         Columns.GetNextColumn(Columns[DisplayedBandsInfo.LastTotallyDisplayedScrollingCol], DataGridViewElementStates.Visible, DataGridViewElementStates.None) != null))
+                         Columns.GetNextColumn(Columns[DisplayedBandsInfo.LastTotallyDisplayedScrollingCol], DataGridViewElementStates.Visible, DataGridViewElementStates.None) is not null))
                     {
                         DataGridViewColumn newFirstVisibleScrollingCol = Columns.GetNextColumn(Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol],
                                                                                                             DataGridViewElementStates.Visible,
@@ -9070,13 +9070,13 @@ namespace System.Windows.Forms
                 return hti;
             }
 
-            if (_horizScrollBar != null && _horizScrollBar.Visible && _horizScrollBar.Bounds.Contains(x, y))
+            if (_horizScrollBar is not null && _horizScrollBar.Visible && _horizScrollBar.Bounds.Contains(x, y))
             {
                 hti._type = DataGridViewHitTestType.HorizontalScrollBar;
                 return hti;
             }
 
-            if (_vertScrollBar != null && _vertScrollBar.Visible && _vertScrollBar.Bounds.Contains(x, y))
+            if (_vertScrollBar is not null && _vertScrollBar.Visible && _vertScrollBar.Bounds.Contains(x, y))
             {
                 hti._type = DataGridViewHitTestType.VerticalScrollBar;
                 return hti;
@@ -9172,7 +9172,7 @@ namespace System.Windows.Forms
                                                                                  DataGridViewElementStates.Visible,
                                                                                  DataGridViewElementStates.None);
                     //}
-                    if (dataGridViewColumn != null)
+                    if (dataGridViewColumn is not null)
                     {
                         hti._adjacentCol = dataGridViewColumn.Index;
                         if (RightToLeftInternal)
@@ -9346,7 +9346,7 @@ namespace System.Windows.Forms
                                 DataGridViewElementStates.Visible,
                                 DataGridViewElementStates.None);
                         }
-                        if (dataGridViewColumn != null)
+                        if (dataGridViewColumn is not null)
                         {
                             hti._adjacentCol = dataGridViewColumn.Index;
                             if (RightToLeftInternal)
@@ -9386,7 +9386,7 @@ namespace System.Windows.Forms
                          (RightToLeftInternal && xColumnLeftEdge - x < ColumnSizingHotZone))
                 {
                     DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     if (hti._col == dataGridViewColumn.Index &&
                         RowHeadersVisible &&
                         RowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.EnableResizing)
@@ -9527,11 +9527,11 @@ namespace System.Windows.Forms
             try
             {
                 IDataGridViewEditingCell dataGridViewEditingCell = dataGridViewCell as IDataGridViewEditingCell;
-                Debug.Assert(dataGridViewEditingCell != null);
+                Debug.Assert(dataGridViewEditingCell is not null);
                 object currentFormattedValue = dataGridViewEditingCell.GetEditingCellFormattedValue(DataGridViewDataErrorContexts.Formatting);
-                if ((currentFormattedValue is null && _uneditedFormattedValue != null) ||
-                    (currentFormattedValue != null && _uneditedFormattedValue is null) ||
-                    (currentFormattedValue != null && !_uneditedFormattedValue.Equals(currentFormattedValue)))
+                if ((currentFormattedValue is null && _uneditedFormattedValue is not null) ||
+                    (currentFormattedValue is not null && _uneditedFormattedValue is null) ||
+                    (currentFormattedValue is not null && !_uneditedFormattedValue.Equals(currentFormattedValue)))
                 {
                     Debug.Assert(_ptCurrentCell.X == dataGridViewCell.ColumnIndex);
                     dataGridViewCell = Rows[_ptCurrentCell.Y].Cells[_ptCurrentCell.X]; // unshare the edited cell
@@ -9555,7 +9555,7 @@ namespace System.Windows.Forms
             {
                 _dataGridViewState1[State1_IgnoringEditingChanges] = false;
             }
-            if (dgvdee != null)
+            if (dgvdee is not null)
             {
                 if (dgvdee.ThrowException)
                 {
@@ -9569,8 +9569,8 @@ namespace System.Windows.Forms
         // Returns true for success, returns false when the OnDataError event cancels the operation.
         private bool InitializeEditingControlValue(ref DataGridViewCellStyle dataGridViewCellStyle, DataGridViewCell dataGridViewCell)
         {
-            Debug.Assert(dataGridViewCell != null);
-            Debug.Assert(EditingControl != null);
+            Debug.Assert(dataGridViewCell is not null);
+            Debug.Assert(EditingControl is not null);
 
             DataGridViewDataErrorEventArgs dgvdee = null;
             object initialFormattedValue = dataGridViewCell.GetFormattedValue(_ptCurrentCell.Y, ref dataGridViewCellStyle, DataGridViewDataErrorContexts.Formatting);
@@ -9597,7 +9597,7 @@ namespace System.Windows.Forms
                 _dataGridViewState1[State1_EditingControlChanging] = false;
                 _dataGridViewState1[State1_IgnoringEditingChanges] = false;
             }
-            if (dgvdee != null)
+            if (dgvdee is not null)
             {
                 if (dgvdee.ThrowException)
                 {
@@ -9626,7 +9626,7 @@ namespace System.Windows.Forms
 
         private void InvalidateCellPrivate(DataGridViewCell dataGridViewCell)
         {
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             Debug.Assert(dataGridViewCell.DataGridView == this);
             InvalidateCell(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex);
         }
@@ -9877,11 +9877,11 @@ namespace System.Windows.Forms
             // invalidate the horizontal and the vertical scrollbars
             // note that the scrollbars can be null - this happens when
             // the control has been disposed.
-            if (_horizScrollBar != null && _horizScrollBar.Visible)
+            if (_horizScrollBar is not null && _horizScrollBar.Visible)
             {
                 _horizScrollBar.Invalidate();
             }
-            if (_vertScrollBar != null && _vertScrollBar.Visible)
+            if (_vertScrollBar is not null && _vertScrollBar.Visible)
             {
                 _vertScrollBar.Invalidate();
             }
@@ -9904,7 +9904,7 @@ namespace System.Windows.Forms
 
         protected override bool IsInputChar(char charCode)
         {
-            if (EditingControl != null &&
+            if (EditingControl is not null &&
                 _dataGridViewState1[State1_ForwardCharMessage])
             {
                 // Do not process key press in ProcessDialogChar.
@@ -10286,7 +10286,7 @@ namespace System.Windows.Forms
             _lastRowSplitBar = _currentRowSplitBar;
             _currentRowSplitBar = e.Y;
             Rectangle lastSplitBarRect = CalcRowResizeFeedbackRect(_lastRowSplitBar);
-            if (EditingControl != null &&
+            if (EditingControl is not null &&
                 !_dataGridViewState1[State1_EditingControlHidden] &&
                 _editingPanel.Bounds.IntersectsWith(lastSplitBarRect))
             {
@@ -10301,7 +10301,7 @@ namespace System.Windows.Forms
 
         private void MapDataGridViewColumnToDataBoundField(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(DataSource != null, "this method should only be called when we have a data connection");
+            Debug.Assert(DataSource is not null, "this method should only be called when we have a data connection");
             Debug.Assert(dataGridViewColumn.DataPropertyName.Length != 0, "this method should be called only for columns which have DataPropertyName set");
             DataGridViewDataConnection conn = DataConnection;
 
@@ -10351,7 +10351,7 @@ namespace System.Windows.Forms
             _lastColSplitBar = _currentColSplitBar;
             _currentColSplitBar = x;
             Rectangle lastSplitBarRect = CalcColResizeFeedbackRect(_lastColSplitBar);
-            if (EditingControl != null &&
+            if (EditingControl is not null &&
                 !_dataGridViewState1[State1_EditingControlHidden] &&
                 _editingPanel.Bounds.IntersectsWith(lastSplitBarRect))
             {
@@ -10372,7 +10372,7 @@ namespace System.Windows.Forms
                 // and autosizing code only looks at committed values.
 
                 IsCurrentCellDirtyInternal = dirty;
-                if (dirty && EditingControl != null && ((IDataGridViewEditingControl)EditingControl).RepositionEditingControlOnValueChange)
+                if (dirty && EditingControl is not null && ((IDataGridViewEditingControl)EditingControl).RepositionEditingControlOnValueChange)
                 {
                     PositionEditingControl(true /*setLocation*/, true /*setSize*/, false /*setFocus*/);
                 }
@@ -10565,7 +10565,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentNullException(nameof(dataGridViewColumn));
             }
-            if (dataGridViewColumn.DataGridView != null)
+            if (dataGridViewColumn.DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridView_ColumnAlreadyBelongsToDataGridView);
             }
@@ -10619,9 +10619,9 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridView_CannotAddUntypedColumn);
                 }
 
-                if (dataGridViewColumn.CellTemplate.DefaultNewRowValue != null && NewRowIndex != -1)
+                if (dataGridViewColumn.CellTemplate.DefaultNewRowValue is not null && NewRowIndex != -1)
                 {
-                    // New row needs to be unshared before addition of new cell with a Value != null
+                    // New row needs to be unshared before addition of new cell with a Value is not null
                     DataGridViewRow newRow = Rows[NewRowIndex];
                 }
 
@@ -10675,14 +10675,14 @@ namespace System.Windows.Forms
             Debug.Assert(weightSum <= (float)ushort.MaxValue);
 
             // throw an exception if any of the columns to be added breaks the rules
-            Debug.Assert(dataGridViewColumns != null);
+            Debug.Assert(dataGridViewColumns is not null);
             foreach (DataGridViewColumn dataGridViewColumn in dataGridViewColumns)
             {
                 if (dataGridViewColumn is null)
                 {
                     throw new InvalidOperationException(SR.DataGridView_AtLeastOneColumnIsNull);
                 }
-                if (dataGridViewColumn.DataGridView != null)
+                if (dataGridViewColumn.DataGridView is not null)
                 {
                     throw new InvalidOperationException(SR.DataGridView_ColumnAlreadyBelongsToDataGridView);
                 }
@@ -10752,10 +10752,10 @@ namespace System.Windows.Forms
             {
                 foreach (DataGridViewColumn dataGridViewColumn in dataGridViewColumns)
                 {
-                    Debug.Assert(dataGridViewColumn.CellType != null);
-                    if (dataGridViewColumn.CellTemplate.DefaultNewRowValue != null && NewRowIndex != -1)
+                    Debug.Assert(dataGridViewColumn.CellType is not null);
+                    if (dataGridViewColumn.CellTemplate.DefaultNewRowValue is not null && NewRowIndex != -1)
                     {
-                        // New row needs to be unshared before addition of new cell with a Value != null
+                        // New row needs to be unshared before addition of new cell with a Value is not null
                         DataGridViewRow newRow = Rows[NewRowIndex];
                         break;
                     }
@@ -10769,7 +10769,7 @@ namespace System.Windows.Forms
                     foreach (DataGridViewColumn dataGridViewColumn in dataGridViewColumns)
                     {
                         addedColumnCount++;
-                        Debug.Assert(dataGridViewColumn.CellType != null);
+                        Debug.Assert(dataGridViewColumn.CellType is not null);
                         for (int rowIndex = 0; rowIndex < Rows.Count; rowIndex++)
                         {
                             DataGridViewRow dataGridViewRow = Rows.SharedRow(rowIndex);
@@ -10805,7 +10805,7 @@ namespace System.Windows.Forms
 
         internal void OnAddingRow(DataGridViewRow dataGridViewRow, DataGridViewElementStates rowState, bool checkFrozenState)
         {
-            // Note dataGridViewRow.DataGridView != null for duplication of shared rows.
+            // Note dataGridViewRow.DataGridView is not null for duplication of shared rows.
 
             // throw an exception if the row to be added breaks the rules
             if (dataGridViewRow is null)
@@ -10814,7 +10814,7 @@ namespace System.Windows.Forms
             }
 
             // !Do not check for dataGridViewRow.Selected flag. Caller does it instead!
-            // !Do not check for dataGridViewRow.DataGridView != null. Caller does it instead!
+            // !Do not check for dataGridViewRow.DataGridView is not null. Caller does it instead!
 
             if (checkFrozenState)
             {
@@ -10846,7 +10846,7 @@ namespace System.Windows.Forms
         internal void OnAddingRows(DataGridViewRow[] dataGridViewRows, bool checkFrozenStates)
         {
             // throw an exception if any of the rows to be added breaks the rules
-            Debug.Assert(dataGridViewRows != null);
+            Debug.Assert(dataGridViewRows is not null);
 
             foreach (DataGridViewRow dataGridViewRow in dataGridViewRows)
             {
@@ -10855,7 +10855,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridView_AtLeastOneRowIsNull);
                 }
 
-                if (dataGridViewRow.DataGridView != null)
+                if (dataGridViewRow.DataGridView is not null)
                 {
                     throw new InvalidOperationException(SR.DataGridView_RowAlreadyBelongsToDataGridView);
                 }
@@ -10967,7 +10967,7 @@ namespace System.Windows.Forms
             else
             {
                 OnRowsGlobalAutoSize();
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     PositionEditingControl(true /*setLocation*/, true /*setSize*/, false /*setFocus*/);
                 }
@@ -10981,7 +10981,7 @@ namespace System.Windows.Forms
 
         protected virtual void OnAutoGenerateColumnsChanged(EventArgs e)
         {
-            if (AutoGenerateColumns && DataSource != null)
+            if (AutoGenerateColumns && DataSource is not null)
             {
                 // refresh the list of columns and the rows
                 RefreshColumnsAndRows();
@@ -10994,7 +10994,7 @@ namespace System.Windows.Forms
 
         internal void OnAutoSizeColumnModeChanged(DataGridViewColumn dataGridViewColumn, DataGridViewAutoSizeColumnMode previousInheritedMode)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             DataGridViewAutoSizeColumnModeEventArgs dgvascme = new DataGridViewAutoSizeColumnModeEventArgs(dataGridViewColumn, previousInheritedMode);
             OnAutoSizeColumnModeChanged(dgvascme);
         }
@@ -11297,7 +11297,7 @@ namespace System.Windows.Forms
             _dataGridViewState2[State2_InBindingContextChanged] = true;
             try
             {
-                if (DataConnection != null)
+                if (DataConnection is not null)
                 {
                     CurrentCell = null;
                     try
@@ -11321,7 +11321,7 @@ namespace System.Windows.Forms
                     }
                     RefreshColumnsAndRows();
                     base.OnBindingContextChanged(e);
-                    if (DataConnection.CurrencyManager != null)
+                    if (DataConnection.CurrencyManager is not null)
                     {
                         OnDataBindingComplete(ListChangedType.Reset);
                     }
@@ -11397,7 +11397,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException("e.RowIndex");
             }
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             if (e.RowIndex >= 0 && dataGridViewCell.ClickUnsharesRowInternal(e))
             {
                 DataGridViewRow dataGridViewRow = Rows[e.RowIndex];
@@ -11480,7 +11480,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException("e.RowIndex");
             }
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             if (e.RowIndex >= 0 && dataGridViewCell.ContentClickUnsharesRowInternal(e))
             {
                 DataGridViewRow dataGridViewRow = Rows[e.RowIndex];
@@ -11513,7 +11513,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException("e.RowIndex");
             }
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             if (e.RowIndex >= 0 && dataGridViewCell.ContentDoubleClickUnsharesRowInternal(e))
             {
                 DataGridViewRow dataGridViewRow = Rows[e.RowIndex];
@@ -11586,7 +11586,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException("e.RowIndex");
             }
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             if (e.RowIndex >= 0 && dataGridViewCell.DoubleClickUnsharesRowInternal(e))
             {
                 DataGridViewRow dataGridViewRow = Rows[e.RowIndex];
@@ -11622,7 +11622,7 @@ namespace System.Windows.Forms
         internal void OnCellEnter(ref DataGridViewCell dataGridViewCell, int columnIndex, int rowIndex)
         {
             OnCellEnter(new DataGridViewCellEventArgs(columnIndex, rowIndex));
-            if (dataGridViewCell != null)
+            if (dataGridViewCell is not null)
             {
                 if (IsInnerCellOutOfBounds(columnIndex, rowIndex))
                 {
@@ -11743,7 +11743,7 @@ namespace System.Windows.Forms
         internal void OnCellLeave(ref DataGridViewCell dataGridViewCell, int columnIndex, int rowIndex)
         {
             OnCellLeave(new DataGridViewCellEventArgs(columnIndex, rowIndex));
-            if (dataGridViewCell != null)
+            if (dataGridViewCell is not null)
             {
                 if (IsInnerCellOutOfBounds(columnIndex, rowIndex))
                 {
@@ -11794,7 +11794,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException("e.RowIndex");
             }
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             if (e.RowIndex >= 0 && dataGridViewCell.MouseClickUnsharesRowInternal(e))
             {
                 DataGridViewRow dataGridViewRow = Rows[e.RowIndex];
@@ -11823,7 +11823,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException("e.RowIndex");
             }
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             if (e.RowIndex >= 0 && dataGridViewCell.MouseDoubleClickUnsharesRowInternal(e))
             {
                 DataGridViewRow dataGridViewRow = Rows[e.RowIndex];
@@ -11853,7 +11853,7 @@ namespace System.Windows.Forms
             }
 
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
 
             // Only left clicks for now
             Keys nModifier = ModifierKeys;
@@ -12047,7 +12047,7 @@ namespace System.Windows.Forms
             {
                 DataGridViewColumn dataGridViewLastVisibleColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible,
                                                                                               DataGridViewElementStates.None);
-                if (_ptCurrentCell.X == -1 && dataGridViewLastVisibleColumn != null)
+                if (_ptCurrentCell.X == -1 && dataGridViewLastVisibleColumn is not null)
                 {
                     // CurrentCell was reset because CommitEdit deleted column(s).
                     // Since the user clicked on a cell, we don't want to end up
@@ -12508,7 +12508,7 @@ namespace System.Windows.Forms
             _ptMouseEnteredCell.Y = e.RowIndex;
 
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             if (e.RowIndex >= 0 && dataGridViewCell.MouseEnterUnsharesRowInternal(e.RowIndex))
             {
                 DataGridViewRow dataGridViewRow = Rows[e.RowIndex];
@@ -12539,7 +12539,7 @@ namespace System.Windows.Forms
             _ptMouseEnteredCell.Y = -2;
 
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             if (e.RowIndex >= 0 && dataGridViewCell.MouseLeaveUnsharesRowInternal(e.RowIndex))
             {
                 DataGridViewRow dataGridViewRow = Rows[e.RowIndex];
@@ -12567,7 +12567,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException("e.RowIndex");
             }
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             if (e.RowIndex >= 0 && dataGridViewCell.MouseMoveUnsharesRowInternal(e))
             {
                 DataGridViewRow dataGridViewRow = Rows[e.RowIndex];
@@ -12632,7 +12632,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException("e.RowIndex");
             }
             DataGridViewCell dataGridViewCell = GetCellInternal(e.ColumnIndex, e.RowIndex);
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             if (e.RowIndex >= 0 && dataGridViewCell.MouseUpUnsharesRowInternal(e))
             {
                 DataGridViewRow dataGridViewRow = Rows[e.RowIndex];
@@ -12788,7 +12788,7 @@ namespace System.Windows.Forms
 
         internal void OnCellStyleContentChanged(DataGridViewCellStyle dataGridViewCellStyle, DataGridViewCellStyle.DataGridViewCellStylePropertyInternal property)
         {
-            Debug.Assert(dataGridViewCellStyle != null);
+            Debug.Assert(dataGridViewCellStyle is not null);
             switch (property)
             {
                 case DataGridViewCellStyle.DataGridViewCellStylePropertyInternal.Font:
@@ -12932,7 +12932,7 @@ namespace System.Windows.Forms
                 OnAlternatingRowsDefaultCellStyleChanged(CellStyleChangedEventArgs);
             }
 
-            if (repositionEditingControl && EditingControl != null)
+            if (repositionEditingControl && EditingControl is not null)
             {
                 PositionEditingControl(true /*setLocation*/, true /*setSize*/, false /*setFocus*/);
             }
@@ -12991,7 +12991,7 @@ namespace System.Windows.Forms
         internal void OnCellValidated(ref DataGridViewCell dataGridViewCell, int columnIndex, int rowIndex)
         {
             OnCellValidated(new DataGridViewCellEventArgs(columnIndex, rowIndex));
-            if (dataGridViewCell != null)
+            if (dataGridViewCell is not null)
             {
                 if (IsInnerCellOutOfBounds(columnIndex, rowIndex))
                 {
@@ -13040,7 +13040,7 @@ namespace System.Windows.Forms
             object editedFormattedValue = currentCell.GetEditedFormattedValue(val, rowIndex, ref dataGridViewCellStyle, context);
             DataGridViewCellValidatingEventArgs dgvcfvce = new DataGridViewCellValidatingEventArgs(columnIndex, rowIndex, editedFormattedValue);
             OnCellValidating(dgvcfvce);
-            if (dataGridViewCell != null)
+            if (dataGridViewCell is not null)
             {
                 if (IsInnerCellOutOfBounds(columnIndex, rowIndex))
                 {
@@ -13211,7 +13211,7 @@ namespace System.Windows.Forms
             _dataGridViewState2[State2_RaiseSelectionChanged] = _selectedBandIndexes.Count > 0 ||
                                                                                 _individualSelectedCells.Count > 0;
             _selectedBandIndexes.Clear();
-            if (_selectedBandSnapshotIndexes != null)
+            if (_selectedBandSnapshotIndexes is not null)
             {
                 _selectedBandSnapshotIndexes.Clear();
             }
@@ -13234,7 +13234,7 @@ namespace System.Windows.Forms
         internal void OnColumnCollectionChanged_PreNotification(CollectionChangeEventArgs ccea)
         {
             // we need to map columns w/ DataPropertyName to bound columns
-            if (DataSource != null && !_dataGridViewOper[OperationInRefreshColumns])
+            if (DataSource is not null && !_dataGridViewOper[OperationInRefreshColumns])
             {
                 if (ccea.Action == CollectionChangeAction.Add)
                 {
@@ -13263,7 +13263,7 @@ namespace System.Windows.Forms
         {
             if (Columns.Count != 0 && Rows.Count == 0)
             {
-                if (DataSource != null && !_dataGridViewOper[OperationInRefreshColumns])
+                if (DataSource is not null && !_dataGridViewOper[OperationInRefreshColumns])
                 {
                     // this will create the 'add new row' when AllowUserToAddRowsInternal == true
                     RefreshRows(true /*scrollIntoView*/);
@@ -13308,11 +13308,11 @@ namespace System.Windows.Forms
                 throw new ArgumentException(SR.DataGridView_ColumnDoesNotBelongToDataGridView);
             }
             // map the dataGridView column to some data field
-            if (DataSource != null && e.Column.DataPropertyName.Length != 0 && !_dataGridViewOper[OperationInRefreshColumns])
+            if (DataSource is not null && e.Column.DataPropertyName.Length != 0 && !_dataGridViewOper[OperationInRefreshColumns])
             {
                 MapDataGridViewColumnToDataBoundField(e.Column);
             }
-            else if (DataSource != null && e.Column.DataPropertyName.Length == 0)
+            else if (DataSource is not null && e.Column.DataPropertyName.Length == 0)
             {
                 if (e.Column.IsDataBound)
                 {
@@ -13345,14 +13345,14 @@ namespace System.Windows.Forms
 
         internal void OnColumnDisplayIndexChanged(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             DataGridViewColumnEventArgs dgvce = new DataGridViewColumnEventArgs(dataGridViewColumn);
             OnColumnDisplayIndexChanged(dgvce);
         }
 
         internal void OnColumnDisplayIndexChanging(DataGridViewColumn dataGridViewColumn, int newDisplayIndex)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             Debug.Assert(newDisplayIndex != dataGridViewColumn.DisplayIndex);
 
             if (_dataGridViewOper[OperationInDisplayIndexAdjustments])
@@ -13430,7 +13430,7 @@ namespace System.Windows.Forms
             Columns.InvalidateCachedColumnsOrder();
 
             PerformLayoutPrivate(false /*useRowShortcut*/, false /*computeVisibleRows*/, true /*invalidInAdjustFillingColumns*/, false /*repositionEditingControl*/);
-            if (EditingControl != null)
+            if (EditingControl is not null)
             {
                 PositionEditingControl(true, true, false);
             }
@@ -13636,7 +13636,7 @@ namespace System.Windows.Forms
                     }
 
                     if ((DataSource is null) ||
-                        (DataSource != null &&
+                        (DataSource is not null &&
                          (DataConnection.List is IBindingList) &&
                          ((IBindingList)DataConnection.List).SupportsSorting &&
                          dataGridViewColumn.IsDataBound))
@@ -13872,7 +13872,7 @@ namespace System.Windows.Forms
                 if (!(e is DataGridViewCellStyleChangedEventArgs dgvcsce) || dgvcsce.ChangeAffectsPreferredSize)
                 {
                     OnColumnHeadersGlobalAutoSize();
-                    if (EditingControl != null)
+                    if (EditingControl is not null)
                     {
                         PositionEditingControl(true /*setLocation*/, true /*setSize*/, false /*setFocus*/);
                     }
@@ -13933,7 +13933,7 @@ namespace System.Windows.Forms
 
         protected virtual void OnColumnHeadersHeightChanged(EventArgs e)
         {
-            if (EditingControl != null)
+            if (EditingControl is not null)
             {
                 PositionEditingControl(true, false, false);
             }
@@ -13972,7 +13972,7 @@ namespace System.Windows.Forms
 
         internal void OnColumnHidden(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             if (dataGridViewColumn.Displayed)
             {
                 dataGridViewColumn.Displayed = false;
@@ -14020,7 +14020,7 @@ namespace System.Windows.Forms
 
         internal void OnColumnNameChanged(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             DataGridViewColumnEventArgs dgvce = new DataGridViewColumnEventArgs(dataGridViewColumn);
             OnColumnNameChanged(dgvce);
         }
@@ -14072,7 +14072,7 @@ namespace System.Windows.Forms
 
         internal void OnColumnRemoved(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             Debug.Assert(dataGridViewColumn.DataGridView is null);
             OnColumnRemoved(new DataGridViewColumnEventArgs(dataGridViewColumn));
         }
@@ -14108,62 +14108,62 @@ namespace System.Windows.Forms
                 if (_trackColumnEdge >= 0 && (Columns.DisplayInOrder(_trackColumn, _trackColumnEdge) || _trackColumnEdge == _trackColumn) && Columns.DisplayInOrder(_trackColumnEdge, hti._col))
                 {
                     DataGridViewColumn dataGridViewColumn = Columns.GetNextColumn(Columns[_trackColumnEdge], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectColumnRange(dataGridViewColumn.Index, hti._col, true);
                     _trackColumnEdge = hti._col;
                 }
                 else if (_trackColumnEdge >= 0 && Columns.DisplayInOrder(_trackColumn, _trackColumnEdge) && Columns.DisplayInOrder(hti._col, _trackColumnEdge) && (Columns.DisplayInOrder(_trackColumn, hti._col) || hti._col == _trackColumn))
                 {
                     DataGridViewColumn dataGridViewColumn = Columns.GetNextColumn(Columns[hti._col], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectColumnRange(dataGridViewColumn.Index, _trackColumnEdge, false);
                     _trackColumnEdge = hti._col;
                 }
                 else if (_trackColumnEdge == -1 && Columns.DisplayInOrder(_trackColumn, hti._col))
                 {
                     DataGridViewColumn dataGridViewColumn = Columns.GetNextColumn(Columns[_trackColumn], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectColumnRange(dataGridViewColumn.Index, hti._col, true);
                     _trackColumnEdge = hti._col;
                 }
                 else if (_trackColumnEdge >= 0 && (Columns.DisplayInOrder(_trackColumnEdge, _trackColumn) || _trackColumnEdge == _trackColumn) && Columns.DisplayInOrder(hti._col, _trackColumnEdge))
                 {
                     DataGridViewColumn dataGridViewColumn = Columns.GetPreviousColumn(Columns[_trackColumnEdge], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectColumnRange(hti._col, dataGridViewColumn.Index, true);
                     _trackColumnEdge = hti._col;
                 }
                 else if (_trackColumnEdge >= 0 && Columns.DisplayInOrder(_trackColumnEdge, _trackColumn) && Columns.DisplayInOrder(_trackColumnEdge, hti._col) && (Columns.DisplayInOrder(hti._col, _trackColumn) || hti._col == _trackColumn))
                 {
                     DataGridViewColumn dataGridViewColumn = Columns.GetPreviousColumn(Columns[hti._col], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectColumnRange(_trackColumnEdge, dataGridViewColumn.Index, false);
                     _trackColumnEdge = hti._col;
                 }
                 else if (_trackColumnEdge == -1 && Columns.DisplayInOrder(hti._col, _trackColumn))
                 {
                     DataGridViewColumn dataGridViewColumn = Columns.GetPreviousColumn(Columns[_trackColumn], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectColumnRange(hti._col, dataGridViewColumn.Index, true);
                     _trackColumnEdge = hti._col;
                 }
                 else if (_trackColumnEdge >= 0 && Columns.DisplayInOrder(_trackColumn, _trackColumnEdge) && Columns.DisplayInOrder(hti._col, _trackColumn))
                 {
                     DataGridViewColumn dataGridViewColumn = Columns.GetNextColumn(Columns[_trackColumn], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectColumnRange(dataGridViewColumn.Index, _trackColumnEdge, false);
                     dataGridViewColumn = Columns.GetPreviousColumn(Columns[_trackColumn], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectColumnRange(hti._col, dataGridViewColumn.Index, true);
                     _trackColumnEdge = hti._col;
                 }
                 else if (_trackColumnEdge >= 0 && Columns.DisplayInOrder(_trackColumn, hti._col) && Columns.DisplayInOrder(_trackColumnEdge, _trackColumn))
                 {
                     DataGridViewColumn dataGridViewColumn = Columns.GetPreviousColumn(Columns[_trackColumn], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectColumnRange(_trackColumnEdge, dataGridViewColumn.Index, false);
                     dataGridViewColumn = Columns.GetNextColumn(Columns[_trackColumn], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectColumnRange(dataGridViewColumn.Index, hti._col, true);
                     _trackColumnEdge = hti._col;
                 }
@@ -14214,7 +14214,7 @@ namespace System.Windows.Forms
 
         internal void OnColumnSortModeChanged(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             DataGridViewColumnEventArgs dgvce = new DataGridViewColumnEventArgs(dataGridViewColumn);
             OnColumnSortModeChanged(dgvce);
         }
@@ -14462,7 +14462,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     PositionEditingControl(_ptCurrentCell.X != e.Column.Index, true, false);
                 }
@@ -14515,7 +14515,7 @@ namespace System.Windows.Forms
                 eh(this, e);
             }
 
-            if (CurrentCell != null && (ShowCellToolTips || (ShowCellErrors && !string.IsNullOrEmpty(CurrentCell?.ErrorText))))
+            if (CurrentCell is not null && (ShowCellToolTips || (ShowCellErrors && !string.IsNullOrEmpty(CurrentCell?.ErrorText))))
             {
                 ActivateToolTip(false /*activate*/, String.Empty, CurrentCell.ColumnIndex, CurrentCell.RowIndex);
                 KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(CurrentCell);
@@ -14619,7 +14619,7 @@ namespace System.Windows.Forms
             {
                 if (element is DataGridViewRow dataGridViewRow)
                 {
-                    if (Events[s_rowStateChangedEvent] is DataGridViewRowStateChangedEventHandler eh && dataGridViewRow.DataGridView != null && dataGridViewRow.Index == -1)
+                    if (Events[s_rowStateChangedEvent] is DataGridViewRowStateChangedEventHandler eh && dataGridViewRow.DataGridView is not null && dataGridViewRow.Index == -1)
                     {
                         dataGridViewRow = Rows[index];
                     }
@@ -14739,10 +14739,10 @@ namespace System.Windows.Forms
                             {
                                 Debug.Assert((Rows.GetRowState(rowIndex) & DataGridViewElementStates.Visible) != 0);
                                 // Row of the current cell is made invisible.
-                                if (DataSource != null)
+                                if (DataSource is not null)
                                 {
-                                    Debug.Assert(DataConnection != null);
-                                    Debug.Assert(DataConnection.CurrencyManager != null);
+                                    Debug.Assert(DataConnection is not null);
+                                    Debug.Assert(DataConnection.CurrencyManager is not null);
                                     Debug.Assert(DataConnection.CurrencyManager.Position == _ptCurrentCell.Y);
                                     // the row associated with the currency manager's position cannot be made invisble.
                                     throw new InvalidOperationException(SR.DataGridView_CurrencyManagerRowCannotBeInvisible);
@@ -14839,7 +14839,7 @@ namespace System.Windows.Forms
                 eh(this, e);
             }
 
-            if (DataConnection != null && DataConnection.CurrencyManager != null)
+            if (DataConnection is not null && DataConnection.CurrencyManager is not null)
             {
                 OnDataBindingComplete(ListChangedType.Reset);
             }
@@ -14855,7 +14855,7 @@ namespace System.Windows.Forms
                 eh(this, e);
             }
 
-            if (DataConnection != null && DataConnection.CurrencyManager != null)
+            if (DataConnection is not null && DataConnection.CurrencyManager is not null)
             {
                 OnDataBindingComplete(ListChangedType.Reset);
             }
@@ -14870,7 +14870,7 @@ namespace System.Windows.Forms
             else
             {
                 OnGlobalAutoSize();
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     PositionEditingControl(true /*setLocation*/, true /*setSize*/, false /*setFocus*/);
                 }
@@ -14945,7 +14945,7 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated && Enabled)
             {
-                if (_vertScrollBar != null && _vertScrollBar.Visible)
+                if (_vertScrollBar is not null && _vertScrollBar.Visible)
                 {
                     int totalVisibleHeight = Rows.GetRowsHeight(DataGridViewElementStates.Visible);
                     int totalVisibleFrozenHeight = Rows.GetRowsHeight(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
@@ -14953,7 +14953,7 @@ namespace System.Windows.Forms
 
                     _vertScrollBar.Enabled = true;
                 }
-                if (_horizScrollBar != null && _horizScrollBar.Visible)
+                if (_horizScrollBar is not null && _horizScrollBar.Visible)
                 {
                     _horizScrollBar.Enabled = true;
                 }
@@ -14962,7 +14962,7 @@ namespace System.Windows.Forms
 
         protected override void OnEnter(EventArgs e)
         {
-            if (EditingControl != null && EditingControl.ContainsFocus)
+            if (EditingControl is not null && EditingControl.ContainsFocus)
             {
                 return;
             }
@@ -15155,7 +15155,7 @@ namespace System.Windows.Forms
                 // However, AccessibilityNotifyCurrentCellChanged is now a public method so we can't change its name
                 // to better reflect its purpose.
                 AccessibilityNotifyCurrentCellChanged(_ptCurrentCell);
-                if (CurrentCell != null && (ShowCellToolTips || (ShowCellErrors && !string.IsNullOrEmpty(CurrentCell.ErrorText))))
+                if (CurrentCell is not null && (ShowCellToolTips || (ShowCellErrors && !string.IsNullOrEmpty(CurrentCell.ErrorText))))
                 {
                     ActivateToolTip(false /*activate*/, String.Empty, CurrentCell.ColumnIndex, CurrentCell.RowIndex);
                     KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(CurrentCell);
@@ -15274,7 +15274,7 @@ namespace System.Windows.Forms
         internal void OnInsertedRows_PreNotification(int rowIndex, DataGridViewRow[] dataGridViewRows)
         {
             Debug.Assert(rowIndex >= 0);
-            Debug.Assert(dataGridViewRows != null);
+            Debug.Assert(dataGridViewRows is not null);
             Debug.Assert(dataGridViewRows.Length > 0);
 
             // Fix the OldFirstDisplayedScrollingRow
@@ -15289,7 +15289,7 @@ namespace System.Windows.Forms
 
         internal void OnInsertedRows_PostNotification(DataGridViewRow[] dataGridViewRows, Point newCurrentCell)
         {
-            Debug.Assert(dataGridViewRows != null);
+            Debug.Assert(dataGridViewRows is not null);
             Debug.Assert(dataGridViewRows.Length > 0);
 
             // Same effect as adding the rows
@@ -15306,9 +15306,9 @@ namespace System.Windows.Forms
 
         internal void OnInsertingColumn(int columnIndexInserted, DataGridViewColumn dataGridViewColumn, out Point newCurrentCell)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
 
-            if (dataGridViewColumn.DataGridView != null)
+            if (dataGridViewColumn.DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridView_ColumnAlreadyBelongsToDataGridView);
             }
@@ -15364,9 +15364,9 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridView_CannotAddUntypedColumn);
                 }
 
-                if (dataGridViewColumn.CellTemplate.DefaultNewRowValue != null && NewRowIndex != -1)
+                if (dataGridViewColumn.CellTemplate.DefaultNewRowValue is not null && NewRowIndex != -1)
                 {
-                    // New row needs to be unshared before addition of new cell with a Value != null
+                    // New row needs to be unshared before addition of new cell with a Value is not null
                     DataGridViewRow newRow = Rows[NewRowIndex];
                 }
 
@@ -15427,7 +15427,7 @@ namespace System.Windows.Forms
                         }
                         columnEntry++;
                     }
-                    if (_selectedBandSnapshotIndexes != null)
+                    if (_selectedBandSnapshotIndexes is not null)
                     {
                         columnEntries = _selectedBandSnapshotIndexes.Count;
                         columnEntry = 0;
@@ -15507,7 +15507,7 @@ namespace System.Windows.Forms
                         }
                         rowEntry++;
                     }
-                    if (_selectedBandSnapshotIndexes != null)
+                    if (_selectedBandSnapshotIndexes is not null)
                     {
                         rowEntries = _selectedBandSnapshotIndexes.Count;
                         rowEntry = 0;
@@ -15527,7 +15527,7 @@ namespace System.Windows.Forms
 
         internal void OnInsertingRows(int rowIndexInserted, DataGridViewRow[] dataGridViewRows, ref Point newCurrentCell)
         {
-            Debug.Assert(dataGridViewRows != null);
+            Debug.Assert(dataGridViewRows is not null);
 
             // Reset the current cell's address if it's after the inserted row.
             if (_ptCurrentCell.Y != -1 && rowIndexInserted <= _ptCurrentCell.Y)
@@ -15563,7 +15563,7 @@ namespace System.Windows.Forms
                         }
                         rowEntry++;
                     }
-                    if (_selectedBandSnapshotIndexes != null)
+                    if (_selectedBandSnapshotIndexes is not null)
                     {
                         rowEntries = _selectedBandSnapshotIndexes.Count;
                         rowEntry = 0;
@@ -15594,7 +15594,7 @@ namespace System.Windows.Forms
             if (_ptCurrentCell.X != -1)
             {
                 DataGridViewCell dataGridViewCell = CurrentCellInternal;
-                Debug.Assert(dataGridViewCell != null);
+                Debug.Assert(dataGridViewCell is not null);
                 if (dataGridViewCell.KeyDownUnsharesRowInternal(e, _ptCurrentCell.Y))
                 {
                     DataGridViewRow dataGridViewRow = Rows[_ptCurrentCell.Y];
@@ -15652,7 +15652,7 @@ namespace System.Windows.Forms
             if (_ptCurrentCell.X != -1)
             {
                 DataGridViewCell dataGridViewCell = CurrentCellInternal;
-                Debug.Assert(dataGridViewCell != null);
+                Debug.Assert(dataGridViewCell is not null);
                 if (dataGridViewCell.KeyPressUnsharesRowInternal(e, _ptCurrentCell.Y))
                 {
                     DataGridViewRow dataGridViewRow = Rows[_ptCurrentCell.Y];
@@ -15685,7 +15685,7 @@ namespace System.Windows.Forms
             if (_ptCurrentCell.X != -1)
             {
                 DataGridViewCell dataGridViewCell = CurrentCellInternal;
-                Debug.Assert(dataGridViewCell != null);
+                Debug.Assert(dataGridViewCell is not null);
                 if (dataGridViewCell.KeyUpUnsharesRowInternal(e, _ptCurrentCell.Y))
                 {
                     DataGridViewRow dataGridViewRow = Rows[_ptCurrentCell.Y];
@@ -15711,7 +15711,7 @@ namespace System.Windows.Forms
             {
                 Invalidate();
             }
-            if (EditingControl != null)
+            if (EditingControl is not null)
             {
                 PositionEditingControl(true, true, false);
             }
@@ -15756,7 +15756,7 @@ namespace System.Windows.Forms
                 InvalidateCell(_ptCurrentCell.X, _ptCurrentCell.Y);
             }
 
-            if (CurrentCell != null)
+            if (CurrentCell is not null)
             {
                 KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(CurrentCell);
             }
@@ -15821,7 +15821,7 @@ namespace System.Windows.Forms
                             case DataGridViewHitTestTypeInternal.ColumnHeaderRight:
                             case DataGridViewHitTestTypeInternal.FirstColumnHeaderLeft:
                                 {
-                                    Debug.Assert(dgvcme != null);
+                                    Debug.Assert(dgvcme is not null);
                                     if (dgvcme.ColumnIndex < Columns.Count && dgvcme.RowIndex < Rows.Count)
                                     {
                                         OnColumnHeaderMouseClick(dgvcme);
@@ -15831,7 +15831,7 @@ namespace System.Windows.Forms
 
                             case DataGridViewHitTestTypeInternal.RowHeader:
                                 {
-                                    Debug.Assert(dgvcme != null);
+                                    Debug.Assert(dgvcme is not null);
                                     if (dgvcme.ColumnIndex < Columns.Count && dgvcme.RowIndex < Rows.Count)
                                     {
                                         OnRowHeaderMouseClick(dgvcme);
@@ -15885,7 +15885,7 @@ namespace System.Windows.Forms
                             case DataGridViewHitTestTypeInternal.ColumnHeaderRight:
                             case DataGridViewHitTestTypeInternal.FirstColumnHeaderLeft:
                                 {
-                                    Debug.Assert(dgvcme != null);
+                                    Debug.Assert(dgvcme is not null);
                                     if (dgvcme.ColumnIndex < Columns.Count && dgvcme.RowIndex < Rows.Count)
                                     {
                                         OnColumnHeaderMouseDoubleClick(dgvcme);
@@ -15921,7 +15921,7 @@ namespace System.Windows.Forms
 
                             case DataGridViewHitTestTypeInternal.RowHeader:
                                 {
-                                    Debug.Assert(dgvcme != null);
+                                    Debug.Assert(dgvcme is not null);
                                     if (dgvcme.ColumnIndex < Columns.Count && dgvcme.RowIndex < Rows.Count)
                                     {
                                         OnRowHeaderMouseDoubleClick(dgvcme);
@@ -16145,7 +16145,7 @@ namespace System.Windows.Forms
                 {
                     if (xOffset == 0)
                     {
-                        if (_horizScrollTimer != null && _horizScrollTimer.Enabled)
+                        if (_horizScrollTimer is not null && _horizScrollTimer.Enabled)
                         {
                             // Mouse's X came in-bound - need to stop the horizontal scroll timer
                             _horizScrollTimer.Enabled = false;
@@ -16160,7 +16160,7 @@ namespace System.Windows.Forms
 
                     if (yOffset == 0)
                     {
-                        if (_vertScrollTimer != null && _vertScrollTimer.Enabled)
+                        if (_vertScrollTimer is not null && _vertScrollTimer.Enabled)
                         {
                             // Mouse's Y came in-bound - need to stop the vertical scroll timer
                             _vertScrollTimer.Enabled = false;
@@ -16246,7 +16246,7 @@ namespace System.Windows.Forms
                         if (hti._col >= 0 && _ptMouseDownCell.X == hti._col &&
                             hti._row >= 0 && _ptMouseDownCell.Y == hti._row &&
                             EditMode == DataGridViewEditMode.EditOnEnter &&
-                            EditingControl != null)
+                            EditingControl is not null)
                         {
                             OnClick(e);
                             OnMouseClick(e);
@@ -16321,7 +16321,7 @@ namespace System.Windows.Forms
             base.OnMouseWheel(e);
 
             HandledMouseEventArgs hme = e as HandledMouseEventArgs;
-            if (hme != null && hme.Handled)
+            if (hme is not null && hme.Handled)
             {
                 // The application event handler handled the scrolling - don't do anything more.
                 return;
@@ -16341,7 +16341,7 @@ namespace System.Windows.Forms
                 return; // Do not scroll when the corresponding scrollbar is invisible or disabled
             }
 
-            if (hme != null)
+            if (hme is not null)
             {
                 hme.Handled = true;
             }
@@ -16891,7 +16891,7 @@ namespace System.Windows.Forms
 
         internal void OnRemovingColumn(DataGridViewColumn dataGridViewColumn, out Point newCurrentCell, bool force)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             Debug.Assert(dataGridViewColumn.Index >= 0 && dataGridViewColumn.Index < Columns.Count);
 
             _dataGridViewState1[State1_TemporarilyResetCurrentCell] = false;
@@ -16907,7 +16907,7 @@ namespace System.Windows.Forms
                         Columns[columnIndex],
                         DataGridViewElementStates.Visible,
                         DataGridViewElementStates.None);
-                    if (dataGridViewColumnNext != null)
+                    if (dataGridViewColumnNext is not null)
                     {
                         if (dataGridViewColumnNext.Index > columnIndex)
                         {
@@ -16924,7 +16924,7 @@ namespace System.Windows.Forms
                             Columns[columnIndex],
                             DataGridViewElementStates.Visible,
                             DataGridViewElementStates.None);
-                        if (dataGridViewColumnPrevious != null)
+                        if (dataGridViewColumnPrevious is not null)
                         {
                             if (dataGridViewColumnPrevious.Index > columnIndex)
                             {
@@ -17211,7 +17211,7 @@ namespace System.Windows.Forms
                             rowEntry++;
                         }
                     }
-                    if (_selectedBandSnapshotIndexes != null)
+                    if (_selectedBandSnapshotIndexes is not null)
                     {
                         rowEntries = _selectedBandSnapshotIndexes.Count;
                         rowEntry = 0;
@@ -17543,9 +17543,9 @@ namespace System.Windows.Forms
                     if (canCreateNewRow)
                     {
                         DataGridViewRowEventArgs dgvre = new DataGridViewRowEventArgs(Rows[NewRowIndex]);
-                        if (VirtualMode || DataSource != null)
+                        if (VirtualMode || DataSource is not null)
                         {
-                            if (DataConnection != null && DataConnection.InterestedInRowEvents)
+                            if (DataConnection is not null && DataConnection.InterestedInRowEvents)
                             {
                                 DataConnection.OnNewRowNeeded();
                                 calledAddNewOnTheDataConnection = true;
@@ -17582,7 +17582,7 @@ namespace System.Windows.Forms
 
                 DataGridViewCellEventArgs dgvce = new DataGridViewCellEventArgs(columnIndex, rowIndex);
                 OnRowEnter(dgvce);
-                if (DataConnection != null &&
+                if (DataConnection is not null &&
                     DataConnection.InterestedInRowEvents &&
                     !DataConnection.PositionChangingOutsideDataGridView &&
                     !DataConnection.ListWasReset &&
@@ -17591,7 +17591,7 @@ namespace System.Windows.Forms
                     DataConnection.OnRowEnter(dgvce);
                 }
 
-                if (dataGridViewCell != null)
+                if (dataGridViewCell is not null)
                 {
                     if (IsInnerCellOutOfBounds(columnIndex, rowIndex))
                     {
@@ -17833,7 +17833,7 @@ namespace System.Windows.Forms
                             if (select)
                             {
                                 DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-                                if (dataGridViewColumn != null && hti._row != _ptCurrentCell.Y)
+                                if (dataGridViewColumn is not null && hti._row != _ptCurrentCell.Y)
                                 {
                                     int oldCurrentCellX = _ptCurrentCell.X;
                                     int oldCurrentCellY = _ptCurrentCell.Y;
@@ -17984,7 +17984,7 @@ namespace System.Windows.Forms
                                                  ((Rows.GetRowState(hti._row) & DataGridViewElementStates.Selected) != 0));
                                     SetSelectedRowCore(hti._row, true);
                                 }
-                                if (dataGridViewColumn != null)
+                                if (dataGridViewColumn is not null)
                                 {
                                     if (hti._row != _ptCurrentCell.Y)
                                     {
@@ -18052,7 +18052,7 @@ namespace System.Windows.Forms
                 if (!(e is DataGridViewCellStyleChangedEventArgs dgvcsce) || dgvcsce.ChangeAffectsPreferredSize)
                 {
                     OnRowHeadersGlobalAutoSize(false /*expandingRows*/);
-                    if (EditingControl != null)
+                    if (EditingControl is not null)
                     {
                         PositionEditingControl(true /*setLocation*/, true /*setSize*/, false /*setFocus*/);
                     }
@@ -18104,7 +18104,7 @@ namespace System.Windows.Forms
         {
             if (RowHeadersVisible)
             {
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     PositionEditingControl(true, false, false);
                 }
@@ -18181,7 +18181,7 @@ namespace System.Windows.Forms
         {
             Debug.Assert(rowIndex != -1);
             Debug.Assert(_autoSizeRowsMode == DataGridViewAutoSizeRowsMode.None);
-            if (VirtualMode || DataSource != null)
+            if (VirtualMode || DataSource is not null)
             {
                 DataGridViewRowHeightInfoPushedEventArgs dgvrhipe = new DataGridViewRowHeightInfoPushedEventArgs(rowIndex, height, minimumHeight);
                 OnRowHeightInfoPushed(dgvrhipe);
@@ -18209,7 +18209,7 @@ namespace System.Windows.Forms
             {
                 DataGridViewCellEventArgs dgvce = new DataGridViewCellEventArgs(columnIndex, rowIndex);
                 OnRowLeave(dgvce);
-                if (dataGridViewCell != null)
+                if (dataGridViewCell is not null)
                 {
                     if (IsInnerCellOutOfBounds(columnIndex, rowIndex))
                     {
@@ -18293,7 +18293,7 @@ namespace System.Windows.Forms
             else
             {
                 OnRowsGlobalAutoSize();
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     PositionEditingControl(true /*setLocation*/, true /*setSize*/, false /*setFocus*/);
                 }
@@ -18599,7 +18599,7 @@ namespace System.Windows.Forms
 
         internal void OnRowUnshared(DataGridViewRow dataGridViewRow)
         {
-            if (-1 != _ptCurrentCell.X && dataGridViewRow.Index == _ptCurrentCell.Y && EditingControl != null)
+            if (-1 != _ptCurrentCell.X && dataGridViewRow.Index == _ptCurrentCell.Y && EditingControl is not null)
             {
                 CurrentCellInternal.CacheEditingControl();
             }
@@ -18625,7 +18625,7 @@ namespace System.Windows.Forms
             OnRowValidating(dgvcce);
             if (!dgvcce.Cancel)
             {
-                if (DataConnection != null &&
+                if (DataConnection is not null &&
                     DataConnection.InterestedInRowEvents &&
                     !DataConnection.PositionChangingOutsideDataGridView &&
                     !DataConnection.ListWasReset)
@@ -18633,7 +18633,7 @@ namespace System.Windows.Forms
                     DataConnection.OnRowValidating(dgvcce);
                 }
             }
-            if (dataGridViewCell != null && rowIndex < Rows.Count && columnIndex < Columns.Count)
+            if (dataGridViewCell is not null && rowIndex < Rows.Count && columnIndex < Columns.Count)
             {
                 dataGridViewCell = Rows.SharedRow(rowIndex).Cells[columnIndex];
             }
@@ -18671,7 +18671,7 @@ namespace System.Windows.Forms
 
             DataGridViewCellEventArgs dgvce = new DataGridViewCellEventArgs(columnIndex, rowIndex);
             OnRowValidated(dgvce);
-            if (dataGridViewCell != null)
+            if (dataGridViewCell is not null)
             {
                 if (IsInnerCellOutOfBounds(columnIndex, rowIndex))
                 {
@@ -18843,7 +18843,7 @@ namespace System.Windows.Forms
 
         internal void OnSortGlyphDirectionChanged(DataGridViewColumnHeaderCell dataGridViewColumnHeaderCell)
         {
-            Debug.Assert(dataGridViewColumnHeaderCell != null);
+            Debug.Assert(dataGridViewColumnHeaderCell is not null);
 
             if (dataGridViewColumnHeaderCell.OwningColumn == SortedColumn)
             {
@@ -18874,7 +18874,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                SortOrder = SortedColumn != null ? SortedColumn.HeaderCell.SortGlyphDirection : SortOrder.None;
+                SortOrder = SortedColumn is not null ? SortedColumn.HeaderCell.SortGlyphDirection : SortOrder.None;
             }
 
             InvalidateCellPrivate(dataGridViewColumnHeaderCell);
@@ -18937,7 +18937,7 @@ namespace System.Windows.Forms
                 if (e.Category == UserPreferenceCategory.Window)
                 {
                     _cachedEditingControl = null;
-                    if (EditingControl != null)
+                    if (EditingControl is not null)
                     {
                         // The editing control may not adapt well to the new system rendering,
                         // so instead of caching it into the this.cachedEditingControl variable
@@ -18987,7 +18987,7 @@ namespace System.Windows.Forms
                     }
                     OnRowValidated(ref dataGridViewCellTmp, _ptCurrentCell.X, _ptCurrentCell.Y);
                     // Row validation was not cancelled, but does operation need to be re-evaluated.
-                    if (DataSource != null &&
+                    if (DataSource is not null &&
                         _ptCurrentCell.X >= 0 &&
                         AllowUserToAddRowsInternal &&
                         NewRowIndex == _ptCurrentCell.Y)
@@ -19250,7 +19250,7 @@ namespace System.Windows.Forms
 
                 // first paint the visible frozen columns
                 DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
-                while (dataGridViewColumn != null)
+                while (dataGridViewColumn is not null)
                 {
                     cell = dataGridViewColumn.HeaderCell;
                     cellBounds.Width = dataGridViewColumn.Thickness;
@@ -19325,7 +19325,7 @@ namespace System.Windows.Forms
                     }
 
                     dataGridViewColumn = Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol];
-                    while (dataGridViewColumn != null)
+                    while (dataGridViewColumn is not null)
                     {
                         Debug.Assert(dataGridViewColumn.Visible && !dataGridViewColumn.Frozen);
 
@@ -19376,7 +19376,7 @@ namespace System.Windows.Forms
 
                     if (FirstDisplayedScrollingColumnHiddenWidth > 0)
                     {
-                        Debug.Assert(clipRegion != null);
+                        Debug.Assert(clipRegion is not null);
                         g.Clip = clipRegion;
                         clipRegion.Dispose();
                     }
@@ -19626,7 +19626,7 @@ namespace System.Windows.Forms
                             AutoResizeColumnHeadersHeight(true /*fixedRowHeadersWidth*/, true /*fixedColumnWidth*/);
                         }
                     }
-                    if (repositionEditingControl && EditingControl != null)
+                    if (repositionEditingControl && EditingControl is not null)
                     {
                         PositionEditingControl(true /*setLocation*/, false /*setSize*/, false /*setFocus*/);
                     }
@@ -19645,7 +19645,7 @@ namespace System.Windows.Forms
                     DisplayedBandsInfo.NumTotallyDisplayedScrollingRows = 0;
                     DisplayedBandsInfo.LastDisplayedScrollingRow = -1;
                     DisplayedBandsInfo.LastTotallyDisplayedScrollingCol = -1;
-                    if (_layout != null)
+                    if (_layout is not null)
                     {
                         _layout._dirty = true;
                     }
@@ -19666,7 +19666,7 @@ namespace System.Windows.Forms
                 DataGridViewCellCollection newRowCells = newRow.Cells;
                 foreach (DataGridViewCell dataGridViewCell in newRowCells)
                 {
-                    if (dataGridViewCell.DefaultNewRowValue != null)
+                    if (dataGridViewCell.DefaultNewRowValue is not null)
                     {
                         newRow = Rows[NewRowIndex]; // unshare the 'new row'.
                         newRowCells = newRow.Cells;
@@ -19682,7 +19682,7 @@ namespace System.Windows.Forms
 
         private void PositionEditingControl(bool setLocation, bool setSize, bool setFocus)
         {
-            Debug.Assert(EditingControl != null);
+            Debug.Assert(EditingControl is not null);
 
             if (!IsHandleCreated)
             {
@@ -19691,7 +19691,7 @@ namespace System.Windows.Forms
 
 #if DEBUG
             DataGridViewCell dataGridViewCell = CurrentCellInternal;
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             Debug.Assert(dataGridViewCell.ColumnIndex == _ptCurrentCell.X);
             Debug.Assert(dataGridViewCell.RowIndex == _ptCurrentCell.Y || dataGridViewCell.RowIndex == -1);
 #endif
@@ -19736,7 +19736,7 @@ namespace System.Windows.Forms
                     // we cannot simply make the control invisible because we want it to keep the focus.
                     // (and Control::CanFocus returns false if the control is not visible).
                     // So we place the editing control to the right of the DataGridView.
-                    Debug.Assert(EditingControl != null);
+                    Debug.Assert(EditingControl is not null);
                     _editingPanel.Location = new Point(Width + 1, 0);
                     _dataGridViewState1[State1_EditingControlHidden] = true;
                 }
@@ -19800,7 +19800,7 @@ namespace System.Windows.Forms
         {
             if (AllowUserToDeleteRowsInternal)
             {
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     // editing control gets a chance to handle the Delete key first
                     return false;
@@ -19828,7 +19828,7 @@ namespace System.Windows.Forms
                                     if (!dgvrce.Cancel)
                                     {
                                         DataGridViewRow dataGridViewRow = Rows[rowIndex];
-                                        if (DataSource != null)
+                                        if (DataSource is not null)
                                         {
                                             int dataGridRowsCount = Rows.Count;
 #if DEBUG
@@ -19976,7 +19976,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    if (EditingControl != null)
+                    if (EditingControl is not null)
                     {
                         _dataGridViewState1[State1_LeavingWithTabKey] = true;
                         if (!EndEdit(DataGridViewDataErrorContexts.Parsing | DataGridViewDataErrorContexts.Commit | DataGridViewDataErrorContexts.LeaveControl,
@@ -21233,7 +21233,7 @@ namespace System.Windows.Forms
                 ModifierKeys == 0)
             {
                 Debug.Assert(_ptCurrentCell.Y != -1);
-                Debug.Assert(CurrentCellInternal != null);
+                Debug.Assert(CurrentCellInternal is not null);
                 Debug.Assert(EditMode != DataGridViewEditMode.EditOnEnter ||
                     (IsSharedCellReadOnly(CurrentCellInternal, _ptCurrentCell.Y) || !ColumnEditable(_ptCurrentCell.X)));
                 if (ColumnEditable(_ptCurrentCell.X) &&
@@ -21260,7 +21260,7 @@ namespace System.Windows.Forms
             if (_ptCurrentCell.X != -1)
             {
                 DataGridViewColumn dataGridViewColumn = Columns[_ptCurrentCell.X];
-                if (dataGridViewColumn != null && CanSort(dataGridViewColumn))
+                if (dataGridViewColumn is not null && CanSort(dataGridViewColumn))
                 {
                     ListSortDirection listSortDirection = SortedColumn == dataGridViewColumn && SortOrder == SortOrder.Ascending ?
                         ListSortDirection.Descending : ListSortDirection.Ascending;
@@ -21546,7 +21546,7 @@ namespace System.Windows.Forms
                 ClipboardCopyMode != DataGridViewClipboardCopyMode.Disable)
             {
                 DataObject dataObject = GetClipboardContent();
-                if (dataObject != null)
+                if (dataObject is not null)
                 {
                     Clipboard.SetDataObject(dataObject);
                     return true;
@@ -21562,7 +21562,7 @@ namespace System.Windows.Forms
                 if (_ptCurrentCell.X != -1)
                 {
                     DataGridViewCell dataGridViewCell = CurrentCellInternal;
-                    Debug.Assert(dataGridViewCell != null);
+                    Debug.Assert(dataGridViewCell is not null);
 
                     if (!IsCurrentCellInEditMode &&
                         ColumnEditable(_ptCurrentCell.X) &&
@@ -21580,7 +21580,7 @@ namespace System.Windows.Forms
                                 editingCellInterface = dataGridViewCell.GetType().GetInterface("System.Windows.Forms.IDataGridViewEditingCell");
                             }
 
-                            if ((editControlType != null || editingCellInterface is null) &&
+                            if ((editControlType is not null || editingCellInterface is null) &&
                                 dataGridViewCell.KeyEntersEditMode(ke))
                             {
                                 // Cell wants to go to edit mode
@@ -21589,7 +21589,7 @@ namespace System.Windows.Forms
                                 if (BeginEditInternal(!(ke.KeyCode == Keys.F2 && ModifierKeys == 0 && EditMode == DataGridViewEditMode.EditOnKeystrokeOrF2) /*selectAll*/))
                                 {
                                     // Forward the key message to the editing control if any
-                                    if (EditingControl != null)
+                                    if (EditingControl is not null)
                                     {
                                         User32.SendMessageW(EditingControl, (User32.WM)m.Msg, m.WParam, m.LParam);
                                         _dataGridViewState1[State1_ForwardCharMessage] = true;
@@ -21605,7 +21605,7 @@ namespace System.Windows.Forms
                      (m.Msg == (int)User32.WM.SYSCHAR || m.Msg == (int)User32.WM.CHAR || m.Msg == (int)User32.WM.IME_CHAR))
             {
                 _dataGridViewState1[State1_ForwardCharMessage] = false;
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     User32.SendMessageW(EditingControl, (User32.WM)m.Msg, m.WParam, m.LParam);
                     return true;
@@ -21666,7 +21666,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (EditingControl != null && (m.Msg == (int)User32.WM.KEYDOWN || m.Msg == (int)User32.WM.SYSKEYDOWN))
+            if (EditingControl is not null && (m.Msg == (int)User32.WM.KEYDOWN || m.Msg == (int)User32.WM.SYSKEYDOWN))
             {
                 _dataGridViewState2[State2_CurrentCellWantsInputKey] = ((IDataGridViewEditingControl)EditingControl).EditingControlWantsInputKey(ke.KeyData, dataGridViewWantsInputKey);
             }
@@ -21705,7 +21705,7 @@ namespace System.Windows.Forms
                 if (_currentColSplitBar == -1)
                 {
                     DataGridViewColumn dataGridViewColumn = Columns[_ptCurrentCell.X];
-                    if (dataGridViewColumn != null && dataGridViewColumn.Resizable == DataGridViewTriState.True &&
+                    if (dataGridViewColumn is not null && dataGridViewColumn.Resizable == DataGridViewTriState.True &&
                         (dataGridViewColumn.InheritedAutoSizeMode == DataGridViewAutoSizeColumnMode.None || dataGridViewColumn.InheritedAutoSizeMode == DataGridViewAutoSizeColumnMode.Fill))
                     {
                         BeginKeyboardColumnResize(_ptCurrentCell.X);
@@ -21787,7 +21787,7 @@ namespace System.Windows.Forms
                 dataGridViewColumn = Columns.GetPreviousColumn(Columns[_ptCurrentCell.X],
                     DataGridViewElementStates.Visible,
                     DataGridViewElementStates.None);
-                if (dataGridViewColumn != null)
+                if (dataGridViewColumn is not null)
                 {
                     previousVisibleColumnIndex = dataGridViewColumn.Index;
                 }
@@ -22995,7 +22995,7 @@ namespace System.Windows.Forms
                 dataGridViewColumn = Columns.GetNextColumn(Columns[_ptCurrentCell.X],
                     DataGridViewElementStates.Visible,
                     DataGridViewElementStates.None);
-                if (dataGridViewColumn != null)
+                if (dataGridViewColumn is not null)
                 {
                     nextVisibleColumnIndex = dataGridViewColumn.Index;
                 }
@@ -24607,11 +24607,11 @@ namespace System.Windows.Forms
             if (_ptCurrentCell.X != -1 && !IsCurrentCellInEditMode && ColumnEditable(_ptCurrentCell.X))
             {
                 DataGridViewCell dataGridViewCell = CurrentCellInternal;
-                Debug.Assert(dataGridViewCell != null);
+                Debug.Assert(dataGridViewCell is not null);
 
                 if (!IsSharedCellReadOnly(dataGridViewCell, _ptCurrentCell.Y) &&
                     (EditMode == DataGridViewEditMode.EditOnKeystroke || EditMode == DataGridViewEditMode.EditOnKeystrokeOrF2) &&
-                    dataGridViewCell.EditType != null)
+                    dataGridViewCell.EditType is not null)
                 {
                     bool success = ScrollIntoView(_ptCurrentCell.X, _ptCurrentCell.Y, false);
                     Debug.Assert(success);
@@ -24626,12 +24626,12 @@ namespace System.Windows.Forms
                 IsCurrentCellInEditMode)
             {
                 DataGridViewCell dataGridViewCurrentCell = CurrentCellInternal;
-                Debug.Assert(dataGridViewCurrentCell != null);
+                Debug.Assert(dataGridViewCurrentCell is not null);
                 object nullValue = dataGridViewCurrentCell.GetInheritedStyle(null, _ptCurrentCell.Y, false).NullValue;
                 if (nullValue is null ||
-                    (dataGridViewCurrentCell.FormattedValueType != null && dataGridViewCurrentCell.FormattedValueType.IsAssignableFrom(nullValue.GetType())))
+                    (dataGridViewCurrentCell.FormattedValueType is not null && dataGridViewCurrentCell.FormattedValueType.IsAssignableFrom(nullValue.GetType())))
                 {
-                    if (EditingControl != null)
+                    if (EditingControl is not null)
                     {
                         ((IDataGridViewEditingControl)EditingControl).EditingControlFormattedValue = nullValue;
                         ((IDataGridViewEditingControl)EditingControl).EditingControlValueChanged = true;
@@ -24641,7 +24641,7 @@ namespace System.Windows.Forms
                     {
                         Debug.Assert(_dataGridViewState1[State1_CurrentCellInEditMode]);
                         IDataGridViewEditingCell dataGridViewEditingCell = dataGridViewCurrentCell as IDataGridViewEditingCell;
-                        Debug.Assert(dataGridViewEditingCell != null);
+                        Debug.Assert(dataGridViewEditingCell is not null);
                         dataGridViewEditingCell.EditingCellFormattedValue = nullValue;
                         dataGridViewEditingCell.EditingCellValueChanged = true;
                         dataGridViewEditingCell.PrepareEditingCellForEdit(true /*selectAll*/);
@@ -24686,8 +24686,8 @@ namespace System.Windows.Forms
                                                                     dataGridViewCurrentCell.ValueType,
                                                                     cellStyle);
             if (dgvcpe.ParsingApplied &&
-                dgvcpe.Value != null &&
-                dataGridViewCurrentCell.ValueType != null &&
+                dgvcpe.Value is not null &&
+                dataGridViewCurrentCell.ValueType is not null &&
                 dataGridViewCurrentCell.ValueType.IsAssignableFrom(dgvcpe.Value.GetType()))
             {
                 if (dataGridViewCurrentCell.RowIndex == -1)
@@ -24755,7 +24755,7 @@ namespace System.Windows.Forms
                 DataGridViewColumnCollection dataGridViewCols = Columns;
                 DataGridViewColumn[] boundColumns = null;
 
-                if (DataConnection != null)
+                if (DataConnection is not null)
                 {
                     boundColumns = DataConnection.GetCollectionOfBoundDataGridViewColumns();
                 }
@@ -24773,14 +24773,14 @@ namespace System.Windows.Forms
                         dataGridViewCols[j].BoundColumnIndex = -1;
                         dataGridViewCols[j].BoundColumnConverter = null;
                         // set up the columns which have DataPropertyName set to something
-                        if (DataSource != null && dataGridViewCols[j].DataPropertyName.Length != 0)
+                        if (DataSource is not null && dataGridViewCols[j].DataPropertyName.Length != 0)
                         {
                             MapDataGridViewColumnToDataBoundField(dataGridViewCols[j]);
                         }
                     }
                 }
 
-                if (DataSource != null)
+                if (DataSource is not null)
                 {
                     DataConnection.ApplySortingInformationFromBackEnd();
                 }
@@ -24805,7 +24805,7 @@ namespace System.Windows.Forms
                 Debug.Assert(_ptCurrentCell.Y != -1);
                 DataGridViewCell dataGridViewCurrentCell = CurrentCellInternal;
                 DataGridViewCellStyle dataGridViewCellStyle = dataGridViewCurrentCell.GetInheritedStyle(null, _ptCurrentCell.Y, true);
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     if (InitializeEditingControlValue(ref dataGridViewCellStyle, dataGridViewCurrentCell))
                     {
@@ -24826,7 +24826,7 @@ namespace System.Windows.Forms
                     if (InitializeEditingCellValue(ref dataGridViewCellStyle, ref dataGridViewCurrentCell))
                     {
                         IDataGridViewEditingCell dataGridViewEditingCell = dataGridViewCurrentCell as IDataGridViewEditingCell;
-                        Debug.Assert(dataGridViewEditingCell != null);
+                        Debug.Assert(dataGridViewEditingCell is not null);
                         dataGridViewEditingCell.PrepareEditingCellForEdit(true /*selectAll*/);
                         dataGridViewEditingCell.EditingCellValueChanged = false;
                         IsCurrentCellDirtyInternal = false;
@@ -24857,10 +24857,10 @@ namespace System.Windows.Forms
                 Rows.ClearInternal(true /*recreateNewRow*/);
 
                 // Add a row for each object in the data source
-                if (DataConnection != null && Columns.Count > 0)
+                if (DataConnection is not null && Columns.Count > 0)
                 {
                     IList list = DataConnection.List;
-                    if (list != null && list.Count > 0)
+                    if (list is not null && list.Count > 0)
                     {
                         int rowsCount = list.Count;
                         bool oldDoNotChangePositionInTheCurrencyManager = DataConnection.DoNotChangePositionInTheCurrencyManager;
@@ -25109,11 +25109,11 @@ namespace System.Windows.Forms
             {
                 return;
             }
-            if (_horizScrollTimer != null && _horizScrollTimer.Enabled)
+            if (_horizScrollTimer is not null && _horizScrollTimer.Enabled)
             {
                 _horizScrollTimer.Enabled = false;
             }
-            if (_vertScrollTimer != null && _vertScrollTimer.Enabled)
+            if (_vertScrollTimer is not null && _vertScrollTimer.Enabled)
             {
                 _vertScrollTimer.Enabled = false;
             }
@@ -25384,7 +25384,7 @@ namespace System.Windows.Forms
                 if (DisplayedBandsInfo.LastTotallyDisplayedScrollingCol >= 0)
                 {
                     dataGridViewColumnTmp = Columns[DisplayedBandsInfo.LastTotallyDisplayedScrollingCol];
-                    while (colCount < columns && dataGridViewColumnTmp != null)
+                    while (colCount < columns && dataGridViewColumnTmp is not null)
                     {
                         dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp,
                             DataGridViewElementStates.Visible,
@@ -25401,7 +25401,7 @@ namespace System.Windows.Forms
                 Debug.Assert(DisplayedBandsInfo.FirstDisplayedScrollingCol >= 0);
                 dataGridViewColumnTmp = Columns[DisplayedBandsInfo.FirstDisplayedScrollingCol];
                 colCount = 0;
-                while (colCount < columns && dataGridViewColumnTmp != null)
+                while (colCount < columns && dataGridViewColumnTmp is not null)
                 {
                     dataGridViewColumnTmp = Columns.GetNextColumn(dataGridViewColumnTmp,
                         DataGridViewElementStates.Visible,
@@ -25419,7 +25419,7 @@ namespace System.Windows.Forms
                 {
                     colCount++;
                 }
-                while (colCount < -columns && dataGridViewColumnTmp != null)
+                while (colCount < -columns && dataGridViewColumnTmp is not null)
                 {
                     dataGridViewColumnTmp = Columns.GetPreviousColumn(dataGridViewColumnTmp,
                         DataGridViewElementStates.Visible,
@@ -25498,7 +25498,7 @@ namespace System.Windows.Forms
 
         private void ScrollRectangles(RECT[] rects, int change)
         {
-            if (rects != null)
+            if (rects is not null)
             {
                 if (MouseButtons != MouseButtons.None)
                 {
@@ -25605,7 +25605,7 @@ namespace System.Windows.Forms
             rowsRect.Height -= frozenRowsThickness;
             Debug.Assert(rowsRect.Height >= 0);
 
-            if (EditingControl != null &&
+            if (EditingControl is not null &&
                 (Rows.GetRowState(_ptCurrentCell.Y) & DataGridViewElementStates.Frozen) == 0)
             {
                 Debug.Assert(DisplayedBandsInfo.FirstDisplayedScrollingRow > -1);
@@ -25860,7 +25860,7 @@ namespace System.Windows.Forms
 
             DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
             int firstVisibleRowIndex = Rows.GetFirstRow(DataGridViewElementStates.Visible);
-            if (dataGridViewColumn != null && firstVisibleRowIndex != -1)
+            if (dataGridViewColumn is not null && firstVisibleRowIndex != -1)
             {
                 // This is the only place in the code outside of SetCurrentCellAddressCore where this.ptAnchorCell gets changed.
                 // There is no way in SetCurrentCellAddressCore to just change the anchor cell.
@@ -26020,7 +26020,7 @@ namespace System.Windows.Forms
                             _dataGridViewState1[State1_TemporarilyResetCurrentCell] = false;
                             _ptCurrentCell.X = columnIndex;
                             _ptCurrentCell.Y = rowIndex;
-                            if (_cachedEditingControl != null)
+                            if (_cachedEditingControl is not null)
                             {
                                 EditingControl = _cachedEditingControl;
                                 ((IDataGridViewEditingControl)EditingControl).EditingControlRowIndex = rowIndex;
@@ -26134,7 +26134,7 @@ namespace System.Windows.Forms
 
                             _ptCurrentCell.X = columnIndex;
                             _ptCurrentCell.Y = rowIndex;
-                            if (EditingControl != null)
+                            if (EditingControl is not null)
                             {
                                 ((IDataGridViewEditingControl)EditingControl).EditingControlRowIndex = rowIndex;
                             }
@@ -26279,7 +26279,7 @@ namespace System.Windows.Forms
                     }
                     if (_dataGridViewState1[State1_TemporarilyResetCurrentCell])
                     {
-                        if (EditingControl != null)
+                        if (EditingControl is not null)
                         {
                             if (_dataGridViewState2[State2_DiscardEditingControl])
                             {
@@ -26354,7 +26354,7 @@ namespace System.Windows.Forms
                             DataGridViewColumn dataGridViewColumn = Columns.GetNextColumn(Columns[columnIndex],
                                 DataGridViewElementStates.Visible,
                                 DataGridViewElementStates.None);
-                            Debug.Assert(dataGridViewColumn != null);
+                            Debug.Assert(dataGridViewColumn is not null);
                             columnIndex = dataGridViewColumn.Index;
                         }
                     }
@@ -26382,7 +26382,7 @@ namespace System.Windows.Forms
                             DataGridViewColumn dataGridViewColumn = Columns.GetPreviousColumn(Columns[columnIndex],
                                 DataGridViewElementStates.Visible,
                                 DataGridViewElementStates.None);
-                            Debug.Assert(dataGridViewColumn != null);
+                            Debug.Assert(dataGridViewColumn is not null);
                             columnIndex = dataGridViewColumn.Index;
                         }
                     }
@@ -26462,7 +26462,7 @@ namespace System.Windows.Forms
                     DataGridViewColumn dataGridViewColumn = Columns.GetNextColumn(Columns[columnIndex],
                         DataGridViewElementStates.Visible,
                         DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     columnIndex = dataGridViewColumn.Index;
                 }
             }
@@ -27338,7 +27338,7 @@ namespace System.Windows.Forms
             }
 
             // can't sort a data bound dataGridView control using a comparer
-            if (DataSource != null)
+            if (DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridView_CannotUseAComparerToSortDataGridViewWhenDataBound);
             }
@@ -27366,7 +27366,7 @@ namespace System.Windows.Forms
 
         private void SortInternal(IComparer comparer, DataGridViewColumn dataGridViewColumn, ListSortDirection direction)
         {
-            Debug.Assert(!(comparer != null && DataSource != null));
+            Debug.Assert(!(comparer is not null && DataSource is not null));
             Debug.Assert(direction == ListSortDirection.Ascending || direction == ListSortDirection.Descending);
 
             // Exit editing mode if needed
@@ -27375,7 +27375,7 @@ namespace System.Windows.Forms
             _dataGridViewOper[OperationInSort] = true;
             try
             {
-                if (CurrentCell != null)
+                if (CurrentCell is not null)
                 {
                     KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(CurrentCell);
                 }
@@ -27397,7 +27397,7 @@ namespace System.Windows.Forms
                     Debug.Assert(0 == Rows.GetRowCount(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen));
                 }
 
-                if (SortedColumn != null &&
+                if (SortedColumn is not null &&
                     SortedColumn.SortMode == DataGridViewColumnSortMode.Automatic &&
                     SortedColumn.HasHeaderCell)
                 {
@@ -27406,7 +27406,7 @@ namespace System.Windows.Forms
 
                 if (comparer is null)
                 {
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SortedColumn = dataGridViewColumn;
                     SortOrder = (direction == ListSortDirection.Ascending) ? SortOrder.Ascending : SortOrder.Descending;
                     if (dataGridViewColumn.SortMode == DataGridViewColumnSortMode.Automatic && dataGridViewColumn.HasHeaderCell)
@@ -27513,7 +27513,7 @@ namespace System.Windows.Forms
                     {
                         _selectedBandIndexes[row2Selected] = rowIndex1;
                     }
-                    if (_selectedBandSnapshotIndexes != null)
+                    if (_selectedBandSnapshotIndexes is not null)
                     {
                         row1Selected = _selectedBandSnapshotIndexes.IndexOf(rowIndex1);
                         row2Selected = _selectedBandSnapshotIndexes.IndexOf(rowIndex2);
@@ -27636,7 +27636,7 @@ namespace System.Windows.Forms
                 dataGridViewColumn = Columns.GetNextColumn(Columns[_ptCurrentCell.X],
                     DataGridViewElementStates.Visible,
                     DataGridViewElementStates.None);
-                if (dataGridViewColumn != null)
+                if (dataGridViewColumn is not null)
                 {
                     nextVisibleColumnIndex = dataGridViewColumn.Index;
                 }
@@ -27784,7 +27784,7 @@ namespace System.Windows.Forms
                 dataGridViewColumn = Columns.GetPreviousColumn(Columns[_ptCurrentCell.X],
                     DataGridViewElementStates.Visible,
                     DataGridViewElementStates.None);
-                if (dataGridViewColumn != null)
+                if (dataGridViewColumn is not null)
                 {
                     previousVisibleColumnIndex = dataGridViewColumn.Index;
                 }
@@ -27798,7 +27798,7 @@ namespace System.Windows.Forms
 
             dataGridViewColumn = Columns.GetLastColumn(DataGridViewElementStates.Visible,
                 DataGridViewElementStates.None);
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             int lastVisibleColumnIndex = dataGridViewColumn.Index;
             int lastVisibleRowIndex = Rows.GetLastRow(DataGridViewElementStates.Visible);
             Debug.Assert(lastVisibleRowIndex != -1);
@@ -27928,7 +27928,7 @@ namespace System.Windows.Forms
 
         private void UnwireEditingControlEvents()
         {
-            Debug.Assert(_editingPanel != null);
+            Debug.Assert(_editingPanel is not null);
             _editingPanel.Click -= new EventHandler(EditingControls_Click);
             _editingPanel.DoubleClick -= new EventHandler(EditingControls_DoubleClick);
             _editingPanel.MouseClick -= new MouseEventHandler(EditingControls_MouseClick);
@@ -27939,7 +27939,7 @@ namespace System.Windows.Forms
             _editingPanel.MouseMove -= new MouseEventHandler(EditingControls_MouseMove);
             _editingPanel.MouseUp -= new MouseEventHandler(EditingControls_MouseUp);
 
-            Debug.Assert(EditingControl != null);
+            Debug.Assert(EditingControl is not null);
             EditingControl.Click -= new EventHandler(EditingControls_Click);
             EditingControl.DoubleClick -= new EventHandler(EditingControls_DoubleClick);
             EditingControl.MouseClick -= new MouseEventHandler(EditingControls_MouseClick);
@@ -27953,12 +27953,12 @@ namespace System.Windows.Forms
 
         private void UnwireScrollBarsEvents()
         {
-            if (_horizScrollBar != null)
+            if (_horizScrollBar is not null)
             {
                 _horizScrollBar.MouseEnter -= new EventHandler(ScrollBar_MouseEnter);
                 _horizScrollBar.MouseLeave -= new EventHandler(ScrollBar_MouseLeave);
             }
-            if (_vertScrollBar != null)
+            if (_vertScrollBar is not null)
             {
                 _vertScrollBar.MouseEnter -= new EventHandler(ScrollBar_MouseEnter);
                 _vertScrollBar.MouseLeave -= new EventHandler(ScrollBar_MouseLeave);
@@ -28007,7 +28007,7 @@ namespace System.Windows.Forms
                 dataGridViewColumnTmp = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
                 while (numDisplayedFrozenCols > 0)
                 {
-                    Debug.Assert(dataGridViewColumnTmp != null);
+                    Debug.Assert(dataGridViewColumnTmp is not null);
                     if (dataGridViewColumnTmp.Displayed != displayed)
                     {
                         dataGridViewColumnTmp.Displayed = displayed;
@@ -28027,7 +28027,7 @@ namespace System.Windows.Forms
                 dataGridViewColumnTmp = Columns[columnIndexTmp];
                 while (numDisplayedScrollingCols > 0)
                 {
-                    Debug.Assert(dataGridViewColumnTmp != null);
+                    Debug.Assert(dataGridViewColumnTmp is not null);
                     if (dataGridViewColumnTmp.Displayed != displayed)
                     {
                         dataGridViewColumnTmp.Displayed = displayed;
@@ -28141,7 +28141,7 @@ namespace System.Windows.Forms
                         Invalidate(bottomArea);
                     }
 
-                    if (EditingControl != null)
+                    if (EditingControl is not null)
                     {
                         PositionEditingControl(true /*setLocation*/, true /*setSize*/, false /*setFocus*/);
                     }
@@ -28199,7 +28199,7 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    if (EditingControl != null)
+                    if (EditingControl is not null)
                     {
                         PositionEditingControl(rowIndex == -1 || _ptCurrentCell.Y != rowIndex, true, false);
                     }
@@ -28257,7 +28257,7 @@ namespace System.Windows.Forms
 
             Point ptMouse = PointToClient(Control.MousePosition);
             HitTestInfo htiToUse;
-            if (hti != null)
+            if (hti is not null)
             {
                 htiToUse = hti;
             }
@@ -28284,7 +28284,7 @@ namespace System.Windows.Forms
                     dgvce = new DataGridViewCellEventArgs(htiToUse._col, htiToUse._row);
                     OnCellMouseEnter(dgvce);
                 }
-                if (e != null)
+                if (e is not null)
                 {
                     int mouseX = e.X - htiToUse.ColumnX;
                     if (RightToLeftInternal)
@@ -28342,7 +28342,7 @@ namespace System.Windows.Forms
             {
                 // h1
                 DataGridViewColumn dataGridViewColumn = Columns.GetNextColumn(Columns[oldEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                Debug.Assert(dataGridViewColumn != null);
+                Debug.Assert(dataGridViewColumn is not null);
                 if (anchorRowIndex <= newEdgeRowIndex)
                 {
                     SelectCellRange(dataGridViewColumn.Index, anchorRowIndex, newEdgeColumnIndex, newEdgeRowIndex, true);
@@ -28359,7 +28359,7 @@ namespace System.Windows.Forms
             {
                 // h2
                 DataGridViewColumn dataGridViewColumn = Columns.GetPreviousColumn(Columns[oldEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                Debug.Assert(dataGridViewColumn != null);
+                Debug.Assert(dataGridViewColumn is not null);
                 if (anchorRowIndex <= newEdgeRowIndex)
                 {
                     SelectCellRange(newEdgeColumnIndex, anchorRowIndex, dataGridViewColumn.Index, newEdgeRowIndex, true);
@@ -28422,7 +28422,7 @@ namespace System.Windows.Forms
             {
                 // h5
                 DataGridViewColumn dataGridViewColumn = Columns.GetNextColumn(Columns[oldEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                Debug.Assert(dataGridViewColumn != null);
+                Debug.Assert(dataGridViewColumn is not null);
                 SelectCellRange(dataGridViewColumn.Index, anchorRowIndex, newEdgeColumnIndex, oldEdgeRowIndex, true);
                 SelectCellRange(anchorColumnIndex,
                     Rows.GetNextRow(oldEdgeRowIndex, DataGridViewElementStates.Visible),
@@ -28437,7 +28437,7 @@ namespace System.Windows.Forms
                 {
                     // h6
                     DataGridViewColumn dataGridViewColumn = Columns.GetNextColumn(Columns[oldEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectCellRange(dataGridViewColumn.Index, oldEdgeRowIndex, newEdgeColumnIndex, anchorRowIndex, true);
                     SelectCellRange(anchorColumnIndex,
                         newEdgeRowIndex,
@@ -28459,7 +28459,7 @@ namespace System.Windows.Forms
                         {
                             // b4
                             DataGridViewColumn dataGridViewColumn = Columns.GetPreviousColumn(Columns[newEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                            Debug.Assert(dataGridViewColumn != null);
+                            Debug.Assert(dataGridViewColumn is not null);
                             Debug.Assert(oldEdgeRowIndex < anchorRowIndex);
                             SelectCellRange(oldEdgeColumnIndex, oldEdgeRowIndex, dataGridViewColumn.Index, anchorRowIndex, false);
                             SelectCellRange(newEdgeColumnIndex,
@@ -28478,7 +28478,7 @@ namespace System.Windows.Forms
                 {
                     // h7
                     DataGridViewColumn dataGridViewColumn = Columns.GetPreviousColumn(Columns[oldEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                    Debug.Assert(dataGridViewColumn != null);
+                    Debug.Assert(dataGridViewColumn is not null);
                     SelectCellRange(newEdgeColumnIndex, oldEdgeRowIndex, dataGridViewColumn.Index, anchorRowIndex, true);
                     SelectCellRange(newEdgeColumnIndex,
                         newEdgeRowIndex,
@@ -28492,7 +28492,7 @@ namespace System.Windows.Forms
                     {
                         // a4
                         DataGridViewColumn dataGridViewColumn = Columns.GetNextColumn(Columns[newEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                        Debug.Assert(dataGridViewColumn != null);
+                        Debug.Assert(dataGridViewColumn is not null);
                         Debug.Assert(oldEdgeRowIndex <= anchorRowIndex);
                         SelectCellRange(dataGridViewColumn.Index, oldEdgeRowIndex, oldEdgeColumnIndex, anchorRowIndex, false);
                         SelectCellRange(anchorColumnIndex,
@@ -28515,7 +28515,7 @@ namespace System.Windows.Forms
             {
                 // h8
                 DataGridViewColumn dataGridViewColumn = Columns.GetPreviousColumn(Columns[oldEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                Debug.Assert(dataGridViewColumn != null);
+                Debug.Assert(dataGridViewColumn is not null);
                 SelectCellRange(newEdgeColumnIndex, anchorRowIndex, dataGridViewColumn.Index, oldEdgeRowIndex, true);
                 SelectCellRange(newEdgeColumnIndex,
                     Rows.GetNextRow(oldEdgeRowIndex, DataGridViewElementStates.Visible),
@@ -28531,7 +28531,7 @@ namespace System.Windows.Forms
                     if (Columns.DisplayInOrder(anchorColumnIndex, newEdgeColumnIndex) || (anchorColumnIndex == newEdgeColumnIndex))
                     {
                         // a1
-                        Debug.Assert(dataGridViewColumn != null);
+                        Debug.Assert(dataGridViewColumn is not null);
                         if (oldEdgeRowIndex > anchorRowIndex)
                         {
                             SelectCellRange(dataGridViewColumn.Index, anchorRowIndex, oldEdgeColumnIndex, oldEdgeRowIndex, false);
@@ -28555,7 +28555,7 @@ namespace System.Windows.Forms
                                     if (!Columns.DisplayInOrder(newEdgeColumnIndex, anchorColumnIndex))
                                     {
                                         // a2
-                                        Debug.Assert(dataGridViewColumn != null);
+                                        Debug.Assert(dataGridViewColumn is not null);
                                         SelectCellRange(dataGridViewColumn.Index, anchorRowIndex, oldEdgeColumnIndex, oldEdgeRowIndex, false);
                                         SelectCellRange(anchorColumnIndex,
                                             Rows.GetNextRow(newEdgeRowIndex, DataGridViewElementStates.Visible),
@@ -28568,7 +28568,7 @@ namespace System.Windows.Forms
                                 {
                                     // d3
                                     dataGridViewColumn = Columns.GetPreviousColumn(Columns[oldEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                                    Debug.Assert(dataGridViewColumn != null);
+                                    Debug.Assert(dataGridViewColumn is not null);
                                     SelectCellRange(oldEdgeColumnIndex,
                                         Rows.GetNextRow(newEdgeRowIndex, DataGridViewElementStates.Visible),
                                         anchorColumnIndex,
@@ -28592,7 +28592,7 @@ namespace System.Windows.Forms
                             newEdgeRowIndex <= anchorRowIndex)
                         {
                             // a3
-                            Debug.Assert(dataGridViewColumn != null);
+                            Debug.Assert(dataGridViewColumn is not null);
                             SelectCellRange(dataGridViewColumn.Index, oldEdgeRowIndex, oldEdgeColumnIndex, anchorRowIndex, false);
                             SelectCellRange(anchorColumnIndex,
                                 oldEdgeRowIndex,
@@ -28608,7 +28608,7 @@ namespace System.Windows.Forms
                                 {
                                     // c3
                                     dataGridViewColumn = Columns.GetPreviousColumn(Columns[oldEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                                    Debug.Assert(dataGridViewColumn != null);
+                                    Debug.Assert(dataGridViewColumn is not null);
                                     SelectCellRange(oldEdgeColumnIndex,
                                         oldEdgeRowIndex,
                                         anchorColumnIndex,
@@ -28629,7 +28629,7 @@ namespace System.Windows.Forms
                         {
                             // a5
                             Debug.Assert(oldEdgeRowIndex >= anchorRowIndex);
-                            Debug.Assert(dataGridViewColumn != null);
+                            Debug.Assert(dataGridViewColumn is not null);
                             SelectCellRange(dataGridViewColumn.Index, anchorRowIndex, oldEdgeColumnIndex, oldEdgeRowIndex, false);
                             SelectCellRange(anchorColumnIndex,
                                 Rows.GetNextRow(anchorRowIndex, DataGridViewElementStates.Visible),
@@ -28648,7 +28648,7 @@ namespace System.Windows.Forms
                     if (Columns.DisplayInOrder(newEdgeColumnIndex, anchorColumnIndex) || (newEdgeColumnIndex == anchorColumnIndex))
                     {
                         // b1
-                        Debug.Assert(dataGridViewColumn != null);
+                        Debug.Assert(dataGridViewColumn is not null);
                         if (oldEdgeRowIndex > anchorRowIndex)
                         {
                             SelectCellRange(oldEdgeColumnIndex, anchorRowIndex, dataGridViewColumn.Index, oldEdgeRowIndex, false);
@@ -28682,7 +28682,7 @@ namespace System.Windows.Forms
                                 {
                                     // d2
                                     dataGridViewColumn = Columns.GetNextColumn(Columns[oldEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                                    Debug.Assert(dataGridViewColumn != null);
+                                    Debug.Assert(dataGridViewColumn is not null);
                                     SelectCellRange(anchorColumnIndex,
                                         Rows.GetNextRow(newEdgeRowIndex, DataGridViewElementStates.Visible),
                                         oldEdgeColumnIndex,
@@ -28721,7 +28721,7 @@ namespace System.Windows.Forms
                                 {
                                     // c2
                                     dataGridViewColumn = Columns.GetNextColumn(Columns[oldEdgeColumnIndex], DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                                    Debug.Assert(dataGridViewColumn != null);
+                                    Debug.Assert(dataGridViewColumn is not null);
                                     SelectCellRange(anchorColumnIndex,
                                         oldEdgeRowIndex,
                                         oldEdgeColumnIndex,
@@ -28870,7 +28870,7 @@ namespace System.Windows.Forms
 
         private void WireEditingControlEvents()
         {
-            Debug.Assert(_editingPanel != null);
+            Debug.Assert(_editingPanel is not null);
             _editingPanel.Click += new EventHandler(EditingControls_Click);
             _editingPanel.DoubleClick += new EventHandler(EditingControls_DoubleClick);
             _editingPanel.MouseClick += new MouseEventHandler(EditingControls_MouseClick);
@@ -28881,7 +28881,7 @@ namespace System.Windows.Forms
             _editingPanel.MouseMove += new MouseEventHandler(EditingControls_MouseMove);
             _editingPanel.MouseUp += new MouseEventHandler(EditingControls_MouseUp);
 
-            Debug.Assert(EditingControl != null);
+            Debug.Assert(EditingControl is not null);
             EditingControl.Click += new EventHandler(EditingControls_Click);
             EditingControl.DoubleClick += new EventHandler(EditingControls_DoubleClick);
             EditingControl.MouseClick += new MouseEventHandler(EditingControls_MouseClick);
@@ -28895,12 +28895,12 @@ namespace System.Windows.Forms
 
         private void WireScrollBarsEvents()
         {
-            if (_horizScrollBar != null)
+            if (_horizScrollBar is not null)
             {
                 _horizScrollBar.MouseEnter += new EventHandler(ScrollBar_MouseEnter);
                 _horizScrollBar.MouseLeave += new EventHandler(ScrollBar_MouseLeave);
             }
-            if (_vertScrollBar != null)
+            if (_vertScrollBar is not null)
             {
                 _vertScrollBar.MouseEnter += new EventHandler(ScrollBar_MouseEnter);
                 _vertScrollBar.MouseLeave += new EventHandler(ScrollBar_MouseLeave);
@@ -28950,7 +28950,7 @@ namespace System.Windows.Forms
                         dataGridViewCell = TopLeftHeaderCell;
                         break;
                 }
-                if (dataGridViewCell != null)
+                if (dataGridViewCell is not null)
                 {
                     contextMenuStrip = dataGridViewCell.GetInheritedContextMenuStrip(hti._row);
                 }
@@ -28961,7 +28961,7 @@ namespace System.Windows.Forms
             }
 
             // VisualStudio7 # 156, only show the context menu when clicked in the client area
-            if (contextMenuStrip != null && ClientRectangle.Contains(client))
+            if (contextMenuStrip is not null && ClientRectangle.Contains(client))
             {
                 contextMenuStrip.ShowInternal(this, client, keyboardActivated);
             }
@@ -29049,7 +29049,7 @@ namespace System.Windows.Forms
 
                 case User32.WM.IME_STARTCOMPOSITION:
                 case User32.WM.IME_COMPOSITION:
-                    if (EditingControl != null)
+                    if (EditingControl is not null)
                     {
                         // Make sure that the first character is forwarded to the editing control.
                         User32.SendMessageW(EditingControl, (User32.WM)m.Msg, m.WParam, m.LParam);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.SelectedCellsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.SelectedCellsAccessibleObject.cs
@@ -79,7 +79,7 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetFocused()
             {
-                if (_ownerDataGridView.CurrentCell != null && _ownerDataGridView.CurrentCell.Selected)
+                if (_ownerDataGridView.CurrentCell is not null && _ownerDataGridView.CurrentCell.Selected)
                 {
                     return _ownerDataGridView.CurrentCell.AccessibilityObject;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.ToolTip.cs
@@ -46,7 +46,7 @@ namespace System.Windows.Forms
                     ToolTip.Active = true;
                     ToolTip.Show(_dataGridView.ToolTipPrivate, _dataGridView);
                 }
-                else if (ToolTip != null)
+                else if (ToolTip is not null)
                 {
                     ToolTip.Hide(_dataGridView);
                     ToolTip.Active = false;
@@ -57,7 +57,7 @@ namespace System.Windows.Forms
 
             public void Dispose()
             {
-                if (ToolTip != null)
+                if (ToolTip is not null)
                 {
                     ToolTip.Dispose();
                     ToolTip = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
@@ -59,7 +59,7 @@ namespace System.Windows.Forms
                 }
                 set
                 {
-                    if (_ownerDataGridView != null)
+                    if (_ownerDataGridView is not null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewTopRowAccessibleObject_OwnerAlreadySet);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -657,7 +657,7 @@ namespace System.Windows.Forms
                 if (AllowUserToAddRows != value)
                 {
                     _dataGridViewState1[State1_AllowUserToAddRows] = value;
-                    if (DataSource != null)
+                    if (DataSource is not null)
                     {
                         DataConnection.ResetCachedAllowUserToAddRowsInternal();
                     }
@@ -838,7 +838,7 @@ namespace System.Windows.Forms
                 DataGridViewCellStyle cs = AlternatingRowsDefaultCellStyle;
                 cs.RemoveScope(DataGridViewCellStyleScopes.AlternatingRows);
                 _alternatingRowsDefaultCellStyle = value;
-                if (value != null)
+                if (value is not null)
                 {
                     _alternatingRowsDefaultCellStyle.AddScope(this, DataGridViewCellStyleScopes.AlternatingRows);
                 }
@@ -1190,7 +1190,7 @@ namespace System.Windows.Forms
                 if (_ptCurrentCell.X != -1 && ColumnEditable(_ptCurrentCell.X))
                 {
                     DataGridViewCell dataGridViewCell = CurrentCellInternal;
-                    Debug.Assert(dataGridViewCell != null);
+                    Debug.Assert(dataGridViewCell is not null);
 
                     if (!IsSharedCellReadOnly(dataGridViewCell, _ptCurrentCell.Y))
                     {
@@ -1457,7 +1457,7 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(ColumnCount), value, 0));
                 }
-                if (DataSource != null)
+                if (DataSource is not null)
                 {
                     throw new InvalidOperationException(SR.DataGridView_CannotSetColumnCountOnDataBoundDataGridView);
                 }
@@ -1596,7 +1596,7 @@ namespace System.Windows.Forms
                 DataGridViewCellStyle cs = ColumnHeadersDefaultCellStyle;
                 cs.RemoveScope(DataGridViewCellStyleScopes.ColumnHeaders);
                 _columnHeadersDefaultCellStyle = value;
-                if (value != null)
+                if (value is not null)
                 {
                     _columnHeadersDefaultCellStyle.AddScope(this, DataGridViewCellStyleScopes.ColumnHeaders);
                 }
@@ -1741,7 +1741,7 @@ namespace System.Windows.Forms
                     {
                         // Make sure that there is no visible column that only counts on the column headers to autosize
                         DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-                        while (dataGridViewColumn != null)
+                        while (dataGridViewColumn is not null)
                         {
                             if (dataGridViewColumn.InheritedAutoSizeMode == DataGridViewAutoSizeColumnMode.ColumnHeader)
                             {
@@ -1801,7 +1801,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if ((value != null && (value.RowIndex != _ptCurrentCell.Y || value.ColumnIndex != _ptCurrentCell.X)) ||
+                if ((value is not null && (value.RowIndex != _ptCurrentCell.Y || value.ColumnIndex != _ptCurrentCell.X)) ||
                     (value is null && _ptCurrentCell.X != -1))
                 {
                     if (value is null)
@@ -1858,7 +1858,7 @@ namespace System.Windows.Forms
                 Debug.Assert(_ptCurrentCell.X >= 0 && _ptCurrentCell.X < Columns.Count);
                 Debug.Assert(_ptCurrentCell.Y >= 0 && _ptCurrentCell.Y < Rows.Count);
                 DataGridViewRow dataGridViewRow = Rows.SharedRow(_ptCurrentCell.Y);
-                Debug.Assert(dataGridViewRow != null);
+                Debug.Assert(dataGridViewRow is not null);
                 DataGridViewCell dataGridViewCell = dataGridViewRow.Cells[_ptCurrentCell.X];
                 Debug.Assert(IsSharedCellVisible(dataGridViewCell, _ptCurrentCell.Y));
                 return dataGridViewCell;
@@ -1911,7 +1911,7 @@ namespace System.Windows.Forms
 
                 Debug.Assert(_ptCurrentCell.Y != -1);
 
-                return EditingControl != null &&
+                return EditingControl is not null &&
                        GetCellCount(DataGridViewElementStates.Selected) == 1 &&
                        CurrentCellInternal.Selected;
             }
@@ -2113,7 +2113,7 @@ namespace System.Windows.Forms
                 DataGridViewCellStyle cs = DefaultCellStyle;
                 cs.RemoveScope(DataGridViewCellStyleScopes.DataGridView);
                 _defaultCellStyle = value;
-                if (value != null)
+                if (value is not null)
                 {
                     _defaultCellStyle.AddScope(this, DataGridViewCellStyleScopes.DataGridView);
                 }
@@ -2242,11 +2242,11 @@ namespace System.Windows.Forms
             get
             {
                 Rectangle rectDisplay = ClientRectangle;
-                if (_horizScrollBar != null && _horizScrollBar.Visible)
+                if (_horizScrollBar is not null && _horizScrollBar.Visible)
                 {
                     rectDisplay.Height -= _horizScrollBar.Height;
                 }
-                if (_vertScrollBar != null && _vertScrollBar.Visible)
+                if (_vertScrollBar is not null && _vertScrollBar.Visible)
                 {
                     rectDisplay.Width -= _vertScrollBar.Width;
                     if (RightToLeftInternal)
@@ -2300,7 +2300,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (EditingControl != null)
+                if (EditingControl is not null)
                 {
                     Point ptMouse = PointToClient(Control.MousePosition);
                     return EditingControl.Bounds.Contains(ptMouse);
@@ -2313,7 +2313,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_editingPanel != null)
+                if (_editingPanel is not null)
                 {
                     Point ptMouse = PointToClient(Control.MousePosition);
                     return _editingPanel.Bounds.Contains(ptMouse);
@@ -2327,14 +2327,14 @@ namespace System.Windows.Forms
             get
             {
                 Point ptMouse = PointToClient(Control.MousePosition);
-                if (_vertScrollBar != null && _vertScrollBar.Visible)
+                if (_vertScrollBar is not null && _vertScrollBar.Visible)
                 {
                     if (_vertScrollBar.Bounds.Contains(ptMouse))
                     {
                         return true;
                     }
                 }
-                if (_horizScrollBar != null && _horizScrollBar.Visible)
+                if (_horizScrollBar is not null && _horizScrollBar.Visible)
                 {
                     return _horizScrollBar.Bounds.Contains(ptMouse);
                 }
@@ -2423,7 +2423,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null)
+                if (value is not null)
                 {
                     DataGridViewCell firstDisplayedCell = value;
                     if (firstDisplayedCell.DataGridView != this)
@@ -2504,7 +2504,7 @@ namespace System.Windows.Forms
 
                 int firstDisplayedColumnIndex = -1;
                 DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
-                if (dataGridViewColumn != null)
+                if (dataGridViewColumn is not null)
                 {
                     if (dataGridViewColumn.Frozen)
                     {
@@ -2521,7 +2521,7 @@ namespace System.Windows.Forms
 
                 int firstDisplayedColumnIndexDbg2 = -1;
                 DataGridViewColumn dataGridViewColumnDbg = Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
-                if (dataGridViewColumnDbg != null)
+                if (dataGridViewColumnDbg is not null)
                 {
                     firstDisplayedColumnIndexDbg2 = dataGridViewColumnDbg.Index;
                 }
@@ -2855,7 +2855,7 @@ namespace System.Windows.Forms
                 // Update the lastTotallyDisplayedScrollingCol
                 ComputeVisibleColumns();
 
-                if (EditingControl != null
+                if (EditingControl is not null
                     && !Columns[_ptCurrentCell.X].Frozen
                     && DisplayedBandsInfo.FirstDisplayedScrollingCol > -1)
                 {
@@ -2986,7 +2986,7 @@ namespace System.Windows.Forms
 
         [Browsable(false)]
         public bool IsCurrentCellInEditMode
-            => EditingControl != null || _dataGridViewState1[State1_CurrentCellInEditMode];
+            => EditingControl is not null || _dataGridViewState1[State1_CurrentCellInEditMode];
 
         // Only used in bound scenarios, when binding to a IEditableObject
         [Browsable(false)]
@@ -3029,8 +3029,8 @@ namespace System.Windows.Forms
             || _dataGridViewOper[OperationTrackRowHeadersResize]
             || _dataGridViewOper[OperationTrackColRelocation]
             || IsCurrentCellDirty
-            || ((VirtualMode || DataSource != null) && IsCurrentRowDirty)
-            || (EditMode != DataGridViewEditMode.EditOnEnter && EditingControl != null)
+            || ((VirtualMode || DataSource is not null) && IsCurrentRowDirty)
+            || (EditMode != DataGridViewEditMode.EditOnEnter && EditingControl is not null)
             || _dataGridViewState1[State1_NewRowEdited];
 
         private bool IsMinimized
@@ -3038,32 +3038,32 @@ namespace System.Windows.Forms
 
         private bool IsSharedCellReadOnly(DataGridViewCell dataGridViewCell, int rowIndex)
         {
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             Debug.Assert(rowIndex >= 0);
             DataGridViewElementStates rowState = Rows.GetRowState(rowIndex);
             return ReadOnly
                 || (rowState & DataGridViewElementStates.ReadOnly) != 0
-                || (dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningColumn.ReadOnly)
+                || (dataGridViewCell.OwningColumn is not null && dataGridViewCell.OwningColumn.ReadOnly)
                 || dataGridViewCell.StateIncludes(DataGridViewElementStates.ReadOnly);
         }
 
         internal bool IsSharedCellSelected(DataGridViewCell dataGridViewCell, int rowIndex)
         {
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             Debug.Assert(rowIndex >= 0);
             DataGridViewElementStates rowState = Rows.GetRowState(rowIndex);
             return (rowState & DataGridViewElementStates.Selected) != 0
-                || (dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningColumn.Selected)
+                || (dataGridViewCell.OwningColumn is not null && dataGridViewCell.OwningColumn.Selected)
                 || dataGridViewCell.StateIncludes(DataGridViewElementStates.Selected);
         }
 
         internal bool IsSharedCellVisible(DataGridViewCell dataGridViewCell, int rowIndex)
         {
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             Debug.Assert(rowIndex >= 0);
             DataGridViewElementStates rowState = Rows.GetRowState(rowIndex);
             return (rowState & DataGridViewElementStates.Visible) != 0
-                && dataGridViewCell.OwningColumn != null
+                && dataGridViewCell.OwningColumn is not null
                 && dataGridViewCell.OwningColumn.Visible;
         }
 
@@ -3321,7 +3321,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (DataSource != null)
+                if (DataSource is not null)
                 {
                     throw new InvalidOperationException(SR.DataGridView_CannotSetRowCountOnDataBoundDataGridView);
                 }
@@ -3465,7 +3465,7 @@ namespace System.Windows.Forms
                 DataGridViewCellStyle cs = RowHeadersDefaultCellStyle;
                 cs.RemoveScope(DataGridViewCellStyleScopes.RowHeaders);
                 _rowHeadersDefaultCellStyle = value;
-                if (value != null)
+                if (value is not null)
                 {
                     _rowHeadersDefaultCellStyle.AddScope(this, DataGridViewCellStyleScopes.RowHeaders);
                 }
@@ -3666,7 +3666,7 @@ namespace System.Windows.Forms
                 DataGridViewCellStyle cs = RowsDefaultCellStyle;
                 cs.RemoveScope(DataGridViewCellStyleScopes.Rows);
                 _rowsDefaultCellStyle = value;
-                if (value != null)
+                if (value is not null)
                 {
                     _rowsDefaultCellStyle.AddScope(this, DataGridViewCellStyleScopes.Rows);
                 }
@@ -3704,9 +3704,9 @@ namespace System.Windows.Forms
             set
             {
                 DataGridViewRow dataGridViewRow = value;
-                if (dataGridViewRow != null)
+                if (dataGridViewRow is not null)
                 {
-                    if (dataGridViewRow.DataGridView != null)
+                    if (dataGridViewRow.DataGridView is not null)
                     {
                         throw new InvalidOperationException(SR.DataGridView_RowAlreadyBelongsToDataGridView);
                     }
@@ -3721,7 +3721,7 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeRowTemplate()
         {
-            return _rowTemplate != null;
+            return _rowTemplate is not null;
         }
 
         internal DataGridViewRow RowTemplateClone
@@ -3761,7 +3761,7 @@ namespace System.Windows.Forms
                         DataGridViewColumn dataGridViewColumn = Columns.GetFirstColumn(DataGridViewElementStates.Visible);
                         int firstVisibleRowIndex = Rows.GetFirstRow(DataGridViewElementStates.Visible);
 
-                        if (dataGridViewColumn != null && firstVisibleRowIndex != -1)
+                        if (dataGridViewColumn is not null && firstVisibleRowIndex != -1)
                         {
                             if (!ScrollIntoView(dataGridViewColumn.Index, firstVisibleRowIndex, false))
                             {
@@ -4047,7 +4047,7 @@ namespace System.Windows.Forms
                     // invalidate the row header to pick up the new ShowEditingIcon value
                     if (RowHeadersVisible)
                     {
-                        if (VirtualMode || DataSource != null)
+                        if (VirtualMode || DataSource is not null)
                         {
                             if (IsCurrentRowDirty)
                             {
@@ -4229,13 +4229,13 @@ namespace System.Windows.Forms
             {
                 if (_topLeftHeaderCell != value)
                 {
-                    if (_topLeftHeaderCell != null)
+                    if (_topLeftHeaderCell is not null)
                     {
                         // Detach existing header cell
                         _topLeftHeaderCell.DataGridView = null;
                     }
                     _topLeftHeaderCell = value;
-                    if (value != null)
+                    if (value is not null)
                     {
                         _topLeftHeaderCell.DataGridView = this;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAdvancedBorderStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAdvancedBorderStyle.cs
@@ -68,7 +68,7 @@ namespace System.Windows.Forms
                 {
                     all = true;
                     top = left = right = bottom = value;
-                    if (owner != null)
+                    if (owner is not null)
                     {
                         owner.OnAdvancedBorderStyleChanged(this);
                     }
@@ -113,7 +113,7 @@ namespace System.Windows.Forms
                     }
                     all = false;
                     bottom = value;
-                    if (owner != null)
+                    if (owner is not null)
                     {
                         owner.OnAdvancedBorderStyleChanged(this);
                     }
@@ -149,7 +149,7 @@ namespace System.Windows.Forms
             {
                 if ((all && top != value) || (!all && left != value))
                 {
-                    if ((owner != null && owner.RightToLeftInternal) &&
+                    if ((owner is not null && owner.RightToLeftInternal) &&
                         (value == DataGridViewAdvancedCellBorderStyle.InsetDouble || value == DataGridViewAdvancedCellBorderStyle.OutsetDouble))
                     {
                         throw new ArgumentException(string.Format(SR.DataGridView_AdvancedCellBorderStyleInvalid, "Left"));
@@ -167,7 +167,7 @@ namespace System.Windows.Forms
                     }
                     all = false;
                     left = value;
-                    if (owner != null)
+                    if (owner is not null)
                     {
                         owner.OnAdvancedBorderStyleChanged(this);
                     }
@@ -203,7 +203,7 @@ namespace System.Windows.Forms
             {
                 if ((all && top != value) || (!all && right != value))
                 {
-                    if ((owner != null && !owner.RightToLeftInternal) &&
+                    if ((owner is not null && !owner.RightToLeftInternal) &&
                         (value == DataGridViewAdvancedCellBorderStyle.InsetDouble || value == DataGridViewAdvancedCellBorderStyle.OutsetDouble))
                     {
                         throw new ArgumentException(string.Format(SR.DataGridView_AdvancedCellBorderStyleInvalid, "Right"));
@@ -217,7 +217,7 @@ namespace System.Windows.Forms
                     }
                     all = false;
                     right = value;
-                    if (owner != null)
+                    if (owner is not null)
                     {
                         owner.OnAdvancedBorderStyleChanged(this);
                     }
@@ -262,7 +262,7 @@ namespace System.Windows.Forms
                     }
                     all = false;
                     top = value;
-                    if (owner != null)
+                    if (owner is not null)
                     {
                         owner.OnAdvancedBorderStyleChanged(this);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -62,13 +62,13 @@ namespace System.Windows.Forms
                 if (oldValue != value)
                 {
                     EventHandler disposedHandler = new EventHandler(DetachContextMenuStrip);
-                    if (oldValue != null)
+                    if (oldValue is not null)
                     {
                         oldValue.Disposed -= disposedHandler;
                     }
 
                     Properties.SetObject(s_propContextMenuStrip, value);
-                    if (value != null)
+                    if (value is not null)
                     {
                         value.Disposed += disposedHandler;
                     }
@@ -102,15 +102,15 @@ namespace System.Windows.Forms
                     style = DefaultCellStyle;
                     style.RemoveScope(IsRow ? DataGridViewCellStyleScopes.Row : DataGridViewCellStyleScopes.Column);
                 }
-                if (value != null || Properties.ContainsObject(s_propDefaultCellStyle))
+                if (value is not null || Properties.ContainsObject(s_propDefaultCellStyle))
                 {
                     value?.AddScope(DataGridView, IsRow ? DataGridViewCellStyleScopes.Row : DataGridViewCellStyleScopes.Column);
                     Properties.SetObject(s_propDefaultCellStyle, value);
                 }
 
-                if (DataGridView != null &&
-                   ((style != null ^ value != null) ||
-                   (style != null && value != null && !style.Equals(DefaultCellStyle))))
+                if (DataGridView is not null &&
+                   ((style is not null ^ value is not null) ||
+                   (style is not null && value is not null && !style.Equals(DefaultCellStyle))))
                 {
                     DataGridView.OnBandDefaultCellStyleChanged(this);
                 }
@@ -123,7 +123,7 @@ namespace System.Windows.Forms
             get
             {
                 Type? type = (Type?)Properties.GetObject(s_propDefaultHeaderCellType);
-                if (type != null)
+                if (type is not null)
                 {
                     return type;
                 }
@@ -139,7 +139,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(s_propDefaultHeaderCellType))
+                if (value is not null || Properties.ContainsObject(s_propDefaultHeaderCellType))
                 {
                     if (!typeof(DataGridViewHeaderCell).IsAssignableFrom(value))
                     {
@@ -171,7 +171,7 @@ namespace System.Windows.Forms
                 {
                     State = State & ~DataGridViewElementStates.Displayed;
                 }
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     OnStateChanged(DataGridViewElementStates.Displayed);
                 }
@@ -247,17 +247,17 @@ namespace System.Windows.Forms
         [Browsable(false)]
         public bool HasDefaultCellStyle
         {
-            get => Properties.ContainsObject(s_propDefaultCellStyle) && Properties.GetObject(s_propDefaultCellStyle) != null;
+            get => Properties.ContainsObject(s_propDefaultCellStyle) && Properties.GetObject(s_propDefaultCellStyle) is not null;
         }
 
         internal bool HasDefaultHeaderCellType
         {
-            get => Properties.ContainsObject(s_propDefaultHeaderCellType) && Properties.GetObject(s_propDefaultHeaderCellType) != null;
+            get => Properties.ContainsObject(s_propDefaultHeaderCellType) && Properties.GetObject(s_propDefaultHeaderCellType) is not null;
         }
 
         internal bool HasHeaderCell
         {
-            get => Properties.ContainsObject(s_propHeaderCell) && Properties.GetObject(s_propHeaderCell) != null;
+            get => Properties.ContainsObject(s_propHeaderCell) && Properties.GetObject(s_propHeaderCell) is not null;
         }
 
         [Browsable(false)]
@@ -285,10 +285,10 @@ namespace System.Windows.Forms
                         headerCell.OwningColumn = dataGridViewColumn;
                         // Set the headerCell in the property store before setting the SortOrder.
                         Properties.SetObject(s_propHeaderCell, headerCell);
-                        if (DataGridView != null && DataGridView.SortedColumn == dataGridViewColumn)
+                        if (DataGridView is not null && DataGridView.SortedColumn == dataGridViewColumn)
                         {
                             DataGridViewColumnHeaderCell? dataGridViewColumnHeaderCell = headerCell as DataGridViewColumnHeaderCell;
-                            Debug.Assert(dataGridViewColumnHeaderCell != null);
+                            Debug.Assert(dataGridViewColumnHeaderCell is not null);
                             dataGridViewColumnHeaderCell.SortGlyphDirection = DataGridView.SortOrder;
                         }
                     }
@@ -299,9 +299,9 @@ namespace System.Windows.Forms
             set
             {
                 DataGridViewHeaderCell? headerCell = (DataGridViewHeaderCell?)Properties.GetObject(s_propHeaderCell);
-                if (value != null || Properties.ContainsObject(s_propHeaderCell))
+                if (value is not null || Properties.ContainsObject(s_propHeaderCell))
                 {
-                    if (headerCell != null)
+                    if (headerCell is not null)
                     {
                         headerCell.DataGridView = null;
                         if (IsRow)
@@ -315,7 +315,7 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    if (value != null)
+                    if (value is not null)
                     {
                         if (IsRow)
                         {
@@ -325,7 +325,7 @@ namespace System.Windows.Forms
                             }
 
                             // A HeaderCell can only be used by one band.
-                            if (value.OwningRow != null)
+                            if (value.OwningRow is not null)
                             {
                                 value.OwningRow.HeaderCell = null;
                             }
@@ -340,7 +340,7 @@ namespace System.Windows.Forms
                             }
 
                             // A HeaderCell can only be used by one band.
-                            if (value.OwningColumn != null)
+                            if (value.OwningColumn is not null)
                             {
                                 value.OwningColumn.HeaderCell = null;
                             }
@@ -354,7 +354,7 @@ namespace System.Windows.Forms
 
                     Properties.SetObject(s_propHeaderCell, value);
                 }
-                if (((value is null && headerCell != null) || (value != null && headerCell is null) || (value != null && headerCell != null && !headerCell.Equals(value))) && DataGridView != null)
+                if (((value is null && headerCell is not null) || (value is not null && headerCell is null) || (value is not null && headerCell is not null && !headerCell.Equals(value))) && DataGridView is not null)
                 {
                     DataGridView.OnBandHeaderCellChanged(this);
                 }
@@ -400,7 +400,7 @@ namespace System.Windows.Forms
                     if (Thickness < value)
                     {
                         // Force the new minimum width on potential auto fill column.
-                        if (DataGridView != null && !IsRow)
+                        if (DataGridView is not null && !IsRow)
                         {
                             DataGridView.OnColumnMinimumWidthChanging((DataGridViewColumn)this, value);
                         }
@@ -426,11 +426,11 @@ namespace System.Windows.Forms
             {
                 Debug.Assert(!IsRow);
                 return ((State & DataGridViewElementStates.ReadOnly) != 0 ||
-                    (DataGridView != null && DataGridView.ReadOnly));
+                    (DataGridView is not null && DataGridView.ReadOnly));
             }
             set
             {
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     if (DataGridView.ReadOnly)
                     {
@@ -499,7 +499,7 @@ namespace System.Windows.Forms
                     State = State & ~DataGridViewElementStates.ReadOnly;
                 }
 
-                Debug.Assert(DataGridView != null);
+                Debug.Assert(DataGridView is not null);
                 OnStateChanged(DataGridViewElementStates.ReadOnly);
             }
         }
@@ -567,7 +567,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     // this may trigger a call to set_SelectedInternal
                     if (IsRow)
@@ -612,7 +612,7 @@ namespace System.Windows.Forms
                     State = State & ~DataGridViewElementStates.Selected;
                 }
 
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     OnStateChanged(DataGridViewElementStates.Selected);
                 }
@@ -626,7 +626,7 @@ namespace System.Windows.Forms
             get => Properties.GetObject(s_propUserData);
             set
             {
-                if (value != null || Properties.ContainsObject(s_propUserData))
+                if (value is not null || Properties.ContainsObject(s_propUserData))
                 {
                     Properties.SetObject(s_propUserData, value);
                 }
@@ -667,7 +667,7 @@ namespace System.Windows.Forms
                 bool setThickness = true;
                 if (IsRow)
                 {
-                    if (DataGridView != null && DataGridView.AutoSizeRowsMode != DataGridViewAutoSizeRowsMode.None)
+                    if (DataGridView is not null && DataGridView.AutoSizeRowsMode != DataGridViewAutoSizeRowsMode.None)
                     {
                         CachedThickness = value;
                         setThickness = false;
@@ -684,7 +684,7 @@ namespace System.Windows.Forms
                         CachedThickness = value;
                         setThickness = false;
                     }
-                    else if (inheritedAutoSizeMode == DataGridViewAutoSizeColumnMode.Fill && DataGridView != null)
+                    else if (inheritedAutoSizeMode == DataGridViewAutoSizeColumnMode.Fill && DataGridView is not null)
                     {
                         if (dataGridViewColumn.Visible)
                         {
@@ -729,7 +729,7 @@ namespace System.Windows.Forms
             {
                 if (((State & DataGridViewElementStates.Visible) != 0) != value)
                 {
-                    if (DataGridView != null &&
+                    if (DataGridView is not null &&
                         IsRow &&
                         DataGridView.NewRowIndex != -1 &&
                         DataGridView.NewRowIndex == Index &&
@@ -781,7 +781,7 @@ namespace System.Windows.Forms
             {
                 dataGridViewBand.DefaultHeaderCellType = DefaultHeaderCellType;
             }
-            if (ContextMenuStripInternal != null)
+            if (ContextMenuStripInternal is not null)
             {
                 dataGridViewBand.ContextMenuStrip = ContextMenuStripInternal.Clone();
             }
@@ -803,7 +803,7 @@ namespace System.Windows.Forms
             if (disposing)
             {
                 ContextMenuStrip? contextMenuStrip = ContextMenuStripInternal;
-                if (contextMenuStrip != null)
+                if (contextMenuStrip is not null)
                 {
                     contextMenuStrip.Disposed -= new EventHandler(DetachContextMenuStrip);
                 }
@@ -813,8 +813,8 @@ namespace System.Windows.Forms
         internal void GetHeightInfo(int rowIndex, out int height, out int minimumHeight)
         {
             Debug.Assert(IsRow);
-            if (DataGridView != null &&
-                (DataGridView.VirtualMode || DataGridView.DataSource != null) &&
+            if (DataGridView is not null &&
+                (DataGridView.VirtualMode || DataGridView.DataSource is not null) &&
                 DataGridView.AutoSizeRowsMode == DataGridViewAutoSizeRowsMode.None)
             {
                 Debug.Assert(rowIndex > -1);
@@ -830,7 +830,7 @@ namespace System.Windows.Forms
 
         private void OnStateChanged(DataGridViewElementStates elementState)
         {
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 // maybe move this code into OnDataGridViewElementStateChanged
                 if (IsRow)
@@ -855,7 +855,7 @@ namespace System.Windows.Forms
 
         private void OnStateChanging(DataGridViewElementStates elementState)
         {
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 if (IsRow)
                 {
@@ -890,7 +890,7 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeDefaultHeaderCellType()
         {
-            return Properties.GetObject(s_propDefaultHeaderCellType) != null;
+            return Properties.GetObject(s_propDefaultHeaderCellType) is not null;
         }
 
         // internal because DataGridViewColumn needs to access it

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.DataGridViewButtonCellAccessibleObject.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                if (dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningRow != null)
+                if (dataGridViewCell.OwningColumn is not null && dataGridViewCell.OwningRow is not null)
                 {
                     dataGridView.OnCellClickInternal(new DataGridViewCellEventArgs(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex));
                     dataGridView.OnCellContentClickInternal(new DataGridViewCellEventArgs(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonCell.cs
@@ -155,7 +155,7 @@ namespace System.Windows.Forms
             get
             {
                 Type valueType = base.ValueType;
-                if (valueType != null)
+                if (valueType is not null)
                 {
                     return valueType;
                 }
@@ -446,9 +446,9 @@ namespace System.Windows.Forms
         protected override object GetValue(int rowIndex)
         {
             if (UseColumnTextForButtonValue &&
-                DataGridView != null &&
+                DataGridView is not null &&
                 DataGridView.NewRowIndex != rowIndex &&
-                OwningColumn != null &&
+                OwningColumn is not null &&
                 OwningColumn is DataGridViewButtonColumn)
             {
                 return ((DataGridViewButtonColumn)OwningColumn).Text;
@@ -511,7 +511,7 @@ namespace System.Windows.Forms
                 if (!e.Alt && !e.Control && !e.Shift)
                 {
                     RaiseCellClick(new DataGridViewCellEventArgs(ColumnIndex, rowIndex));
-                    if (DataGridView != null &&
+                    if (DataGridView is not null &&
                         ColumnIndex < DataGridView.Columns.Count &&
                         rowIndex < DataGridView.Rows.Count)
                     {
@@ -682,7 +682,7 @@ namespace System.Windows.Forms
             Debug.Assert(!paint || !computeContentBounds || !computeErrorIconBounds);
             Debug.Assert(!computeContentBounds || !computeErrorIconBounds || !paint);
             Debug.Assert(!computeErrorIconBounds || !paint || !computeContentBounds);
-            Debug.Assert(cellStyle != null);
+            Debug.Assert(cellStyle is not null);
 
             Point ptCurrentCell = DataGridView.CurrentCellAddress;
             bool cellSelected = (elementState & DataGridViewElementStates.Selected) != 0;
@@ -980,7 +980,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (formattedString != null && paint && PaintContentForeground(paintParts))
+            if (formattedString is not null && paint && PaintContentForeground(paintParts))
             {
                 // Font independent margins
                 valBounds.Offset(DATAGRIDVIEWBUTTONCELL_horizontalTextMargin, DATAGRIDVIEWBUTTONCELL_verticalTextMargin);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewButtonColumn.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms
             get => base.CellTemplate;
             set
             {
-                if (value != null && !(value is DataGridViewButtonCell))
+                if (value is not null && !(value is DataGridViewButtonCell))
                 {
                     throw new InvalidCastException(string.Format(SR.DataGridViewTypeColumn_WrongCellTemplateType, "System.Windows.Forms.DataGridViewButtonCell"));
                 }
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
                 if (FlatStyle != value)
                 {
                     ((DataGridViewButtonCell)CellTemplate).FlatStyle = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -101,7 +101,7 @@ namespace System.Windows.Forms
                 if (!string.Equals(value, _text, StringComparison.Ordinal))
                 {
                     _text = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (UseColumnTextForButtonValue)
                         {
@@ -145,7 +145,7 @@ namespace System.Windows.Forms
                 if (UseColumnTextForButtonValue != value)
                 {
                     ((DataGridViewButtonCell)CellTemplate).UseColumnTextForButtonValueInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -176,7 +176,7 @@ namespace System.Windows.Forms
             {
                 dataGridViewColumn = (DataGridViewButtonColumn)System.Activator.CreateInstance(thisType);
             }
-            if (dataGridViewColumn != null)
+            if (dataGridViewColumn is not null)
             {
                 base.CloneInternal(dataGridViewColumn);
                 dataGridViewColumn.Text = _text;
@@ -197,14 +197,14 @@ namespace System.Windows.Forms
                     !defaultCellStyle.ForeColor.IsEmpty ||
                     !defaultCellStyle.SelectionBackColor.IsEmpty ||
                     !defaultCellStyle.SelectionForeColor.IsEmpty ||
-                    defaultCellStyle.Font != null ||
+                    defaultCellStyle.Font is not null ||
                     !defaultCellStyle.IsNullValueDefault ||
                     !defaultCellStyle.IsDataSourceNullValueDefault ||
                     !string.IsNullOrEmpty(defaultCellStyle.Format) ||
                     !defaultCellStyle.FormatProvider.Equals(System.Globalization.CultureInfo.CurrentCulture) ||
                     defaultCellStyle.Alignment != DataGridViewContentAlignment.MiddleCenter ||
                     defaultCellStyle.WrapMode != DataGridViewTriState.NotSet ||
-                    defaultCellStyle.Tag != null ||
+                    defaultCellStyle.Tag is not null ||
                     !defaultCellStyle.Padding.Equals(Padding.Empty));
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -62,8 +62,8 @@ namespace System.Windows.Forms
                         DataGridViewCell dataGridViewCell = _owner;
                         DataGridView? dataGridView = dataGridViewCell.DataGridView;
 
-                        if (dataGridView != null &&
-                            dataGridViewCell.OwningColumn != null &&
+                        if (dataGridView is not null &&
+                            dataGridViewCell.OwningColumn is not null &&
                             dataGridViewCell.OwningColumn == dataGridView.SortedColumn)
                         {
                             name += ", " + (dataGridView.SortOrder == SortOrder.Ascending
@@ -85,7 +85,7 @@ namespace System.Windows.Forms
                 get => _owner;
                 set
                 {
-                    if (_owner != null)
+                    if (_owner is not null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerAlreadySet);
                     }
@@ -121,7 +121,7 @@ namespace System.Windows.Forms
                     }
 
                     AccessibleStates state = AccessibleStates.Selectable | AccessibleStates.Focusable;
-                    if (_owner.DataGridView != null && _owner == _owner.DataGridView.CurrentCell)
+                    if (_owner.DataGridView is not null && _owner == _owner.DataGridView.CurrentCell)
                     {
                         state |= AccessibleStates.Focused;
                     }
@@ -142,15 +142,15 @@ namespace System.Windows.Forms
                     }
 
                     Rectangle cellBounds;
-                    if (_owner.OwningColumn != null && _owner.OwningRow != null)
+                    if (_owner.OwningColumn is not null && _owner.OwningRow is not null)
                     {
                         cellBounds = _owner.DataGridView.GetCellDisplayRectangle(_owner.OwningColumn.Index, _owner.OwningRow.Index, cutOverflow: false);
                     }
-                    else if (_owner.OwningRow != null)
+                    else if (_owner.OwningRow is not null)
                     {
                         cellBounds = _owner.DataGridView.GetCellDisplayRectangle(-1, _owner.OwningRow.Index, cutOverflow: false);
                     }
-                    else if (_owner.OwningColumn != null)
+                    else if (_owner.OwningColumn is not null)
                     {
                         cellBounds = _owner.DataGridView.GetCellDisplayRectangle(_owner.OwningColumn.Index, -1, cutOverflow: false);
                     }
@@ -179,18 +179,18 @@ namespace System.Windows.Forms
 
                     object? formattedValue = _owner.FormattedValue;
                     string? formattedValueAsString = formattedValue as string;
-                    if (formattedValue is null || (formattedValueAsString != null && string.IsNullOrEmpty(formattedValueAsString)))
+                    if (formattedValue is null || (formattedValueAsString is not null && string.IsNullOrEmpty(formattedValueAsString)))
                     {
                         return SR.DataGridView_AccNullValue;
                     }
-                    else if (formattedValueAsString != null)
+                    else if (formattedValueAsString is not null)
                     {
                         return formattedValueAsString;
                     }
-                    else if (_owner.OwningColumn != null)
+                    else if (_owner.OwningColumn is not null)
                     {
                         TypeConverter converter = _owner.FormattedValueTypeConverter;
-                        if (converter != null && converter.CanConvertTo(typeof(string)))
+                        if (converter is not null && converter.CanConvertTo(typeof(string)))
                         {
                             return converter.ConvertToString(formattedValue);
                         }
@@ -268,7 +268,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                if (dataGridViewCell.EditType != null)
+                if (dataGridViewCell.EditType is not null)
                 {
                     if (dataGridView.InBeginEdit || dataGridView.InEndEdit)
                     {
@@ -375,8 +375,8 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.DataGridView != null &&
-                    _owner.DataGridView.EditingControl != null &&
+                if (_owner.DataGridView is not null &&
+                    _owner.DataGridView.EditingControl is not null &&
                     _owner.DataGridView.IsCurrentCellInEditMode &&
                     _owner.DataGridView.CurrentCell == _owner &&
                     index == 0)
@@ -396,8 +396,8 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.DataGridView != null &&
-                    _owner.DataGridView.EditingControl != null &&
+                if (_owner.DataGridView is not null &&
+                    _owner.DataGridView.EditingControl is not null &&
                     _owner.DataGridView.IsCurrentCellInEditMode &&
                     _owner.DataGridView.CurrentCell == _owner)
                 {
@@ -474,10 +474,10 @@ namespace System.Windows.Forms
 
             private AccessibleObject? NavigateBackward(bool wrapAround)
             {
-                Debug.Assert(_owner != null);
-                Debug.Assert(_owner.DataGridView != null);
-                Debug.Assert(_owner.OwningColumn != null);
-                Debug.Assert(_owner.OwningRow != null);
+                Debug.Assert(_owner is not null);
+                Debug.Assert(_owner.DataGridView is not null);
+                Debug.Assert(_owner.OwningColumn is not null);
+                Debug.Assert(_owner.OwningRow is not null);
 
                 if (_owner.OwningColumn == _owner.DataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible))
                 {
@@ -510,10 +510,10 @@ namespace System.Windows.Forms
 
             private AccessibleObject? NavigateForward(bool wrapAround)
             {
-                Debug.Assert(_owner != null);
-                Debug.Assert(_owner.DataGridView != null);
-                Debug.Assert(_owner.OwningColumn != null);
-                Debug.Assert(_owner.OwningRow != null);
+                Debug.Assert(_owner is not null);
+                Debug.Assert(_owner.DataGridView is not null);
+                Debug.Assert(_owner.OwningColumn is not null);
+                Debug.Assert(_owner.OwningRow is not null);
 
                 if (_owner.OwningColumn == _owner.DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible,
                                                                                         DataGridViewElementStates.None))
@@ -522,7 +522,7 @@ namespace System.Windows.Forms
                     {
                         // Return the first cell in the next visible row.
                         AccessibleObject? nextRow = _owner.OwningRow.AccessibilityObject.Navigate(AccessibleNavigation.Next);
-                        if (nextRow != null && nextRow.GetChildCount() > 0)
+                        if (nextRow is not null && nextRow.GetChildCount() > 0)
                         {
                             return _owner.DataGridView.RowHeadersVisible ? nextRow.GetChild(1) : nextRow.GetChild(0);
                         }
@@ -658,7 +658,7 @@ namespace System.Windows.Forms
                     case UiaCore.NavigateDirection.LastChild:
                         if (_owner.DataGridView.CurrentCell == _owner &&
                             _owner.DataGridView.IsCurrentCellInEditMode &&
-                            _owner.DataGridView.EditingControl != null)
+                            _owner.DataGridView.EditingControl is not null)
                         {
                             return _child;
                         }
@@ -734,9 +734,9 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            internal override int Row => _owner?.OwningRow != null ? _owner.OwningRow.Index : -1;
+            internal override int Row => _owner?.OwningRow is not null ? _owner.OwningRow.Index : -1;
 
-            internal override int Column => _owner?.OwningColumn != null ? _owner.OwningColumn.Index : -1;
+            internal override int Column => _owner?.OwningColumn is not null ? _owner.OwningColumn.Index : -1;
 
             internal override UiaCore.IRawElementProviderSimple? ContainingGrid => _owner?.DataGridView?.AccessibilityObject;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -145,16 +145,16 @@ namespace System.Windows.Forms
                 if (oldValue != value)
                 {
                     EventHandler disposedHandler = new EventHandler(DetachContextMenuStrip);
-                    if (oldValue != null)
+                    if (oldValue is not null)
                     {
                         oldValue.Disposed -= disposedHandler;
                     }
                     Properties.SetObject(s_propCellContextMenuStrip, value);
-                    if (value != null)
+                    if (value is not null)
                     {
                         value.Disposed += disposedHandler;
                     }
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridView.OnCellContextMenuStripChanged(this);
                     }
@@ -280,7 +280,7 @@ namespace System.Windows.Forms
                 {
                     Properties.SetObject(s_propCellErrorText, value);
                 }
-                if (DataGridView != null && !errorText.Equals(ErrorTextInternal))
+                if (DataGridView is not null && !errorText.Equals(ErrorTextInternal))
                 {
                     DataGridView.OnCellErrorTextChanged(this);
                 }
@@ -316,9 +316,9 @@ namespace System.Windows.Forms
             get
             {
                 TypeConverter formattedValueTypeConverter = null;
-                if (FormattedValueType != null)
+                if (FormattedValueType is not null)
                 {
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         formattedValueTypeConverter = DataGridView.GetCachedTypeConverter(FormattedValueType);
                     }
@@ -336,12 +336,12 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null && RowIndex >= 0 && ColumnIndex >= 0)
+                if (DataGridView is not null && RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
                     return OwningColumn.Frozen && OwningRow.Frozen;
                 }
-                else if (OwningRow != null && (OwningRow.DataGridView is null || RowIndex >= 0))
+                else if (OwningRow is not null && (OwningRow.DataGridView is null || RowIndex >= 0))
                 {
                     return OwningRow.Frozen;
                 }
@@ -351,7 +351,7 @@ namespace System.Windows.Forms
 
         private bool HasErrorText
         {
-            get => Properties.ContainsObject(s_propCellErrorText) && Properties.GetObject(s_propCellErrorText) != null;
+            get => Properties.ContainsObject(s_propCellErrorText) && Properties.GetObject(s_propCellErrorText) is not null;
         }
 
         [Browsable(false)]
@@ -359,7 +359,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return Properties.ContainsObject(s_propCellStyle) && Properties.GetObject(s_propCellStyle) != null;
+                return Properties.ContainsObject(s_propCellStyle) && Properties.GetObject(s_propCellStyle) is not null;
             }
         }
 
@@ -367,7 +367,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return Properties.ContainsObject(s_propCellToolTipText) && Properties.GetObject(s_propCellToolTipText) != null;
+                return Properties.ContainsObject(s_propCellToolTipText) && Properties.GetObject(s_propCellToolTipText) is not null;
             }
         }
 
@@ -375,17 +375,17 @@ namespace System.Windows.Forms
         {
             get
             {
-                return Properties.ContainsObject(s_propCellValue) && Properties.GetObject(s_propCellValue) != null;
+                return Properties.ContainsObject(s_propCellValue) && Properties.GetObject(s_propCellValue) is not null;
             }
         }
 
         private protected virtual bool HasValueType
         {
-            get => Properties.ContainsObject(s_propCellValueType) && Properties.GetObject(s_propCellValueType) != null;
+            get => Properties.ContainsObject(s_propCellValueType) && Properties.GetObject(s_propCellValueType) is not null;
         }
 
         #region IKeyboardToolTip implementation
-        bool IKeyboardToolTip.CanShowToolTipsNow() => Visible && DataGridView != null;
+        bool IKeyboardToolTip.CanShowToolTipsNow() => Visible && DataGridView is not null;
 
         Rectangle IKeyboardToolTip.GetNativeScreenRectangle() => AccessibilityObject.Bounds;
 
@@ -535,11 +535,11 @@ namespace System.Windows.Forms
                 {
                     return true;
                 }
-                if (OwningRow != null && (OwningRow.DataGridView is null || RowIndex >= 0) && OwningRow.ReadOnly)
+                if (OwningRow is not null && (OwningRow.DataGridView is null || RowIndex >= 0) && OwningRow.ReadOnly)
                 {
                     return true;
                 }
-                if (DataGridView != null && RowIndex >= 0 && ColumnIndex >= 0)
+                if (DataGridView is not null && RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
                     return OwningColumn.ReadOnly;
@@ -548,7 +548,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     if (RowIndex == -1)
                     {
@@ -602,12 +602,12 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (OwningRow != null && (OwningRow.DataGridView is null || RowIndex >= 0) && OwningRow.Resizable == DataGridViewTriState.True)
+                if (OwningRow is not null && (OwningRow.DataGridView is null || RowIndex >= 0) && OwningRow.Resizable == DataGridViewTriState.True)
                 {
                     return true;
                 }
 
-                if (DataGridView != null && RowIndex >= 0 && ColumnIndex >= 0)
+                if (DataGridView is not null && RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
                     return OwningColumn.Resizable == DataGridViewTriState.True;
@@ -634,12 +634,12 @@ namespace System.Windows.Forms
                     return true;
                 }
 
-                if (OwningRow != null && (OwningRow.DataGridView is null || RowIndex >= 0) && OwningRow.Selected)
+                if (OwningRow is not null && (OwningRow.DataGridView is null || RowIndex >= 0) && OwningRow.Selected)
                 {
                     return true;
                 }
 
-                if (DataGridView != null && RowIndex >= 0 && ColumnIndex >= 0)
+                if (DataGridView is not null && RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
                     return OwningColumn.Selected;
@@ -649,7 +649,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     if (RowIndex == -1)
                     {
@@ -679,7 +679,7 @@ namespace System.Windows.Forms
                 {
                     State = State & ~DataGridViewElementStates.Selected;
                 }
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridView.OnDataGridViewElementStateChanged(this, -1, DataGridViewElementStates.Selected);
                 }
@@ -699,7 +699,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridViewAdvancedBorderStyle dataGridViewAdvancedBorderStylePlaceholder = new DataGridViewAdvancedBorderStyle(), dgvabsEffective;
                     dgvabsEffective = AdjustCellBorderStyle(
@@ -740,17 +740,17 @@ namespace System.Windows.Forms
                     dgvcs = Style;
                     dgvcs.RemoveScope(DataGridViewCellStyleScopes.Cell);
                 }
-                if (value != null || Properties.ContainsObject(s_propCellStyle))
+                if (value is not null || Properties.ContainsObject(s_propCellStyle))
                 {
-                    if (value != null)
+                    if (value is not null)
                     {
                         value.AddScope(DataGridView, DataGridViewCellStyleScopes.Cell);
                     }
                     Properties.SetObject(s_propCellStyle, value);
                 }
-                if (((dgvcs != null && value is null) ||
-                    (dgvcs is null && value != null) ||
-                    (dgvcs != null && value != null && !dgvcs.Equals(Style))) && DataGridView != null)
+                if (((dgvcs is not null && value is null) ||
+                    (dgvcs is null && value is not null) ||
+                    (dgvcs is not null && value is not null && !dgvcs.Equals(Style))) && DataGridView is not null)
                 {
                     DataGridView.OnCellStyleChanged(this);
                 }
@@ -771,7 +771,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(s_propCellTag))
+                if (value is not null || Properties.ContainsObject(s_propCellTag))
                 {
                     Properties.SetObject(s_propCellTag, value);
                 }
@@ -807,7 +807,7 @@ namespace System.Windows.Forms
                 {
                     Properties.SetObject(s_propCellToolTipText, value);
                 }
-                if (DataGridView != null && !toolTipText.Equals(ToolTipTextInternal))
+                if (DataGridView is not null && !toolTipText.Equals(ToolTipTextInternal))
                 {
                     DataGridView.OnCellToolTipTextChanged(this);
                 }
@@ -835,7 +835,7 @@ namespace System.Windows.Forms
             get
             {
                 Type cellValueType = (Type)Properties.GetObject(s_propCellValueType);
-                if (cellValueType is null && OwningColumn != null)
+                if (cellValueType is null && OwningColumn is not null)
                 {
                     cellValueType = OwningColumn.ValueType;
                 }
@@ -844,7 +844,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(s_propCellValueType))
+                if (value is not null || Properties.ContainsObject(s_propCellValueType))
                 {
                     Properties.SetObject(s_propCellValueType, value);
                 }
@@ -856,13 +856,13 @@ namespace System.Windows.Forms
             get
             {
                 TypeConverter valueTypeConverter = null;
-                if (OwningColumn != null)
+                if (OwningColumn is not null)
                 {
                     valueTypeConverter = OwningColumn.BoundColumnConverter;
                 }
-                if (valueTypeConverter is null && ValueType != null)
+                if (valueTypeConverter is null && ValueType is not null)
                 {
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         valueTypeConverter = DataGridView.GetCachedTypeConverter(ValueType);
                     }
@@ -880,12 +880,12 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null && RowIndex >= 0 && ColumnIndex >= 0)
+                if (DataGridView is not null && RowIndex >= 0 && ColumnIndex >= 0)
                 {
                     Debug.Assert(DataGridView.Rows.GetRowState(RowIndex) == DataGridView.Rows.SharedRow(RowIndex).State);
                     return OwningColumn.Visible && OwningRow.Visible;
                 }
-                else if (OwningRow != null && (OwningRow.DataGridView is null || RowIndex >= 0))
+                else if (OwningRow is not null && (OwningRow.DataGridView is null || RowIndex >= 0))
                 {
                     return OwningRow.Visible;
                 }
@@ -913,7 +913,7 @@ namespace System.Windows.Forms
             switch (dataGridViewAdvancedBorderStyleInput.All)
             {
                 case DataGridViewAdvancedCellBorderStyle.Single:
-                    if (DataGridView != null && DataGridView.RightToLeftInternal)
+                    if (DataGridView is not null && DataGridView.RightToLeftInternal)
                     {
                         dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Single;
                         dataGridViewAdvancedBorderStylePlaceholder.RightInternal = (isFirstDisplayedColumn && singleVerticalBorderAdded) ? DataGridViewAdvancedCellBorderStyle.Single : DataGridViewAdvancedCellBorderStyle.None;
@@ -928,7 +928,7 @@ namespace System.Windows.Forms
                     return dataGridViewAdvancedBorderStylePlaceholder;
 
                 case DataGridViewAdvancedCellBorderStyle.NotSet:
-                    if (DataGridView != null && DataGridView.AdvancedCellBorderStyle == dataGridViewAdvancedBorderStyleInput)
+                    if (DataGridView is not null && DataGridView.AdvancedCellBorderStyle == dataGridViewAdvancedBorderStyleInput)
                     {
                         switch (DataGridView.CellBorderStyle)
                         {
@@ -994,9 +994,9 @@ namespace System.Windows.Forms
                 rect.Height++;
             }
 
-            if (OwningColumn != null)
+            if (OwningColumn is not null)
             {
-                if (DataGridView != null && DataGridView.RightToLeftInternal)
+                if (DataGridView is not null && DataGridView.RightToLeftInternal)
                 {
                     rect.X += OwningColumn.DividerWidth;
                 }
@@ -1005,7 +1005,7 @@ namespace System.Windows.Forms
                     rect.Width += OwningColumn.DividerWidth;
                 }
             }
-            if (OwningRow != null)
+            if (OwningRow is not null)
             {
                 rect.Height += OwningRow.DividerHeight;
             }
@@ -1021,7 +1021,7 @@ namespace System.Windows.Forms
 
         internal DataGridViewElementStates CellStateFromColumnRowStates(DataGridViewElementStates rowState)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             Debug.Assert(ColumnIndex >= 0);
             DataGridViewElementStates orFlags = DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Resizable | DataGridViewElementStates.Selected;
             DataGridViewElementStates andFlags = DataGridViewElementStates.Displayed | DataGridViewElementStates.Frozen | DataGridViewElementStates.Visible;
@@ -1059,14 +1059,14 @@ namespace System.Windows.Forms
             {
                 dataGridViewCell.ToolTipText = ToolTipTextInternal;
             }
-            if (ContextMenuStripInternal != null)
+            if (ContextMenuStripInternal is not null)
             {
                 dataGridViewCell.ContextMenuStrip = ContextMenuStripInternal.Clone();
             }
             dataGridViewCell.State = State & ~DataGridViewElementStates.Selected;
             dataGridViewCell.Tag = Tag;
 
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 KeyboardToolTipStateMachine.Instance.Hook(dataGridViewCell, DataGridView.KeyboardToolTip);
             }
@@ -1092,12 +1092,12 @@ namespace System.Windows.Forms
             out DataGridViewElementStates cellState,
             out Rectangle cellBounds)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             bool singleVerticalBorderAdded = !DataGridView.RowHeadersVisible && DataGridView.AdvancedCellBorderStyle.All == DataGridViewAdvancedCellBorderStyle.Single;
             bool singleHorizontalBorderAdded = !DataGridView.ColumnHeadersVisible && DataGridView.AdvancedCellBorderStyle.All == DataGridViewAdvancedCellBorderStyle.Single;
             DataGridViewAdvancedBorderStyle dataGridViewAdvancedBorderStylePlaceholder = new DataGridViewAdvancedBorderStyle();
 
-            if (rowIndex > -1 && OwningColumn != null)
+            if (rowIndex > -1 && OwningColumn is not null)
             {
                 // Inner cell case
                 dgvabsEffective = AdjustCellBorderStyle(DataGridView.AdvancedCellBorderStyle,
@@ -1110,20 +1110,20 @@ namespace System.Windows.Forms
                 cellState = CellStateFromColumnRowStates(rowState);
                 cellState |= State;
             }
-            else if (OwningColumn != null)
+            else if (OwningColumn is not null)
             {
                 // Column header cell case
                 Debug.Assert(rowIndex == -1);
                 Debug.Assert(this is DataGridViewColumnHeaderCell, "if the row index == -1 and we have an owning column this should be a column header cell");
                 DataGridViewColumn dataGridViewColumn = DataGridView.Columns.GetLastColumn(DataGridViewElementStates.Visible, DataGridViewElementStates.None);
-                bool isLastVisibleColumn = (dataGridViewColumn != null && dataGridViewColumn.Index == ColumnIndex);
+                bool isLastVisibleColumn = (dataGridViewColumn is not null && dataGridViewColumn.Index == ColumnIndex);
                 dgvabsEffective = DataGridView.AdjustColumnHeaderBorderStyle(DataGridView.AdvancedColumnHeadersBorderStyle,
                     dataGridViewAdvancedBorderStylePlaceholder,
                     ColumnIndex == DataGridView.FirstDisplayedColumnIndex,
                     isLastVisibleColumn);
                 cellState = OwningColumn.State | State;
             }
-            else if (OwningRow != null)
+            else if (OwningRow is not null)
             {
                 // Row header cell case
                 Debug.Assert(this is DataGridViewRowHeaderCell);
@@ -1205,7 +1205,7 @@ namespace System.Windows.Forms
             {
                 throw new InvalidOperationException();
             }
-            if (dgv.EditingControl.ParentInternal != null)
+            if (dgv.EditingControl.ParentInternal is not null)
             {
                 if (dgv.EditingControl.ContainsFocus)
                 {
@@ -1234,7 +1234,7 @@ namespace System.Windows.Forms
                     AccessibilityObject.RaiseStructureChangedEvent(UiaCore.StructureChangeType.ChildRemoved, dgv.EditingControlAccessibleObject.RuntimeId);
                 }
             }
-            if (dgv.EditingPanel.ParentInternal != null)
+            if (dgv.EditingPanel.ParentInternal is not null)
             {
                 Debug.Assert(dgv.EditingPanel.ParentInternal == dgv);
                 Debug.Assert(dgv.Controls.Contains(dgv.EditingPanel));
@@ -1283,7 +1283,7 @@ namespace System.Windows.Forms
             if (disposing)
             {
                 ContextMenuStrip contextMenuStrip = (ContextMenuStrip)ContextMenuStripInternal;
-                if (contextMenuStrip != null)
+                if (contextMenuStrip is not null)
                 {
                     contextMenuStrip.Disposed -= new EventHandler(DetachContextMenuStrip);
                 }
@@ -1432,7 +1432,7 @@ namespace System.Windows.Forms
             if (DpiHelper.IsScalingRequired)
             {
                 Bitmap scaledBitmap = DpiHelper.CreateResizedBitmap(b, new Size(s_iconsWidth, s_iconsHeight));
-                if (scaledBitmap != null)
+                if (scaledBitmap is not null)
                 {
                     b.Dispose();
                     b = scaledBitmap;
@@ -1479,7 +1479,7 @@ namespace System.Windows.Forms
                     sb.Append("<TR>");
                 }
                 sb.Append("<TD>");
-                if (formattedValue != null)
+                if (formattedValue is not null)
                 {
                     using var sw = new StringWriter(sb, CultureInfo.CurrentCulture);
                     FormatPlainTextAsHtml(formattedValue.ToString(), sw);
@@ -1506,7 +1506,7 @@ namespace System.Windows.Forms
                     string.Equals(format, DataFormats.Text, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(format, DataFormats.UnicodeText, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (formattedValue != null)
+                    if (formattedValue is not null)
                     {
                         if (firstCell && lastCell && inFirstRow && inLastRow)
                         {
@@ -1559,8 +1559,8 @@ namespace System.Windows.Forms
         internal ContextMenuStrip GetContextMenuStrip(int rowIndex)
         {
             ContextMenuStrip contextMenuStrip = ContextMenuStripInternal;
-            if (DataGridView != null &&
-                (DataGridView.VirtualMode || DataGridView.DataSource != null))
+            if (DataGridView is not null &&
+                (DataGridView.VirtualMode || DataGridView.DataSource is not null))
             {
                 contextMenuStrip = DataGridView.OnCellContextMenuStripNeeded(ColumnIndex, rowIndex, contextMenuStrip);
             }
@@ -1569,7 +1569,7 @@ namespace System.Windows.Forms
 
         internal (Color darkColor, Color lightColor) GetContrastedColors(Color baseline)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             int darkDistance = ColorDistance(baseline, SystemColors.ControlDark);
             int lightDistance = ColorDistance(baseline, SystemColors.ControlLightLight);
@@ -1626,12 +1626,12 @@ namespace System.Windows.Forms
 
         internal object GetEditedFormattedValue(object value, int rowIndex, ref DataGridViewCellStyle dataGridViewCellStyle, DataGridViewDataErrorContexts context)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             Point ptCurrentCell = DataGridView.CurrentCellAddress;
             if (ColumnIndex == ptCurrentCell.X && rowIndex == ptCurrentCell.Y)
             {
                 IDataGridViewEditingControl dgvectl = (IDataGridViewEditingControl)DataGridView.EditingControl;
-                if (dgvectl != null)
+                if (dgvectl is not null)
                 {
                     return dgvectl.GetEditingControlFormattedValue(context);
                 }
@@ -1670,21 +1670,21 @@ namespace System.Windows.Forms
         {
             string errorText = string.Empty;
             object objErrorText = Properties.GetObject(s_propCellErrorText);
-            if (objErrorText != null)
+            if (objErrorText is not null)
             {
                 errorText = (string)objErrorText;
             }
-            else if (DataGridView != null &&
+            else if (DataGridView is not null &&
                      rowIndex != -1 &&
                      rowIndex != DataGridView.NewRowIndex &&
-                     OwningColumn != null &&
+                     OwningColumn is not null &&
                      OwningColumn.IsDataBound &&
-                     DataGridView.DataConnection != null)
+                     DataGridView.DataConnection is not null)
             {
                 errorText = DataGridView.DataConnection.GetError(OwningColumn.BoundColumnIndex, ColumnIndex, rowIndex);
             }
 
-            if (DataGridView != null && (DataGridView.VirtualMode || DataGridView.DataSource != null) &&
+            if (DataGridView is not null && (DataGridView.VirtualMode || DataGridView.DataSource is not null) &&
                 ColumnIndex >= 0 && rowIndex >= 0)
             {
                 errorText = DataGridView.OnCellErrorTextNeeded(ColumnIndex, rowIndex, errorText);
@@ -1723,7 +1723,7 @@ namespace System.Windows.Forms
             bool checkFormattedValType = true;
 
             if (!formattingApplied &&
-                FormattedValueType != null &&
+                FormattedValueType is not null &&
                 (formattedValue is null || !FormattedValueType.IsAssignableFrom(formattedValue.GetType())))
             {
                 try
@@ -1762,7 +1762,7 @@ namespace System.Windows.Forms
             {
                 if (formattedValue is null &&
                     cellStyle.NullValue is null &&
-                    FormattedValueType != null &&
+                    FormattedValueType is not null &&
                     !typeof(ValueType).IsAssignableFrom(FormattedValueType))
                 {
                     // null is an acceptable formatted value
@@ -1827,13 +1827,13 @@ namespace System.Windows.Forms
                 return -1;
             }
 
-            Debug.Assert(OwningRow != null);
+            Debug.Assert(OwningRow is not null);
             return OwningRow.GetHeight(rowIndex);
         }
 
         public virtual ContextMenuStrip GetInheritedContextMenuStrip(int rowIndex)
         {
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 if (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
                 {
@@ -1847,30 +1847,30 @@ namespace System.Windows.Forms
             }
 
             ContextMenuStrip contextMenuStrip = GetContextMenuStrip(rowIndex);
-            if (contextMenuStrip != null)
+            if (contextMenuStrip is not null)
             {
                 return contextMenuStrip;
             }
 
-            if (OwningRow != null)
+            if (OwningRow is not null)
             {
                 contextMenuStrip = OwningRow.GetContextMenuStrip(rowIndex);
-                if (contextMenuStrip != null)
+                if (contextMenuStrip is not null)
                 {
                     return contextMenuStrip;
                 }
             }
 
-            if (OwningColumn != null)
+            if (OwningColumn is not null)
             {
                 contextMenuStrip = OwningColumn.ContextMenuStrip;
-                if (contextMenuStrip != null)
+                if (contextMenuStrip is not null)
                 {
                     return contextMenuStrip;
                 }
             }
 
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 return DataGridView.ContextMenuStrip;
             }
@@ -1891,7 +1891,7 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentException(string.Format(SR.InvalidArgument, nameof(rowIndex), rowIndex));
                 }
-                if (OwningRow != null)
+                if (OwningRow is not null)
                 {
                     state |= (OwningRow.GetState(-1) & (DataGridViewElementStates.Frozen | DataGridViewElementStates.ReadOnly | DataGridViewElementStates.Selected | DataGridViewElementStates.Visible));
                     if (OwningRow.GetResizable(rowIndex) == DataGridViewTriState.True)
@@ -1908,8 +1908,8 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException(nameof(rowIndex));
             }
 
-            Debug.Assert(OwningColumn != null);
-            Debug.Assert(OwningRow != null);
+            Debug.Assert(OwningColumn is not null);
+            Debug.Assert(OwningRow is not null);
             Debug.Assert(ColumnIndex >= 0);
 
             if (DataGridView.Rows.SharedRow(rowIndex) != OwningRow)
@@ -2007,33 +2007,33 @@ namespace System.Windows.Forms
             if (HasStyle)
             {
                 cellStyle = Style;
-                Debug.Assert(cellStyle != null);
+                Debug.Assert(cellStyle is not null);
             }
 
             DataGridViewCellStyle rowStyle = null;
             if (DataGridView.Rows.SharedRow(rowIndex).HasDefaultCellStyle)
             {
                 rowStyle = DataGridView.Rows.SharedRow(rowIndex).DefaultCellStyle;
-                Debug.Assert(rowStyle != null);
+                Debug.Assert(rowStyle is not null);
             }
 
             DataGridViewCellStyle columnStyle = null;
             if (OwningColumn.HasDefaultCellStyle)
             {
                 columnStyle = OwningColumn.DefaultCellStyle;
-                Debug.Assert(columnStyle != null);
+                Debug.Assert(columnStyle is not null);
             }
 
             DataGridViewCellStyle dataGridViewStyle = DataGridView.DefaultCellStyle;
-            Debug.Assert(dataGridViewStyle != null);
+            Debug.Assert(dataGridViewStyle is not null);
 
             if (includeColors)
             {
-                if (cellStyle != null && !cellStyle.BackColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.BackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.BackColor = cellStyle.BackColor;
                 }
-                else if (rowStyle != null && !rowStyle.BackColor.IsEmpty)
+                else if (rowStyle is not null && !rowStyle.BackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.BackColor = rowStyle.BackColor;
                 }
@@ -2046,7 +2046,7 @@ namespace System.Windows.Forms
                 {
                     inheritedCellStyleTmp.BackColor = DataGridView.AlternatingRowsDefaultCellStyle.BackColor;
                 }
-                else if (columnStyle != null && !columnStyle.BackColor.IsEmpty)
+                else if (columnStyle is not null && !columnStyle.BackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.BackColor = columnStyle.BackColor;
                 }
@@ -2055,11 +2055,11 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.BackColor = dataGridViewStyle.BackColor;
                 }
 
-                if (cellStyle != null && !cellStyle.ForeColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.ForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.ForeColor = cellStyle.ForeColor;
                 }
-                else if (rowStyle != null && !rowStyle.ForeColor.IsEmpty)
+                else if (rowStyle is not null && !rowStyle.ForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.ForeColor = rowStyle.ForeColor;
                 }
@@ -2072,7 +2072,7 @@ namespace System.Windows.Forms
                 {
                     inheritedCellStyleTmp.ForeColor = DataGridView.AlternatingRowsDefaultCellStyle.ForeColor;
                 }
-                else if (columnStyle != null && !columnStyle.ForeColor.IsEmpty)
+                else if (columnStyle is not null && !columnStyle.ForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.ForeColor = columnStyle.ForeColor;
                 }
@@ -2081,11 +2081,11 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.ForeColor = dataGridViewStyle.ForeColor;
                 }
 
-                if (cellStyle != null && !cellStyle.SelectionBackColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.SelectionBackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionBackColor = cellStyle.SelectionBackColor;
                 }
-                else if (rowStyle != null && !rowStyle.SelectionBackColor.IsEmpty)
+                else if (rowStyle is not null && !rowStyle.SelectionBackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionBackColor = rowStyle.SelectionBackColor;
                 }
@@ -2098,7 +2098,7 @@ namespace System.Windows.Forms
                 {
                     inheritedCellStyleTmp.SelectionBackColor = DataGridView.AlternatingRowsDefaultCellStyle.SelectionBackColor;
                 }
-                else if (columnStyle != null && !columnStyle.SelectionBackColor.IsEmpty)
+                else if (columnStyle is not null && !columnStyle.SelectionBackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionBackColor = columnStyle.SelectionBackColor;
                 }
@@ -2107,11 +2107,11 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.SelectionBackColor = dataGridViewStyle.SelectionBackColor;
                 }
 
-                if (cellStyle != null && !cellStyle.SelectionForeColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.SelectionForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionForeColor = cellStyle.SelectionForeColor;
                 }
-                else if (rowStyle != null && !rowStyle.SelectionForeColor.IsEmpty)
+                else if (rowStyle is not null && !rowStyle.SelectionForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionForeColor = rowStyle.SelectionForeColor;
                 }
@@ -2124,7 +2124,7 @@ namespace System.Windows.Forms
                 {
                     inheritedCellStyleTmp.SelectionForeColor = DataGridView.AlternatingRowsDefaultCellStyle.SelectionForeColor;
                 }
-                else if (columnStyle != null && !columnStyle.SelectionForeColor.IsEmpty)
+                else if (columnStyle is not null && !columnStyle.SelectionForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionForeColor = columnStyle.SelectionForeColor;
                 }
@@ -2134,24 +2134,24 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (cellStyle != null && cellStyle.Font != null)
+            if (cellStyle is not null && cellStyle.Font is not null)
             {
                 inheritedCellStyleTmp.Font = cellStyle.Font;
             }
-            else if (rowStyle != null && rowStyle.Font != null)
+            else if (rowStyle is not null && rowStyle.Font is not null)
             {
                 inheritedCellStyleTmp.Font = rowStyle.Font;
             }
-            else if (DataGridView.RowsDefaultCellStyle.Font != null &&
+            else if (DataGridView.RowsDefaultCellStyle.Font is not null &&
                 (rowIndex % 2 == 0 || DataGridView.AlternatingRowsDefaultCellStyle.Font is null))
             {
                 inheritedCellStyleTmp.Font = DataGridView.RowsDefaultCellStyle.Font;
             }
-            else if (rowIndex % 2 == 1 && DataGridView.AlternatingRowsDefaultCellStyle.Font != null)
+            else if (rowIndex % 2 == 1 && DataGridView.AlternatingRowsDefaultCellStyle.Font is not null)
             {
                 inheritedCellStyleTmp.Font = DataGridView.AlternatingRowsDefaultCellStyle.Font;
             }
-            else if (columnStyle != null && columnStyle.Font != null)
+            else if (columnStyle is not null && columnStyle.Font is not null)
             {
                 inheritedCellStyleTmp.Font = columnStyle.Font;
             }
@@ -2160,11 +2160,11 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.Font = dataGridViewStyle.Font;
             }
 
-            if (cellStyle != null && !cellStyle.IsNullValueDefault)
+            if (cellStyle is not null && !cellStyle.IsNullValueDefault)
             {
                 inheritedCellStyleTmp.NullValue = cellStyle.NullValue;
             }
-            else if (rowStyle != null && !rowStyle.IsNullValueDefault)
+            else if (rowStyle is not null && !rowStyle.IsNullValueDefault)
             {
                 inheritedCellStyleTmp.NullValue = rowStyle.NullValue;
             }
@@ -2178,7 +2178,7 @@ namespace System.Windows.Forms
             {
                 inheritedCellStyleTmp.NullValue = DataGridView.AlternatingRowsDefaultCellStyle.NullValue;
             }
-            else if (columnStyle != null && !columnStyle.IsNullValueDefault)
+            else if (columnStyle is not null && !columnStyle.IsNullValueDefault)
             {
                 inheritedCellStyleTmp.NullValue = columnStyle.NullValue;
             }
@@ -2187,11 +2187,11 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.NullValue = dataGridViewStyle.NullValue;
             }
 
-            if (cellStyle != null && !cellStyle.IsDataSourceNullValueDefault)
+            if (cellStyle is not null && !cellStyle.IsDataSourceNullValueDefault)
             {
                 inheritedCellStyleTmp.DataSourceNullValue = cellStyle.DataSourceNullValue;
             }
-            else if (rowStyle != null && !rowStyle.IsDataSourceNullValueDefault)
+            else if (rowStyle is not null && !rowStyle.IsDataSourceNullValueDefault)
             {
                 inheritedCellStyleTmp.DataSourceNullValue = rowStyle.DataSourceNullValue;
             }
@@ -2205,7 +2205,7 @@ namespace System.Windows.Forms
             {
                 inheritedCellStyleTmp.DataSourceNullValue = DataGridView.AlternatingRowsDefaultCellStyle.DataSourceNullValue;
             }
-            else if (columnStyle != null && !columnStyle.IsDataSourceNullValueDefault)
+            else if (columnStyle is not null && !columnStyle.IsDataSourceNullValueDefault)
             {
                 inheritedCellStyleTmp.DataSourceNullValue = columnStyle.DataSourceNullValue;
             }
@@ -2214,11 +2214,11 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.DataSourceNullValue = dataGridViewStyle.DataSourceNullValue;
             }
 
-            if (cellStyle != null && cellStyle.Format.Length != 0)
+            if (cellStyle is not null && cellStyle.Format.Length != 0)
             {
                 inheritedCellStyleTmp.Format = cellStyle.Format;
             }
-            else if (rowStyle != null && rowStyle.Format.Length != 0)
+            else if (rowStyle is not null && rowStyle.Format.Length != 0)
             {
                 inheritedCellStyleTmp.Format = rowStyle.Format;
             }
@@ -2231,7 +2231,7 @@ namespace System.Windows.Forms
             {
                 inheritedCellStyleTmp.Format = DataGridView.AlternatingRowsDefaultCellStyle.Format;
             }
-            else if (columnStyle != null && columnStyle.Format.Length != 0)
+            else if (columnStyle is not null && columnStyle.Format.Length != 0)
             {
                 inheritedCellStyleTmp.Format = columnStyle.Format;
             }
@@ -2240,11 +2240,11 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.Format = dataGridViewStyle.Format;
             }
 
-            if (cellStyle != null && !cellStyle.IsFormatProviderDefault)
+            if (cellStyle is not null && !cellStyle.IsFormatProviderDefault)
             {
                 inheritedCellStyleTmp.FormatProvider = cellStyle.FormatProvider;
             }
-            else if (rowStyle != null && !rowStyle.IsFormatProviderDefault)
+            else if (rowStyle is not null && !rowStyle.IsFormatProviderDefault)
             {
                 inheritedCellStyleTmp.FormatProvider = rowStyle.FormatProvider;
             }
@@ -2257,7 +2257,7 @@ namespace System.Windows.Forms
             {
                 inheritedCellStyleTmp.FormatProvider = DataGridView.AlternatingRowsDefaultCellStyle.FormatProvider;
             }
-            else if (columnStyle != null && !columnStyle.IsFormatProviderDefault)
+            else if (columnStyle is not null && !columnStyle.IsFormatProviderDefault)
             {
                 inheritedCellStyleTmp.FormatProvider = columnStyle.FormatProvider;
             }
@@ -2266,11 +2266,11 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.FormatProvider = dataGridViewStyle.FormatProvider;
             }
 
-            if (cellStyle != null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
+            if (cellStyle is not null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyleTmp.AlignmentInternal = cellStyle.Alignment;
             }
-            else if (rowStyle != null && rowStyle.Alignment != DataGridViewContentAlignment.NotSet)
+            else if (rowStyle is not null && rowStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyleTmp.AlignmentInternal = rowStyle.Alignment;
             }
@@ -2283,7 +2283,7 @@ namespace System.Windows.Forms
             {
                 inheritedCellStyleTmp.AlignmentInternal = DataGridView.AlternatingRowsDefaultCellStyle.Alignment;
             }
-            else if (columnStyle != null && columnStyle.Alignment != DataGridViewContentAlignment.NotSet)
+            else if (columnStyle is not null && columnStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyleTmp.AlignmentInternal = columnStyle.Alignment;
             }
@@ -2293,11 +2293,11 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.AlignmentInternal = dataGridViewStyle.Alignment;
             }
 
-            if (cellStyle != null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
+            if (cellStyle is not null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyleTmp.WrapModeInternal = cellStyle.WrapMode;
             }
-            else if (rowStyle != null && rowStyle.WrapMode != DataGridViewTriState.NotSet)
+            else if (rowStyle is not null && rowStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyleTmp.WrapModeInternal = rowStyle.WrapMode;
             }
@@ -2310,7 +2310,7 @@ namespace System.Windows.Forms
             {
                 inheritedCellStyleTmp.WrapModeInternal = DataGridView.AlternatingRowsDefaultCellStyle.WrapMode;
             }
-            else if (columnStyle != null && columnStyle.WrapMode != DataGridViewTriState.NotSet)
+            else if (columnStyle is not null && columnStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyleTmp.WrapModeInternal = columnStyle.WrapMode;
             }
@@ -2320,24 +2320,24 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.WrapModeInternal = dataGridViewStyle.WrapMode;
             }
 
-            if (cellStyle != null && cellStyle.Tag != null)
+            if (cellStyle is not null && cellStyle.Tag is not null)
             {
                 inheritedCellStyleTmp.Tag = cellStyle.Tag;
             }
-            else if (rowStyle != null && rowStyle.Tag != null)
+            else if (rowStyle is not null && rowStyle.Tag is not null)
             {
                 inheritedCellStyleTmp.Tag = rowStyle.Tag;
             }
-            else if (DataGridView.RowsDefaultCellStyle.Tag != null &&
+            else if (DataGridView.RowsDefaultCellStyle.Tag is not null &&
                 (rowIndex % 2 == 0 || DataGridView.AlternatingRowsDefaultCellStyle.Tag is null))
             {
                 inheritedCellStyleTmp.Tag = DataGridView.RowsDefaultCellStyle.Tag;
             }
-            else if (rowIndex % 2 == 1 && DataGridView.AlternatingRowsDefaultCellStyle.Tag != null)
+            else if (rowIndex % 2 == 1 && DataGridView.AlternatingRowsDefaultCellStyle.Tag is not null)
             {
                 inheritedCellStyleTmp.Tag = DataGridView.AlternatingRowsDefaultCellStyle.Tag;
             }
-            else if (columnStyle != null && columnStyle.Tag != null)
+            else if (columnStyle is not null && columnStyle.Tag is not null)
             {
                 inheritedCellStyleTmp.Tag = columnStyle.Tag;
             }
@@ -2346,11 +2346,11 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.Tag = dataGridViewStyle.Tag;
             }
 
-            if (cellStyle != null && cellStyle.Padding != Padding.Empty)
+            if (cellStyle is not null && cellStyle.Padding != Padding.Empty)
             {
                 inheritedCellStyleTmp.PaddingInternal = cellStyle.Padding;
             }
-            else if (rowStyle != null && rowStyle.Padding != Padding.Empty)
+            else if (rowStyle is not null && rowStyle.Padding != Padding.Empty)
             {
                 inheritedCellStyleTmp.PaddingInternal = rowStyle.Padding;
             }
@@ -2363,7 +2363,7 @@ namespace System.Windows.Forms
             {
                 inheritedCellStyleTmp.PaddingInternal = DataGridView.AlternatingRowsDefaultCellStyle.Padding;
             }
-            else if (columnStyle != null && columnStyle.Padding != Padding.Empty)
+            else if (columnStyle is not null && columnStyle.Padding != Padding.Empty)
             {
                 inheritedCellStyleTmp.PaddingInternal = columnStyle.Padding;
             }
@@ -2459,16 +2459,16 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertyGetOnSharedCell, "Size"));
             }
 
-            Debug.Assert(OwningColumn != null);
-            Debug.Assert(OwningRow != null);
+            Debug.Assert(OwningColumn is not null);
+            Debug.Assert(OwningRow is not null);
             return new Size(OwningColumn.Thickness, OwningRow.GetHeight(rowIndex));
         }
 
         private protected string GetInternalToolTipText(int rowIndex)
         {
             string toolTipText = ToolTipTextInternal;
-            if (DataGridView != null &&
-                (DataGridView.VirtualMode || DataGridView.DataSource != null))
+            if (DataGridView is not null &&
+                (DataGridView.VirtualMode || DataGridView.DataSource is not null))
             {
                 toolTipText = DataGridView.OnCellToolTipTextNeeded(ColumnIndex, rowIndex, toolTipText);
             }
@@ -2512,7 +2512,7 @@ namespace System.Windows.Forms
         protected virtual object GetValue(int rowIndex)
         {
             DataGridView dataGridView = DataGridView;
-            if (dataGridView != null)
+            if (dataGridView is not null)
             {
                 if (rowIndex < 0 || rowIndex >= dataGridView.Rows.Count)
                 {
@@ -2527,13 +2527,13 @@ namespace System.Windows.Forms
 
             if (dataGridView is null ||
                 (dataGridView.AllowUserToAddRowsInternal && rowIndex > -1 && rowIndex == dataGridView.NewRowIndex && rowIndex != dataGridView.CurrentCellAddress.Y) ||
-                (!dataGridView.VirtualMode && OwningColumn != null && !OwningColumn.IsDataBound) ||
+                (!dataGridView.VirtualMode && OwningColumn is not null && !OwningColumn.IsDataBound) ||
                 rowIndex == -1 ||
                 ColumnIndex == -1)
             {
                 return Properties.GetObject(s_propCellValue);
             }
-            else if (OwningColumn != null && OwningColumn.IsDataBound)
+            else if (OwningColumn is not null && OwningColumn.IsDataBound)
             {
                 DataGridView.DataGridViewDataConnection dataConnection = dataGridView.DataConnection;
                 if (dataConnection is null)
@@ -2863,7 +2863,7 @@ namespace System.Windows.Forms
 
         private void OnCellDataAreaMouseEnterInternal(int rowIndex)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             if (!DataGridView.ShowCellToolTips)
             {
                 return;
@@ -2874,7 +2874,7 @@ namespace System.Windows.Forms
             if (ptCurrentCell.X != -1 &&
                 ptCurrentCell.X == ColumnIndex &&
                 ptCurrentCell.Y == rowIndex &&
-                DataGridView.EditingControl != null)
+                DataGridView.EditingControl is not null)
             {
                 Debug.Assert(DataGridView.IsCurrentCellInEditMode);
                 return;
@@ -2887,7 +2887,7 @@ namespace System.Windows.Forms
             {
                 if (FormattedValueType == s_stringType)
                 {
-                    if (rowIndex != -1 && OwningColumn != null)
+                    if (rowIndex != -1 && OwningColumn is not null)
                     {
                         int width = GetPreferredWidth(rowIndex, OwningRow.Height);
                         int height = GetPreferredHeight(rowIndex, OwningColumn.Width);
@@ -2905,7 +2905,7 @@ namespace System.Windows.Forms
                             }
                         }
                     }
-                    else if ((rowIndex != -1 && OwningRow != null && DataGridView.RowHeadersVisible && DataGridView.RowHeadersWidth > 0 && OwningColumn is null) ||
+                    else if ((rowIndex != -1 && OwningRow is not null && DataGridView.RowHeadersVisible && DataGridView.RowHeadersWidth > 0 && OwningColumn is null) ||
                              rowIndex == -1)
                     {
                         // we are on a header cell.
@@ -2995,7 +2995,7 @@ namespace System.Windows.Forms
 
         internal void OnCommonChange()
         {
-            if (DataGridView != null && !DataGridView.IsDisposed && !DataGridView.Disposing)
+            if (DataGridView is not null && !DataGridView.IsDisposed && !DataGridView.Disposing)
             {
                 if (RowIndex == -1)
                 {
@@ -3212,7 +3212,7 @@ namespace System.Windows.Forms
                 DataGridView.OnCommonCellContentClick(e.ColumnIndex, e.RowIndex, e.Clicks > 1);
             }
 
-            if (DataGridView != null && e.ColumnIndex < DataGridView.Columns.Count && e.RowIndex < DataGridView.Rows.Count)
+            if (DataGridView is not null && e.ColumnIndex < DataGridView.Columns.Count && e.RowIndex < DataGridView.Rows.Count)
             {
                 OnMouseUp(e);
             }
@@ -3692,7 +3692,7 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(graphics));
 
             Bitmap bmp = ErrorBitmap;
-            if (bmp != null)
+            if (bmp is not null)
             {
                 lock (bmp)
                 {
@@ -3776,7 +3776,7 @@ namespace System.Windows.Forms
             DataGridViewAdvancedBorderStyle advancedBorderStyle,
             DataGridViewPaintParts paintParts)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             DataGridView dataGridView = DataGridView;
             int columnIndex = ColumnIndex;
             object formattedValue, value = GetValue(rowIndex);
@@ -3980,12 +3980,12 @@ namespace System.Windows.Forms
         {
             object originalValue = null;
             DataGridView dataGridView = DataGridView;
-            if (dataGridView != null && !dataGridView.InSortOperation)
+            if (dataGridView is not null && !dataGridView.InSortOperation)
             {
                 originalValue = GetValue(rowIndex);
             }
 
-            if (dataGridView != null && OwningColumn != null && OwningColumn.IsDataBound)
+            if (dataGridView is not null && OwningColumn is not null && OwningColumn.IsDataBound)
             {
                 DataGridView.DataGridViewDataConnection dataConnection = dataGridView.DataConnection;
                 if (dataConnection is null)
@@ -3994,7 +3994,7 @@ namespace System.Windows.Forms
                 }
                 else if (dataConnection.CurrencyManager.Count <= rowIndex)
                 {
-                    if (value != null || Properties.ContainsObject(s_propCellValue))
+                    if (value is not null || Properties.ContainsObject(s_propCellValue))
                     {
                         Properties.SetObject(s_propCellValue, value);
                     }
@@ -4034,7 +4034,7 @@ namespace System.Windows.Forms
                 rowIndex == -1 ||
                 ColumnIndex == -1)
             {
-                if (value != null || Properties.ContainsObject(s_propCellValue))
+                if (value is not null || Properties.ContainsObject(s_propCellValue))
                 {
                     Properties.SetObject(s_propCellValue, value);
                 }
@@ -4046,11 +4046,11 @@ namespace System.Windows.Forms
                 dataGridView.OnCellValuePushed(ColumnIndex, rowIndex, value);
             }
 
-            if (dataGridView != null &&
+            if (dataGridView is not null &&
                 !dataGridView.InSortOperation &&
-                ((originalValue is null && value != null) ||
-                 (originalValue != null && value is null) ||
-                 (originalValue != null && !value.Equals(originalValue))))
+                ((originalValue is null && value is not null) ||
+                 (originalValue is not null && value is null) ||
+                 (originalValue is not null && !value.Equals(originalValue))))
             {
                 RaiseCellValueChanged(new DataGridViewCellEventArgs(ColumnIndex, rowIndex));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCollection.cs
@@ -99,7 +99,7 @@ namespace System.Windows.Forms
 
         public DataGridViewCellCollection(DataGridViewRow dataGridViewRow)
         {
-            Debug.Assert(dataGridViewRow != null);
+            Debug.Assert(dataGridViewRow is not null);
             _owner = dataGridViewRow;
         }
 
@@ -127,15 +127,15 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentNullException(nameof(value));
                 }
-                if (dataGridViewCell.DataGridView != null)
+                if (dataGridViewCell.DataGridView is not null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellCollection_CellAlreadyBelongsToDataGridView);
                 }
-                if (dataGridViewCell.OwningRow != null)
+                if (dataGridViewCell.OwningRow is not null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellCollection_CellAlreadyBelongsToDataGridViewRow);
                 }
-                if (_owner.DataGridView != null)
+                if (_owner.DataGridView is not null)
                 {
                     _owner.DataGridView.OnReplacingCell(_owner, index);
                 }
@@ -144,7 +144,7 @@ namespace System.Windows.Forms
                 _items[index] = dataGridViewCell;
                 dataGridViewCell.OwningRow = _owner;
                 dataGridViewCell.State = oldDataGridViewCell.State;
-                if (_owner.DataGridView != null)
+                if (_owner.DataGridView is not null)
                 {
                     dataGridViewCell.DataGridView = _owner.DataGridView;
                     dataGridViewCell.OwningColumn = _owner.DataGridView.Columns[index];
@@ -173,7 +173,7 @@ namespace System.Windows.Forms
             get
             {
                 DataGridViewColumn dataGridViewColumn = null;
-                if (_owner.DataGridView != null)
+                if (_owner.DataGridView is not null)
                 {
                     dataGridViewColumn = _owner.DataGridView.Columns[columnName];
                 }
@@ -186,7 +186,7 @@ namespace System.Windows.Forms
             set
             {
                 DataGridViewColumn dataGridViewColumn = null;
-                if (_owner.DataGridView != null)
+                if (_owner.DataGridView is not null)
                 {
                     dataGridViewColumn = _owner.DataGridView.Columns[columnName];
                 }
@@ -209,11 +209,11 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual int Add(DataGridViewCell dataGridViewCell)
         {
-            if (_owner.DataGridView != null)
+            if (_owner.DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewCellCollection_OwningRowAlreadyBelongsToDataGridView);
             }
-            if (dataGridViewCell.OwningRow != null)
+            if (dataGridViewCell.OwningRow is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewCellCollection_CellAlreadyBelongsToDataGridViewRow);
             }
@@ -227,7 +227,7 @@ namespace System.Windows.Forms
             int index = _items.Add(dataGridViewCell);
             dataGridViewCell.OwningRow = _owner;
             DataGridView dataGridView = _owner.DataGridView;
-            if (dataGridView != null && dataGridView.Columns.Count > index)
+            if (dataGridView is not null && dataGridView.Columns.Count > index)
             {
                 dataGridViewCell.OwningColumn = dataGridView.Columns[index];
             }
@@ -242,7 +242,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentNullException(nameof(dataGridViewCells));
             }
-            if (_owner.DataGridView != null)
+            if (_owner.DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewCellCollection_OwningRowAlreadyBelongsToDataGridView);
             }
@@ -253,7 +253,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewCellCollection_AtLeastOneCellIsNull);
                 }
 
-                if (dataGridViewCell.OwningRow != null)
+                if (dataGridViewCell.OwningRow is not null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewCellCollection_CellAlreadyBelongsToDataGridViewRow);
                 }
@@ -283,7 +283,7 @@ namespace System.Windows.Forms
 
         public virtual void Clear()
         {
-            if (_owner.DataGridView != null)
+            if (_owner.DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewCellCollection_OwningRowAlreadyBelongsToDataGridView);
             }
@@ -316,11 +316,11 @@ namespace System.Windows.Forms
 
         public virtual void Insert(int index, DataGridViewCell dataGridViewCell)
         {
-            if (_owner.DataGridView != null)
+            if (_owner.DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewCellCollection_OwningRowAlreadyBelongsToDataGridView);
             }
-            if (dataGridViewCell.OwningRow != null)
+            if (dataGridViewCell.OwningRow is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewCellCollection_CellAlreadyBelongsToDataGridViewRow);
             }
@@ -337,7 +337,7 @@ namespace System.Windows.Forms
             _items.Insert(index, dataGridViewCell);
             dataGridViewCell.OwningRow = _owner;
             DataGridView dataGridView = _owner.DataGridView;
-            if (dataGridView != null && dataGridView.Columns.Count > index)
+            if (dataGridView is not null && dataGridView.Columns.Count > index)
             {
                 dataGridViewCell.OwningColumn = dataGridView.Columns[index];
             }
@@ -351,7 +351,7 @@ namespace System.Windows.Forms
 
         public virtual void Remove(DataGridViewCell cell)
         {
-            if (_owner.DataGridView != null)
+            if (_owner.DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewCellCollection_OwningRowAlreadyBelongsToDataGridView);
             }
@@ -377,7 +377,7 @@ namespace System.Windows.Forms
 
         public virtual void RemoveAt(int index)
         {
-            if (_owner.DataGridView != null)
+            if (_owner.DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewCellCollection_OwningRowAlreadyBelongsToDataGridView);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellConverter.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms
             if (destinationType == typeof(InstanceDescriptor) && value is DataGridViewCell cell)
             {
                 ConstructorInfo ctor = cell.GetType().GetConstructor(Array.Empty<Type>());
-                if (ctor != null)
+                if (ctor is not null)
                 {
                     return new InstanceDescriptor(ctor, Array.Empty<object>(), false);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellLinkedList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellLinkedList.cs
@@ -71,19 +71,19 @@ namespace System.Windows.Forms
         {
             get
             {
-                Debug.Assert(headElement != null);
+                Debug.Assert(headElement is not null);
                 return headElement.DataGridViewCell;
             }
         }
 
         public void Add(DataGridViewCell dataGridViewCell)
         {
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             Debug.Assert(dataGridViewCell.DataGridView.SelectionMode == DataGridViewSelectionMode.CellSelect ||
                          dataGridViewCell.DataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect ||
                          dataGridViewCell.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect);
             DataGridViewCellLinkedListElement newHead = new DataGridViewCellLinkedListElement(dataGridViewCell);
-            if (headElement != null)
+            if (headElement is not null)
             {
                 newHead.Next = headElement;
             }
@@ -103,10 +103,10 @@ namespace System.Windows.Forms
 
         public bool Contains(DataGridViewCell dataGridViewCell)
         {
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             int index = 0;
             DataGridViewCellLinkedListElement tmp = headElement;
-            while (tmp != null)
+            while (tmp is not null)
             {
                 if (tmp.DataGridViewCell == dataGridViewCell)
                 {
@@ -122,9 +122,9 @@ namespace System.Windows.Forms
 
         public bool Remove(DataGridViewCell dataGridViewCell)
         {
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             DataGridViewCellLinkedListElement tmp1 = null, tmp2 = headElement;
-            while (tmp2 != null)
+            while (tmp2 is not null)
             {
                 if (tmp2.DataGridViewCell == dataGridViewCell)
                 {
@@ -156,7 +156,7 @@ namespace System.Windows.Forms
         {
             int removedCount = 0;
             DataGridViewCellLinkedListElement tmp1 = null, tmp2 = headElement;
-            while (tmp2 != null)
+            while (tmp2 is not null)
             {
                 if ((column && tmp2.DataGridViewCell.ColumnIndex == bandIndex) ||
                     (!column && tmp2.DataGridViewCell.RowIndex == bandIndex))
@@ -205,7 +205,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                Debug.Assert(current != null); // Since this is for internal use only.
+                Debug.Assert(current is not null); // Since this is for internal use only.
                 return current.DataGridViewCell;
             }
         }
@@ -220,10 +220,10 @@ namespace System.Windows.Forms
             }
             else
             {
-                Debug.Assert(current != null); // Since this is for internal use only.
+                Debug.Assert(current is not null); // Since this is for internal use only.
                 current = current.Next;
             }
-            return (current != null);
+            return (current is not null);
         }
 
         void IEnumerator.Reset()
@@ -243,7 +243,7 @@ namespace System.Windows.Forms
 
         public DataGridViewCellLinkedListElement(DataGridViewCell dataGridViewCell)
         {
-            Debug.Assert(dataGridViewCell != null);
+            Debug.Assert(dataGridViewCell is not null);
             this.dataGridViewCell = dataGridViewCell;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellPaintingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellPaintingEventArgs.cs
@@ -50,7 +50,7 @@ namespace System.Windows.Forms
 
         internal DataGridViewCellPaintingEventArgs(DataGridView dataGridView)
         {
-            Debug.Assert(dataGridView != null);
+            Debug.Assert(dataGridView is not null);
             _dataGridView = dataGridView;
         }
 
@@ -168,7 +168,7 @@ namespace System.Windows.Forms
                                     DataGridViewAdvancedBorderStyle advancedBorderStyle,
                                     DataGridViewPaintParts paintParts)
         {
-            Debug.Assert(graphics != null);
+            Debug.Assert(graphics is not null);
 
             Graphics = graphics;
             ClipBounds = clipBounds;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
@@ -157,7 +157,7 @@ namespace System.Windows.Forms
                 object oldDataSourceNullValue = DataSourceNullValue;
 
                 if ((oldDataSourceNullValue == value) ||
-                    (oldDataSourceNullValue != null && oldDataSourceNullValue.Equals(value)))
+                    (oldDataSourceNullValue is not null && oldDataSourceNullValue.Equals(value)))
                 {
                     return;
                 }
@@ -172,8 +172,8 @@ namespace System.Windows.Forms
                     Properties.SetObject(PropDataSourceNullValue, value);
                 }
 
-                Debug.Assert((oldDataSourceNullValue is null && DataSourceNullValue != null) ||
-                             (oldDataSourceNullValue != null && DataSourceNullValue is null) ||
+                Debug.Assert((oldDataSourceNullValue is null && DataSourceNullValue is not null) ||
+                             (oldDataSourceNullValue is not null && DataSourceNullValue is null) ||
                              (oldDataSourceNullValue != DataSourceNullValue && !oldDataSourceNullValue.Equals(DataSourceNullValue)));
 
                 OnPropertyChanged(DataGridViewCellStylePropertyInternal.Other);
@@ -190,13 +190,13 @@ namespace System.Windows.Forms
             set
             {
                 Font f = Font;
-                if (value != null || Properties.ContainsObject(PropFont))
+                if (value is not null || Properties.ContainsObject(PropFont))
                 {
                     Properties.SetObject(PropFont, value);
                 }
-                if ((f is null && value != null) ||
-                    (f != null && value is null) ||
-                    (f != null && value != null && !f.Equals(Font)))
+                if ((f is null && value is not null) ||
+                    (f is not null && value is null) ||
+                    (f is not null && value is not null && !f.Equals(Font)))
                 {
                     OnPropertyChanged(DataGridViewCellStylePropertyInternal.Font);
                 }
@@ -245,7 +245,7 @@ namespace System.Windows.Forms
             set
             {
                 string format = Format;
-                if ((value != null && value.Length > 0) || Properties.ContainsObject(PropFormat))
+                if ((value is not null && value.Length > 0) || Properties.ContainsObject(PropFormat))
                 {
                     Properties.SetObject(PropFormat, value);
                 }
@@ -341,7 +341,7 @@ namespace System.Windows.Forms
                 object oldNullValue = NullValue;
 
                 if ((oldNullValue == value) ||
-                    (oldNullValue != null && oldNullValue.Equals(value)))
+                    (oldNullValue is not null && oldNullValue.Equals(value)))
                 {
                     return;
                 }
@@ -355,8 +355,8 @@ namespace System.Windows.Forms
                     Properties.SetObject(PropNullValue, value);
                 }
 
-                Debug.Assert((oldNullValue is null && NullValue != null) ||
-                             (oldNullValue != null && NullValue is null) ||
+                Debug.Assert((oldNullValue is null && NullValue is not null) ||
+                             (oldNullValue is not null && NullValue is null) ||
                              (oldNullValue != NullValue && !oldNullValue.Equals(NullValue)));
 
                 OnPropertyChanged(DataGridViewCellStylePropertyInternal.Other);
@@ -476,7 +476,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(PropTag))
+                if (value is not null || Properties.ContainsObject(PropTag))
                 {
                     Properties.SetObject(PropTag, value);
                 }
@@ -545,7 +545,7 @@ namespace System.Windows.Forms
             {
                 SelectionForeColor = dataGridViewCellStyle.SelectionForeColor;
             }
-            if (dataGridViewCellStyle.Font != null)
+            if (dataGridViewCellStyle.Font is not null)
             {
                 Font = dataGridViewCellStyle.Font;
             }
@@ -573,7 +573,7 @@ namespace System.Windows.Forms
             {
                 WrapModeInternal = dataGridViewCellStyle.WrapMode;
             }
-            if (dataGridViewCellStyle.Tag != null)
+            if (dataGridViewCellStyle.Tag is not null)
             {
                 Tag = dataGridViewCellStyle.Tag;
             }
@@ -602,7 +602,7 @@ namespace System.Windows.Forms
 
         internal DataGridViewCellStyleDifferences GetDifferencesFrom(DataGridViewCellStyle dgvcs)
         {
-            Debug.Assert(dgvcs != null);
+            Debug.Assert(dgvcs is not null);
 
             bool preferredSizeAffectingPropDifferent = (
                     dgvcs.Alignment != Alignment ||
@@ -655,7 +655,7 @@ namespace System.Windows.Forms
 
         private void OnPropertyChanged(DataGridViewCellStylePropertyInternal property)
         {
-            if (dataGridView != null && scope != DataGridViewCellStyleScopes.None)
+            if (dataGridView is not null && scope != DataGridViewCellStyleScopes.None)
             {
                 dataGridView.OnCellStyleContentChanged(this, property);
             }
@@ -678,7 +678,7 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeFont()
         {
-            return Properties.GetObject(PropFont) != null;
+            return Properties.GetObject(PropFont) is not null;
         }
 
         private bool ShouldSerializeForeColor()
@@ -689,7 +689,7 @@ namespace System.Windows.Forms
 
         private bool ShouldSerializeFormatProvider()
         {
-            return Properties.GetObject(PropFormatProvider) != null;
+            return Properties.GetObject(PropFormatProvider) is not null;
         }
 
         private bool ShouldSerializePadding()
@@ -746,7 +746,7 @@ namespace System.Windows.Forms
                 sb.Append(" SelectionForeColor=" + SelectionForeColor.ToString());
                 firstPropAdded = false;
             }
-            if (Font != null)
+            if (Font is not null)
             {
                 if (!firstPropAdded)
                 {
@@ -755,7 +755,7 @@ namespace System.Windows.Forms
                 sb.Append(" Font=" + Font.ToString());
                 firstPropAdded = false;
             }
-            if (!IsNullValueDefault && NullValue != null)
+            if (!IsNullValueDefault && NullValue is not null)
             {
                 if (!firstPropAdded)
                 {
@@ -764,7 +764,7 @@ namespace System.Windows.Forms
                 sb.Append(" NullValue=" + NullValue.ToString());
                 firstPropAdded = false;
             }
-            if (!IsDataSourceNullValueDefault && DataSourceNullValue != null)
+            if (!IsDataSourceNullValueDefault && DataSourceNullValue is not null)
             {
                 if (!firstPropAdded)
                 {
@@ -809,7 +809,7 @@ namespace System.Windows.Forms
                 sb.Append(" Padding=" + Padding.ToString());
                 firstPropAdded = false;
             }
-            if (Tag != null)
+            if (Tag is not null)
             {
                 if (!firstPropAdded)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.cs
@@ -101,7 +101,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                if (!dataGridViewCell.ReadOnly && dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningRow != null)
+                if (!dataGridViewCell.ReadOnly && dataGridViewCell.OwningColumn is not null && dataGridViewCell.OwningRow is not null)
                 {
                     dataGridView.CurrentCell = dataGridViewCell;
                     bool endEditMode = false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -227,10 +227,10 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(PropFalseValue))
+                if (value is not null || Properties.ContainsObject(PropFalseValue))
                 {
                     Properties.SetObject(PropFalseValue, value);
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -249,7 +249,7 @@ namespace System.Windows.Forms
         {
             set
             {
-                if (value != null || Properties.ContainsObject(PropFalseValue))
+                if (value is not null || Properties.ContainsObject(PropFalseValue))
                 {
                     Properties.SetObject(PropFalseValue, value);
                 }
@@ -316,10 +316,10 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(PropIndeterminateValue))
+                if (value is not null || Properties.ContainsObject(PropIndeterminateValue))
                 {
                     Properties.SetObject(PropIndeterminateValue, value);
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -338,7 +338,7 @@ namespace System.Windows.Forms
         {
             set
             {
-                if (value != null || Properties.ContainsObject(PropIndeterminateValue))
+                if (value is not null || Properties.ContainsObject(PropIndeterminateValue))
                 {
                     Properties.SetObject(PropIndeterminateValue, value);
                 }
@@ -357,7 +357,7 @@ namespace System.Windows.Forms
                 if (ThreeState != value)
                 {
                     ThreeStateInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -399,10 +399,10 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(PropTrueValue))
+                if (value is not null || Properties.ContainsObject(PropTrueValue))
                 {
                     Properties.SetObject(PropTrueValue, value);
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -421,7 +421,7 @@ namespace System.Windows.Forms
         {
             set
             {
-                if (value != null || Properties.ContainsObject(PropTrueValue))
+                if (value is not null || Properties.ContainsObject(PropTrueValue))
                 {
                     Properties.SetObject(PropTrueValue, value);
                 }
@@ -433,7 +433,7 @@ namespace System.Windows.Forms
             get
             {
                 Type valueType = base.ValueType;
-                if (valueType != null)
+                if (valueType is not null)
                 {
                     return valueType;
                 }
@@ -450,7 +450,7 @@ namespace System.Windows.Forms
             set
             {
                 base.ValueType = value;
-                ThreeState = (value != null && defaultCheckStateType.IsAssignableFrom(value));
+                ThreeState = (value is not null && defaultCheckStateType.IsAssignableFrom(value));
             }
         }
 
@@ -610,7 +610,7 @@ namespace System.Windows.Forms
                                                     TypeConverter formattedValueTypeConverter,
                                                     DataGridViewDataErrorContexts context)
         {
-            if (value != null)
+            if (value is not null)
             {
                 if (ThreeState)
                 {
@@ -646,7 +646,7 @@ namespace System.Windows.Forms
             }
 
             object ret = base.GetFormattedValue(value, rowIndex, ref cellStyle, valueTypeConverter, formattedValueTypeConverter, context);
-            if (ret != null && (context & DataGridViewDataErrorContexts.ClipboardContent) != 0)
+            if (ret is not null && (context & DataGridViewDataErrorContexts.ClipboardContent) != 0)
             {
                 if (ret is bool retBool)
                 {
@@ -885,7 +885,7 @@ namespace System.Windows.Forms
                 if (!e.Alt && !e.Control && !e.Shift)
                 {
                     RaiseCellClick(new DataGridViewCellEventArgs(ColumnIndex, rowIndex));
-                    if (DataGridView != null &&
+                    if (DataGridView is not null &&
                         ColumnIndex < DataGridView.Columns.Count &&
                         rowIndex < DataGridView.Rows.Count)
                     {
@@ -1108,7 +1108,7 @@ namespace System.Windows.Forms
             Debug.Assert(!paint || !computeContentBounds || !computeErrorIconBounds);
             Debug.Assert(!computeContentBounds || !computeErrorIconBounds || !paint);
             Debug.Assert(!computeErrorIconBounds || !paint || !computeContentBounds);
-            Debug.Assert(cellStyle != null);
+            Debug.Assert(cellStyle is not null);
 
             Rectangle resultBounds;
 
@@ -1133,13 +1133,13 @@ namespace System.Windows.Forms
                 drawErrorText = false;
             }
 
-            if (formattedValue != null && formattedValue is CheckState)
+            if (formattedValue is not null && formattedValue is CheckState)
             {
                 checkState = (CheckState)formattedValue;
                 bs = (checkState == CheckState.Unchecked) ? ButtonState.Normal : ButtonState.Checked;
                 drawAsMixedCheckBox = (checkState == CheckState.Indeterminate);
             }
-            else if (formattedValue != null && formattedValue is bool)
+            else if (formattedValue is not null && formattedValue is bool)
             {
                 if ((bool)formattedValue)
                 {
@@ -1395,7 +1395,7 @@ namespace System.Windows.Forms
 
                                 if (checkImage is null || checkImage.Width != fullSize.Width || checkImage.Height != fullSize.Height)
                                 {
-                                    if (checkImage != null)
+                                    if (checkImage is not null)
                                     {
                                         checkImage.Dispose();
                                         checkImage = null;
@@ -1619,36 +1619,36 @@ namespace System.Windows.Forms
         {
             Debug.Assert(formattedValue is null || FormattedValueType is null || FormattedValueType.IsAssignableFrom(formattedValue.GetType()));
 
-            if (formattedValue != null)
+            if (formattedValue is not null)
             {
                 if (formattedValue is bool boolean)
                 {
                     if (boolean)
                     {
-                        if (TrueValue != null)
+                        if (TrueValue is not null)
                         {
                             return TrueValue;
                         }
-                        else if (ValueType != null && ValueType.IsAssignableFrom(defaultBooleanType))
+                        else if (ValueType is not null && ValueType.IsAssignableFrom(defaultBooleanType))
                         {
                             return true;
                         }
-                        else if (ValueType != null && ValueType.IsAssignableFrom(defaultCheckStateType))
+                        else if (ValueType is not null && ValueType.IsAssignableFrom(defaultCheckStateType))
                         {
                             return CheckState.Checked;
                         }
                     }
                     else
                     {
-                        if (FalseValue != null)
+                        if (FalseValue is not null)
                         {
                             return FalseValue;
                         }
-                        else if (ValueType != null && ValueType.IsAssignableFrom(defaultBooleanType))
+                        else if (ValueType is not null && ValueType.IsAssignableFrom(defaultBooleanType))
                         {
                             return false;
                         }
-                        else if (ValueType != null && ValueType.IsAssignableFrom(defaultCheckStateType))
+                        else if (ValueType is not null && ValueType.IsAssignableFrom(defaultCheckStateType))
                         {
                             return CheckState.Unchecked;
                         }
@@ -1659,39 +1659,39 @@ namespace System.Windows.Forms
                     switch (state)
                     {
                         case CheckState.Checked:
-                            if (TrueValue != null)
+                            if (TrueValue is not null)
                             {
                                 return TrueValue;
                             }
-                            else if (ValueType != null && ValueType.IsAssignableFrom(defaultBooleanType))
+                            else if (ValueType is not null && ValueType.IsAssignableFrom(defaultBooleanType))
                             {
                                 return true;
                             }
-                            else if (ValueType != null && ValueType.IsAssignableFrom(defaultCheckStateType))
+                            else if (ValueType is not null && ValueType.IsAssignableFrom(defaultCheckStateType))
                             {
                                 return CheckState.Checked;
                             }
                             break;
                         case CheckState.Unchecked:
-                            if (FalseValue != null)
+                            if (FalseValue is not null)
                             {
                                 return FalseValue;
                             }
-                            else if (ValueType != null && ValueType.IsAssignableFrom(defaultBooleanType))
+                            else if (ValueType is not null && ValueType.IsAssignableFrom(defaultBooleanType))
                             {
                                 return false;
                             }
-                            else if (ValueType != null && ValueType.IsAssignableFrom(defaultCheckStateType))
+                            else if (ValueType is not null && ValueType.IsAssignableFrom(defaultCheckStateType))
                             {
                                 return CheckState.Unchecked;
                             }
                             break;
                         case CheckState.Indeterminate:
-                            if (IndeterminateValue != null)
+                            if (IndeterminateValue is not null)
                             {
                                 return IndeterminateValue;
                             }
-                            else if (ValueType != null && ValueType.IsAssignableFrom(defaultCheckStateType))
+                            else if (ValueType is not null && ValueType.IsAssignableFrom(defaultCheckStateType))
                             {
                                 return CheckState.Indeterminate;
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxColumn.cs
@@ -44,7 +44,7 @@ namespace System.Windows.Forms
             get => base.CellTemplate;
             set
             {
-                if (value != null && !(value is DataGridViewCheckBoxCell))
+                if (value is not null && !(value is DataGridViewCheckBoxCell))
                 {
                     throw new InvalidCastException(string.Format(SR.DataGridViewTypeColumn_WrongCellTemplateType, "System.Windows.Forms.DataGridViewCheckBoxCell"));
                 }
@@ -88,7 +88,7 @@ namespace System.Windows.Forms
                 if (FalseValue != value)
                 {
                     CheckBoxCellTemplate.FalseValueInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -124,7 +124,7 @@ namespace System.Windows.Forms
                 if (FlatStyle != value)
                 {
                     CheckBoxCellTemplate.FlatStyle = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -161,7 +161,7 @@ namespace System.Windows.Forms
                 if (IndeterminateValue != value)
                 {
                     CheckBoxCellTemplate.IndeterminateValueInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -197,7 +197,7 @@ namespace System.Windows.Forms
                 if (ThreeState != value)
                 {
                     CheckBoxCellTemplate.ThreeStateInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -247,7 +247,7 @@ namespace System.Windows.Forms
                 if (TrueValue != value)
                 {
                     CheckBoxCellTemplate.TrueValueInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -294,14 +294,14 @@ namespace System.Windows.Forms
                     !defaultCellStyle.ForeColor.IsEmpty ||
                     !defaultCellStyle.SelectionBackColor.IsEmpty ||
                     !defaultCellStyle.SelectionForeColor.IsEmpty ||
-                    defaultCellStyle.Font != null ||
+                    defaultCellStyle.Font is not null ||
                     !defaultCellStyle.NullValue.Equals(defaultNullValue) ||
                     !defaultCellStyle.IsDataSourceNullValueDefault ||
                     !string.IsNullOrEmpty(defaultCellStyle.Format) ||
                     !defaultCellStyle.FormatProvider.Equals(System.Globalization.CultureInfo.CurrentCulture) ||
                     defaultCellStyle.Alignment != DataGridViewContentAlignment.MiddleCenter ||
                     defaultCellStyle.WrapMode != DataGridViewTriState.NotSet ||
-                    defaultCellStyle.Tag != null ||
+                    defaultCellStyle.Tag is not null ||
                     !defaultCellStyle.Padding.Equals(Padding.Empty));
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
@@ -99,7 +99,7 @@ namespace System.Windows.Forms
                 }
                 if (_autoSizeMode != value)
                 {
-                    if (Visible && DataGridView != null)
+                    if (Visible && DataGridView is not null)
                     {
                         if (!DataGridView.ColumnHeadersVisible &&
                             (value == DataGridViewAutoSizeColumnMode.ColumnHeader ||
@@ -194,7 +194,7 @@ namespace System.Windows.Forms
                 if (value != _dataPropertyName)
                 {
                     _dataPropertyName = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridView.OnColumnDataPropertyNameChanged(this);
                     }
@@ -224,14 +224,14 @@ namespace System.Windows.Forms
                     !defaultCellStyle.ForeColor.IsEmpty ||
                     !defaultCellStyle.SelectionBackColor.IsEmpty ||
                     !defaultCellStyle.SelectionForeColor.IsEmpty ||
-                    defaultCellStyle.Font != null ||
+                    defaultCellStyle.Font is not null ||
                     !defaultCellStyle.IsNullValueDefault ||
                     !defaultCellStyle.IsDataSourceNullValueDefault ||
                     !string.IsNullOrEmpty(defaultCellStyle.Format) ||
                     !defaultCellStyle.FormatProvider.Equals(System.Globalization.CultureInfo.CurrentCulture) ||
                     defaultCellStyle.Alignment != DataGridViewContentAlignment.NotSet ||
                     defaultCellStyle.WrapMode != DataGridViewTriState.NotSet ||
-                    defaultCellStyle.Tag != null ||
+                    defaultCellStyle.Tag is not null ||
                     !defaultCellStyle.Padding.Equals(Padding.Empty));
         }
 
@@ -255,7 +255,7 @@ namespace System.Windows.Forms
                     {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.DataGridViewColumn_DisplayIndexTooLarge, int.MaxValue));
                     }
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (value < 0)
                         {
@@ -365,7 +365,7 @@ namespace System.Windows.Forms
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidHighBoundArgumentEx, nameof(FillWeight), value, ushort.MaxValue));
                 }
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridView.OnColumnFillWeightChanging(this, value);
                     _fillWeight = value;
@@ -433,8 +433,8 @@ namespace System.Windows.Forms
             }
             set
             {
-                if ((value != null || HasHeaderCell) &&
-                    HeaderCell.ValueType != null &&
+                if ((value is not null || HasHeaderCell) &&
+                    HeaderCell.ValueType is not null &&
                     HeaderCell.ValueType.IsAssignableFrom(typeof(string)))
                 {
                     HeaderCell.Value = value;
@@ -467,7 +467,7 @@ namespace System.Windows.Forms
                 if (HasDefaultCellStyle)
                 {
                     columnStyle = DefaultCellStyle;
-                    Debug.Assert(columnStyle != null);
+                    Debug.Assert(columnStyle is not null);
                 }
 
                 if (DataGridView is null)
@@ -477,9 +477,9 @@ namespace System.Windows.Forms
 
                 DataGridViewCellStyle inheritedCellStyleTmp = new DataGridViewCellStyle();
                 DataGridViewCellStyle dataGridViewStyle = DataGridView.DefaultCellStyle;
-                Debug.Assert(dataGridViewStyle != null);
+                Debug.Assert(dataGridViewStyle is not null);
 
-                if (columnStyle != null && !columnStyle.BackColor.IsEmpty)
+                if (columnStyle is not null && !columnStyle.BackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.BackColor = columnStyle.BackColor;
                 }
@@ -488,7 +488,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.BackColor = dataGridViewStyle.BackColor;
                 }
 
-                if (columnStyle != null && !columnStyle.ForeColor.IsEmpty)
+                if (columnStyle is not null && !columnStyle.ForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.ForeColor = columnStyle.ForeColor;
                 }
@@ -497,7 +497,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.ForeColor = dataGridViewStyle.ForeColor;
                 }
 
-                if (columnStyle != null && !columnStyle.SelectionBackColor.IsEmpty)
+                if (columnStyle is not null && !columnStyle.SelectionBackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionBackColor = columnStyle.SelectionBackColor;
                 }
@@ -506,7 +506,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.SelectionBackColor = dataGridViewStyle.SelectionBackColor;
                 }
 
-                if (columnStyle != null && !columnStyle.SelectionForeColor.IsEmpty)
+                if (columnStyle is not null && !columnStyle.SelectionForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionForeColor = columnStyle.SelectionForeColor;
                 }
@@ -515,7 +515,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.SelectionForeColor = dataGridViewStyle.SelectionForeColor;
                 }
 
-                if (columnStyle != null && columnStyle.Font != null)
+                if (columnStyle is not null && columnStyle.Font is not null)
                 {
                     inheritedCellStyleTmp.Font = columnStyle.Font;
                 }
@@ -524,7 +524,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.Font = dataGridViewStyle.Font;
                 }
 
-                if (columnStyle != null && !columnStyle.IsNullValueDefault)
+                if (columnStyle is not null && !columnStyle.IsNullValueDefault)
                 {
                     inheritedCellStyleTmp.NullValue = columnStyle.NullValue;
                 }
@@ -533,7 +533,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.NullValue = dataGridViewStyle.NullValue;
                 }
 
-                if (columnStyle != null && !columnStyle.IsDataSourceNullValueDefault)
+                if (columnStyle is not null && !columnStyle.IsDataSourceNullValueDefault)
                 {
                     inheritedCellStyleTmp.DataSourceNullValue = columnStyle.DataSourceNullValue;
                 }
@@ -542,7 +542,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.DataSourceNullValue = dataGridViewStyle.DataSourceNullValue;
                 }
 
-                if (columnStyle != null && columnStyle.Format.Length != 0)
+                if (columnStyle is not null && columnStyle.Format.Length != 0)
                 {
                     inheritedCellStyleTmp.Format = columnStyle.Format;
                 }
@@ -551,7 +551,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.Format = dataGridViewStyle.Format;
                 }
 
-                if (columnStyle != null && !columnStyle.IsFormatProviderDefault)
+                if (columnStyle is not null && !columnStyle.IsFormatProviderDefault)
                 {
                     inheritedCellStyleTmp.FormatProvider = columnStyle.FormatProvider;
                 }
@@ -560,7 +560,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.FormatProvider = dataGridViewStyle.FormatProvider;
                 }
 
-                if (columnStyle != null && columnStyle.Alignment != DataGridViewContentAlignment.NotSet)
+                if (columnStyle is not null && columnStyle.Alignment != DataGridViewContentAlignment.NotSet)
                 {
                     inheritedCellStyleTmp.AlignmentInternal = columnStyle.Alignment;
                 }
@@ -570,7 +570,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.AlignmentInternal = dataGridViewStyle.Alignment;
                 }
 
-                if (columnStyle != null && columnStyle.WrapMode != DataGridViewTriState.NotSet)
+                if (columnStyle is not null && columnStyle.WrapMode != DataGridViewTriState.NotSet)
                 {
                     inheritedCellStyleTmp.WrapModeInternal = columnStyle.WrapMode;
                 }
@@ -580,7 +580,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.WrapModeInternal = dataGridViewStyle.WrapMode;
                 }
 
-                if (columnStyle != null && columnStyle.Tag != null)
+                if (columnStyle is not null && columnStyle.Tag is not null)
                 {
                     inheritedCellStyleTmp.Tag = columnStyle.Tag;
                 }
@@ -589,7 +589,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.Tag = dataGridViewStyle.Tag;
                 }
 
-                if (columnStyle != null && columnStyle.Padding != Padding.Empty)
+                if (columnStyle is not null && columnStyle.Padding != Padding.Empty)
                 {
                     inheritedCellStyleTmp.PaddingInternal = columnStyle.Padding;
                 }
@@ -690,7 +690,7 @@ namespace System.Windows.Forms
                 // I talked w/ MarkRi and he is perfectly fine w/ DataGridViewColumn::Name changing w/o ColumnNameChanged
                 // being fired.
                 //
-                if (Site != null && !string.IsNullOrEmpty(Site.Name))
+                if (Site is not null && !string.IsNullOrEmpty(Site.Name))
                 {
                     _name = Site.Name;
                 }
@@ -709,7 +709,7 @@ namespace System.Windows.Forms
                     _name = value;
                 }
 
-                if (DataGridView != null && !string.Equals(_name, oldName, StringComparison.Ordinal))
+                if (DataGridView is not null && !string.Equals(_name, oldName, StringComparison.Ordinal))
                 {
                     DataGridView.OnColumnNameChanged(this);
                 }
@@ -724,8 +724,8 @@ namespace System.Windows.Forms
             set
             {
                 if (IsDataBound &&
-                    DataGridView != null &&
-                    DataGridView.DataConnection != null &&
+                    DataGridView is not null &&
+                    DataGridView.DataConnection is not null &&
                     BoundColumnIndex != -1 &&
                     DataGridView.DataConnection.DataFieldIsReadOnly(BoundColumnIndex) &&
                     !value)
@@ -774,7 +774,7 @@ namespace System.Windows.Forms
                 {
                     if (value != DataGridViewColumnSortMode.NotSortable)
                     {
-                        if (DataGridView != null &&
+                        if (DataGridView is not null &&
                             !DataGridView.InInitialization &&
                             value == DataGridViewColumnSortMode.Automatic &&
                             (DataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
@@ -798,7 +798,7 @@ namespace System.Windows.Forms
                         _flags = (byte)(_flags & ~AutomaticSort);
                         _flags = (byte)(_flags & ~ProgrammaticSort);
                     }
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridView.OnColumnSortModeChanged(this);
                     }
@@ -822,7 +822,7 @@ namespace System.Windows.Forms
                 {
                     HeaderCell.ToolTipText = value;
 
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridView.OnColumnToolTipTextChanged(this);
                     }
@@ -890,7 +890,7 @@ namespace System.Windows.Forms
             //
 
             DataGridViewColumn dataGridViewColumn = (DataGridViewColumn)System.Activator.CreateInstance(GetType());
-            if (dataGridViewColumn != null)
+            if (dataGridViewColumn is not null)
             {
                 CloneInternal(dataGridViewColumn);
             }
@@ -939,7 +939,7 @@ namespace System.Windows.Forms
 
         internal DataGridViewAutoSizeColumnMode GetInheritedAutoSizeMode(DataGridView dataGridView)
         {
-            if (dataGridView != null && _autoSizeMode == DataGridViewAutoSizeColumnMode.NotSet)
+            if (dataGridView is not null && _autoSizeMode == DataGridViewAutoSizeColumnMode.NotSet)
             {
                 switch (dataGridView.AutoSizeColumnsMode)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
@@ -216,7 +216,7 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual int Add(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             if (DataGridView.NoDimensionChangeAllowed)
             {
                 throw new InvalidOperationException(SR.DataGridView_ForbiddenOperationInEventHandler);
@@ -249,7 +249,7 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(dataGridViewColumns));
             }
 
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             if (DataGridView.NoDimensionChangeAllowed)
             {
                 throw new InvalidOperationException(SR.DataGridView_ForbiddenOperationInEventHandler);
@@ -383,7 +383,7 @@ namespace System.Windows.Forms
             // map the column index to the actual display index
             DataGridViewColumn dataGridViewColumn = GetFirstColumn(includeFilter);
             int actualDisplayIndex = 0;
-            while (dataGridViewColumn != null && dataGridViewColumn.Index != columnIndex)
+            while (dataGridViewColumn is not null && dataGridViewColumn.Index != columnIndex)
             {
                 dataGridViewColumn = GetNextColumn(dataGridViewColumn, includeFilter, DataGridViewElementStates.None);
                 actualDisplayIndex++;
@@ -530,7 +530,7 @@ namespace System.Windows.Forms
             {
                 dataGridViewColumn = GetNextColumn(dataGridViewColumn, includeFilter,
                     DataGridViewElementStates.None);
-                Debug.Assert(dataGridViewColumn != null);
+                Debug.Assert(dataGridViewColumn is not null);
                 if (dataGridViewColumn.StateIncludes(includeFilter))
                 {
                     jumpColumns++;
@@ -541,8 +541,8 @@ namespace System.Windows.Forms
 
         private int GetColumnSortedIndex(DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(dataGridViewColumn != null);
-            Debug.Assert(_itemsSorted != null);
+            Debug.Assert(dataGridViewColumn is not null);
+            Debug.Assert(_itemsSorted is not null);
             Debug.Assert(_lastAccessedSortedIndex == -1 ||
                 _lastAccessedSortedIndex < Count);
 
@@ -887,7 +887,7 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual void Insert(int columnIndex, DataGridViewColumn dataGridViewColumn)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             if (DataGridView.NoDimensionChangeAllowed)
             {
                 throw new InvalidOperationException(SR.DataGridView_ForbiddenOperationInEventHandler);
@@ -997,13 +997,13 @@ namespace System.Windows.Forms
 
         private void OnCollectionChanged_PreNotification(CollectionChangeEventArgs ccea)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             DataGridView.OnColumnCollectionChanged_PreNotification(ccea);
         }
 
         private void OnCollectionChanged_PostNotification(CollectionChangeEventArgs ccea, bool changeIsInsertion, Point newCurrentCell)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             DataGridViewColumn dataGridViewColumn = (DataGridViewColumn)ccea.Element;
             if (ccea.Action == CollectionChangeAction.Add && changeIsInsertion)
             {
@@ -1096,7 +1096,7 @@ namespace System.Windows.Forms
             // If force is true, the underlying data is gone and can't be accessed anymore.
 
             Debug.Assert(index >= 0 && index < Count);
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             Debug.Assert(!DataGridView.NoDimensionChangeAllowed);
             Debug.Assert(!DataGridView.InDisplayIndexAdjustments);
 
@@ -1212,14 +1212,14 @@ namespace System.Windows.Forms
 
             public int Compare(object x, object y)
             {
-                Debug.Assert(x != null);
-                Debug.Assert(y != null);
+                Debug.Assert(x is not null);
+                Debug.Assert(y is not null);
 
                 DataGridViewColumn dataGridViewColumn1 = x as DataGridViewColumn;
                 DataGridViewColumn dataGridViewColumn2 = y as DataGridViewColumn;
 
-                Debug.Assert(dataGridViewColumn1 != null);
-                Debug.Assert(dataGridViewColumn2 != null);
+                Debug.Assert(dataGridViewColumn1 is not null);
+                Debug.Assert(dataGridViewColumn2 is not null);
 
                 return dataGridViewColumn1.DisplayIndex - dataGridViewColumn2.DisplayIndex;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnConverter.cs
@@ -42,10 +42,10 @@ namespace System.Windows.Forms
 
                 // public DataGridViewColumn(Type cellType)
                 //
-                if (dataGridViewColumn.CellType != null)
+                if (dataGridViewColumn.CellType is not null)
                 {
                     ctor = dataGridViewColumn.GetType().GetConstructor(new Type[] { typeof(Type) });
-                    if (ctor != null)
+                    if (ctor is not null)
                     {
                         return new InstanceDescriptor(ctor, new object[] { dataGridViewColumn.CellType }, false);
                     }
@@ -54,7 +54,7 @@ namespace System.Windows.Forms
                 // public DataGridViewColumn()
                 //
                 ctor = dataGridViewColumn.GetType().GetConstructor(Array.Empty<Type>());
-                if (ctor != null)
+                if (ctor is not null)
                 {
                     return new InstanceDescriptor(ctor, Array.Empty<object>(), false);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.cs
@@ -30,13 +30,13 @@ namespace System.Windows.Forms
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
 
-                    if (Owner.OwningColumn != null)
+                    if (Owner.OwningColumn is not null)
                     {
                         if (Owner.OwningColumn.SortMode == DataGridViewColumnSortMode.Automatic)
                         {
                             return SR.DataGridView_AccColumnHeaderCellDefaultAction;
                         }
-                        else if (Owner.DataGridView != null && (
+                        else if (Owner.DataGridView is not null && (
                                 Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
                                 Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect))
                         {
@@ -77,7 +77,7 @@ namespace System.Windows.Forms
                         resultState |= AccessibleStates.Offscreen;
                     }
 
-                    if (Owner.DataGridView != null && Owner.OwningColumn != null && Owner.OwningColumn.Selected)
+                    if (Owner.DataGridView is not null && Owner.OwningColumn is not null && Owner.OwningColumn.Selected)
                     {
                         if (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
                         Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect)
@@ -161,7 +161,7 @@ namespace System.Windows.Forms
 
             private AccessibleObject? NavigateBackward()
             {
-                Debug.Assert(Owner != null);
+                Debug.Assert(Owner is not null);
 
                 // This method is called after _owner and its properties are validated
                 if (Owner.OwningColumn is null || Owner.DataGridView is null)
@@ -188,7 +188,7 @@ namespace System.Windows.Forms
 
             private AccessibleObject? NavigateForward()
             {
-                Debug.Assert(Owner != null);
+                Debug.Assert(Owner is not null);
 
                 // This method is called after _owner and its properties are validated
                 if (Owner.OwningColumn is null ||
@@ -233,7 +233,7 @@ namespace System.Windows.Forms
                     dataGridView.Focus();
                 }
 
-                if (dataGridViewCell.OwningColumn != null &&
+                if (dataGridViewCell.OwningColumn is not null &&
                     (dataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
                      dataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect))
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
@@ -158,7 +158,7 @@ namespace System.Windows.Forms
                     sb.Append("<THEAD>");
                 }
                 sb.Append("<TH>");
-                if (val != null)
+                if (val is not null)
                 {
                     using var sw = new StringWriter(sb, CultureInfo.CurrentCulture);
                     FormatPlainTextAsHtml(val.ToString(), sw);
@@ -185,7 +185,7 @@ namespace System.Windows.Forms
                     string.Equals(format, DataFormats.Text, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(format, DataFormats.UnicodeText, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (val != null)
+                    if (val is not null)
                     {
                         bool escapeApplied = false;
                         int insertionPoint = sb.Length;
@@ -281,12 +281,12 @@ namespace System.Windows.Forms
             }
 
             ContextMenuStrip contextMenuStrip = GetContextMenuStrip(-1);
-            if (contextMenuStrip != null)
+            if (contextMenuStrip is not null)
             {
                 return contextMenuStrip;
             }
 
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 return DataGridView.ContextMenuStrip;
             }
@@ -313,18 +313,18 @@ namespace System.Windows.Forms
             if (HasStyle)
             {
                 cellStyle = Style;
-                Debug.Assert(cellStyle != null);
+                Debug.Assert(cellStyle is not null);
             }
 
             DataGridViewCellStyle columnHeadersStyle = DataGridView.ColumnHeadersDefaultCellStyle;
-            Debug.Assert(columnHeadersStyle != null);
+            Debug.Assert(columnHeadersStyle is not null);
 
             DataGridViewCellStyle dataGridViewStyle = DataGridView.DefaultCellStyle;
-            Debug.Assert(dataGridViewStyle != null);
+            Debug.Assert(dataGridViewStyle is not null);
 
             if (includeColors)
             {
-                if (cellStyle != null && !cellStyle.BackColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.BackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.BackColor = cellStyle.BackColor;
                 }
@@ -337,7 +337,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.BackColor = dataGridViewStyle.BackColor;
                 }
 
-                if (cellStyle != null && !cellStyle.ForeColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.ForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.ForeColor = cellStyle.ForeColor;
                 }
@@ -350,7 +350,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.ForeColor = dataGridViewStyle.ForeColor;
                 }
 
-                if (cellStyle != null && !cellStyle.SelectionBackColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.SelectionBackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionBackColor = cellStyle.SelectionBackColor;
                 }
@@ -363,7 +363,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.SelectionBackColor = dataGridViewStyle.SelectionBackColor;
                 }
 
-                if (cellStyle != null && !cellStyle.SelectionForeColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.SelectionForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionForeColor = cellStyle.SelectionForeColor;
                 }
@@ -377,11 +377,11 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (cellStyle != null && cellStyle.Font != null)
+            if (cellStyle is not null && cellStyle.Font is not null)
             {
                 inheritedCellStyleTmp.Font = cellStyle.Font;
             }
-            else if (columnHeadersStyle.Font != null)
+            else if (columnHeadersStyle.Font is not null)
             {
                 inheritedCellStyleTmp.Font = columnHeadersStyle.Font;
             }
@@ -390,7 +390,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.Font = dataGridViewStyle.Font;
             }
 
-            if (cellStyle != null && !cellStyle.IsNullValueDefault)
+            if (cellStyle is not null && !cellStyle.IsNullValueDefault)
             {
                 inheritedCellStyleTmp.NullValue = cellStyle.NullValue;
             }
@@ -403,7 +403,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.NullValue = dataGridViewStyle.NullValue;
             }
 
-            if (cellStyle != null && !cellStyle.IsDataSourceNullValueDefault)
+            if (cellStyle is not null && !cellStyle.IsDataSourceNullValueDefault)
             {
                 inheritedCellStyleTmp.DataSourceNullValue = cellStyle.DataSourceNullValue;
             }
@@ -416,7 +416,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.DataSourceNullValue = dataGridViewStyle.DataSourceNullValue;
             }
 
-            if (cellStyle != null && cellStyle.Format.Length != 0)
+            if (cellStyle is not null && cellStyle.Format.Length != 0)
             {
                 inheritedCellStyleTmp.Format = cellStyle.Format;
             }
@@ -429,7 +429,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.Format = dataGridViewStyle.Format;
             }
 
-            if (cellStyle != null && !cellStyle.IsFormatProviderDefault)
+            if (cellStyle is not null && !cellStyle.IsFormatProviderDefault)
             {
                 inheritedCellStyleTmp.FormatProvider = cellStyle.FormatProvider;
             }
@@ -442,7 +442,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.FormatProvider = dataGridViewStyle.FormatProvider;
             }
 
-            if (cellStyle != null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
+            if (cellStyle is not null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyleTmp.AlignmentInternal = cellStyle.Alignment;
             }
@@ -456,7 +456,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.AlignmentInternal = dataGridViewStyle.Alignment;
             }
 
-            if (cellStyle != null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
+            if (cellStyle is not null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyleTmp.WrapModeInternal = cellStyle.WrapMode;
             }
@@ -470,11 +470,11 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.WrapModeInternal = dataGridViewStyle.WrapMode;
             }
 
-            if (cellStyle != null && cellStyle.Tag != null)
+            if (cellStyle is not null && cellStyle.Tag is not null)
             {
                 inheritedCellStyleTmp.Tag = cellStyle.Tag;
             }
-            else if (columnHeadersStyle.Tag != null)
+            else if (columnHeadersStyle.Tag is not null)
             {
                 inheritedCellStyleTmp.Tag = columnHeadersStyle.Tag;
             }
@@ -483,7 +483,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.Tag = dataGridViewStyle.Tag;
             }
 
-            if (cellStyle != null && cellStyle.Padding != Padding.Empty)
+            if (cellStyle is not null && cellStyle.Padding != Padding.Empty)
             {
                 inheritedCellStyleTmp.PaddingInternal = cellStyle.Padding;
             }
@@ -558,7 +558,7 @@ namespace System.Windows.Forms
                             }
                         }
                         if (constraintSize.Height - borderAndPaddingHeights - 2 * VerticalMargin > s_sortGlyphHeight &&
-                            OwningColumn != null &&
+                            OwningColumn is not null &&
                             OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
                         {
                             preferredSize.Width += s_sortGlyphWidth +
@@ -578,7 +578,7 @@ namespace System.Windows.Forms
                         preferredSize = new Size(0, 0);
 
                         if (allowedWidth >= s_sortGlyphWidth + 2 * s_sortGlyphHorizontalMargin &&
-                            OwningColumn != null &&
+                            OwningColumn is not null &&
                             OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
                         {
                             glyphSize = new Size(s_sortGlyphWidth + 2 * s_sortGlyphHorizontalMargin,
@@ -654,7 +654,7 @@ namespace System.Windows.Forms
                         {
                             preferredSize = new Size(0, 0);
                         }
-                        if (OwningColumn != null &&
+                        if (OwningColumn is not null &&
                             OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
                         {
                             preferredSize.Width += s_sortGlyphWidth +
@@ -710,7 +710,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                if (OwningColumn != null)
+                if (OwningColumn is not null)
                 {
                     return OwningColumn.Name;
                 }
@@ -765,7 +765,7 @@ namespace System.Windows.Forms
             DataGridViewPaintParts paintParts,
             bool paint)
         {
-            Debug.Assert(cellStyle != null);
+            Debug.Assert(cellStyle is not null);
             Rectangle contentBounds = Rectangle.Empty;
 
             if (paint && DataGridViewCell.PaintBorder(paintParts))
@@ -808,7 +808,7 @@ namespace System.Windows.Forms
 
                     // Set the state to Pressed/Hot only if the column can be sorted or selected
 #pragma warning disable SA1408 // Conditional expressions should declare precedence
-                    if (OwningColumn != null && OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable ||
+                    if (OwningColumn is not null && OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable ||
 #pragma warning restore SA1408 // Conditional expressions should declare precedence
                         DataGridView.SelectionMode == DataGridViewSelectionMode.FullColumnSelect ||
                         DataGridView.SelectionMode == DataGridViewSelectionMode.ColumnHeaderSelect)
@@ -925,7 +925,7 @@ namespace System.Windows.Forms
                     textColor = cellSelected ? cellStyle.SelectionForeColor : cellStyle.ForeColor;
                 }
 
-                if (OwningColumn != null && OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
+                if (OwningColumn is not null && OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
                 {
                     // Is there enough room to show the glyph?
                     int width = valBounds.Width -
@@ -1179,7 +1179,7 @@ namespace System.Windows.Forms
         private bool IsHighlighted()
         {
             return DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect &&
-                DataGridView.CurrentCell != null && DataGridView.CurrentCell.Selected &&
+                DataGridView.CurrentCell is not null && DataGridView.CurrentCell.Selected &&
                 DataGridView.CurrentCell.OwningColumn == OwningColumn;
         }
 
@@ -1192,7 +1192,7 @@ namespace System.Windows.Forms
 
             object originalValue = GetValue(rowIndex);
             Properties.SetObject(s_propCellValue, value);
-            if (DataGridView != null && originalValue != value)
+            if (DataGridView is not null && originalValue != value)
             {
                 RaiseCellValueChanged(new DataGridViewCellEventArgs(ColumnIndex, -1));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -142,7 +142,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(s_propComboBoxCellDataManager))
+                if (value is not null || Properties.ContainsObject(s_propComboBoxCellDataManager))
                 {
                     Properties.SetObject(s_propComboBoxCellDataManager, value);
                 }
@@ -159,7 +159,7 @@ namespace System.Windows.Forms
             {
                 //CheckNoSharedCell();
                 // Same check as for ListControl's DataSource
-                if (value != null && !(value is IList || value is IListSource))
+                if (value is not null && !(value is IList || value is IListSource))
                 {
                     throw new ArgumentException(SR.BadDataSourceForComplexBinding);
                 }
@@ -188,7 +188,7 @@ namespace System.Windows.Forms
                         {
                             throw;
                         }
-                        Debug.Assert(DisplayMember != null && DisplayMember.Length > 0);
+                        Debug.Assert(DisplayMember is not null && DisplayMember.Length > 0);
                         DisplayMemberInternal = null;
                     }
 
@@ -202,7 +202,7 @@ namespace System.Windows.Forms
                         {
                             throw;
                         }
-                        Debug.Assert(ValueMember != null && ValueMember.Length > 0);
+                        Debug.Assert(ValueMember is not null && ValueMember.Length > 0);
                         ValueMemberInternal = null;
                     }
 
@@ -261,7 +261,7 @@ namespace System.Windows.Forms
             set
             {
                 InitializeDisplayMemberPropertyDescriptor(value);
-                if ((value != null && value.Length > 0) || Properties.ContainsObject(s_propComboBoxCellDisplayMember))
+                if ((value is not null && value.Length > 0) || Properties.ContainsObject(s_propComboBoxCellDisplayMember))
                 {
                     Properties.SetObject(s_propComboBoxCellDisplayMember, value);
                 }
@@ -276,7 +276,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(s_propComboBoxCellDisplayMemberProp))
+                if (value is not null || Properties.ContainsObject(s_propComboBoxCellDisplayMemberProp))
                 {
                     Properties.SetObject(s_propComboBoxCellDisplayMemberProp, value);
                 }
@@ -302,7 +302,7 @@ namespace System.Windows.Forms
                 if (value != DisplayStyle)
                 {
                     Properties.SetInteger(s_propComboBoxCellDisplayStyle, (int)value);
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -346,7 +346,7 @@ namespace System.Windows.Forms
                 if (value != DisplayStyleForCurrentCellOnly)
                 {
                     Properties.SetInteger(s_propComboBoxCellDisplayStyleForCurrentCellOnly, value ? 1 : 0);
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -376,11 +376,11 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DisplayMemberProperty != null)
+                if (DisplayMemberProperty is not null)
                 {
                     return DisplayMemberProperty.PropertyType;
                 }
-                else if (ValueMemberProperty != null)
+                else if (ValueMemberProperty is not null)
                 {
                     return ValueMemberProperty.PropertyType;
                 }
@@ -395,7 +395,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     return DataGridView.GetCachedTypeConverter(DisplayType);
                 }
@@ -437,7 +437,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(s_propComboBoxCellEditingComboBox))
+                if (value is not null || Properties.ContainsObject(s_propComboBoxCellEditingComboBox))
                 {
                     Properties.SetObject(s_propComboBoxCellEditingComboBox, value);
                 }
@@ -500,7 +500,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return Properties.ContainsObject(s_propComboBoxCellItems) && Properties.GetObject(s_propComboBoxCellItems) != null;
+                return Properties.ContainsObject(s_propComboBoxCellItems) && Properties.GetObject(s_propComboBoxCellItems) is not null;
             }
         }
 
@@ -641,7 +641,7 @@ namespace System.Windows.Forms
             set
             {
                 InitializeValueMemberPropertyDescriptor(value);
-                if ((value != null && value.Length > 0) || Properties.ContainsObject(s_propComboBoxCellValueMember))
+                if ((value is not null && value.Length > 0) || Properties.ContainsObject(s_propComboBoxCellValueMember))
                 {
                     Properties.SetObject(s_propComboBoxCellValueMember, value);
                 }
@@ -656,7 +656,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(s_propComboBoxCellValueMemberProp))
+                if (value is not null || Properties.ContainsObject(s_propComboBoxCellValueMemberProp))
                 {
                     Properties.SetObject(s_propComboBoxCellValueMemberProp, value);
                 }
@@ -667,18 +667,18 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (ValueMemberProperty != null)
+                if (ValueMemberProperty is not null)
                 {
                     return ValueMemberProperty.PropertyType;
                 }
-                else if (DisplayMemberProperty != null)
+                else if (DisplayMemberProperty is not null)
                 {
                     return DisplayMemberProperty.PropertyType;
                 }
                 else
                 {
                     Type baseValueType = base.ValueType;
-                    if (baseValueType != null)
+                    if (baseValueType is not null)
                     {
                         return baseValueType;
                     }
@@ -695,7 +695,7 @@ namespace System.Windows.Forms
 
         private void CheckDropDownList(int x, int y, int rowIndex)
         {
-            Debug.Assert(EditingComboBox != null);
+            Debug.Assert(EditingComboBox is not null);
             DataGridViewAdvancedBorderStyle dgvabsPlaceholder = new DataGridViewAdvancedBorderStyle(), dgvabsEffective;
             dgvabsEffective = AdjustCellBorderStyle(DataGridView.AdvancedCellBorderStyle,
                 dgvabsPlaceholder,
@@ -746,7 +746,7 @@ namespace System.Windows.Forms
 
         private void CheckNoDataSource()
         {
-            if (DataSource != null)
+            if (DataSource is not null)
             {
                 throw new ArgumentException(SR.DataSourceLocksItems);
             }
@@ -754,8 +754,8 @@ namespace System.Windows.Forms
 
         private void ComboBox_DropDown(object sender, EventArgs e)
         {
-            Debug.Assert(DataGridView != null);
-            Debug.Assert(EditingComboBox != null);
+            Debug.Assert(DataGridView is not null);
+            Debug.Assert(EditingComboBox is not null);
 
             ComboBox comboBox = EditingComboBox;
             if (OwningColumn is DataGridViewComboBoxColumn owningComboBoxColumn)
@@ -888,7 +888,7 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException();
             }
 
-            if (EditingComboBox != null &&
+            if (EditingComboBox is not null &&
                 (_flags & DropDownHookedUp) != 0x00)
             {
                 EditingComboBox.DropDown -= new EventHandler(ComboBox_DropDown);
@@ -957,7 +957,7 @@ namespace System.Windows.Forms
         private CurrencyManager GetDataManager(DataGridView dataGridView)
         {
             CurrencyManager cm = (CurrencyManager)Properties.GetObject(s_propComboBoxCellDataManager);
-            if (cm is null && DataSource != null && dataGridView != null && dataGridView.BindingContext != null && !(DataSource == Convert.DBNull))
+            if (cm is null && DataSource is not null && dataGridView is not null && dataGridView.BindingContext is not null && !(DataSource == Convert.DBNull))
             {
                 if (DataSource is ISupportInitializeNotification dsInit && !dsInit.IsInitialized)
                 {
@@ -1071,17 +1071,17 @@ namespace System.Windows.Forms
         {
             if (valueTypeConverter is null)
             {
-                if (ValueMemberProperty != null)
+                if (ValueMemberProperty is not null)
                 {
                     valueTypeConverter = ValueMemberProperty.Converter;
                 }
-                else if (DisplayMemberProperty != null)
+                else if (DisplayMemberProperty is not null)
                 {
                     valueTypeConverter = DisplayMemberProperty.Converter;
                 }
             }
 
-            if (value is null || ((ValueType != null && !ValueType.IsAssignableFrom(value.GetType())) && value != System.DBNull.Value))
+            if (value is null || ((ValueType is not null && !ValueType.IsAssignableFrom(value.GetType())) && value != System.DBNull.Value))
             {
                 // Do not raise the DataError event if the value is null and the row is the 'new row'.
 
@@ -1089,7 +1089,7 @@ namespace System.Windows.Forms
                 {
                     return base.GetFormattedValue(null, rowIndex, ref cellStyle, valueTypeConverter, formattedValueTypeConverter, context);
                 }
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(
                         new FormatException(SR.DataGridViewComboBoxCell_InvalidValue), ColumnIndex,
@@ -1104,7 +1104,7 @@ namespace System.Windows.Forms
             }
 
             string strValue = value as string;
-            if ((DataManager != null && (ValueMemberProperty != null || DisplayMemberProperty != null)) ||
+            if ((DataManager is not null && (ValueMemberProperty is not null || DisplayMemberProperty is not null)) ||
                 !string.IsNullOrEmpty(ValueMember) || !string.IsNullOrEmpty(DisplayMember))
             {
                 if (!LookupDisplayValue(rowIndex, value, out object displayValue))
@@ -1113,11 +1113,11 @@ namespace System.Windows.Forms
                     {
                         displayValue = System.DBNull.Value;
                     }
-                    else if (strValue != null && string.IsNullOrEmpty(strValue) && DisplayType == typeof(string))
+                    else if (strValue is not null && string.IsNullOrEmpty(strValue) && DisplayType == typeof(string))
                     {
                         displayValue = string.Empty;
                     }
-                    else if (DataGridView != null)
+                    else if (DataGridView is not null)
                     {
                         DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(
                             new ArgumentException(SR.DataGridViewComboBoxCell_InvalidValue), ColumnIndex,
@@ -1143,7 +1143,7 @@ namespace System.Windows.Forms
                     value != System.DBNull.Value &&
                     (!(value is string) || !string.IsNullOrEmpty(strValue)))
                 {
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(
                             new ArgumentException(SR.DataGridViewComboBoxCell_InvalidValue), ColumnIndex,
@@ -1171,20 +1171,20 @@ namespace System.Windows.Forms
         internal string GetItemDisplayText(object item)
         {
             object displayValue = GetItemDisplayValue(item);
-            return (displayValue != null) ? Convert.ToString(displayValue, CultureInfo.CurrentCulture) : string.Empty;
+            return (displayValue is not null) ? Convert.ToString(displayValue, CultureInfo.CurrentCulture) : string.Empty;
         }
 
         internal object GetItemDisplayValue(object item)
         {
-            Debug.Assert(item != null);
+            Debug.Assert(item is not null);
             bool displayValueSet = false;
             object displayValue = null;
-            if (DisplayMemberProperty != null)
+            if (DisplayMemberProperty is not null)
             {
                 displayValue = DisplayMemberProperty.GetValue(item);
                 displayValueSet = true;
             }
-            else if (ValueMemberProperty != null)
+            else if (ValueMemberProperty is not null)
             {
                 displayValue = ValueMemberProperty.GetValue(item);
                 displayValueSet = true;
@@ -1192,7 +1192,7 @@ namespace System.Windows.Forms
             else if (!string.IsNullOrEmpty(DisplayMember))
             {
                 PropertyDescriptor propDesc = TypeDescriptor.GetProperties(item).Find(DisplayMember, true /*caseInsensitive*/);
-                if (propDesc != null)
+                if (propDesc is not null)
                 {
                     displayValue = propDesc.GetValue(item);
                     displayValueSet = true;
@@ -1201,7 +1201,7 @@ namespace System.Windows.Forms
             else if (!string.IsNullOrEmpty(ValueMember))
             {
                 PropertyDescriptor propDesc = TypeDescriptor.GetProperties(item).Find(ValueMember, true /*caseInsensitive*/);
-                if (propDesc != null)
+                if (propDesc is not null)
                 {
                     displayValue = propDesc.GetValue(item);
                     displayValueSet = true;
@@ -1226,7 +1226,7 @@ namespace System.Windows.Forms
             {
                 items.ClearInternal();
                 CurrencyManager dataManager = GetDataManager(dataGridView);
-                if (dataManager != null && dataManager.Count != -1)
+                if (dataManager is not null && dataManager.Count != -1)
                 {
                     object[] newItems = new object[dataManager.Count];
                     for (int i = 0; i < newItems.Length; i++)
@@ -1236,7 +1236,7 @@ namespace System.Windows.Forms
                     items.AddRangeInternal(newItems);
                 }
                 // Do not clear the CreateItemsFromDataSource flag when the data source has not been initialized yet
-                if (dataManager != null || (_flags & DataSourceInitializedHookedUp) == 0x00)
+                if (dataManager is not null || (_flags & DataSourceInitializedHookedUp) == 0x00)
                 {
                     CreateItemsFromDataSource = false;
                 }
@@ -1248,12 +1248,12 @@ namespace System.Windows.Forms
         {
             bool valueSet = false;
             object value = null;
-            if (ValueMemberProperty != null)
+            if (ValueMemberProperty is not null)
             {
                 value = ValueMemberProperty.GetValue(item);
                 valueSet = true;
             }
-            else if (DisplayMemberProperty != null)
+            else if (DisplayMemberProperty is not null)
             {
                 value = DisplayMemberProperty.GetValue(item);
                 valueSet = true;
@@ -1261,7 +1261,7 @@ namespace System.Windows.Forms
             else if (!string.IsNullOrEmpty(ValueMember))
             {
                 PropertyDescriptor propDesc = TypeDescriptor.GetProperties(item).Find(ValueMember, true /*caseInsensitive*/);
-                if (propDesc != null)
+                if (propDesc is not null)
                 {
                     value = propDesc.GetValue(item);
                     valueSet = true;
@@ -1270,7 +1270,7 @@ namespace System.Windows.Forms
             if (!valueSet && !string.IsNullOrEmpty(DisplayMember))
             {
                 PropertyDescriptor propDesc = TypeDescriptor.GetProperties(item).Find(DisplayMember, true /*caseInsensitive*/);
-                if (propDesc != null)
+                if (propDesc is not null)
                 {
                     value = propDesc.GetValue(item);
                     valueSet = true;
@@ -1352,7 +1352,7 @@ namespace System.Windows.Forms
 
         private void InitializeComboBoxText()
         {
-            Debug.Assert(EditingComboBox != null);
+            Debug.Assert(EditingComboBox is not null);
             ((IDataGridViewEditingControl)EditingComboBox).EditingControlValueChanged = false;
             int rowIndex = ((IDataGridViewEditingControl)EditingComboBox).EditingControlRowIndex;
             Debug.Assert(rowIndex > -1);
@@ -1362,9 +1362,9 @@ namespace System.Windows.Forms
 
         public override void InitializeEditingControl(int rowIndex, object initialFormattedValue, DataGridViewCellStyle dataGridViewCellStyle)
         {
-            Debug.Assert(DataGridView != null &&
-                         DataGridView.EditingPanel != null &&
-                         DataGridView.EditingControl != null);
+            Debug.Assert(DataGridView is not null &&
+                         DataGridView.EditingPanel is not null &&
+                         DataGridView.EditingControl is not null);
             Debug.Assert(!ReadOnly);
             base.InitializeEditingControl(rowIndex, initialFormattedValue, dataGridViewCellStyle);
             if (DataGridView.EditingControl is ComboBox comboBox)
@@ -1378,7 +1378,7 @@ namespace System.Windows.Forms
                 // We need the comboBox to be parented by a control which has a handle or else the native ComboBox ends up
                 // w/ its parentHwnd pointing to the WinFormsParkingWindow.
                 IntPtr h;
-                if (comboBox.ParentInternal != null)
+                if (comboBox.ParentInternal is not null)
                 {
                     h = comboBox.ParentInternal.Handle;
                 }
@@ -1395,7 +1395,7 @@ namespace System.Windows.Forms
                    the DataGridView and the DataGridViewComboBoxCell share the same DataManager.
                    Then setting the position on the DataManager will also set the position on the DataGridView.
                    And this causes problems when changing position inside the DataGridView.
-                if (this.DataManager != null && this.DataManager.Count > 0)
+                if (this.DataManager is not null && this.DataManager.Count > 0)
                 {
                     this.DataManager.Position = 0;
                 }
@@ -1447,7 +1447,7 @@ namespace System.Windows.Forms
 
         private void InitializeDisplayMemberPropertyDescriptor(string displayMember)
         {
-            if (DataManager != null)
+            if (DataManager is not null)
             {
                 if (string.IsNullOrEmpty(displayMember))
                 {
@@ -1475,7 +1475,7 @@ namespace System.Windows.Forms
 
         private void InitializeValueMemberPropertyDescriptor(string valueMember)
         {
-            if (DataManager != null)
+            if (DataManager is not null)
             {
                 if (string.IsNullOrEmpty(valueMember))
                 {
@@ -1518,8 +1518,8 @@ namespace System.Windows.Forms
             //    return this.valueUsedDuringAutoSize;
             //}
 
-            Debug.Assert(property != null);
-            Debug.Assert(DataManager != null);
+            Debug.Assert(property is not null);
+            Debug.Assert(DataManager is not null);
             object item = null;
 
             //If the data source is a bindinglist use that as it's probably more efficient
@@ -1559,7 +1559,7 @@ namespace System.Windows.Forms
                 item = EditingComboBox.SelectedItem;
                 object displayValue = null;
                 PropertyDescriptor propDesc = TypeDescriptor.GetProperties(item).Find(field, true /*caseInsensitive*/);
-                if (propDesc != null)
+                if (propDesc is not null)
                 {
                     displayValue = propDesc.GetValue(item);
                 }
@@ -1575,11 +1575,11 @@ namespace System.Windows.Forms
                 {
                     object displayValue = null;
                     PropertyDescriptor propDesc = TypeDescriptor.GetProperties(itemCandidate).Find(field, true /*caseInsensitive*/);
-                    if (propDesc != null)
+                    if (propDesc is not null)
                     {
                         displayValue = propDesc.GetValue(itemCandidate);
                     }
-                    if (displayValue != null && displayValue.Equals(key))
+                    if (displayValue is not null && displayValue.Equals(key))
                     {
                         // Found the item.
                         item = itemCandidate;
@@ -1632,12 +1632,12 @@ namespace System.Windows.Forms
         /// </summary>
         private bool LookupDisplayValue(int rowIndex, object value, out object displayValue)
         {
-            Debug.Assert(value != null);
-            Debug.Assert(ValueMemberProperty != null || DisplayMemberProperty != null ||
+            Debug.Assert(value is not null);
+            Debug.Assert(ValueMemberProperty is not null || DisplayMemberProperty is not null ||
                          !string.IsNullOrEmpty(ValueMember) || !string.IsNullOrEmpty(DisplayMember));
 
             object item = null;
-            if (DisplayMemberProperty != null || ValueMemberProperty != null)
+            if (DisplayMemberProperty is not null || ValueMemberProperty is not null)
             {
                 //Now look up the item in the Combobox datasource - this can be horribly inefficient
                 //and it uses reflection which makes it expensive - ripe for optimization
@@ -1675,11 +1675,11 @@ namespace System.Windows.Forms
                 return true;
             }
 
-            Debug.Assert(DisplayMemberProperty != null || ValueMemberProperty != null ||
+            Debug.Assert(DisplayMemberProperty is not null || ValueMemberProperty is not null ||
                          !string.IsNullOrEmpty(DisplayMember) || !string.IsNullOrEmpty(ValueMember));
 
             object item = null;
-            if (DisplayMemberProperty != null || ValueMemberProperty != null)
+            if (DisplayMemberProperty is not null || ValueMemberProperty is not null)
             {
                 //Now look up the item in the DataGridViewComboboxCell datasource - this can be horribly inefficient
                 //and it uses reflection which makes it expensive - ripe for optimization
@@ -1703,7 +1703,7 @@ namespace System.Windows.Forms
 
         protected override void OnDataGridViewChanged()
         {
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 // Will throw an error if DataGridView is set and a member is invalid
                 InitializeDisplayMemberPropertyDescriptor(DisplayMember);
@@ -1726,7 +1726,7 @@ namespace System.Windows.Forms
 
         private void OnItemsCollectionChanged()
         {
-            if (TemplateComboBoxColumn != null)
+            if (TemplateComboBoxColumn is not null)
             {
                 Debug.Assert(TemplateComboBoxColumn.CellTemplate == this);
                 TemplateComboBoxColumn.OnItemsCollectionChanged();
@@ -1769,7 +1769,7 @@ namespace System.Windows.Forms
                          DataGridView.EditMode != DataGridViewEditMode.EditProgrammatically &&
                          DataGridView.BeginEdit(true /*selectAll*/))
                 {
-                    if (EditingComboBox != null && DisplayStyle != DataGridViewComboBoxDisplayStyle.Nothing)
+                    if (EditingComboBox is not null && DisplayStyle != DataGridViewComboBoxDisplayStyle.Nothing)
                     {
                         CheckDropDownList(e.X, e.Y, e.RowIndex);
                     }
@@ -1888,7 +1888,7 @@ namespace System.Windows.Forms
 
         private bool OwnsEditingComboBox(int rowIndex)
         {
-            return rowIndex != -1 && EditingComboBox != null && rowIndex == ((IDataGridViewEditingControl)EditingComboBox).EditingControlRowIndex;
+            return rowIndex != -1 && EditingComboBox is not null && rowIndex == ((IDataGridViewEditingControl)EditingComboBox).EditingControlRowIndex;
         }
 
         protected override void Paint(Graphics graphics,
@@ -1961,7 +1961,7 @@ namespace System.Windows.Forms
             Debug.Assert(!computeContentBounds || !computeErrorIconBounds || !computeDropDownButtonRect || !paint);
             Debug.Assert(!computeErrorIconBounds || !paint || !computeContentBounds || !computeDropDownButtonRect);
             Debug.Assert(!computeErrorIconBounds || !paint || !computeDropDownButtonRect || !computeContentBounds);
-            Debug.Assert(cellStyle != null);
+            Debug.Assert(cellStyle is not null);
 
             Rectangle resultBounds = Rectangle.Empty;
             dropDownButtonRect = Rectangle.Empty;
@@ -1995,7 +1995,7 @@ namespace System.Windows.Forms
 
             Point ptCurrentCell = DataGridView.CurrentCellAddress;
             bool cellCurrent = ptCurrentCell.X == ColumnIndex && ptCurrentCell.Y == rowIndex;
-            bool cellEdited = cellCurrent && DataGridView.EditingControl != null;
+            bool cellEdited = cellCurrent && DataGridView.EditingControl is not null;
             bool cellSelected = (elementState & DataGridViewElementStates.Selected) != 0;
             bool drawComboBox = DisplayStyle == DataGridViewComboBoxDisplayStyle.ComboBox &&
                                 ((DisplayStyleForCurrentCellOnly && cellCurrent) || !DisplayStyleForCurrentCellOnly);
@@ -2452,19 +2452,19 @@ namespace System.Windows.Forms
         {
             if (valueTypeConverter is null)
             {
-                if (ValueMemberProperty != null)
+                if (ValueMemberProperty is not null)
                 {
                     valueTypeConverter = ValueMemberProperty.Converter;
                 }
-                else if (DisplayMemberProperty != null)
+                else if (DisplayMemberProperty is not null)
                 {
                     valueTypeConverter = DisplayMemberProperty.Converter;
                 }
             }
 
             // Find the item given its display value
-            if ((DataManager != null &&
-                (DisplayMemberProperty != null || ValueMemberProperty != null)) ||
+            if ((DataManager is not null &&
+                (DisplayMemberProperty is not null || ValueMemberProperty is not null)) ||
                 !string.IsNullOrEmpty(DisplayMember) || !string.IsNullOrEmpty(ValueMember))
             {
                 object value = ParseFormattedValueInternal(DisplayType, formattedValue, cellStyle,
@@ -2537,7 +2537,7 @@ namespace System.Windows.Forms
 
             public ObjectCollection(DataGridViewComboBoxCell owner)
             {
-                Debug.Assert(owner != null);
+                Debug.Assert(owner is not null);
                 this.owner = owner;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxColumn.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Forms
                 if (AutoComplete != value)
                 {
                     ComboBoxCellTemplate.AutoComplete = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -67,12 +67,12 @@ namespace System.Windows.Forms
             set
             {
                 DataGridViewComboBoxCell dataGridViewComboBoxCell = value as DataGridViewComboBoxCell;
-                if (value != null && dataGridViewComboBoxCell is null)
+                if (value is not null && dataGridViewComboBoxCell is null)
                 {
                     throw new InvalidCastException(string.Format(SR.DataGridViewTypeColumn_WrongCellTemplateType, "System.Windows.Forms.DataGridViewComboBoxCell"));
                 }
                 base.CellTemplate = value;
-                if (value != null)
+                if (value is not null)
                 {
                     dataGridViewComboBoxCell.TemplateComboBoxColumn = this;
                 }
@@ -109,7 +109,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewColumn_CellTemplateRequired);
                 }
                 ComboBoxCellTemplate.DataSource = value;
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                     int rowCount = dataGridViewRows.Count;
@@ -148,7 +148,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewColumn_CellTemplateRequired);
                 }
                 ComboBoxCellTemplate.DisplayMember = value;
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                     int rowCount = dataGridViewRows.Count;
@@ -185,7 +185,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewColumn_CellTemplateRequired);
                 }
                 ComboBoxCellTemplate.DisplayStyle = value;
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                     int rowCount = dataGridViewRows.Count;
@@ -223,7 +223,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewColumn_CellTemplateRequired);
                 }
                 ComboBoxCellTemplate.DisplayStyleForCurrentCellOnly = value;
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                     int rowCount = dataGridViewRows.Count;
@@ -259,7 +259,7 @@ namespace System.Windows.Forms
                 if (DropDownWidth != value)
                 {
                     ComboBoxCellTemplate.DropDownWidth = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -294,7 +294,7 @@ namespace System.Windows.Forms
                 if (FlatStyle != value)
                 {
                     ((DataGridViewComboBoxCell)CellTemplate).FlatStyle = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -350,7 +350,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewColumn_CellTemplateRequired);
                 }
                 ComboBoxCellTemplate.ValueMember = value;
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                     int rowCount = dataGridViewRows.Count;
@@ -385,7 +385,7 @@ namespace System.Windows.Forms
                 if (MaxDropDownItems != value)
                 {
                     ComboBoxCellTemplate.MaxDropDownItems = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -420,7 +420,7 @@ namespace System.Windows.Forms
                 if (Sorted != value)
                 {
                     ComboBoxCellTemplate.Sorted = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -452,7 +452,7 @@ namespace System.Windows.Forms
 
                 dataGridViewColumn = (DataGridViewComboBoxColumn)System.Activator.CreateInstance(thisType);
             }
-            if (dataGridViewColumn != null)
+            if (dataGridViewColumn is not null)
             {
                 base.CloneInternal(dataGridViewColumn);
                 ((DataGridViewComboBoxCell)dataGridViewColumn.CellTemplate).TemplateComboBoxColumn = dataGridViewColumn;
@@ -464,7 +464,7 @@ namespace System.Windows.Forms
         {
             // Items collection of the CellTemplate was changed.
             // Update the items collection of each existing DataGridViewComboBoxCell in the column.
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                 int rowCount = dataGridViewRows.Count;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -58,7 +58,7 @@ namespace System.Windows.Forms
 
         protected override void Dispose(bool disposing)
         {
-            if (FlipXPThemesBitmap != null && disposing)
+            if (FlipXPThemesBitmap is not null && disposing)
             {
                 FlipXPThemesBitmap.Dispose();
             }
@@ -76,13 +76,13 @@ namespace System.Windows.Forms
                     return false;
                 }
 
-                if (OwningRow != null)
+                if (OwningRow is not null)
                 {
                     // row header cell
                     return DataGridView.RowHeadersVisible && OwningRow.Displayed;
                 }
 
-                if (OwningColumn != null)
+                if (OwningColumn is not null)
                 {
                     // column header cell
                     return DataGridView.ColumnHeadersVisible && OwningColumn.Displayed;
@@ -101,7 +101,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(s_propFlipXPThemesBitmap))
+                if (value is not null || Properties.ContainsObject(s_propFlipXPThemesBitmap))
                 {
                     Properties.SetObject(s_propFlipXPThemesBitmap, value);
                 }
@@ -121,19 +121,19 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (OwningRow != null)
+                if (OwningRow is not null)
                 {
                     // row header cell
                     return OwningRow.Frozen;
                 }
 
-                if (OwningColumn != null)
+                if (OwningColumn is not null)
                 {
                     // column header cell
                     return OwningColumn.Frozen;
                 }
 
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     // top left header cell
                     return true;
@@ -146,7 +146,7 @@ namespace System.Windows.Forms
 
         private protected override bool HasValueType
         {
-            get => Properties.ContainsObject(s_propValueType) && Properties.GetObject(s_propValueType) != null;
+            get => Properties.ContainsObject(s_propValueType) && Properties.GetObject(s_propValueType) is not null;
         }
 
         [Browsable(false)]
@@ -168,21 +168,21 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (OwningRow != null)
+                if (OwningRow is not null)
                 {
                     // must be a row header cell
-                    return (OwningRow.Resizable == DataGridViewTriState.True) || (DataGridView != null && DataGridView.RowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.EnableResizing);
+                    return (OwningRow.Resizable == DataGridViewTriState.True) || (DataGridView is not null && DataGridView.RowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.EnableResizing);
                 }
 
-                if (OwningColumn != null)
+                if (OwningColumn is not null)
                 {
                     // must be a column header cell
                     return (OwningColumn.Resizable == DataGridViewTriState.True) ||
-                           (DataGridView != null && DataGridView.ColumnHeadersHeightSizeMode == DataGridViewColumnHeadersHeightSizeMode.EnableResizing);
+                           (DataGridView is not null && DataGridView.ColumnHeadersHeightSizeMode == DataGridViewColumnHeadersHeightSizeMode.EnableResizing);
                 }
 
                 // must be the top left header cell
-                return DataGridView != null && (DataGridView.RowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.EnableResizing || DataGridView.ColumnHeadersHeightSizeMode == DataGridViewColumnHeadersHeightSizeMode.EnableResizing);
+                return DataGridView is not null && (DataGridView.RowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.EnableResizing || DataGridView.ColumnHeadersHeightSizeMode == DataGridViewColumnHeadersHeightSizeMode.EnableResizing);
             }
         }
 
@@ -205,7 +205,7 @@ namespace System.Windows.Forms
             get
             {
                 Type valueType = (Type)Properties.GetObject(s_propValueType);
-                if (valueType != null)
+                if (valueType is not null)
                 {
                     return valueType;
                 }
@@ -213,7 +213,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(s_propValueType))
+                if (value is not null || Properties.ContainsObject(s_propValueType))
                 {
                     Properties.SetObject(s_propValueType, value);
                 }
@@ -225,21 +225,21 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (OwningRow != null)
+                if (OwningRow is not null)
                 {
                     // row header cell
                     return OwningRow.Visible &&
                             (DataGridView is null || DataGridView.RowHeadersVisible);
                 }
 
-                if (OwningColumn != null)
+                if (OwningColumn is not null)
                 {
                     // column header cell
                     return OwningColumn.Visible &&
                             (DataGridView is null || DataGridView.ColumnHeadersVisible);
                 }
 
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     // top left header cell
                     return DataGridView.RowHeadersVisible && DataGridView.ColumnHeadersVisible;
@@ -271,12 +271,12 @@ namespace System.Windows.Forms
         public override ContextMenuStrip GetInheritedContextMenuStrip(int rowIndex)
         {
             ContextMenuStrip contextMenuStrip = GetContextMenuStrip(rowIndex);
-            if (contextMenuStrip != null)
+            if (contextMenuStrip is not null)
             {
                 return contextMenuStrip;
             }
 
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 return DataGridView.ContextMenuStrip;
             }
@@ -290,20 +290,20 @@ namespace System.Windows.Forms
         {
             DataGridViewElementStates state = DataGridViewElementStates.ResizableSet | DataGridViewElementStates.ReadOnly;
 
-            if (OwningRow != null)
+            if (OwningRow is not null)
             {
                 // row header cell
                 if ((DataGridView is null && rowIndex != -1) ||
-                    (DataGridView != null && (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)))
+                    (DataGridView is not null && (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)))
                 {
                     throw new ArgumentException(string.Format(SR.InvalidArgument, nameof(rowIndex), rowIndex), nameof(rowIndex));
                 }
-                if (DataGridView != null && DataGridView.Rows.SharedRow(rowIndex) != OwningRow)
+                if (DataGridView is not null && DataGridView.Rows.SharedRow(rowIndex) != OwningRow)
                 {
                     throw new ArgumentException(string.Format(SR.InvalidArgument, nameof(rowIndex), rowIndex), nameof(rowIndex));
                 }
                 state |= (OwningRow.GetState(rowIndex) & DataGridViewElementStates.Frozen);
-                if (OwningRow.GetResizable(rowIndex) == DataGridViewTriState.True || (DataGridView != null && DataGridView.RowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.EnableResizing))
+                if (OwningRow.GetResizable(rowIndex) == DataGridViewTriState.True || (DataGridView is not null && DataGridView.RowHeadersWidthSizeMode == DataGridViewRowHeadersWidthSizeMode.EnableResizing))
                 {
                     state |= DataGridViewElementStates.Resizable;
                 }
@@ -316,7 +316,7 @@ namespace System.Windows.Forms
                     }
                 }
             }
-            else if (OwningColumn != null)
+            else if (OwningColumn is not null)
             {
                 // column header cell
                 if (rowIndex != -1)
@@ -325,7 +325,7 @@ namespace System.Windows.Forms
                 }
                 state |= (OwningColumn.State & DataGridViewElementStates.Frozen);
                 if (OwningColumn.Resizable == DataGridViewTriState.True ||
-                    (DataGridView != null && DataGridView.ColumnHeadersHeightSizeMode == DataGridViewColumnHeadersHeightSizeMode.EnableResizing))
+                    (DataGridView is not null && DataGridView.ColumnHeadersHeightSizeMode == DataGridViewColumnHeadersHeightSizeMode.EnableResizing))
                 {
                     state |= DataGridViewElementStates.Resizable;
                 }
@@ -338,7 +338,7 @@ namespace System.Windows.Forms
                     }
                 }
             }
-            else if (DataGridView != null)
+            else if (DataGridView is not null)
             {
                 // top left header cell
                 if (rowIndex != -1)
@@ -406,7 +406,7 @@ namespace System.Windows.Forms
                 }
                 return new Size(-1, -1);
             }
-            if (OwningColumn != null)
+            if (OwningColumn is not null)
             {
                 // must be a column header cell
                 if (rowIndex != -1)
@@ -415,7 +415,7 @@ namespace System.Windows.Forms
                 }
                 return new Size(OwningColumn.Thickness, DataGridView.ColumnHeadersHeight);
             }
-            else if (OwningRow != null)
+            else if (OwningRow is not null)
             {
                 // must be a row header cell
                 if (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count)
@@ -623,7 +623,7 @@ namespace System.Windows.Forms
 
         private void UpdateButtonState(ButtonState newButtonState, int rowIndex)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             ButtonStatePrivate = newButtonState;
             DataGridView.InvalidateCell(ColumnIndex, rowIndex);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.DataGridViewImageCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.DataGridViewImageCellAccessibleObject.cs
@@ -46,11 +46,11 @@ namespace System.Windows.Forms
                 }
 
                 DataGridView? dataGridView = dataGridViewCell.DataGridView;
-                if (dataGridView != null &&
+                if (dataGridView is not null &&
                     dataGridView.IsHandleCreated &&
                     dataGridViewCell.RowIndex != -1 &&
-                    dataGridViewCell.OwningColumn != null &&
-                    dataGridViewCell.OwningRow != null)
+                    dataGridViewCell.OwningColumn is not null &&
+                    dataGridViewCell.OwningRow is not null)
                 {
                     dataGridView.OnCellContentClickInternal(new DataGridViewCellEventArgs(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Forms
             get
             {
                 object description = Properties.GetObject(s_propImageCellDescription);
-                if (description != null)
+                if (description is not null)
                 {
                     return (string)description;
                 }
@@ -175,7 +175,7 @@ namespace System.Windows.Forms
                 if (ValueIsIcon != value)
                 {
                     ValueIsIconInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -204,7 +204,7 @@ namespace System.Windows.Forms
                     {
                         _flags = (byte)(_flags & ~CellValueIsIcon);
                     }
-                    if (DataGridView != null &&
+                    if (DataGridView is not null &&
                         RowIndex != -1 &&
                         DataGridView.NewRowIndex == RowIndex &&
                         !DataGridView.VirtualMode)
@@ -226,7 +226,7 @@ namespace System.Windows.Forms
             {
                 Type baseValueType = base.ValueType;
 
-                if (baseValueType != null)
+                if (baseValueType is not null)
                 {
                     return baseValueType;
                 }
@@ -243,7 +243,7 @@ namespace System.Windows.Forms
             set
             {
                 base.ValueType = value;
-                ValueIsIcon = (value != null && s_defaultTypeIcon.IsAssignableFrom(value));
+                ValueIsIcon = (value is not null && s_defaultTypeIcon.IsAssignableFrom(value));
             }
         }
 
@@ -448,9 +448,9 @@ namespace System.Windows.Forms
             if (freeDimension == DataGridViewFreeDimension.Height &&
                 ImageLayout == DataGridViewImageCellLayout.Zoom)
             {
-                if (img != null || ico != null)
+                if (img is not null || ico is not null)
                 {
-                    if (img != null)
+                    if (img is not null)
                     {
                         int imgWidthAllowed = constraintSize.Width - borderAndPaddingWidths;
                         if (imgWidthAllowed <= 0 || img.Width == 0)
@@ -483,9 +483,9 @@ namespace System.Windows.Forms
             else if (freeDimension == DataGridViewFreeDimension.Width &&
                      ImageLayout == DataGridViewImageCellLayout.Zoom)
             {
-                if (img != null || ico != null)
+                if (img is not null || ico is not null)
                 {
-                    if (img != null)
+                    if (img is not null)
                     {
                         int imgHeightAllowed = constraintSize.Height - borderAndPaddingHeights;
                         if (imgHeightAllowed <= 0 || img.Height == 0)
@@ -517,11 +517,11 @@ namespace System.Windows.Forms
             }
             else
             {
-                if (img != null)
+                if (img is not null)
                 {
                     preferredSize = new Size(img.Width, img.Height);
                 }
-                else if (ico != null)
+                else if (ico is not null)
                 {
                     preferredSize = new Size(ico.Width, ico.Height);
                 }
@@ -570,7 +570,7 @@ namespace System.Windows.Forms
                     if (s_defaultTypeImage.IsAssignableFrom(ValueType))
                     {
                         Image image = owningImageColumn.Image;
-                        if (image != null)
+                        if (image is not null)
                         {
                             return image;
                         }
@@ -578,7 +578,7 @@ namespace System.Windows.Forms
                     else if (s_defaultTypeIcon.IsAssignableFrom(ValueType))
                     {
                         Icon icon = owningImageColumn.Icon;
-                        if (icon != null)
+                        if (icon is not null)
                         {
                             return icon;
                         }
@@ -755,7 +755,7 @@ namespace System.Windows.Forms
             Debug.Assert(!paint || !computeContentBounds || !computeErrorIconBounds);
             Debug.Assert(!computeContentBounds || !computeErrorIconBounds || !paint);
             Debug.Assert(!computeErrorIconBounds || !paint || !computeContentBounds);
-            Debug.Assert(cellStyle != null);
+            Debug.Assert(cellStyle is not null);
 
             if (paint && PaintBorder(paintParts))
             {
@@ -847,7 +847,7 @@ namespace System.Windows.Forms
 
                     if (PaintContentForeground(paintParts))
                     {
-                        if (image != null)
+                        if (image is not null)
                         {
                             using ImageAttributes attr = new ImageAttributes();
                             attr.SetWrapMode(WrapMode.TileFlipXY);
@@ -890,7 +890,7 @@ namespace System.Windows.Forms
                                 Rectangle.Intersect(imageBounds2, imageBounds),
                                 Rectangle.Truncate(g.VisibleClipBounds)));
 
-                            if (image != null)
+                            if (image is not null)
                             {
                                 g.DrawImage(image, imageBounds2);
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageColumn.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms
             get => base.CellTemplate;
             set
             {
-                if (value != null && !(value is DataGridViewImageCell))
+                if (value is not null && !(value is DataGridViewImageCell))
                 {
                     throw new InvalidCastException(string.Format(SR.DataGridViewTypeColumn_WrongCellTemplateType, "System.Windows.Forms.DataGridViewImageCell"));
                 }
@@ -86,7 +86,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewColumn_CellTemplateRequired);
                 }
                 ImageCellTemplate.Description = value;
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                     int rowCount = dataGridViewRows.Count;
@@ -113,7 +113,7 @@ namespace System.Windows.Forms
             set
             {
                 _icon = value;
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridView.OnColumnCommonChange(Index);
                 }
@@ -132,7 +132,7 @@ namespace System.Windows.Forms
             set
             {
                 _image = value;
-                if (DataGridView != null)
+                if (DataGridView is not null)
                 {
                     DataGridView.OnColumnCommonChange(Index);
                 }
@@ -170,7 +170,7 @@ namespace System.Windows.Forms
                 if (ImageLayout != value)
                 {
                     ImageCellTemplate.ImageLayout = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -205,7 +205,7 @@ namespace System.Windows.Forms
                 if (ValuesAreIcons != value)
                 {
                     ImageCellTemplate.ValueIsIconInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -251,7 +251,7 @@ namespace System.Windows.Forms
 
                 dataGridViewColumn = (DataGridViewImageColumn)System.Activator.CreateInstance(thisType);
             }
-            if (dataGridViewColumn != null)
+            if (dataGridViewColumn is not null)
             {
                 base.CloneInternal(dataGridViewColumn);
                 dataGridViewColumn.Icon = _icon;
@@ -289,14 +289,14 @@ namespace System.Windows.Forms
                     !defaultCellStyle.ForeColor.IsEmpty ||
                     !defaultCellStyle.SelectionBackColor.IsEmpty ||
                     !defaultCellStyle.SelectionForeColor.IsEmpty ||
-                    defaultCellStyle.Font != null ||
+                    defaultCellStyle.Font is not null ||
                     !defaultNullValue.Equals(defaultCellStyle.NullValue) ||
                     !defaultCellStyle.IsDataSourceNullValueDefault ||
                     !string.IsNullOrEmpty(defaultCellStyle.Format) ||
                     !defaultCellStyle.FormatProvider.Equals(System.Globalization.CultureInfo.CurrentCulture) ||
                     defaultCellStyle.Alignment != DataGridViewContentAlignment.MiddleCenter ||
                     defaultCellStyle.WrapMode != DataGridViewTriState.NotSet ||
-                    defaultCellStyle.Tag != null ||
+                    defaultCellStyle.Tag is not null ||
                     !defaultCellStyle.Padding.Equals(Padding.Empty));
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewIntLinkedList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewIntLinkedList.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms
 
         public DataGridViewIntLinkedList(DataGridViewIntLinkedList source)
         {
-            Debug.Assert(source != null);
+            Debug.Assert(source is not null);
             int elements = source.Count;
             for (int element = 0; element < elements; element++)
             {
@@ -85,7 +85,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                Debug.Assert(_headElement != null);
+                Debug.Assert(_headElement is not null);
                 return _headElement.Int;
             }
         }
@@ -93,7 +93,7 @@ namespace System.Windows.Forms
         public void Add(int integer)
         {
             DataGridViewIntLinkedListElement newHead = new DataGridViewIntLinkedListElement(integer);
-            if (_headElement != null)
+            if (_headElement is not null)
             {
                 newHead.Next = _headElement;
             }
@@ -115,7 +115,7 @@ namespace System.Windows.Forms
         {
             int index = 0;
             DataGridViewIntLinkedListElement tmp = _headElement;
-            while (tmp != null)
+            while (tmp is not null)
             {
                 if (tmp.Int == integer)
                 {
@@ -144,7 +144,7 @@ namespace System.Windows.Forms
         public bool Remove(int integer)
         {
             DataGridViewIntLinkedListElement tmp1 = null, tmp2 = _headElement;
-            while (tmp2 != null)
+            while (tmp2 is not null)
             {
                 if (tmp2.Int == integer)
                 {
@@ -215,7 +215,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                Debug.Assert(_current != null); // Since this is for internal use only.
+                Debug.Assert(_current is not null); // Since this is for internal use only.
                 return _current.Int;
             }
         }
@@ -230,10 +230,10 @@ namespace System.Windows.Forms
             }
             else
             {
-                Debug.Assert(_current != null); // Since this is for internal use only.
+                Debug.Assert(_current is not null); // Since this is for internal use only.
                 _current = _current.Next;
             }
-            return (_current != null);
+            return (_current is not null);
         }
 
         void IEnumerator.Reset()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.DataGridViewLinkCellAccessibleObject.cs
@@ -45,7 +45,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                if (dataGridViewCell.OwningColumn != null && dataGridViewCell.OwningRow != null)
+                if (dataGridViewCell.OwningColumn is not null && dataGridViewCell.OwningRow is not null)
                 {
                     dataGridView.OnCellContentClickInternal(new DataGridViewCellEventArgs(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
@@ -68,7 +68,7 @@ namespace System.Windows.Forms
                 if (!value.Equals(ActiveLinkColor))
                 {
                     Properties.SetObject(s_propLinkCellActiveLinkColor, value);
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -140,7 +140,7 @@ namespace System.Windows.Forms
                 if (value != LinkBehavior)
                 {
                     Properties.SetInteger(s_propLinkCellLinkBehavior, (int)value);
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -190,7 +190,7 @@ namespace System.Windows.Forms
                 if (!value.Equals(LinkColor))
                 {
                     Properties.SetObject(s_propLinkCellLinkColor, value);
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -264,7 +264,7 @@ namespace System.Windows.Forms
                 if (value != LinkVisited)
                 {
                     _linkVisited = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -301,7 +301,7 @@ namespace System.Windows.Forms
                 if (value != TrackVisitedState)
                 {
                     Properties.SetInteger(s_propLinkCellTrackVisitedState, value ? 1 : 0);
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -384,7 +384,7 @@ namespace System.Windows.Forms
                 if (!value.Equals(VisitedLinkColor))
                 {
                     Properties.SetObject(s_propLinkCellVisitedLinkColor, value);
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (RowIndex != -1)
                         {
@@ -436,7 +436,7 @@ namespace System.Windows.Forms
             get
             {
                 Type valueType = base.ValueType;
-                if (valueType != null)
+                if (valueType is not null)
                 {
                     return valueType;
                 }
@@ -726,9 +726,9 @@ namespace System.Windows.Forms
         protected override object GetValue(int rowIndex)
         {
             if (UseColumnTextForLinkValue &&
-                DataGridView != null &&
+                DataGridView is not null &&
                 DataGridView.NewRowIndex != rowIndex &&
-                OwningColumn != null &&
+                OwningColumn is not null &&
                 OwningColumn is DataGridViewLinkColumn)
             {
                 return ((DataGridViewLinkColumn)OwningColumn).Text;
@@ -791,7 +791,7 @@ namespace System.Windows.Forms
             if (e.KeyCode == Keys.Space && !e.Alt && !e.Control && !e.Shift)
             {
                 RaiseCellClick(new DataGridViewCellEventArgs(ColumnIndex, rowIndex));
-                if (DataGridView != null &&
+                if (DataGridView is not null &&
                     ColumnIndex < DataGridView.Columns.Count &&
                     rowIndex < DataGridView.Rows.Count)
                 {
@@ -826,7 +826,7 @@ namespace System.Windows.Forms
             {
                 return;
             }
-            if (s_dataGridViewCursor != null)
+            if (s_dataGridViewCursor is not null)
             {
                 DataGridView.Cursor = s_dataGridViewCursor;
                 s_dataGridViewCursor = null;
@@ -949,7 +949,7 @@ namespace System.Windows.Forms
             Debug.Assert(!paint || !computeContentBounds || !computeErrorIconBounds);
             Debug.Assert(!computeContentBounds || !computeErrorIconBounds || !paint);
             Debug.Assert(!computeErrorIconBounds || !paint || !computeContentBounds);
-            Debug.Assert(cellStyle != null);
+            Debug.Assert(cellStyle is not null);
 
             if (paint && PaintBorder(paintParts))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkColumn.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms
                 if (!ActiveLinkColor.Equals(value))
                 {
                     ((DataGridViewLinkCell)CellTemplate).ActiveLinkColorInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -74,7 +74,7 @@ namespace System.Windows.Forms
             get => base.CellTemplate;
             set
             {
-                if (value != null && !(value is DataGridViewLinkCell))
+                if (value is not null && !(value is DataGridViewLinkCell))
                 {
                     throw new InvalidCastException(string.Format(SR.DataGridViewTypeColumn_WrongCellTemplateType, "System.Windows.Forms.DataGridViewLinkCell"));
                 }
@@ -100,7 +100,7 @@ namespace System.Windows.Forms
                 if (!LinkBehavior.Equals(value))
                 {
                     ((DataGridViewLinkCell)CellTemplate).LinkBehavior = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -135,7 +135,7 @@ namespace System.Windows.Forms
                 if (!LinkColor.Equals(value))
                 {
                     ((DataGridViewLinkCell)CellTemplate).LinkColorInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -177,7 +177,7 @@ namespace System.Windows.Forms
                 if (!string.Equals(value, _text, StringComparison.Ordinal))
                 {
                     _text = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         if (UseColumnTextForLinkValue)
                         {
@@ -221,7 +221,7 @@ namespace System.Windows.Forms
                 if (TrackVisitedState != value)
                 {
                     ((DataGridViewLinkCell)CellTemplate).TrackVisitedStateInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -257,7 +257,7 @@ namespace System.Windows.Forms
                 if (UseColumnTextForLinkValue != value)
                 {
                     ((DataGridViewLinkCell)CellTemplate).UseColumnTextForLinkValueInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -292,7 +292,7 @@ namespace System.Windows.Forms
                 if (!VisitedLinkColor.Equals(value))
                 {
                     ((DataGridViewLinkCell)CellTemplate).VisitedLinkColorInternal = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;
@@ -335,7 +335,7 @@ namespace System.Windows.Forms
 
                 dataGridViewColumn = (DataGridViewLinkColumn)System.Activator.CreateInstance(thisType);
             }
-            if (dataGridViewColumn != null)
+            if (dataGridViewColumn is not null)
             {
                 base.CloneInternal(dataGridViewColumn);
                 dataGridViewColumn.Text = _text;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -73,8 +73,8 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null &&
-                    DataGridView.DataConnection != null &&
+                if (DataGridView is not null &&
+                    DataGridView.DataConnection is not null &&
                     Index > -1 &&
                     Index != DataGridView.NewRowIndex)
                 {
@@ -97,7 +97,7 @@ namespace System.Windows.Forms
             get => base.DefaultCellStyle;
             set
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertySetOnSharedRow, nameof(DefaultCellStyle)));
                 }
@@ -111,7 +111,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertyGetOnSharedRow, nameof(Displayed)));
                 }
@@ -129,7 +129,7 @@ namespace System.Windows.Forms
             get => DividerThickness;
             set
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertySetOnSharedRow, nameof(DividerHeight)));
                 }
@@ -166,7 +166,7 @@ namespace System.Windows.Forms
                 {
                     Properties.SetObject(s_propRowErrorText, value);
                 }
-                if (DataGridView != null && !errorText.Equals(ErrorTextInternal))
+                if (DataGridView is not null && !errorText.Equals(ErrorTextInternal))
                 {
                     DataGridView.OnRowErrorTextChanged(this);
                 }
@@ -178,7 +178,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertyGetOnSharedRow, nameof(Frozen)));
                 }
@@ -187,7 +187,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertySetOnSharedRow, nameof(Frozen)));
                 }
@@ -198,7 +198,7 @@ namespace System.Windows.Forms
 
         private bool HasErrorText
         {
-            get => Properties.ContainsObject(s_propRowErrorText) && Properties.GetObject(s_propRowErrorText) != null;
+            get => Properties.ContainsObject(s_propRowErrorText) && Properties.GetObject(s_propRowErrorText) is not null;
         }
 
         [Browsable(false)]
@@ -218,7 +218,7 @@ namespace System.Windows.Forms
             get => Thickness;
             set
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertySetOnSharedRow, nameof(Height)));
                 }
@@ -245,7 +245,7 @@ namespace System.Windows.Forms
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsNewRow
         {
-            get => DataGridView != null && DataGridView.NewRowIndex == Index;
+            get => DataGridView is not null && DataGridView.NewRowIndex == Index;
         }
 
         [Browsable(false)]
@@ -255,7 +255,7 @@ namespace System.Windows.Forms
             get => MinimumThickness;
             set
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertySetOnSharedRow, nameof(MinimumHeight)));
                 }
@@ -273,7 +273,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertyGetOnSharedRow, nameof(ReadOnly)));
                 }
@@ -290,7 +290,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertyGetOnSharedRow, nameof(Resizable)));
                 }
@@ -304,7 +304,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertyGetOnSharedRow, nameof(Selected)));
                 }
@@ -318,7 +318,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertyGetOnSharedRow, nameof(State)));
                 }
@@ -332,7 +332,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertyGetOnSharedRow, nameof(Visible)));
                 }
@@ -341,7 +341,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (DataGridView != null && Index == -1)
+                if (DataGridView is not null && Index == -1)
                 {
                     throw new InvalidOperationException(string.Format(SR.DataGridView_InvalidPropertySetOnSharedRow, nameof(Visible)));
                 }
@@ -358,7 +358,7 @@ namespace System.Windows.Forms
             bool isFirstDisplayedRow,
             bool isLastVisibleRow)
         {
-            if (DataGridView != null && DataGridView.ApplyVisualStylesToHeaderCells)
+            if (DataGridView is not null && DataGridView.ApplyVisualStylesToHeaderCells)
             {
                 switch (dataGridViewAdvancedBorderStyleInput.All)
                 {
@@ -495,7 +495,7 @@ namespace System.Windows.Forms
                         break;
 
                     case DataGridViewAdvancedCellBorderStyle.OutsetPartial:
-                        if (DataGridView != null && DataGridView.RightToLeftInternal)
+                        if (DataGridView is not null && DataGridView.RightToLeftInternal)
                         {
                             dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Outset;
                             dataGridViewAdvancedBorderStylePlaceholder.RightInternal = DataGridViewAdvancedCellBorderStyle.OutsetDouble;
@@ -507,7 +507,7 @@ namespace System.Windows.Forms
                         }
                         if (isFirstDisplayedRow)
                         {
-                            dataGridViewAdvancedBorderStylePlaceholder.TopInternal = DataGridView != null && DataGridView.ColumnHeadersVisible ? DataGridViewAdvancedCellBorderStyle.Outset : DataGridViewAdvancedCellBorderStyle.OutsetDouble;
+                            dataGridViewAdvancedBorderStylePlaceholder.TopInternal = DataGridView is not null && DataGridView.ColumnHeadersVisible ? DataGridViewAdvancedCellBorderStyle.Outset : DataGridViewAdvancedCellBorderStyle.OutsetDouble;
                         }
                         else
                         {
@@ -517,7 +517,7 @@ namespace System.Windows.Forms
                         return dataGridViewAdvancedBorderStylePlaceholder;
 
                     case DataGridViewAdvancedCellBorderStyle.OutsetDouble:
-                        if (DataGridView != null && DataGridView.RightToLeftInternal)
+                        if (DataGridView is not null && DataGridView.RightToLeftInternal)
                         {
                             dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Outset;
                             dataGridViewAdvancedBorderStylePlaceholder.RightInternal = DataGridViewAdvancedCellBorderStyle.OutsetDouble;
@@ -529,7 +529,7 @@ namespace System.Windows.Forms
                         }
                         if (isFirstDisplayedRow)
                         {
-                            dataGridViewAdvancedBorderStylePlaceholder.TopInternal = DataGridView != null && DataGridView.ColumnHeadersVisible ? DataGridViewAdvancedCellBorderStyle.Outset : DataGridViewAdvancedCellBorderStyle.OutsetDouble;
+                            dataGridViewAdvancedBorderStylePlaceholder.TopInternal = DataGridView is not null && DataGridView.ColumnHeadersVisible ? DataGridViewAdvancedCellBorderStyle.Outset : DataGridViewAdvancedCellBorderStyle.OutsetDouble;
                         }
                         else
                         {
@@ -539,7 +539,7 @@ namespace System.Windows.Forms
                         return dataGridViewAdvancedBorderStylePlaceholder;
 
                     case DataGridViewAdvancedCellBorderStyle.InsetDouble:
-                        if (DataGridView != null && DataGridView.RightToLeftInternal)
+                        if (DataGridView is not null && DataGridView.RightToLeftInternal)
                         {
                             dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Inset;
                             dataGridViewAdvancedBorderStylePlaceholder.RightInternal = DataGridViewAdvancedCellBorderStyle.InsetDouble;
@@ -551,7 +551,7 @@ namespace System.Windows.Forms
                         }
                         if (isFirstDisplayedRow)
                         {
-                            dataGridViewAdvancedBorderStylePlaceholder.TopInternal = DataGridView != null && DataGridView.ColumnHeadersVisible ? DataGridViewAdvancedCellBorderStyle.Inset : DataGridViewAdvancedCellBorderStyle.InsetDouble;
+                            dataGridViewAdvancedBorderStylePlaceholder.TopInternal = DataGridView is not null && DataGridView.ColumnHeadersVisible ? DataGridViewAdvancedCellBorderStyle.Inset : DataGridViewAdvancedCellBorderStyle.InsetDouble;
                         }
                         else
                         {
@@ -561,7 +561,7 @@ namespace System.Windows.Forms
                         return dataGridViewAdvancedBorderStylePlaceholder;
 
                     case DataGridViewAdvancedCellBorderStyle.Single:
-                        if (!isFirstDisplayedRow || (DataGridView != null && DataGridView.ColumnHeadersVisible))
+                        if (!isFirstDisplayedRow || (DataGridView is not null && DataGridView.ColumnHeadersVisible))
                         {
                             dataGridViewAdvancedBorderStylePlaceholder.LeftInternal = DataGridViewAdvancedCellBorderStyle.Single;
                             dataGridViewAdvancedBorderStylePlaceholder.TopInternal = DataGridViewAdvancedCellBorderStyle.None;
@@ -577,22 +577,22 @@ namespace System.Windows.Forms
 
         private void BuildInheritedRowHeaderCellStyle(DataGridViewCellStyle inheritedCellStyle)
         {
-            Debug.Assert(inheritedCellStyle != null);
+            Debug.Assert(inheritedCellStyle is not null);
 
             DataGridViewCellStyle cellStyle = null;
             if (HeaderCell.HasStyle)
             {
                 cellStyle = HeaderCell.Style;
-                Debug.Assert(cellStyle != null);
+                Debug.Assert(cellStyle is not null);
             }
 
             DataGridViewCellStyle rowHeadersStyle = DataGridView.RowHeadersDefaultCellStyle;
-            Debug.Assert(rowHeadersStyle != null);
+            Debug.Assert(rowHeadersStyle is not null);
 
             DataGridViewCellStyle dataGridViewStyle = DataGridView.DefaultCellStyle;
-            Debug.Assert(dataGridViewStyle != null);
+            Debug.Assert(dataGridViewStyle is not null);
 
-            if (cellStyle != null && !cellStyle.BackColor.IsEmpty)
+            if (cellStyle is not null && !cellStyle.BackColor.IsEmpty)
             {
                 inheritedCellStyle.BackColor = cellStyle.BackColor;
             }
@@ -605,7 +605,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.BackColor = dataGridViewStyle.BackColor;
             }
 
-            if (cellStyle != null && !cellStyle.ForeColor.IsEmpty)
+            if (cellStyle is not null && !cellStyle.ForeColor.IsEmpty)
             {
                 inheritedCellStyle.ForeColor = cellStyle.ForeColor;
             }
@@ -618,7 +618,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.ForeColor = dataGridViewStyle.ForeColor;
             }
 
-            if (cellStyle != null && !cellStyle.SelectionBackColor.IsEmpty)
+            if (cellStyle is not null && !cellStyle.SelectionBackColor.IsEmpty)
             {
                 inheritedCellStyle.SelectionBackColor = cellStyle.SelectionBackColor;
             }
@@ -631,7 +631,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.SelectionBackColor = dataGridViewStyle.SelectionBackColor;
             }
 
-            if (cellStyle != null && !cellStyle.SelectionForeColor.IsEmpty)
+            if (cellStyle is not null && !cellStyle.SelectionForeColor.IsEmpty)
             {
                 inheritedCellStyle.SelectionForeColor = cellStyle.SelectionForeColor;
             }
@@ -644,11 +644,11 @@ namespace System.Windows.Forms
                 inheritedCellStyle.SelectionForeColor = dataGridViewStyle.SelectionForeColor;
             }
 
-            if (cellStyle != null && cellStyle.Font != null)
+            if (cellStyle is not null && cellStyle.Font is not null)
             {
                 inheritedCellStyle.Font = cellStyle.Font;
             }
-            else if (rowHeadersStyle.Font != null)
+            else if (rowHeadersStyle.Font is not null)
             {
                 inheritedCellStyle.Font = rowHeadersStyle.Font;
             }
@@ -657,7 +657,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.Font = dataGridViewStyle.Font;
             }
 
-            if (cellStyle != null && !cellStyle.IsNullValueDefault)
+            if (cellStyle is not null && !cellStyle.IsNullValueDefault)
             {
                 inheritedCellStyle.NullValue = cellStyle.NullValue;
             }
@@ -670,7 +670,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.NullValue = dataGridViewStyle.NullValue;
             }
 
-            if (cellStyle != null && !cellStyle.IsDataSourceNullValueDefault)
+            if (cellStyle is not null && !cellStyle.IsDataSourceNullValueDefault)
             {
                 inheritedCellStyle.DataSourceNullValue = cellStyle.DataSourceNullValue;
             }
@@ -683,7 +683,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.DataSourceNullValue = dataGridViewStyle.DataSourceNullValue;
             }
 
-            if (cellStyle != null && cellStyle.Format.Length != 0)
+            if (cellStyle is not null && cellStyle.Format.Length != 0)
             {
                 inheritedCellStyle.Format = cellStyle.Format;
             }
@@ -696,7 +696,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.Format = dataGridViewStyle.Format;
             }
 
-            if (cellStyle != null && !cellStyle.IsFormatProviderDefault)
+            if (cellStyle is not null && !cellStyle.IsFormatProviderDefault)
             {
                 inheritedCellStyle.FormatProvider = cellStyle.FormatProvider;
             }
@@ -709,11 +709,11 @@ namespace System.Windows.Forms
                 inheritedCellStyle.FormatProvider = dataGridViewStyle.FormatProvider;
             }
 
-            if (cellStyle != null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
+            if (cellStyle is not null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyle.AlignmentInternal = cellStyle.Alignment;
             }
-            else if (rowHeadersStyle != null && rowHeadersStyle.Alignment != DataGridViewContentAlignment.NotSet)
+            else if (rowHeadersStyle is not null && rowHeadersStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyle.AlignmentInternal = rowHeadersStyle.Alignment;
             }
@@ -723,11 +723,11 @@ namespace System.Windows.Forms
                 inheritedCellStyle.AlignmentInternal = dataGridViewStyle.Alignment;
             }
 
-            if (cellStyle != null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
+            if (cellStyle is not null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyle.WrapModeInternal = cellStyle.WrapMode;
             }
-            else if (rowHeadersStyle != null && rowHeadersStyle.WrapMode != DataGridViewTriState.NotSet)
+            else if (rowHeadersStyle is not null && rowHeadersStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyle.WrapModeInternal = rowHeadersStyle.WrapMode;
             }
@@ -737,11 +737,11 @@ namespace System.Windows.Forms
                 inheritedCellStyle.WrapModeInternal = dataGridViewStyle.WrapMode;
             }
 
-            if (cellStyle != null && cellStyle.Tag != null)
+            if (cellStyle is not null && cellStyle.Tag is not null)
             {
                 inheritedCellStyle.Tag = cellStyle.Tag;
             }
-            else if (rowHeadersStyle.Tag != null)
+            else if (rowHeadersStyle.Tag is not null)
             {
                 inheritedCellStyle.Tag = rowHeadersStyle.Tag;
             }
@@ -750,7 +750,7 @@ namespace System.Windows.Forms
                 inheritedCellStyle.Tag = dataGridViewStyle.Tag;
             }
 
-            if (cellStyle != null && cellStyle.Padding != Padding.Empty)
+            if (cellStyle is not null && cellStyle.Padding != Padding.Empty)
             {
                 inheritedCellStyle.PaddingInternal = cellStyle.Padding;
             }
@@ -766,27 +766,27 @@ namespace System.Windows.Forms
 
         private void BuildInheritedRowStyle(int rowIndex, DataGridViewCellStyle inheritedRowStyle)
         {
-            Debug.Assert(inheritedRowStyle != null);
+            Debug.Assert(inheritedRowStyle is not null);
             Debug.Assert(rowIndex >= 0);
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             DataGridViewCellStyle rowStyle = null;
             if (HasDefaultCellStyle)
             {
                 rowStyle = DefaultCellStyle;
-                Debug.Assert(rowStyle != null);
+                Debug.Assert(rowStyle is not null);
             }
 
             DataGridViewCellStyle dataGridViewStyle = DataGridView.DefaultCellStyle;
-            Debug.Assert(dataGridViewStyle != null);
+            Debug.Assert(dataGridViewStyle is not null);
 
             DataGridViewCellStyle rowsDefaultCellStyle = DataGridView.RowsDefaultCellStyle;
-            Debug.Assert(rowsDefaultCellStyle != null);
+            Debug.Assert(rowsDefaultCellStyle is not null);
 
             DataGridViewCellStyle alternatingRowsDefaultCellStyle = DataGridView.AlternatingRowsDefaultCellStyle;
-            Debug.Assert(alternatingRowsDefaultCellStyle != null);
+            Debug.Assert(alternatingRowsDefaultCellStyle is not null);
 
-            if (rowStyle != null && !rowStyle.BackColor.IsEmpty)
+            if (rowStyle is not null && !rowStyle.BackColor.IsEmpty)
             {
                 inheritedRowStyle.BackColor = rowStyle.BackColor;
             }
@@ -803,7 +803,7 @@ namespace System.Windows.Forms
                 inheritedRowStyle.BackColor = dataGridViewStyle.BackColor;
             }
 
-            if (rowStyle != null && !rowStyle.ForeColor.IsEmpty)
+            if (rowStyle is not null && !rowStyle.ForeColor.IsEmpty)
             {
                 inheritedRowStyle.ForeColor = rowStyle.ForeColor;
             }
@@ -820,7 +820,7 @@ namespace System.Windows.Forms
                 inheritedRowStyle.ForeColor = dataGridViewStyle.ForeColor;
             }
 
-            if (rowStyle != null && !rowStyle.SelectionBackColor.IsEmpty)
+            if (rowStyle is not null && !rowStyle.SelectionBackColor.IsEmpty)
             {
                 inheritedRowStyle.SelectionBackColor = rowStyle.SelectionBackColor;
             }
@@ -837,7 +837,7 @@ namespace System.Windows.Forms
                 inheritedRowStyle.SelectionBackColor = dataGridViewStyle.SelectionBackColor;
             }
 
-            if (rowStyle != null && !rowStyle.SelectionForeColor.IsEmpty)
+            if (rowStyle is not null && !rowStyle.SelectionForeColor.IsEmpty)
             {
                 inheritedRowStyle.SelectionForeColor = rowStyle.SelectionForeColor;
             }
@@ -854,16 +854,16 @@ namespace System.Windows.Forms
                 inheritedRowStyle.SelectionForeColor = dataGridViewStyle.SelectionForeColor;
             }
 
-            if (rowStyle != null && rowStyle.Font != null)
+            if (rowStyle is not null && rowStyle.Font is not null)
             {
                 inheritedRowStyle.Font = rowStyle.Font;
             }
-            else if (rowsDefaultCellStyle.Font != null &&
+            else if (rowsDefaultCellStyle.Font is not null &&
                      (rowIndex % 2 == 0 || alternatingRowsDefaultCellStyle.Font is null))
             {
                 inheritedRowStyle.Font = rowsDefaultCellStyle.Font;
             }
-            else if (rowIndex % 2 == 1 && alternatingRowsDefaultCellStyle.Font != null)
+            else if (rowIndex % 2 == 1 && alternatingRowsDefaultCellStyle.Font is not null)
             {
                 inheritedRowStyle.Font = alternatingRowsDefaultCellStyle.Font;
             }
@@ -872,7 +872,7 @@ namespace System.Windows.Forms
                 inheritedRowStyle.Font = dataGridViewStyle.Font;
             }
 
-            if (rowStyle != null && !rowStyle.IsNullValueDefault)
+            if (rowStyle is not null && !rowStyle.IsNullValueDefault)
             {
                 inheritedRowStyle.NullValue = rowStyle.NullValue;
             }
@@ -890,7 +890,7 @@ namespace System.Windows.Forms
                 inheritedRowStyle.NullValue = dataGridViewStyle.NullValue;
             }
 
-            if (rowStyle != null && !rowStyle.IsDataSourceNullValueDefault)
+            if (rowStyle is not null && !rowStyle.IsDataSourceNullValueDefault)
             {
                 inheritedRowStyle.DataSourceNullValue = rowStyle.DataSourceNullValue;
             }
@@ -908,7 +908,7 @@ namespace System.Windows.Forms
                 inheritedRowStyle.DataSourceNullValue = dataGridViewStyle.DataSourceNullValue;
             }
 
-            if (rowStyle != null && rowStyle.Format.Length != 0)
+            if (rowStyle is not null && rowStyle.Format.Length != 0)
             {
                 inheritedRowStyle.Format = rowStyle.Format;
             }
@@ -925,7 +925,7 @@ namespace System.Windows.Forms
                 inheritedRowStyle.Format = dataGridViewStyle.Format;
             }
 
-            if (rowStyle != null && !rowStyle.IsFormatProviderDefault)
+            if (rowStyle is not null && !rowStyle.IsFormatProviderDefault)
             {
                 inheritedRowStyle.FormatProvider = rowStyle.FormatProvider;
             }
@@ -942,7 +942,7 @@ namespace System.Windows.Forms
                 inheritedRowStyle.FormatProvider = dataGridViewStyle.FormatProvider;
             }
 
-            if (rowStyle != null && rowStyle.Alignment != DataGridViewContentAlignment.NotSet)
+            if (rowStyle is not null && rowStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedRowStyle.AlignmentInternal = rowStyle.Alignment;
             }
@@ -960,7 +960,7 @@ namespace System.Windows.Forms
                 inheritedRowStyle.AlignmentInternal = dataGridViewStyle.Alignment;
             }
 
-            if (rowStyle != null && rowStyle.WrapMode != DataGridViewTriState.NotSet)
+            if (rowStyle is not null && rowStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedRowStyle.WrapModeInternal = rowStyle.WrapMode;
             }
@@ -978,15 +978,15 @@ namespace System.Windows.Forms
                 inheritedRowStyle.WrapModeInternal = dataGridViewStyle.WrapMode;
             }
 
-            if (rowStyle != null && rowStyle.Tag != null)
+            if (rowStyle is not null && rowStyle.Tag is not null)
             {
                 inheritedRowStyle.Tag = rowStyle.Tag;
             }
-            else if (rowsDefaultCellStyle.Tag != null && (rowIndex % 2 == 0 || alternatingRowsDefaultCellStyle.Tag is null))
+            else if (rowsDefaultCellStyle.Tag is not null && (rowIndex % 2 == 0 || alternatingRowsDefaultCellStyle.Tag is null))
             {
                 inheritedRowStyle.Tag = rowsDefaultCellStyle.Tag;
             }
-            else if (rowIndex % 2 == 1 && alternatingRowsDefaultCellStyle.Tag != null)
+            else if (rowIndex % 2 == 1 && alternatingRowsDefaultCellStyle.Tag is not null)
             {
                 inheritedRowStyle.Tag = alternatingRowsDefaultCellStyle.Tag;
             }
@@ -995,7 +995,7 @@ namespace System.Windows.Forms
                 inheritedRowStyle.Tag = dataGridViewStyle.Tag;
             }
 
-            if (rowStyle != null && rowStyle.Padding != Padding.Empty)
+            if (rowStyle is not null && rowStyle.Padding != Padding.Empty)
             {
                 inheritedRowStyle.PaddingInternal = rowStyle.Padding;
             }
@@ -1028,7 +1028,7 @@ namespace System.Windows.Forms
                 dataGridViewRow = (DataGridViewRow)Activator.CreateInstance(thisType);
             }
 
-            if (dataGridViewRow != null)
+            if (dataGridViewRow is not null)
             {
                 base.CloneInternal(dataGridViewRow);
                 if (HasErrorText)
@@ -1070,7 +1070,7 @@ namespace System.Windows.Forms
             {
                 throw new ArgumentNullException(nameof(dataGridView));
             }
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridView_RowAlreadyBelongsToDataGridView);
             }
@@ -1116,7 +1116,7 @@ namespace System.Windows.Forms
 
         internal void DetachFromDataGridView()
         {
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 DataGridView = null;
                 Index = -1;
@@ -1179,7 +1179,7 @@ namespace System.Windows.Forms
         public ContextMenuStrip GetContextMenuStrip(int rowIndex)
         {
             ContextMenuStrip contextMenuStrip = ContextMenuStripInternal;
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 if (rowIndex == -1)
                 {
@@ -1190,7 +1190,7 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(rowIndex));
                 }
 
-                if (DataGridView.VirtualMode || DataGridView.DataSource != null)
+                if (DataGridView.VirtualMode || DataGridView.DataSource is not null)
                 {
                     contextMenuStrip = DataGridView.OnRowContextMenuStripNeeded(rowIndex, contextMenuStrip);
                 }
@@ -1207,7 +1207,7 @@ namespace System.Windows.Forms
         public string GetErrorText(int rowIndex)
         {
             string errorText = ErrorTextInternal;
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 if (rowIndex == -1)
                 {
@@ -1219,12 +1219,12 @@ namespace System.Windows.Forms
                 }
 
                 if (string.IsNullOrEmpty(errorText) &&
-                    DataGridView.DataSource != null &&
+                    DataGridView.DataSource is not null &&
                     rowIndex != DataGridView.NewRowIndex)
                 {
                     errorText = DataGridView.DataConnection.GetError(rowIndex);
                 }
-                if (DataGridView.DataSource != null || DataGridView.VirtualMode)
+                if (DataGridView.DataSource is not null || DataGridView.VirtualMode)
                 {
                     errorText = DataGridView.OnRowErrorTextNeeded(rowIndex, errorText);
                 }
@@ -1312,7 +1312,7 @@ namespace System.Windows.Forms
         internal bool GetReadOnly(int rowIndex)
         {
             return (GetState(rowIndex) & DataGridViewElementStates.ReadOnly) != 0 ||
-                   (DataGridView != null && DataGridView.ReadOnly);
+                   (DataGridView is not null && DataGridView.ReadOnly);
         }
 
         internal DataGridViewTriState GetResizable(int rowIndex)
@@ -1322,7 +1322,7 @@ namespace System.Windows.Forms
                 return ((GetState(rowIndex) & DataGridViewElementStates.Resizable) != 0) ? DataGridViewTriState.True : DataGridViewTriState.False;
             }
 
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 return DataGridView.AllowUserToResizeRows ? DataGridViewTriState.True : DataGridViewTriState.False;
             }
@@ -1365,7 +1365,7 @@ namespace System.Windows.Forms
 
         internal void OnSharedStateChanged(int sharedRowIndex, DataGridViewElementStates elementState)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             DataGridView.Rows.InvalidateCachedRowCount(elementState);
             DataGridView.Rows.InvalidateCachedRowsHeight(elementState);
             DataGridView.OnDataGridViewElementStateChanged(this, sharedRowIndex, elementState);
@@ -1373,7 +1373,7 @@ namespace System.Windows.Forms
 
         internal void OnSharedStateChanging(int sharedRowIndex, DataGridViewElementStates elementState)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             DataGridView.OnDataGridViewElementStateChanging(this, sharedRowIndex, elementState);
         }
         protected internal virtual void Paint(Graphics graphics,
@@ -1487,7 +1487,7 @@ namespace System.Windows.Forms
 
             // first paint the potential visible frozen cells
             DataGridViewColumn dataGridViewColumn = dataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible | DataGridViewElementStates.Frozen);
-            while (dataGridViewColumn != null)
+            while (dataGridViewColumn is not null)
             {
                 cell = Cells[dataGridViewColumn.Index];
                 cellBounds.Width = dataGridViewColumn.Thickness;
@@ -1574,7 +1574,7 @@ namespace System.Windows.Forms
                     dataGridViewColumn = (DataGridViewColumn)dataGridView.Columns[dataGridView.FirstDisplayedScrollingColumnIndex];
                     Debug.Assert(dataGridViewColumn.Visible && !dataGridViewColumn.Frozen);
 
-                    while (dataGridViewColumn != null)
+                    while (dataGridViewColumn is not null)
                     {
                         cell = Cells[dataGridViewColumn.Index];
                         cellBounds.Width = dataGridViewColumn.Thickness;
@@ -1632,7 +1632,7 @@ namespace System.Windows.Forms
                         isFirstDisplayedColumn = false;
                     }
 
-                    if (clipRegion != null)
+                    if (clipRegion is not null)
                     {
                         graphics.Clip = clipRegion;
                         clipRegion.Dispose();
@@ -1724,7 +1724,7 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(values));
             }
 
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 if (DataGridView.VirtualMode)
                 {
@@ -1741,7 +1741,7 @@ namespace System.Windows.Forms
 
         internal bool SetValuesInternal(params object[] values)
         {
-            Debug.Assert(values != null);
+            Debug.Assert(values is not null);
             bool setResult = true;
             DataGridViewCellCollection cells = Cells;
             int cellCount = cells.Count;
@@ -1849,7 +1849,7 @@ namespace System.Windows.Forms
                 get => owner;
                 set
                 {
-                    if (owner != null)
+                    if (owner is not null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerAlreadySet);
                     }
@@ -1941,7 +1941,7 @@ namespace System.Windows.Forms
                         accState |= AccessibleStates.Selected;
                     }
 
-                    if (owner.DataGridView != null && owner.DataGridView.IsHandleCreated)
+                    if (owner.DataGridView is not null && owner.DataGridView.IsHandleCreated)
                     {
                         Rectangle rowBounds = owner.DataGridView.GetRowDisplayRectangle(owner.Index, true /*cutOverflow*/);
                         if (!rowBounds.IntersectsWith(owner.DataGridView.ClientRectangle))
@@ -1961,7 +1961,7 @@ namespace System.Windows.Forms
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
-                    if (owner.DataGridView != null && owner.DataGridView.AllowUserToAddRows && owner.Index == owner.DataGridView.NewRowIndex)
+                    if (owner.DataGridView is not null && owner.DataGridView.AllowUserToAddRows && owner.Index == owner.DataGridView.NewRowIndex)
                     {
                         return SR.DataGridView_AccRowCreateNew;
                     }
@@ -1971,12 +1971,12 @@ namespace System.Windows.Forms
                     int childCount = GetChildCount();
 
                     // filter out the row header acc object even when DataGridView::RowHeadersVisible is turned on
-                    int startIndex = owner.DataGridView != null && owner.DataGridView.RowHeadersVisible ? 1 : 0;
+                    int startIndex = owner.DataGridView is not null && owner.DataGridView.RowHeadersVisible ? 1 : 0;
 
                     for (int i = startIndex; i < childCount; i++)
                     {
                         AccessibleObject cellAccObj = GetChild(i);
-                        if (cellAccObj != null)
+                        if (cellAccObj is not null)
                         {
                             sb.Append(cellAccObj.Value);
                         }
@@ -2054,9 +2054,9 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                if (owner.DataGridView != null &&
+                if (owner.DataGridView is not null &&
                     owner.DataGridView.Focused &&
-                    owner.DataGridView.CurrentCell != null &&
+                    owner.DataGridView.CurrentCell is not null &&
                     owner.DataGridView.CurrentCell.RowIndex == owner.Index)
                 {
                     return owner.DataGridView.CurrentCell.AccessibilityObject;
@@ -2172,7 +2172,7 @@ namespace System.Windows.Forms
                 {
                     if (owner.Cells.Count > 0)
                     {
-                        if (dataGridView.CurrentCell != null && dataGridView.CurrentCell.OwningColumn != null)
+                        if (dataGridView.CurrentCell is not null && dataGridView.CurrentCell.OwningColumn is not null)
                         {
                             dataGridView.CurrentCell = owner.Cells[dataGridView.CurrentCell.OwningColumn.Index]; // Do not change old selection
                         }
@@ -2338,7 +2338,7 @@ namespace System.Windows.Forms
 
             public override AccessibleObject GetFocused()
             {
-                if (owner.DataGridView.CurrentCell != null && owner.DataGridView.CurrentCell.Selected)
+                if (owner.DataGridView.CurrentCell is not null && owner.DataGridView.CurrentCell.Selected)
                 {
                     return owner.DataGridView.CurrentCell.AccessibilityObject;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
@@ -161,7 +161,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return (onCollectionChanged != null);
+                return (onCollectionChanged is not null);
             }
         }
 
@@ -217,7 +217,7 @@ namespace System.Windows.Forms
                         // Simply update the index and return the current row without cloning it.
                         dataGridViewRow.Index = 0;
                         dataGridViewRow.State = SharedRowState(0);
-                        if (DataGridView != null)
+                        if (DataGridView is not null)
                         {
                             DataGridView.OnRowUnshared(dataGridViewRow);
                         }
@@ -243,7 +243,7 @@ namespace System.Windows.Forms
                         newDataGridViewRow.HeaderCell.DataGridView = dataGridViewRow.DataGridView;
                         newDataGridViewRow.HeaderCell.OwningRow = newDataGridViewRow;
                     }
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridView.OnRowUnshared(newDataGridViewRow);
                     }
@@ -265,7 +265,7 @@ namespace System.Windows.Forms
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual int Add()
         {
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -280,7 +280,7 @@ namespace System.Windows.Forms
 
         internal int AddInternal(bool newRow, object[] values)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             if (DataGridView.Columns.Count == 0)
             {
@@ -307,7 +307,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (values != null)
+            if (values is not null)
             {
                 dataGridViewRow.SetValuesInternal(values);
             }
@@ -348,7 +348,7 @@ namespace System.Windows.Forms
             cachedRowHeightsAccessAllowed = false;
             cachedRowCountsAccessAllowed = false;
 #endif
-            if (values != null || !RowIsSharable(index) || RowHasValueOrToolTipText(dataGridViewRow) || IsCollectionChangedListenedTo)
+            if (values is not null || !RowIsSharable(index) || RowHasValueOrToolTipText(dataGridViewRow) || IsCollectionChangedListenedTo)
             {
                 dataGridViewRow.Index = index;
                 Debug.Assert(dataGridViewRow.State == SharedRowState(index));
@@ -360,7 +360,7 @@ namespace System.Windows.Forms
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual int Add(params object[] values)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             if (values is null)
             {
                 throw new ArgumentNullException(nameof(values));
@@ -371,7 +371,7 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridView_InvalidOperationInVirtualMode);
             }
 
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -394,7 +394,7 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_NoColumns);
             }
 
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -410,7 +410,7 @@ namespace System.Windows.Forms
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual int Add(int count)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             if (count <= 0)
             {
@@ -422,7 +422,7 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_NoColumns);
             }
 
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -470,13 +470,13 @@ namespace System.Windows.Forms
 
         internal int AddInternal(DataGridViewRow dataGridViewRow)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             if (dataGridViewRow is null)
             {
                 throw new ArgumentNullException(nameof(dataGridViewRow));
             }
-            if (dataGridViewRow.DataGridView != null)
+            if (dataGridViewRow.DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridView_RowAlreadyBelongsToDataGridView);
             }
@@ -547,7 +547,7 @@ namespace System.Windows.Forms
 
         public virtual int AddCopy(int indexSource)
         {
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -562,7 +562,7 @@ namespace System.Windows.Forms
 
         internal int AddCopyInternal(int indexSource, DataGridViewElementStates dgvesAdd, DataGridViewElementStates dgvesRemove, bool newRow)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             if (DataGridView.NewRowIndex != -1)
             {
@@ -583,7 +583,7 @@ namespace System.Windows.Forms
             DataGridViewRow rowTemplate = SharedRow(indexSource);
             if (rowTemplate.Index == -1 && !IsCollectionChangedListenedTo && !newRow)
             {
-                Debug.Assert(DataGridView != null);
+                Debug.Assert(DataGridView is not null);
                 DataGridViewElementStates rowState = rowStates[indexSource] & ~dgvesRemove;
                 rowState |= dgvesAdd;
                 DataGridView.OnAddingRow(rowTemplate, rowState, true /*checkFrozenState*/);   // will throw an exception if the addition is illegal
@@ -612,7 +612,7 @@ namespace System.Windows.Forms
 
         public virtual int AddCopies(int indexSource, int count)
         {
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -738,7 +738,7 @@ namespace System.Windows.Forms
 
         private int AddDuplicateRow(DataGridViewRow rowTemplate, bool newRow)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             DataGridViewRow dataGridViewRow = (DataGridViewRow)rowTemplate.Clone();
             dataGridViewRow.State = DataGridViewElementStates.None;
@@ -782,14 +782,14 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(dataGridViewRows));
             }
 
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             if (DataGridView.NoDimensionChangeAllowed)
             {
                 throw new InvalidOperationException(SR.DataGridView_ForbiddenOperationInEventHandler);
             }
 
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -855,7 +855,7 @@ namespace System.Windows.Forms
             {
                 throw new InvalidOperationException(SR.DataGridView_ForbiddenOperationInEventHandler);
             }
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 if (DataGridView.DataConnection.List is IBindingList list && list.AllowRemove && list.SupportsChangeNotification)
                 {
@@ -1373,7 +1373,7 @@ namespace System.Windows.Forms
 
         public virtual void Insert(int rowIndex, params object[] values)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             if (values is null)
             {
@@ -1385,7 +1385,7 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridView_InvalidOperationInVirtualMode);
             }
 
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -1400,7 +1400,7 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual void Insert(int rowIndex, DataGridViewRow dataGridViewRow)
         {
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -1415,7 +1415,7 @@ namespace System.Windows.Forms
 
         public virtual void Insert(int rowIndex, int count)
         {
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -1476,7 +1476,7 @@ namespace System.Windows.Forms
 
         internal void InsertInternal(int rowIndex, DataGridViewRow dataGridViewRow)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             if (rowIndex < 0 || Count < rowIndex)
             {
                 throw new ArgumentOutOfRangeException(nameof(rowIndex), SR.DataGridViewRowCollection_RowIndexOutOfRange);
@@ -1487,7 +1487,7 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(dataGridViewRow));
             }
 
-            if (dataGridViewRow.DataGridView != null)
+            if (dataGridViewRow.DataGridView is not null)
             {
                 throw new InvalidOperationException(SR.DataGridView_RowAlreadyBelongsToDataGridView);
             }
@@ -1519,9 +1519,9 @@ namespace System.Windows.Forms
 
         internal void InsertInternal(int rowIndex, DataGridViewRow dataGridViewRow, bool force)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             Debug.Assert(rowIndex >= 0 && rowIndex <= Count);
-            Debug.Assert(dataGridViewRow != null);
+            Debug.Assert(dataGridViewRow is not null);
             Debug.Assert(dataGridViewRow.DataGridView is null);
             Debug.Assert(!DataGridView.NoDimensionChangeAllowed);
             Debug.Assert(DataGridView.NewRowIndex == -1 || rowIndex != Count);
@@ -1588,7 +1588,7 @@ namespace System.Windows.Forms
 
         public virtual void InsertCopies(int indexSource, int indexDestination, int count)
         {
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -1603,7 +1603,7 @@ namespace System.Windows.Forms
 
         private void InsertCopiesPrivate(int indexSource, int indexDestination, int count)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             if (indexSource < 0 || Count <= indexSource)
             {
@@ -1728,7 +1728,7 @@ namespace System.Windows.Forms
 
         private void InsertDuplicateRow(int indexDestination, DataGridViewRow rowTemplate, bool firstInsertion, ref Point newCurrentCell)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             DataGridViewRow dataGridViewRow = (DataGridViewRow)rowTemplate.Clone();
             dataGridViewRow.State = DataGridViewElementStates.None;
@@ -1766,7 +1766,7 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual void InsertRange(int rowIndex, params DataGridViewRow[] dataGridViewRows)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             if (dataGridViewRows is null)
             {
@@ -1796,7 +1796,7 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_NoInsertionAfterNewRow);
             }
 
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 throw new InvalidOperationException(SR.DataGridViewRowCollection_AddUnboundRow);
             }
@@ -1933,7 +1933,7 @@ namespace System.Windows.Forms
             Point newCurrentCell = new Point(-1, -1);
             DataGridViewRow dataGridViewRow = (DataGridViewRow)e.Element;
             int originalIndex = 0;
-            if (dataGridViewRow != null && e.Action == CollectionChangeAction.Add)
+            if (dataGridViewRow is not null && e.Action == CollectionChangeAction.Add)
             {
                 originalIndex = SharedRow(rowIndex).Index;
             }
@@ -1957,7 +1957,7 @@ namespace System.Windows.Forms
         {
             DataGridViewRow dataGridViewRow = (DataGridViewRow)e.Element;
             int originalIndex = 0;
-            if (dataGridViewRow != null && e.Action == CollectionChangeAction.Add)
+            if (dataGridViewRow is not null && e.Action == CollectionChangeAction.Add)
             {
                 originalIndex = SharedRow(rowIndex).Index;
             }
@@ -1977,7 +1977,7 @@ namespace System.Windows.Forms
                                                          ref DataGridViewRow dataGridViewRow,
                                                          bool changeIsInsertion)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             bool useRowShortcut = false;
             bool computeVisibleRows = false;
             switch (cca)
@@ -2101,7 +2101,7 @@ namespace System.Windows.Forms
                                                           bool recreateNewRow,
                                                           Point newCurrentCell)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             if (changeIsDeletion)
             {
                 DataGridView.OnRowsRemovedInternal(rowIndex, rowCount);
@@ -2188,7 +2188,7 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridView_ForbiddenOperationInEventHandler);
             }
 
-            if (DataGridView.DataSource != null)
+            if (DataGridView.DataSource is not null)
             {
                 if (DataGridView.DataConnection.List is IBindingList list && list.AllowRemove && list.SupportsChangeNotification)
                 {
@@ -2210,7 +2210,7 @@ namespace System.Windows.Forms
             // If force is true, the underlying data is gone and can't be accessed anymore.
 
             Debug.Assert(index >= 0 && index < Count);
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             Debug.Assert(!DataGridView.NoDimensionChangeAllowed);
 
             DataGridViewRow dataGridViewRow = SharedRow(index);
@@ -2222,7 +2222,7 @@ namespace System.Windows.Forms
             }
 
             dataGridViewRow = SharedRow(index);
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
             DataGridView.OnRemovingRow(index, out newCurrentCell, force);
             UpdateRowCaches(index, ref dataGridViewRow, false /*adding*/);
             if (dataGridViewRow.Index != -1)
@@ -2239,7 +2239,7 @@ namespace System.Windows.Forms
 
         private static bool RowHasValueOrToolTipText(DataGridViewRow dataGridViewRow)
         {
-            Debug.Assert(dataGridViewRow != null);
+            Debug.Assert(dataGridViewRow is not null);
             Debug.Assert(dataGridViewRow.Index == -1);
 
             DataGridViewCellCollection cells = dataGridViewRow.Cells;
@@ -2483,7 +2483,7 @@ namespace System.Windows.Forms
 
             public void CustomSort(RowComparer rowComparer)
             {
-                Debug.Assert(rowComparer != null);
+                Debug.Assert(rowComparer is not null);
                 Debug.Assert(Count > 0);
 
                 this.rowComparer = rowComparer;
@@ -2600,7 +2600,7 @@ namespace System.Windows.Forms
                 dataGridViewSortedColumn = dataGridView.SortedColumn;
                 if (dataGridViewSortedColumn is null)
                 {
-                    Debug.Assert(customComparer != null);
+                    Debug.Assert(customComparer is not null);
                     sortedColumnIndex = -1;
                 }
                 else
@@ -2624,7 +2624,7 @@ namespace System.Windows.Forms
                 if (customComparer is null)
                 {
                     DataGridViewRow dataGridViewRow = dataGridViewRows.SharedRow(rowIndex);
-                    Debug.Assert(dataGridViewRow != null);
+                    Debug.Assert(dataGridViewRow is not null);
                     Debug.Assert(sortedColumnIndex >= 0);
                     return dataGridViewRow.Cells[sortedColumnIndex].GetValueInternal(rowIndex);
                 }
@@ -2692,8 +2692,8 @@ namespace System.Windows.Forms
                 {
                     Debug.Assert(value1 is DataGridViewRow);
                     Debug.Assert(value2 is DataGridViewRow);
-                    Debug.Assert(value1 != null);
-                    Debug.Assert(value2 != null);
+                    Debug.Assert(value1 is not null);
+                    Debug.Assert(value2 is not null);
                     //
 
                     result = customComparer.Compare(value1, value2);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowConverter.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms
             if (value is DataGridViewRow row && destinationType == typeof(InstanceDescriptor))
             {
                 ConstructorInfo ctor = row.GetType().GetConstructor(Array.Empty<Type>());
-                if (ctor != null)
+                if (ctor is not null)
                 {
                     return new InstanceDescriptor(ctor, Array.Empty<object>(), isComplete: false);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
@@ -52,7 +52,7 @@ namespace System.Windows.Forms
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
 
-                    if (Owner.DataGridView != null &&
+                    if (Owner.DataGridView is not null &&
                         (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
                          Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
                     {
@@ -100,11 +100,11 @@ namespace System.Windows.Forms
                         resultState |= AccessibleStates.Offscreen;
                     }
 
-                    if (Owner.DataGridView != null &&
+                    if (Owner.DataGridView is not null &&
                         (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
                          Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
                     {
-                        if (Owner.OwningRow != null && Owner.OwningRow.Selected)
+                        if (Owner.OwningRow is not null && Owner.OwningRow.Selected)
                         {
                             resultState |= AccessibleStates.Selected;
                         }
@@ -124,7 +124,7 @@ namespace System.Windows.Forms
                 }
 
                 if (Owner.DataGridView?.IsHandleCreated == true &&
-                    Owner.OwningRow != null &&
+                    Owner.OwningRow is not null &&
                     (Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
                      Owner.DataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
                 {
@@ -226,7 +226,7 @@ namespace System.Windows.Forms
                     dataGridView.Focus();
                 }
 
-                if (dataGridViewCell.OwningRow != null &&
+                if (dataGridViewCell.OwningRow is not null &&
                     (dataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect ||
                      dataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect))
                 {
@@ -259,7 +259,7 @@ namespace System.Windows.Forms
                 {
                     UiaCore.NavigateDirection.Parent => Owner.OwningRow.AccessibilityObject,
                     UiaCore.NavigateDirection.NextSibling =>
-                            (Owner.DataGridView != null && Owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0)
+                            (Owner.DataGridView is not null && Owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0)
                                 ? Owner.OwningRow.AccessibilityObject.GetChild(1) // go to the next sibling
                                 : null,
                     _ => null,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.cs
@@ -172,7 +172,7 @@ namespace System.Windows.Forms
             if (DpiHelper.IsScalingRequired && (b.Size.Width != s_iconsWidth || b.Size.Height != s_iconsHeight))
             {
                 Bitmap scaledBitmap = DpiHelper.CreateResizedBitmap(b, desiredSize);
-                if (scaledBitmap != null)
+                if (scaledBitmap is not null)
                 {
                     b.Dispose();
                     b = scaledBitmap;
@@ -211,7 +211,7 @@ namespace System.Windows.Forms
                 }
                 sb.Append("<TR>");
                 sb.Append("<TD ALIGN=\"center\">");
-                if (val != null)
+                if (val is not null)
                 {
                     sb.Append("<B>");
                     using var sw = new StringWriter(sb, CultureInfo.CurrentCulture);
@@ -240,7 +240,7 @@ namespace System.Windows.Forms
                     string.Equals(format, DataFormats.Text, StringComparison.OrdinalIgnoreCase) ||
                     string.Equals(format, DataFormats.UnicodeText, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (val != null)
+                    if (val is not null)
                     {
                         bool escapeApplied = false;
                         int insertionPoint = sb.Length;
@@ -380,18 +380,18 @@ namespace System.Windows.Forms
 
         public override ContextMenuStrip GetInheritedContextMenuStrip(int rowIndex)
         {
-            if (DataGridView != null && (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count))
+            if (DataGridView is not null && (rowIndex < 0 || rowIndex >= DataGridView.Rows.Count))
             {
                 throw new ArgumentOutOfRangeException(nameof(rowIndex));
             }
 
             ContextMenuStrip contextMenuStrip = GetContextMenuStrip(rowIndex);
-            if (contextMenuStrip != null)
+            if (contextMenuStrip is not null)
             {
                 return contextMenuStrip;
             }
 
-            if (DataGridView != null)
+            if (DataGridView is not null)
             {
                 return DataGridView.ContextMenuStrip;
             }
@@ -403,7 +403,7 @@ namespace System.Windows.Forms
 
         public override DataGridViewCellStyle GetInheritedStyle(DataGridViewCellStyle inheritedCellStyle, int rowIndex, bool includeColors)
         {
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             DataGridViewCellStyle inheritedCellStyleTmp = inheritedCellStyle ?? new DataGridViewCellStyle();
 
@@ -411,18 +411,18 @@ namespace System.Windows.Forms
             if (HasStyle)
             {
                 cellStyle = Style;
-                Debug.Assert(cellStyle != null);
+                Debug.Assert(cellStyle is not null);
             }
 
             DataGridViewCellStyle rowHeadersStyle = DataGridView.RowHeadersDefaultCellStyle;
-            Debug.Assert(rowHeadersStyle != null);
+            Debug.Assert(rowHeadersStyle is not null);
 
             DataGridViewCellStyle dataGridViewStyle = DataGridView.DefaultCellStyle;
-            Debug.Assert(dataGridViewStyle != null);
+            Debug.Assert(dataGridViewStyle is not null);
 
             if (includeColors)
             {
-                if (cellStyle != null && !cellStyle.BackColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.BackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.BackColor = cellStyle.BackColor;
                 }
@@ -435,7 +435,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.BackColor = dataGridViewStyle.BackColor;
                 }
 
-                if (cellStyle != null && !cellStyle.ForeColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.ForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.ForeColor = cellStyle.ForeColor;
                 }
@@ -448,7 +448,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.ForeColor = dataGridViewStyle.ForeColor;
                 }
 
-                if (cellStyle != null && !cellStyle.SelectionBackColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.SelectionBackColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionBackColor = cellStyle.SelectionBackColor;
                 }
@@ -461,7 +461,7 @@ namespace System.Windows.Forms
                     inheritedCellStyleTmp.SelectionBackColor = dataGridViewStyle.SelectionBackColor;
                 }
 
-                if (cellStyle != null && !cellStyle.SelectionForeColor.IsEmpty)
+                if (cellStyle is not null && !cellStyle.SelectionForeColor.IsEmpty)
                 {
                     inheritedCellStyleTmp.SelectionForeColor = cellStyle.SelectionForeColor;
                 }
@@ -475,11 +475,11 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (cellStyle != null && cellStyle.Font != null)
+            if (cellStyle is not null && cellStyle.Font is not null)
             {
                 inheritedCellStyleTmp.Font = cellStyle.Font;
             }
-            else if (rowHeadersStyle.Font != null)
+            else if (rowHeadersStyle.Font is not null)
             {
                 inheritedCellStyleTmp.Font = rowHeadersStyle.Font;
             }
@@ -488,7 +488,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.Font = dataGridViewStyle.Font;
             }
 
-            if (cellStyle != null && !cellStyle.IsNullValueDefault)
+            if (cellStyle is not null && !cellStyle.IsNullValueDefault)
             {
                 inheritedCellStyleTmp.NullValue = cellStyle.NullValue;
             }
@@ -501,7 +501,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.NullValue = dataGridViewStyle.NullValue;
             }
 
-            if (cellStyle != null && !cellStyle.IsDataSourceNullValueDefault)
+            if (cellStyle is not null && !cellStyle.IsDataSourceNullValueDefault)
             {
                 inheritedCellStyleTmp.DataSourceNullValue = cellStyle.DataSourceNullValue;
             }
@@ -514,7 +514,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.DataSourceNullValue = dataGridViewStyle.DataSourceNullValue;
             }
 
-            if (cellStyle != null && cellStyle.Format.Length != 0)
+            if (cellStyle is not null && cellStyle.Format.Length != 0)
             {
                 inheritedCellStyleTmp.Format = cellStyle.Format;
             }
@@ -527,7 +527,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.Format = dataGridViewStyle.Format;
             }
 
-            if (cellStyle != null && !cellStyle.IsFormatProviderDefault)
+            if (cellStyle is not null && !cellStyle.IsFormatProviderDefault)
             {
                 inheritedCellStyleTmp.FormatProvider = cellStyle.FormatProvider;
             }
@@ -540,7 +540,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.FormatProvider = dataGridViewStyle.FormatProvider;
             }
 
-            if (cellStyle != null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
+            if (cellStyle is not null && cellStyle.Alignment != DataGridViewContentAlignment.NotSet)
             {
                 inheritedCellStyleTmp.AlignmentInternal = cellStyle.Alignment;
             }
@@ -554,7 +554,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.AlignmentInternal = dataGridViewStyle.Alignment;
             }
 
-            if (cellStyle != null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
+            if (cellStyle is not null && cellStyle.WrapMode != DataGridViewTriState.NotSet)
             {
                 inheritedCellStyleTmp.WrapModeInternal = cellStyle.WrapMode;
             }
@@ -568,11 +568,11 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.WrapModeInternal = dataGridViewStyle.WrapMode;
             }
 
-            if (cellStyle != null && cellStyle.Tag != null)
+            if (cellStyle is not null && cellStyle.Tag is not null)
             {
                 inheritedCellStyleTmp.Tag = cellStyle.Tag;
             }
-            else if (rowHeadersStyle.Tag != null)
+            else if (rowHeadersStyle.Tag is not null)
             {
                 inheritedCellStyleTmp.Tag = rowHeadersStyle.Tag;
             }
@@ -581,7 +581,7 @@ namespace System.Windows.Forms
                 inheritedCellStyleTmp.Tag = dataGridViewStyle.Tag;
             }
 
-            if (cellStyle != null && cellStyle.Padding != Padding.Empty)
+            if (cellStyle is not null && cellStyle.Padding != Padding.Empty)
             {
                 inheritedCellStyleTmp.PaddingInternal = cellStyle.Padding;
             }
@@ -658,7 +658,7 @@ namespace System.Windows.Forms
         {
             // We allow multiple rows to share the same row header value. The row header cell's cloning does this.
             // So here we need to allow rowIndex == -1.
-            if (DataGridView != null && (rowIndex < -1 || rowIndex >= DataGridView.Rows.Count))
+            if (DataGridView is not null && (rowIndex < -1 || rowIndex >= DataGridView.Rows.Count))
             {
                 throw new ArgumentOutOfRangeException(nameof(rowIndex));
             }
@@ -726,7 +726,7 @@ namespace System.Windows.Forms
             Debug.Assert(!paint || !computeContentBounds || !computeErrorIconBounds);
             Debug.Assert(!computeContentBounds || !computeErrorIconBounds || !paint);
             Debug.Assert(!computeErrorIconBounds || !paint || !computeContentBounds);
-            Debug.Assert(cellStyle != null);
+            Debug.Assert(cellStyle is not null);
 
             // If computeContentBounds == TRUE then resultBounds will be the contentBounds.
             // If computeErrorIconBounds == TRUE then resultBounds will be the error icon bounds.
@@ -903,7 +903,7 @@ namespace System.Windows.Forms
                             {
                                 bmp = DataGridViewRowHeaderCell.StarBitmap;
                             }
-                            if (bmp != null)
+                            if (bmp is not null)
                             {
                                 Color iconColor;
                                 if (DataGridView.ApplyVisualStylesToHeaderCells)
@@ -1049,7 +1049,7 @@ namespace System.Windows.Forms
                             {
                                 bmp = DataGridViewRowHeaderCell.StarBitmap;
                             }
-                            if (bmp != null)
+                            if (bmp is not null)
                             {
                                 lock (bmp)
                                 {
@@ -1111,11 +1111,11 @@ namespace System.Windows.Forms
         protected override bool SetValue(int rowIndex, object value)
         {
             object originalValue = GetValue(rowIndex);
-            if (value != null || Properties.ContainsObject(s_propCellValue))
+            if (value is not null || Properties.ContainsObject(s_propCellValue))
             {
                 Properties.SetObject(s_propCellValue, value);
             }
-            if (DataGridView != null && originalValue != value)
+            if (DataGridView is not null && originalValue != value)
             {
                 RaiseCellValueChanged(new DataGridViewCellEventArgs(-1, rowIndex));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowPostPaintEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowPostPaintEventArgs.cs
@@ -38,7 +38,7 @@ namespace System.Windows.Forms
 
         internal DataGridViewRowPostPaintEventArgs(DataGridView dataGridView)
         {
-            Debug.Assert(dataGridView != null);
+            Debug.Assert(dataGridView is not null);
             _dataGridView = dataGridView;
         }
 
@@ -169,7 +169,7 @@ namespace System.Windows.Forms
                                     bool isFirstDisplayedRow,
                                     bool isLastVisibleRow)
         {
-            Debug.Assert(graphics != null);
+            Debug.Assert(graphics is not null);
 
             Graphics = graphics;
             ClipBounds = clipBounds;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowPrePaintEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowPrePaintEventArgs.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms
 
         internal DataGridViewRowPrePaintEventArgs(DataGridView dataGridView)
         {
-            Debug.Assert(dataGridView != null);
+            Debug.Assert(dataGridView is not null);
             _dataGridView = dataGridView;
         }
 
@@ -186,7 +186,7 @@ namespace System.Windows.Forms
                                     bool isFirstDisplayedRow,
                                     bool isLastVisibleRow)
         {
-            Debug.Assert(graphics != null);
+            Debug.Assert(graphics is not null);
 
             Graphics = graphics;
             ClipBounds = clipBounds;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSelectedCellCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSelectedCellCollection.cs
@@ -129,7 +129,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal void AddCellLinkedList(DataGridViewCellLinkedList dataGridViewCells)
         {
-            Debug.Assert(dataGridViewCells != null);
+            Debug.Assert(dataGridViewCells is not null);
             foreach (DataGridViewCell dataGridViewCell in dataGridViewCells)
             {
                 Debug.Assert(!Contains(dataGridViewCell));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSortCompareEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewSortCompareEventArgs.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Forms
             int rowIndex1,
             int rowIndex2)
         {
-            Debug.Assert(dataGridViewColumn != null);
+            Debug.Assert(dataGridViewColumn is not null);
             Debug.Assert(dataGridViewColumn.Index >= 0);
             Column = dataGridViewColumn;
             CellValue1 = cellValue1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.cs
@@ -61,7 +61,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value != null || Properties.ContainsObject(PropTextBoxCellEditingTextBox))
+                if (value is not null || Properties.ContainsObject(PropTextBoxCellEditingTextBox))
                 {
                     Properties.SetObject(PropTextBoxCellEditingTextBox, value);
                 }
@@ -109,7 +109,7 @@ namespace System.Windows.Forms
             get
             {
                 Type valueType = base.ValueType;
-                if (valueType != null)
+                if (valueType is not null)
                 {
                     return valueType;
                 }
@@ -164,7 +164,7 @@ namespace System.Windows.Forms
         private Rectangle GetAdjustedEditingControlBounds(Rectangle editingControlBounds, DataGridViewCellStyle cellStyle)
         {
             Debug.Assert(cellStyle.WrapMode != DataGridViewTriState.NotSet);
-            Debug.Assert(DataGridView != null);
+            Debug.Assert(DataGridView is not null);
 
             int originalWidth = editingControlBounds.Width;
             if (DataGridView.EditingControl is TextBox txtEditingControl)
@@ -499,9 +499,9 @@ namespace System.Windows.Forms
 
         public override void InitializeEditingControl(int rowIndex, object initialFormattedValue, DataGridViewCellStyle dataGridViewCellStyle)
         {
-            Debug.Assert(DataGridView != null &&
-                         DataGridView.EditingPanel != null &&
-                         DataGridView.EditingControl != null);
+            Debug.Assert(DataGridView is not null &&
+                         DataGridView.EditingPanel is not null &&
+                         DataGridView.EditingControl is not null);
             Debug.Assert(!ReadOnly);
             base.InitializeEditingControl(rowIndex, initialFormattedValue, dataGridViewCellStyle);
             if (DataGridView.EditingControl is TextBox textBox)
@@ -580,7 +580,7 @@ namespace System.Windows.Forms
 
         private bool OwnsEditingTextBox(int rowIndex)
         {
-            return rowIndex != -1 && EditingTextBox != null && rowIndex == ((IDataGridViewEditingControl)EditingTextBox).EditingControlRowIndex;
+            return rowIndex != -1 && EditingTextBox is not null && rowIndex == ((IDataGridViewEditingControl)EditingTextBox).EditingControlRowIndex;
         }
 
         protected override void Paint(Graphics graphics,
@@ -642,7 +642,7 @@ namespace System.Windows.Forms
             Debug.Assert(!paint || !computeContentBounds || !computeErrorIconBounds);
             Debug.Assert(!computeContentBounds || !computeErrorIconBounds || !paint);
             Debug.Assert(!computeErrorIconBounds || !paint || !computeContentBounds);
-            Debug.Assert(cellStyle != null);
+            Debug.Assert(cellStyle is not null);
 
             // If computeContentBounds == TRUE then resultBounds will be the contentBounds.
             // If computeErrorIconBounds == TRUE then resultBounds will be the error icon bounds.
@@ -662,7 +662,7 @@ namespace System.Windows.Forms
 
             Point ptCurrentCell = DataGridView.CurrentCellAddress;
             bool cellCurrent = ptCurrentCell.X == ColumnIndex && ptCurrentCell.Y == rowIndex;
-            bool cellEdited = cellCurrent && DataGridView.EditingControl != null;
+            bool cellEdited = cellCurrent && DataGridView.EditingControl is not null;
             bool cellSelected = (cellState & DataGridViewElementStates.Selected) != 0;
             bool notCollapsed = valBounds.Width > 0 && valBounds.Height > 0;
 
@@ -702,7 +702,7 @@ namespace System.Windows.Forms
             Rectangle errorBounds = valBounds;
             string formattedString = formattedValue as string;
 
-            if (formattedString != null && ((paint && !cellEdited) || computeContentBounds))
+            if (formattedString is not null && ((paint && !cellEdited) || computeContentBounds))
             {
                 // Font independent margins
                 int verticalTextMarginTop = cellStyle.WrapMode == DataGridViewTriState.True

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxColumn.cs
@@ -28,7 +28,7 @@ namespace System.Windows.Forms
             get => base.CellTemplate;
             set
             {
-                if (value != null && !(value is DataGridViewTextBoxCell))
+                if (value is not null && !(value is DataGridViewTextBoxCell))
                 {
                     throw new InvalidCastException(string.Format(SR.DataGridViewTypeColumn_WrongCellTemplateType, "System.Windows.Forms.DataGridViewTextBoxCell"));
                 }
@@ -54,7 +54,7 @@ namespace System.Windows.Forms
                 if (MaxInputLength != value)
                 {
                     TextBoxCellTemplate.MaxInputLength = value;
-                    if (DataGridView != null)
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection dataGridViewRows = DataGridView.Rows;
                         int rowCount = dataGridViewRows.Count;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -110,7 +110,7 @@ namespace System.Windows.Forms
                 Color opaqueBackColor = Color.FromArgb(255, dataGridViewCellStyle.BackColor);
                 BackColor = opaqueBackColor;
 
-                if (_dataGridView != null)
+                if (_dataGridView is not null)
                 {
                     _dataGridView.EditingPanel.BackColor = opaqueBackColor;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.cs
@@ -243,7 +243,7 @@ namespace System.Windows.Forms
             Debug.Assert(!paint || !computeContentBounds || !computeErrorIconBounds);
             Debug.Assert(!computeContentBounds || !computeErrorIconBounds || !paint);
             Debug.Assert(!computeErrorIconBounds || !paint || !computeContentBounds);
-            Debug.Assert(cellStyle != null);
+            Debug.Assert(cellStyle is not null);
 
             // If computeContentBounds == TRUE then resultBounds will be the contentBounds.
             // If computeErrorIconBounds == TRUE then resultBounds will be the error icon bounds.
@@ -479,7 +479,7 @@ namespace System.Windows.Forms
                 get
                 {
                     object value = Owner.Value;
-                    if (value != null && !(value is string))
+                    if (value is not null && !(value is string))
                     {
                         // The user set the Value on the DataGridViewTopLeftHeaderCell and it did not set it to a string.
                         // Then the name of the DataGridViewTopLeftHeaderAccessibleObject is String.Empty;
@@ -489,7 +489,7 @@ namespace System.Windows.Forms
                     string strValue = value as string;
                     if (string.IsNullOrEmpty(strValue))
                     {
-                        if (Owner.DataGridView != null)
+                        if (Owner.DataGridView is not null)
                         {
                             if (Owner.DataGridView.RightToLeft == RightToLeft.No)
                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.BitmapBinder.cs
@@ -49,13 +49,13 @@ namespace System.Windows.Forms
                     catch
                     {
                     }
-                    if (nameToBind != null)
+                    if (nameToBind is not null)
                     {
                         if (string.CompareOrdinal(nameToBind.Name, AllowedAssemblyName) == 0)
                         {
                             byte[] tokenToBind = nameToBind.GetPublicKeyToken();
-                            if ((tokenToBind != null) &&
-                                (s_allowedToken != null) &&
+                            if ((tokenToBind is not null) &&
+                                (s_allowedToken is not null) &&
                                 (tokenToBind.Length == s_allowedToken.Length))
                             {
                                 bool block = false;
@@ -89,7 +89,7 @@ namespace System.Windows.Forms
                 // null strings will follow the default codepath in BinaryFormatter
                 assemblyName = null;
                 typeName = null;
-                if (serializedType != null && !serializedType.Equals(typeof(string)) && !serializedType.Equals(typeof(Bitmap)))
+                if (serializedType is not null && !serializedType.Equals(typeof(string)) && !serializedType.Equals(typeof(Bitmap)))
                 {
                     throw new SerializationException(string.Format(SR.UnexpectedTypeForClipboardFormat, serializedType.FullName));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.DataStore.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.DataStore.cs
@@ -50,7 +50,7 @@ namespace System.Windows.Forms
 
                 DataStoreEntry dse = (DataStoreEntry)data[format];
                 object baseVar = null;
-                if (dse != null)
+                if (dse is not null)
                 {
                     baseVar = dse.data;
                 }
@@ -61,18 +61,18 @@ namespace System.Windows.Forms
                     && (baseVar is null || baseVar is MemoryStream))
                 {
                     string[] mappedFormats = GetMappedFormats(format);
-                    if (mappedFormats != null)
+                    if (mappedFormats is not null)
                     {
                         for (int i = 0; i < mappedFormats.Length; i++)
                         {
                             if (!format.Equals(mappedFormats[i]))
                             {
                                 DataStoreEntry found = (DataStoreEntry)data[mappedFormats[i]];
-                                if (found != null)
+                                if (found is not null)
                                 {
                                     baseVar = found.data;
                                 }
-                                if (baseVar != null && !(baseVar is MemoryStream))
+                                if (baseVar is not null && !(baseVar is MemoryStream))
                                 {
                                     original = null;
                                     break;
@@ -82,7 +82,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (original != null)
+                if (original is not null)
                 {
                     return original;
                 }
@@ -186,17 +186,17 @@ namespace System.Windows.Forms
 
                 if (!autoConvert)
                 {
-                    Debug.Assert(data != null, "data must be non-null");
+                    Debug.Assert(data is not null, "data must be non-null");
                     return data.ContainsKey(format);
                 }
                 else
                 {
                     string[] formats = GetFormats(autoConvert);
                     Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "DataStore:  got " + formats.Length.ToString(CultureInfo.InvariantCulture) + " formats from get formats");
-                    Debug.Assert(formats != null, "Null returned from GetFormats");
+                    Debug.Assert(formats is not null, "Null returned from GetFormats");
                     for (int i = 0; i < formats.Length; i++)
                     {
-                        Debug.Assert(formats[i] != null, "Null format inside of formats at index " + i.ToString(CultureInfo.InvariantCulture));
+                        Debug.Assert(formats[i] is not null, "Null format inside of formats at index " + i.ToString(CultureInfo.InvariantCulture));
                         if (format.Equals(formats[i]))
                         {
                             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "DataStore: GetDataPresent: returning true");
@@ -217,12 +217,12 @@ namespace System.Windows.Forms
             public virtual string[] GetFormats(bool autoConvert)
             {
                 Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "DataStore: GetFormats: " + autoConvert.ToString());
-                Debug.Assert(data != null, "data collection can't be null");
-                Debug.Assert(data.Keys != null, "data Keys collection can't be null");
+                Debug.Assert(data is not null, "data collection can't be null");
+                Debug.Assert(data.Keys is not null, "data Keys collection can't be null");
 
                 string[] baseVar = new string[data.Keys.Count];
                 data.Keys.CopyTo(baseVar, 0);
-                Debug.Assert(baseVar != null, "Collections should never return NULL arrays!!!");
+                Debug.Assert(baseVar is not null, "Collections should never return NULL arrays!!!");
                 if (autoConvert)
                 {
                     Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "DataStore: applying autoConvert");
@@ -232,11 +232,11 @@ namespace System.Windows.Forms
                     HashSet<string> distinctFormats = new HashSet<string>(baseVarLength);
                     for (int i = 0; i < baseVarLength; i++)
                     {
-                        Debug.Assert(data[baseVar[i]] != null, "Null item in data collection with key '" + baseVar[i] + "'");
+                        Debug.Assert(data[baseVar[i]] is not null, "Null item in data collection with key '" + baseVar[i] + "'");
                         if (((DataStoreEntry)data[baseVar[i]]).autoConvert)
                         {
                             string[] cur = GetMappedFormats(baseVar[i]);
-                            Debug.Assert(cur != null, "GetMappedFormats returned null for '" + baseVar[i] + "'");
+                            Debug.Assert(cur is not null, "GetMappedFormats returned null for '" + baseVar[i] + "'");
                             for (int j = 0; j < cur.Length; j++)
                             {
                                 distinctFormats.Add(cur[j]);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.FormatEnumerator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.FormatEnumerator.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms
 
                 _parent = parent;
 
-                if (formats != null)
+                if (formats is not null)
                 {
                     for (int i = 0; i < formats.Length; i++)
                     {
@@ -91,7 +91,7 @@ namespace System.Windows.Forms
                     rgelt[0].ptd = IntPtr.Zero;
                     rgelt[0].lindex = -1;
 
-                    if (pceltFetched != null)
+                    if (pceltFetched is not null)
                     {
                         pceltFetched[0] = 1;
                     }
@@ -99,7 +99,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    if (pceltFetched != null)
+                    if (pceltFetched is not null)
                     {
                         pceltFetched[0] = 0;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -106,7 +106,7 @@ namespace System.Windows.Forms
                     if (hglobal != IntPtr.Zero)
                         Kernel32.GlobalFree(hglobal);
 
-                    if (pStream != null)
+                    if (pStream is not null)
                         Marshal.ReleaseComObject(pStream);
 
                     Ole32.ReleaseStgMedium(ref medium);
@@ -165,7 +165,7 @@ namespace System.Windows.Forms
             private object GetDataFromOleHGLOBAL(string format, out bool done)
             {
                 done = false;
-                Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+                Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
 
                 FORMATETC formatetc = new FORMATETC();
                 STGMEDIUM medium = new STGMEDIUM();
@@ -210,7 +210,7 @@ namespace System.Windows.Forms
             /// </summary>
             private object GetDataFromOleOther(string format)
             {
-                Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+                Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
 
                 FORMATETC formatetc = new FORMATETC();
                 STGMEDIUM medium = new STGMEDIUM();
@@ -257,7 +257,7 @@ namespace System.Windows.Forms
                             // This bitmap is created by the com object which originally copied the bitmap to the
                             // clipboard. We call Add here, since DeleteObject calls Remove.
                             Image clipboardImage = Image.FromHbitmap(medium.unionmember);
-                            if (clipboardImage != null)
+                            if (clipboardImage is not null)
                             {
                                 Image firstImage = clipboardImage;
                                 clipboardImage = (Image)clipboardImage.Clone();
@@ -468,14 +468,14 @@ namespace System.Windows.Forms
                 if (!done && autoConvert && (baseVar is null || baseVar is MemoryStream))
                 {
                     string[] mappedFormats = GetMappedFormats(format);
-                    if (mappedFormats != null)
+                    if (mappedFormats is not null)
                     {
                         for (int i = 0; ((!done) && (i < mappedFormats.Length)); i++)
                         {
                             if (!format.Equals(mappedFormats[i]))
                             {
                                 baseVar = GetDataFromBoundOleDataObject(mappedFormats[i], out done);
-                                if (!done && baseVar != null && !(baseVar is MemoryStream))
+                                if (!done && baseVar is not null && !(baseVar is MemoryStream))
                                 {
                                     original = null;
                                     break;
@@ -485,7 +485,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                if (original != null)
+                if (original is not null)
                 {
                     return original;
                 }
@@ -548,7 +548,7 @@ namespace System.Windows.Forms
 
             private bool GetDataPresentInner(string format)
             {
-                Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+                Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
                 FORMATETC formatetc = new FORMATETC
                 {
                     cfFormat = unchecked((short)(ushort)(DataFormats.GetFormat(format).Id)),
@@ -572,7 +572,7 @@ namespace System.Windows.Forms
                 if (!baseVar && autoConvert)
                 {
                     string[] mappedFormats = GetMappedFormats(format);
-                    if (mappedFormats != null)
+                    if (mappedFormats is not null)
                     {
                         for (int i = 0; i < mappedFormats.Length; i++)
                         {
@@ -597,7 +597,7 @@ namespace System.Windows.Forms
 
             public virtual string[] GetFormats(bool autoConvert)
             {
-                Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+                Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
 
                 IEnumFORMATETC enumFORMATETC = null;
 
@@ -611,7 +611,7 @@ namespace System.Windows.Forms
                 {
                 }
 
-                if (enumFORMATETC != null)
+                if (enumFORMATETC is not null)
                 {
                     enumFORMATETC.Reset();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -53,7 +53,7 @@ namespace System.Windows.Forms
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Constructed DataObject based on IDataObject");
             innerData = data;
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace System.Windows.Forms
                 Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Constructed DataObject based on IComDataObject");
                 innerData = new OleConverter(data);
             }
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace System.Windows.Forms
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Constructed DataObject standalone");
             innerData = new DataStore();
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace System.Windows.Forms
                 innerData = new DataStore();
                 SetData(data);
             }
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace System.Windows.Forms
         public DataObject(string format, object data) : this()
         {
             SetData(format, data);
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
         }
 
         private Gdi32.HBITMAP GetCompatibleBitmap(Bitmap bm)
@@ -157,7 +157,7 @@ namespace System.Windows.Forms
         public virtual object GetData(string format, bool autoConvert)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Request data: " + format + ", " + autoConvert.ToString());
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
             return innerData.GetData(format, autoConvert);
         }
 
@@ -212,7 +212,7 @@ namespace System.Windows.Forms
         public virtual bool GetDataPresent(string format, bool autoConvert)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Check data: " + format + ", " + autoConvert.ToString());
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
             bool b = innerData.GetDataPresent(format, autoConvert);
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "  ret: " + b.ToString());
             return b;
@@ -241,7 +241,7 @@ namespace System.Windows.Forms
         public virtual string[] GetFormats(bool autoConvert)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Check formats: " + autoConvert.ToString());
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
             return innerData.GetFormats(autoConvert);
         }
 
@@ -486,7 +486,7 @@ namespace System.Windows.Forms
                     else if ((formatetc.tymed & TYMED.TYMED_GDI) != 0)
                     {
                         if (format.Equals(DataFormats.Bitmap) && data is Bitmap bm
-                            && bm != null)
+                            && bm is not null)
                         {
                             // save bitmap
                             medium.unionmember = (IntPtr)GetCompatibleBitmap(bm);
@@ -771,7 +771,7 @@ namespace System.Windows.Forms
             }
             else if (format.Equals(DataFormats.Serializable)
                      || data is ISerializable
-                     || (data != null && data.GetType().IsSerializable))
+                     || (data is not null && data.GetType().IsSerializable))
             {
                 hr = SaveObjectToHandle(ref medium.unionmember, data, DataObject.RestrictDeserializationToSafeTypes(format));
             }
@@ -1019,7 +1019,7 @@ namespace System.Windows.Forms
         public virtual void SetData(string format, bool autoConvert, object data)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Set data: " + format + ", " + autoConvert.ToString() + ", " + data?.ToString() ?? "(null)");
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
             innerData.SetData(format, autoConvert, data);
         }
 
@@ -1030,7 +1030,7 @@ namespace System.Windows.Forms
         public virtual void SetData(string format, object data)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Set data: " + format + ", " + data?.ToString() ?? "(null)");
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
             innerData.SetData(format, data);
         }
 
@@ -1042,7 +1042,7 @@ namespace System.Windows.Forms
         public virtual void SetData(Type format, object data)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Set data: " + format?.FullName ?? "(null)" + ", " + data?.ToString() ?? "(null)");
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
             innerData.SetData(format, data);
         }
 
@@ -1053,7 +1053,7 @@ namespace System.Windows.Forms
         public virtual void SetData(object data)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Set data: " + data?.ToString() ?? "(null)");
-            Debug.Assert(innerData != null, "You must have an innerData on all DataObjects");
+            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
             innerData.SetData(data);
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
@@ -175,7 +175,7 @@ namespace System.Windows.Forms
         {
             try
             {
-                if (disposing && comStream != null)
+                if (disposing && comStream is not null)
                 {
                     try
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
                     // This code was copied from the Everett sources.
                     Label previousLabel = PreviousLabel;
 
-                    if (previousLabel != null)
+                    if (previousLabel is not null)
                     {
                         char previousLabelMnemonic = WindowsFormsUtils.GetMnemonic(previousLabel.Text, false /*convertToUpperCase*/);
                         if (previousLabelMnemonic != (char)0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -237,7 +237,7 @@ namespace System.Windows.Forms
 
             set
             {
-                if ((value is null && calendarFont != null) || (value != null && !value.Equals(calendarFont)))
+                if ((value is null && calendarFont is not null) || (value is not null && !value.Equals(calendarFont)))
                 {
                     calendarFont = value;
                     calendarFontHandleWrapper = null;
@@ -486,8 +486,8 @@ namespace System.Windows.Forms
 
             set
             {
-                if ((value != null && !value.Equals(customFormat)) ||
-                    (value is null && customFormat != null))
+                if ((value is not null && !value.Equals(customFormat)) ||
+                    (value is null && customFormat is not null))
                 {
                     customFormat = value;
 
@@ -1406,7 +1406,7 @@ namespace System.Windows.Forms
         /// </summary>
         private bool ShouldSerializeCalendarFont()
         {
-            return calendarFont != null;
+            return calendarFont is not null;
         }
 
         /// <summary>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/winforms/issues/3459

## Proposed changes

- Use 'is not null' in some System.Windows.Forms files.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4425)