### PR TITLE
Implemented ScrollItemPattern for ComboBoxItemAccessibleObject (port to 5.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -4659,6 +4659,8 @@ namespace System.Windows.Forms
                         return false;
                     case UiaCore.UIA.IsOffscreenPropertyId:
                         return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
+                    case UiaCore.UIA.IsScrollItemPatternAvailablePropertyId:
+                        return IsPatternSupported(UiaCore.UIA.ScrollItemPatternId);
                     case UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId:
                         return true;
                     case UiaCore.UIA.SelectionItemIsSelectedPropertyId:
@@ -4685,6 +4687,7 @@ namespace System.Windows.Forms
             {
                 if (patternId == UiaCore.UIA.LegacyIAccessiblePatternId ||
                     patternId == UiaCore.UIA.InvokePatternId ||
+                    patternId == UiaCore.UIA.ScrollItemPatternId ||
                     patternId == UiaCore.UIA.SelectionItemPatternId)
                 {
                     return true;
@@ -4767,6 +4770,23 @@ namespace System.Windows.Forms
                 RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
 
                 base.SetFocus();
+            }
+
+            internal override void ScrollIntoView()
+            {
+                if (!_owningComboBox.IsHandleCreated || !_owningComboBox.Enabled)
+                {
+                    return;
+                }
+
+                Rectangle listBounds = _owningComboBox.ChildListAccessibleObject.BoundingRectangle;
+                if (listBounds.IntersectsWith(Bounds))
+                {
+                    // Do nothing because the item is already visible
+                    return;
+                }
+
+                User32.SendMessageW(_owningComboBox, (User32.WM)User32.CB.SETTOPINDEX, (IntPtr)GetCurrentIndex());
             }
 
             internal unsafe override void SelectItem()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -4556,16 +4556,21 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    ChildAccessibleObject listAccessibleObject = _owningComboBox.ChildListAccessibleObject;
                     int currentIndex = GetCurrentIndex();
+                    IntPtr listHandle = _owningComboBox.GetListHandle();
+                    RECT itemRect = new RECT();
+                    int result = unchecked((int)(long)User32.SendMessageW(
+                        listHandle, (User32.WM)User32.LB.GETITEMRECT, (IntPtr)currentIndex, ref itemRect));
 
-                    Rectangle parentRect = listAccessibleObject.BoundingRectangle;
-                    int left = parentRect.Left;
-                    int top = parentRect.Top + _owningComboBox.ItemHeight * currentIndex;
-                    int width = parentRect.Width;
-                    int height = _owningComboBox.ItemHeight;
+                    if (result == User32.LB_ERR)
+                    {
+                        return Rectangle.Empty;
+                    }
 
-                    return new Rectangle(left, top, width, height);
+                    // Translate the item rect to screen coordinates
+                    User32.MapWindowPoints(listHandle, IntPtr.Zero, ref itemRect, 2);
+
+                    return itemRect;
                 }
             }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
@@ -10,6 +10,7 @@ namespace System.Windows.Forms.IntegrationTests.Common
         CalendarButton,
         MultipleControlsButton,
         ComboBoxesButton,
+        ComboBoxesWithScrollBarsButton,
         DateTimePickerButton,
         FolderBrowserDialogButton,
         ThreadExceptionDialogButton,

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxesWithScrollBars.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxesWithScrollBars.Designer.cs
@@ -1,0 +1,405 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace WinformsControlsTest
+{
+    partial class ComboBoxesWithScrollBars
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.comboBox1 = new System.Windows.Forms.ComboBox();
+            this.comboBox2 = new System.Windows.Forms.ComboBox();
+            this.comboBox3 = new System.Windows.Forms.ComboBox();
+            this.changeHeightGroupBox1 = new System.Windows.Forms.GroupBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.changeDDH_UpDown1 = new System.Windows.Forms.NumericUpDown();
+            this.label2 = new System.Windows.Forms.Label();
+            this.changeCBHeight_UpDown2 = new System.Windows.Forms.NumericUpDown();
+            this.label3 = new System.Windows.Forms.Label();
+            this.changeDDH_UpDown3 = new System.Windows.Forms.NumericUpDown();
+            this.changeMaxDropDownItemsGroupBox2 = new System.Windows.Forms.GroupBox();
+            this.maxDropDownItemsUpDown1 = new System.Windows.Forms.NumericUpDown();
+            this.maxDropDownItemsUpDown2 = new System.Windows.Forms.NumericUpDown();
+            this.maxDropDownItemsUpDown3 = new System.Windows.Forms.NumericUpDown();
+            this.changeIntegralHeightGroupBox3 = new System.Windows.Forms.GroupBox();
+            this.integralHeightCheckBox1 = new System.Windows.Forms.CheckBox();
+            this.integralHeightCheckBox2 = new System.Windows.Forms.CheckBox();
+            this.integralHeightCheckBox3 = new System.Windows.Forms.CheckBox();
+            this.changeHeightsStyleGroupBox4 = new System.Windows.Forms.GroupBox();
+            this.useDifferentHeightsCheckBox1 = new System.Windows.Forms.CheckBox();
+            this.useDifferentHeightsCheckBox2 = new System.Windows.Forms.CheckBox();
+            this.useDifferentHeightsCheckBox3 = new System.Windows.Forms.CheckBox();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.changeHeightGroupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.changeDDH_UpDown1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.changeCBHeight_UpDown2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.changeDDH_UpDown3)).BeginInit();
+            this.changeMaxDropDownItemsGroupBox2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.maxDropDownItemsUpDown1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.maxDropDownItemsUpDown2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.maxDropDownItemsUpDown3)).BeginInit();
+            this.changeIntegralHeightGroupBox3.SuspendLayout();
+            this.changeHeightsStyleGroupBox4.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // comboBox1
+            // 
+            this.comboBox1.FormattingEnabled = true;
+            this.comboBox1.IntegralHeight = false;
+            this.comboBox1.Location = new System.Drawing.Point(37, 348);
+            this.comboBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBox1.Name = "comboBox1";
+            this.comboBox1.Size = new System.Drawing.Size(116, 23);
+            this.comboBox1.TabIndex = 0;
+            this.comboBox1.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.comboBox_DrawItem);
+            // 
+            // comboBox2
+            // 
+            this.comboBox2.DropDownStyle = System.Windows.Forms.ComboBoxStyle.Simple;
+            this.comboBox2.FormattingEnabled = true;
+            this.comboBox2.IntegralHeight = false;
+            this.comboBox2.Location = new System.Drawing.Point(206, 348);
+            this.comboBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBox2.Name = "comboBox2";
+            this.comboBox2.Size = new System.Drawing.Size(116, 155);
+            this.comboBox2.TabIndex = 1;
+            this.comboBox2.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.comboBox_DrawItem);
+            // 
+            // comboBox3
+            // 
+            this.comboBox3.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBox3.FormattingEnabled = true;
+            this.comboBox3.IntegralHeight = false;
+            this.comboBox3.Location = new System.Drawing.Point(370, 348);
+            this.comboBox3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBox3.Name = "comboBox3";
+            this.comboBox3.Size = new System.Drawing.Size(116, 23);
+            this.comboBox3.TabIndex = 2;
+            this.comboBox3.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.comboBox_DrawItem);
+            // 
+            // changeHeightGroupBox1
+            // 
+            this.changeHeightGroupBox1.Controls.Add(this.label1);
+            this.changeHeightGroupBox1.Controls.Add(this.changeDDH_UpDown1);
+            this.changeHeightGroupBox1.Controls.Add(this.label2);
+            this.changeHeightGroupBox1.Controls.Add(this.changeCBHeight_UpDown2);
+            this.changeHeightGroupBox1.Controls.Add(this.label3);
+            this.changeHeightGroupBox1.Controls.Add(this.changeDDH_UpDown3);
+            this.changeHeightGroupBox1.Location = new System.Drawing.Point(14, 14);
+            this.changeHeightGroupBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeHeightGroupBox1.Name = "changeHeightGroupBox1";
+            this.changeHeightGroupBox1.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeHeightGroupBox1.Size = new System.Drawing.Size(502, 100);
+            this.changeHeightGroupBox1.TabIndex = 3;
+            this.changeHeightGroupBox1.TabStop = false;
+            this.changeHeightGroupBox1.Text = "Change a height";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(23, 28);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(100, 30);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Change \r\nDropDownHeight";
+            // 
+            // changeDDH_UpDown1
+            // 
+            this.changeDDH_UpDown1.Location = new System.Drawing.Point(23, 61);
+            this.changeDDH_UpDown1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeDDH_UpDown1.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.changeDDH_UpDown1.Name = "changeDDH_UpDown1";
+            this.changeDDH_UpDown1.Size = new System.Drawing.Size(117, 23);
+            this.changeDDH_UpDown1.TabIndex = 0;
+            this.toolTip1.SetToolTip(this.changeDDH_UpDown1, "Sets IntegralHeight to false. MaxDropDownItems won\'t be available after it settin" +
+        "g");
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(192, 28);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(106, 30);
+            this.label2.TabIndex = 1;
+            this.label2.Text = "Change \r\nComboBox Height";
+            // 
+            // changeCBHeight_UpDown2
+            // 
+            this.changeCBHeight_UpDown2.Location = new System.Drawing.Point(192, 61);
+            this.changeCBHeight_UpDown2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeCBHeight_UpDown2.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.changeCBHeight_UpDown2.Name = "changeCBHeight_UpDown2";
+            this.changeCBHeight_UpDown2.Size = new System.Drawing.Size(117, 23);
+            this.changeCBHeight_UpDown2.TabIndex = 1;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(356, 28);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(100, 30);
+            this.label3.TabIndex = 2;
+            this.label3.Text = "Change \r\nDropDownHeight";
+            // 
+            // changeDDH_UpDown3
+            // 
+            this.changeDDH_UpDown3.Location = new System.Drawing.Point(356, 61);
+            this.changeDDH_UpDown3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeDDH_UpDown3.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.changeDDH_UpDown3.Name = "changeDDH_UpDown3";
+            this.changeDDH_UpDown3.Size = new System.Drawing.Size(117, 23);
+            this.changeDDH_UpDown3.TabIndex = 2;
+            this.toolTip1.SetToolTip(this.changeDDH_UpDown3, "Sets IntegralHeight to false. MaxDropDownItems won\'t be available after it settin" +
+        "g");
+            // 
+            // changeMaxDropDownItemsGroupBox2
+            // 
+            this.changeMaxDropDownItemsGroupBox2.Controls.Add(this.maxDropDownItemsUpDown1);
+            this.changeMaxDropDownItemsGroupBox2.Controls.Add(this.maxDropDownItemsUpDown2);
+            this.changeMaxDropDownItemsGroupBox2.Controls.Add(this.maxDropDownItemsUpDown3);
+            this.changeMaxDropDownItemsGroupBox2.Location = new System.Drawing.Point(14, 121);
+            this.changeMaxDropDownItemsGroupBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeMaxDropDownItemsGroupBox2.Name = "changeMaxDropDownItemsGroupBox2";
+            this.changeMaxDropDownItemsGroupBox2.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeMaxDropDownItemsGroupBox2.Size = new System.Drawing.Size(502, 63);
+            this.changeMaxDropDownItemsGroupBox2.TabIndex = 4;
+            this.changeMaxDropDownItemsGroupBox2.TabStop = false;
+            this.changeMaxDropDownItemsGroupBox2.Text = "Change MaxDropDownItems value";
+            // 
+            // maxDropDownItemsUpDown1
+            // 
+            this.maxDropDownItemsUpDown1.Location = new System.Drawing.Point(23, 22);
+            this.maxDropDownItemsUpDown1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.maxDropDownItemsUpDown1.Maximum = new decimal(new int[] {
+            40,
+            0,
+            0,
+            0});
+            this.maxDropDownItemsUpDown1.Name = "maxDropDownItemsUpDown1";
+            this.maxDropDownItemsUpDown1.Size = new System.Drawing.Size(117, 23);
+            this.maxDropDownItemsUpDown1.TabIndex = 0;
+            // 
+            // maxDropDownItemsUpDown2
+            // 
+            this.maxDropDownItemsUpDown2.Location = new System.Drawing.Point(192, 22);
+            this.maxDropDownItemsUpDown2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.maxDropDownItemsUpDown2.Maximum = new decimal(new int[] {
+            40,
+            0,
+            0,
+            0});
+            this.maxDropDownItemsUpDown2.Name = "maxDropDownItemsUpDown2";
+            this.maxDropDownItemsUpDown2.Size = new System.Drawing.Size(117, 23);
+            this.maxDropDownItemsUpDown2.TabIndex = 1;
+            this.toolTip1.SetToolTip(this.maxDropDownItemsUpDown2, "It doesn\'t affect the combobox with the Simple dropdown style");
+            // 
+            // maxDropDownItemsUpDown3
+            // 
+            this.maxDropDownItemsUpDown3.Location = new System.Drawing.Point(356, 22);
+            this.maxDropDownItemsUpDown3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.maxDropDownItemsUpDown3.Maximum = new decimal(new int[] {
+            40,
+            0,
+            0,
+            0});
+            this.maxDropDownItemsUpDown3.Name = "maxDropDownItemsUpDown3";
+            this.maxDropDownItemsUpDown3.Size = new System.Drawing.Size(117, 23);
+            this.maxDropDownItemsUpDown3.TabIndex = 2;
+            // 
+            // changeIntegralHeightGroupBox3
+            // 
+            this.changeIntegralHeightGroupBox3.Controls.Add(this.integralHeightCheckBox1);
+            this.changeIntegralHeightGroupBox3.Controls.Add(this.integralHeightCheckBox2);
+            this.changeIntegralHeightGroupBox3.Controls.Add(this.integralHeightCheckBox3);
+            this.changeIntegralHeightGroupBox3.Location = new System.Drawing.Point(14, 192);
+            this.changeIntegralHeightGroupBox3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeIntegralHeightGroupBox3.Name = "changeIntegralHeightGroupBox3";
+            this.changeIntegralHeightGroupBox3.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeIntegralHeightGroupBox3.Size = new System.Drawing.Size(502, 63);
+            this.changeIntegralHeightGroupBox3.TabIndex = 5;
+            this.changeIntegralHeightGroupBox3.TabStop = false;
+            this.changeIntegralHeightGroupBox3.Text = "Change IntegralHeight value";
+            // 
+            // integralHeightCheckBox1
+            // 
+            this.integralHeightCheckBox1.AutoSize = true;
+            this.integralHeightCheckBox1.Location = new System.Drawing.Point(23, 33);
+            this.integralHeightCheckBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.integralHeightCheckBox1.Name = "integralHeightCheckBox1";
+            this.integralHeightCheckBox1.Size = new System.Drawing.Size(102, 19);
+            this.integralHeightCheckBox1.TabIndex = 0;
+            this.integralHeightCheckBox1.Text = "IntegralHeight";
+            this.integralHeightCheckBox1.UseVisualStyleBackColor = true;
+            // 
+            // integralHeightCheckBox2
+            // 
+            this.integralHeightCheckBox2.AutoSize = true;
+            this.integralHeightCheckBox2.Location = new System.Drawing.Point(192, 33);
+            this.integralHeightCheckBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.integralHeightCheckBox2.Name = "integralHeightCheckBox2";
+            this.integralHeightCheckBox2.Size = new System.Drawing.Size(102, 19);
+            this.integralHeightCheckBox2.TabIndex = 1;
+            this.integralHeightCheckBox2.Text = "IntegralHeight";
+            this.integralHeightCheckBox2.UseVisualStyleBackColor = true;
+            // 
+            // integralHeightCheckBox3
+            // 
+            this.integralHeightCheckBox3.AutoSize = true;
+            this.integralHeightCheckBox3.Location = new System.Drawing.Point(356, 33);
+            this.integralHeightCheckBox3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.integralHeightCheckBox3.Name = "integralHeightCheckBox3";
+            this.integralHeightCheckBox3.Size = new System.Drawing.Size(102, 19);
+            this.integralHeightCheckBox3.TabIndex = 2;
+            this.integralHeightCheckBox3.Text = "IntegralHeight";
+            this.integralHeightCheckBox3.UseVisualStyleBackColor = true;
+            // 
+            // changeHeightsStyleGroupBox4
+            // 
+            this.changeHeightsStyleGroupBox4.Controls.Add(this.useDifferentHeightsCheckBox1);
+            this.changeHeightsStyleGroupBox4.Controls.Add(this.useDifferentHeightsCheckBox2);
+            this.changeHeightsStyleGroupBox4.Controls.Add(this.useDifferentHeightsCheckBox3);
+            this.changeHeightsStyleGroupBox4.Location = new System.Drawing.Point(14, 262);
+            this.changeHeightsStyleGroupBox4.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeHeightsStyleGroupBox4.Name = "changeHeightsStyleGroupBox4";
+            this.changeHeightsStyleGroupBox4.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.changeHeightsStyleGroupBox4.Size = new System.Drawing.Size(502, 63);
+            this.changeHeightsStyleGroupBox4.TabIndex = 6;
+            this.changeHeightsStyleGroupBox4.TabStop = false;
+            this.changeHeightsStyleGroupBox4.Text = "Change items heights style";
+            // 
+            // useDifferentHeightsCheckBox1
+            // 
+            this.useDifferentHeightsCheckBox1.AutoSize = true;
+            this.useDifferentHeightsCheckBox1.Location = new System.Drawing.Point(23, 33);
+            this.useDifferentHeightsCheckBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.useDifferentHeightsCheckBox1.Name = "useDifferentHeightsCheckBox1";
+            this.useDifferentHeightsCheckBox1.Size = new System.Drawing.Size(135, 19);
+            this.useDifferentHeightsCheckBox1.TabIndex = 0;
+            this.useDifferentHeightsCheckBox1.Text = "Use different heights";
+            this.useDifferentHeightsCheckBox1.UseVisualStyleBackColor = true;
+            // 
+            // useDifferentHeightsCheckBox2
+            // 
+            this.useDifferentHeightsCheckBox2.AutoSize = true;
+            this.useDifferentHeightsCheckBox2.Location = new System.Drawing.Point(192, 33);
+            this.useDifferentHeightsCheckBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.useDifferentHeightsCheckBox2.Name = "useDifferentHeightsCheckBox2";
+            this.useDifferentHeightsCheckBox2.Size = new System.Drawing.Size(135, 19);
+            this.useDifferentHeightsCheckBox2.TabIndex = 1;
+            this.useDifferentHeightsCheckBox2.Text = "Use different heights";
+            this.useDifferentHeightsCheckBox2.UseVisualStyleBackColor = true;
+            // 
+            // useDifferentHeightsCheckBox3
+            // 
+            this.useDifferentHeightsCheckBox3.AutoSize = true;
+            this.useDifferentHeightsCheckBox3.Location = new System.Drawing.Point(356, 33);
+            this.useDifferentHeightsCheckBox3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.useDifferentHeightsCheckBox3.Name = "useDifferentHeightsCheckBox3";
+            this.useDifferentHeightsCheckBox3.Size = new System.Drawing.Size(135, 19);
+            this.useDifferentHeightsCheckBox3.TabIndex = 2;
+            this.useDifferentHeightsCheckBox3.Text = "Use different heights";
+            this.toolTip1.SetToolTip(this.useDifferentHeightsCheckBox3, "Changes DropDownList dropdown style to DropDown in view.\nIt is impossible to retu" +
+        "rn DropDownList style for the combobox");
+            this.useDifferentHeightsCheckBox3.UseVisualStyleBackColor = true;
+            // 
+            // ComboBoxesWithScrollBars
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(531, 517);
+            this.Controls.Add(this.changeHeightGroupBox1);
+            this.Controls.Add(this.changeMaxDropDownItemsGroupBox2);
+            this.Controls.Add(this.changeIntegralHeightGroupBox3);
+            this.Controls.Add(this.changeHeightsStyleGroupBox4);
+            this.Controls.Add(this.comboBox1);
+            this.Controls.Add(this.comboBox2);
+            this.Controls.Add(this.comboBox3);
+            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.Name = "ComboBoxesWithScrollBars";
+            this.Text = "ComboBoxes with ScrollBars";
+            this.changeHeightGroupBox1.ResumeLayout(false);
+            this.changeHeightGroupBox1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.changeDDH_UpDown1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.changeCBHeight_UpDown2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.changeDDH_UpDown3)).EndInit();
+            this.changeMaxDropDownItemsGroupBox2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.maxDropDownItemsUpDown1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.maxDropDownItemsUpDown2)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.maxDropDownItemsUpDown3)).EndInit();
+            this.changeIntegralHeightGroupBox3.ResumeLayout(false);
+            this.changeIntegralHeightGroupBox3.PerformLayout();
+            this.changeHeightsStyleGroupBox4.ResumeLayout(false);
+            this.changeHeightsStyleGroupBox4.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ComboBox comboBox1;
+        private System.Windows.Forms.ComboBox comboBox2;
+        private System.Windows.Forms.ComboBox comboBox3;
+        private System.Windows.Forms.GroupBox changeHeightGroupBox1;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.NumericUpDown changeDDH_UpDown1;
+        private System.Windows.Forms.NumericUpDown changeCBHeight_UpDown2;
+        private System.Windows.Forms.NumericUpDown changeDDH_UpDown3;
+        private System.Windows.Forms.GroupBox changeMaxDropDownItemsGroupBox2;
+        private System.Windows.Forms.NumericUpDown maxDropDownItemsUpDown1;
+        private System.Windows.Forms.NumericUpDown maxDropDownItemsUpDown2;
+        private System.Windows.Forms.NumericUpDown maxDropDownItemsUpDown3;
+        private System.Windows.Forms.GroupBox changeIntegralHeightGroupBox3;
+        private System.Windows.Forms.CheckBox integralHeightCheckBox2;
+        private System.Windows.Forms.CheckBox integralHeightCheckBox1;
+        private System.Windows.Forms.CheckBox integralHeightCheckBox3;
+        private System.Windows.Forms.GroupBox changeHeightsStyleGroupBox4;
+        private System.Windows.Forms.CheckBox useDifferentHeightsCheckBox3;
+        private System.Windows.Forms.CheckBox useDifferentHeightsCheckBox2;
+        private System.Windows.Forms.CheckBox useDifferentHeightsCheckBox1;
+        private System.Windows.Forms.ToolTip toolTip1;
+    }
+}
+

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxesWithScrollBars.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxesWithScrollBars.cs
@@ -1,0 +1,149 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    public partial class ComboBoxesWithScrollBars : Form
+    {
+        public ComboBoxesWithScrollBars()
+        {
+            InitializeComponent();
+
+            // Init comboboxes
+            for (int i = 0; i <= 40; i++)
+            {
+                comboBox1.Items.Add(i);
+                comboBox2.Items.Add(i);
+                comboBox3.Items.Add(i);
+            }
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            // Set current NumericUpDowns values to heights
+            changeDDH_UpDown1.Value = comboBox1.DropDownHeight;
+            changeCBHeight_UpDown2.Value = comboBox2.Size.Height;
+            changeDDH_UpDown3.Value = comboBox3.DropDownHeight;
+
+            // Set current NumericUpDowns values to MaxDropDownItems values
+            maxDropDownItemsUpDown1.Value = comboBox1.MaxDropDownItems;
+            maxDropDownItemsUpDown2.Value = comboBox2.MaxDropDownItems;
+            maxDropDownItemsUpDown3.Value = comboBox3.MaxDropDownItems;
+
+            // Set current CheckBoxes values to IntegralHeight values
+            integralHeightCheckBox1.Checked = comboBox1.IntegralHeight;
+            integralHeightCheckBox2.Checked = comboBox2.IntegralHeight;
+            integralHeightCheckBox3.Checked = comboBox3.IntegralHeight;
+
+            // Set current CheckBoxes values to DrawMode values
+            useDifferentHeightsCheckBox1.Checked = comboBox1.DrawMode == DrawMode.OwnerDrawVariable;
+            useDifferentHeightsCheckBox2.Checked = comboBox2.DrawMode == DrawMode.OwnerDrawVariable;
+            useDifferentHeightsCheckBox3.Checked = comboBox3.DrawMode == DrawMode.OwnerDrawVariable;
+
+            // Add event handlers
+            // These handlers are not added to the designer and put here to avoid redundant invocations
+            // when the values of the upDowns and checkBoxes are set above.
+            // These handlers should be invoked when a user changes the upDowns and checkBoxes values only.
+            changeDDH_UpDown1.ValueChanged += (s, e) =>
+            {
+                comboBox1.DropDownHeight = (int)changeDDH_UpDown1.Value;
+                integralHeightCheckBox1.Checked = false;
+            };
+            changeCBHeight_UpDown2.ValueChanged += (s, e) => comboBox2.Size = new Size(comboBox2.Size.Width, (int)changeCBHeight_UpDown2.Value);
+            changeDDH_UpDown3.ValueChanged += (s, e) =>
+            {
+                comboBox3.DropDownHeight = (int)changeDDH_UpDown3.Value;
+                integralHeightCheckBox3.Checked = false;
+            };
+            maxDropDownItemsUpDown1.ValueChanged += (s, e) => comboBox1.MaxDropDownItems = (int)maxDropDownItemsUpDown1.Value;
+            maxDropDownItemsUpDown2.ValueChanged += (s, e) => comboBox2.MaxDropDownItems = (int)maxDropDownItemsUpDown2.Value;
+            maxDropDownItemsUpDown3.ValueChanged += (s, e) => comboBox3.MaxDropDownItems = (int)maxDropDownItemsUpDown3.Value;
+            integralHeightCheckBox1.CheckedChanged += (s, e) => comboBox1.IntegralHeight = integralHeightCheckBox1.Checked;
+            integralHeightCheckBox2.CheckedChanged += (s, e) => comboBox2.IntegralHeight = integralHeightCheckBox2.Checked;
+            integralHeightCheckBox3.CheckedChanged += (s, e) => comboBox3.IntegralHeight = integralHeightCheckBox3.Checked;
+            useDifferentHeightsCheckBox1.CheckedChanged += useDifferentHeightsCheckBox1_CheckedChanged;
+            useDifferentHeightsCheckBox2.CheckedChanged += useDifferentHeightsCheckBox2_CheckedChanged;
+            useDifferentHeightsCheckBox3.CheckedChanged += useDifferentHeightsCheckBox3_CheckedChanged;
+
+            base.OnLoad(e);
+        }
+
+        private void useDifferentHeightsCheckBox1_CheckedChanged(object sender, EventArgs e)
+        {
+            bool isChecked = useDifferentHeightsCheckBox1.Checked;
+
+            if (isChecked)
+            {
+                comboBox1.DrawMode = DrawMode.OwnerDrawVariable;
+                comboBox1.MeasureItem += comboBox_MeasureItem;
+            }
+            else
+            {
+                comboBox1.DrawMode = DrawMode.OwnerDrawFixed;
+                comboBox1.MeasureItem -= comboBox_MeasureItem;
+            }
+        }
+
+        private void useDifferentHeightsCheckBox2_CheckedChanged(object sender, EventArgs e)
+        {
+            bool isChecked = useDifferentHeightsCheckBox2.Checked;
+
+            if (isChecked)
+            {
+                comboBox2.DrawMode = DrawMode.OwnerDrawVariable;
+                comboBox2.MeasureItem += comboBox_MeasureItem;
+            }
+            else
+            {
+                comboBox2.DrawMode = DrawMode.OwnerDrawFixed;
+                comboBox2.MeasureItem -= comboBox_MeasureItem;
+            }
+        }
+
+        private void useDifferentHeightsCheckBox3_CheckedChanged(object sender, EventArgs e)
+        {
+            bool isChecked = useDifferentHeightsCheckBox3.Checked;
+
+            if (isChecked)
+            {
+                comboBox3.SuspendLayout();
+                comboBox3.DrawMode = DrawMode.OwnerDrawVariable;
+                comboBox3.MeasureItem += comboBox_MeasureItem;
+                comboBox3.ResumeLayout(false);
+            }
+            else
+            {
+                comboBox3.SuspendLayout();
+                comboBox3.DrawMode = DrawMode.OwnerDrawFixed;
+                comboBox3.MeasureItem -= comboBox_MeasureItem;
+                comboBox3.ResumeLayout(false);
+            }
+        }
+
+        private void comboBox_MeasureItem(object sender, MeasureItemEventArgs e) => e.ItemHeight = 15 + (e.Index % 5) * 5;
+
+        private void comboBox_DrawItem(object sender, DrawItemEventArgs e)
+        {
+            ComboBox control = (ComboBox)sender;
+
+            if (e.Index < 0 || e.Index >= control.Items.Count)
+            {
+                return;
+            }
+
+            e.DrawBackground();
+            using SolidBrush brush = new SolidBrush(e.ForeColor);
+            e.Graphics.DrawString(
+                control.Items[e.Index].ToString(),
+                e.Font,
+                brush,
+                e.Bounds);
+            e.DrawFocusRectangle();
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxesWithScrollBars.resx
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ComboBoxesWithScrollBars.resx
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -67,6 +67,10 @@ namespace WinformsControlsTest
                 new InitInfo("ComboBoxes", (obj, e) => new ComboBoxes().Show())
             },
             {
+                MainFormControlsTabOrder.ComboBoxesWithScrollBarsButton,
+                new InitInfo("ComboBoxes with ScrollBars", (obj, e) => new ComboBoxesWithScrollBars().Show())
+            },
+            {
                 MainFormControlsTabOrder.DateTimePickerButton,
                 new InitInfo("DateTimePicker", (obj, e) => new DateTimePicker().Show())
             },

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
@@ -135,7 +135,7 @@ namespace System.Windows.Forms.Tests
 
             if (comboBoxStyle == ComboBoxStyle.Simple)
             {
-                comboBox.Size = new Drawing.Size(100, 132);
+                comboBox.Size = new Size(100, 132);
             }
             else
             {
@@ -187,7 +187,7 @@ namespace System.Windows.Forms.Tests
 
             if (comboBoxStyle == ComboBoxStyle.Simple)
             {
-                comboBox.Size = new Drawing.Size(100, 132);
+                comboBox.Size = new Size(100, 132);
             }
             else
             {
@@ -243,6 +243,143 @@ namespace System.Windows.Forms.Tests
             int actual = unchecked((int)(long)User32.SendMessageW(comboBox, (User32.WM)User32.CB.GETTOPINDEX));
 
             Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> ComboBoxItemAccessibleObject_Bounds_ReturnsCorrect_ForVisibleItems_IfComboBoxIsScrollable_TestData()
+        {
+            foreach (ComboBoxStyle comboBoxStyle in Enum.GetValues(typeof(ComboBoxStyle)))
+            {
+                // The tested combobox contains 11 items
+                for (int index = 0; index < 11; index++)
+                {
+                    int y = index * 15;
+                    int initialYPosition = comboBoxStyle == ComboBoxStyle.Simple ? 56 : 55;
+                    int x = comboBoxStyle == ComboBoxStyle.Simple ? 10 : 9;
+                    Point point = new Point(x, y + initialYPosition);
+                    yield return new object[] { comboBoxStyle, index, point };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ComboBoxItemAccessibleObject_Bounds_ReturnsCorrect_ForVisibleItems_IfComboBoxIsScrollable_TestData))]
+        public void ComboBoxItemAccessibleObject_Bounds_ReturnsCorrect_ForVisibleItems_IfComboBoxIsScrollable(ComboBoxStyle comboBoxStyle, int itemIndex, Point expectedPosition)
+        {
+            using ComboBox comboBox = new ComboBox();
+            comboBox.IntegralHeight = false;
+            comboBox.DropDownStyle = comboBoxStyle;
+            comboBox.Items.AddRange(new[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
+            comboBox.CreateControl();
+
+            if (comboBoxStyle == ComboBoxStyle.Simple)
+            {
+                comboBox.Size = new Size(100, 132);
+            }
+            else
+            {
+                comboBox.Size = new Size(100, comboBox.Size.Height);
+                comboBox.DropDownHeight = 105;
+                comboBox.DroppedDown = true;
+            }
+
+            ComboBoxAccessibleObject comboBoxAccessibleObject = (ComboBoxAccessibleObject)comboBox.AccessibilityObject;
+            ComboBoxItemAccessibleObjectCollection itemsCollection = comboBoxAccessibleObject.ItemAccessibleObjects;
+            object item = comboBox.Items[itemIndex];
+            ComboBoxItemAccessibleObject itemAccessibleObject = (ComboBoxItemAccessibleObject)comboBoxAccessibleObject.ItemAccessibleObjects[item];
+            Rectangle actual = itemAccessibleObject.Bounds;
+            Rectangle dropdownRect = comboBox.ChildListAccessibleObject.Bounds;
+            int itemWidth = comboBoxStyle == ComboBoxStyle.Simple ? 79 : 81;
+
+            Assert.Equal(expectedPosition.X, actual.X);
+            Assert.Equal(expectedPosition.Y, actual.Y);
+            Assert.Equal(itemWidth, actual.Width); // All items are the same width
+            Assert.Equal(15, actual.Height); // All items are the same height
+        }
+
+        public static IEnumerable<object[]> ComboBoxItemAccessibleObject_Bounds_ReturnsCorrect_ForDifferentHeightItems_TestData()
+        {
+            foreach (ComboBoxStyle comboBoxStyle in Enum.GetValues(typeof(ComboBoxStyle)))
+            {
+                // The tested combobox contains 11 items
+                for (int index = 0; index < 11; index++)
+                {
+                    int height = DifferentHeightComboBox.GetCustomItemHeight(index);
+                    int width = comboBoxStyle == ComboBoxStyle.Simple ? 96 : 81;
+                    int x = comboBoxStyle == ComboBoxStyle.Simple ? 10 : 9;
+                    int y = comboBoxStyle == ComboBoxStyle.Simple ? 57 : 56;
+
+                    for (int i = 0; i < index; i++)
+                    {
+                        y += DifferentHeightComboBox.GetCustomItemHeight(i); // Calculate the sum of heights of all items before the current
+                    }
+
+                    yield return new object[] { comboBoxStyle, index, new Rectangle(x, y, width, height) };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ComboBoxItemAccessibleObject_Bounds_ReturnsCorrect_ForDifferentHeightItems_TestData))]
+        public void ComboBoxItemAccessibleObject_Bounds_ReturnsCorrect_ForDifferentHeightItems(ComboBoxStyle comboBoxStyle, int itemIndex, Rectangle expectedRect)
+        {
+            using DifferentHeightComboBox comboBox = new DifferentHeightComboBox();
+            comboBox.DropDownStyle = comboBoxStyle;
+            comboBox.Items.AddRange(new[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
+            comboBox.CreateControl();
+
+            if (comboBoxStyle == ComboBoxStyle.Simple)
+            {
+                comboBox.Size = new Size(100, 400);
+            }
+            else
+            {
+                comboBox.Size = new Size(100, comboBox.Size.Height);
+                comboBox.DropDownHeight = 400;
+                comboBox.DroppedDown = true;
+            }
+
+            ComboBoxAccessibleObject comboBoxAccessibleObject = (ComboBoxAccessibleObject)comboBox.AccessibilityObject;
+            ComboBoxItemAccessibleObjectCollection itemsCollection = comboBoxAccessibleObject.ItemAccessibleObjects;
+            object item = comboBox.Items[itemIndex];
+            ComboBoxItemAccessibleObject itemAccessibleObject = (ComboBoxItemAccessibleObject)comboBoxAccessibleObject.ItemAccessibleObjects[item];
+            Rectangle actual = itemAccessibleObject.Bounds;
+            Rectangle dropdownRect = comboBox.ChildListAccessibleObject.Bounds;
+
+            Assert.Equal(expectedRect, actual);
+        }
+
+        private class DifferentHeightComboBox : ComboBox
+        {
+            public DifferentHeightComboBox() : base()
+            {
+                DrawMode = DrawMode.OwnerDrawVariable;
+            }
+
+            public static int GetCustomItemHeight(int index) => 15 + (index % 5) * 5;
+
+            protected override void OnMeasureItem(MeasureItemEventArgs e)
+            {
+                e.ItemHeight = GetCustomItemHeight(e.Index);
+                base.OnMeasureItem(e);
+            }
+
+            protected override void OnDrawItem(DrawItemEventArgs e)
+            {
+                if (e.Index < 0 || e.Index >= Items.Count)
+                {
+                    return;
+                }
+
+                e.DrawBackground();
+                using var brush = new SolidBrush(e.ForeColor);
+                e.Graphics.DrawString(
+                    Items[e.Index].ToString(),
+                    e.Font,
+                    brush,
+                    e.Bounds);
+                e.DrawFocusRectangle();
+                base.OnDrawItem(e);
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
@@ -2,8 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+using System.Drawing;
 using System.Windows.Forms.IntegrationTests.Common;
 using Xunit;
+using static System.Windows.Forms.ComboBox;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -70,6 +74,175 @@ namespace System.Windows.Forms.Tests
                     Assert.Equal(person.Name, itemAccessibleObject.Name);
                 }
             }
+        }
+
+        [WinFormsFact]
+        public void ComboBoxItemAccessibleObject_IsPatternSupported_ReturnsTrue_ForScrollItemPattern()
+        {
+            using ComboBox comboBox = new ComboBox();
+            comboBox.Items.AddRange(new[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
+            comboBox.CreateControl();
+
+            ComboBoxAccessibleObject comboBoxAccessibleObject = (ComboBoxAccessibleObject)comboBox.AccessibilityObject;
+            ComboBoxItemAccessibleObjectCollection itemsCollection = comboBoxAccessibleObject.ItemAccessibleObjects;
+
+            // Check that all items support ScrollItemPattern
+            foreach (string item in comboBox.Items)
+            {
+                ComboBoxItemAccessibleObject itemAccessibleObject = (ComboBoxItemAccessibleObject)comboBoxAccessibleObject.ItemAccessibleObjects[item];
+
+                Assert.True(itemAccessibleObject.IsPatternSupported(UiaCore.UIA.ScrollItemPatternId));
+            }
+        }
+
+        [WinFormsFact]
+        public void ComboBoxItemAccessibleObject_GetPropertyValue_ScrollItemPattern_IsAvailable()
+        {
+            using ComboBox comboBox = new ComboBox();
+            comboBox.Items.AddRange(new[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
+            comboBox.CreateControl();
+
+            ComboBoxAccessibleObject comboBoxAccessibleObject = (ComboBoxAccessibleObject)comboBox.AccessibilityObject;
+            ComboBoxItemAccessibleObjectCollection itemsCollection = comboBoxAccessibleObject.ItemAccessibleObjects;
+
+            // Check that all items support ScrollItemPattern
+            foreach (string item in comboBox.Items)
+            {
+                ComboBoxItemAccessibleObject itemAccessibleObject = (ComboBoxItemAccessibleObject)comboBoxAccessibleObject.ItemAccessibleObjects[item];
+
+                Assert.True((bool)itemAccessibleObject.GetPropertyValue(UiaCore.UIA.IsScrollItemPatternAvailablePropertyId));
+            }
+        }
+
+        public static IEnumerable<object[]> ComboBoxItemAccessibleObject_ScrollIntoView_DoNothing_IfControlIsNotEnabled_TestData()
+        {
+            foreach (ComboBoxStyle comboBoxStyle in Enum.GetValues(typeof(ComboBoxStyle)))
+            {
+                yield return new object[] { comboBoxStyle };
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ComboBoxItemAccessibleObject_ScrollIntoView_DoNothing_IfControlIsNotEnabled_TestData))]
+        public void ComboBoxItemAccessibleObject_ScrollIntoView_DoNothing_IfControlIsNotEnabled(ComboBoxStyle comboBoxStyle)
+        {
+            using ComboBox comboBox = new ComboBox();
+            comboBox.IntegralHeight = false;
+            comboBox.DropDownStyle = comboBoxStyle;
+            comboBox.Enabled = false;
+            comboBox.Items.AddRange(new[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
+            comboBox.CreateControl();
+
+            if (comboBoxStyle == ComboBoxStyle.Simple)
+            {
+                comboBox.Size = new Drawing.Size(100, 132);
+            }
+            else
+            {
+                comboBox.DropDownHeight = 107;
+                comboBox.DroppedDown = true;
+            }
+
+            ComboBoxAccessibleObject comboBoxAccessibleObject = (ComboBoxAccessibleObject)comboBox.AccessibilityObject;
+            ComboBoxItemAccessibleObjectCollection itemsCollection = comboBoxAccessibleObject.ItemAccessibleObjects;
+            object item = comboBox.Items[10];
+            ComboBoxItemAccessibleObject itemAccessibleObject = (ComboBoxItemAccessibleObject)comboBoxAccessibleObject.ItemAccessibleObjects[item];
+
+            itemAccessibleObject.ScrollIntoView();
+
+            int actual = unchecked((int)(long)User32.SendMessageW(comboBox, (User32.WM)User32.CB.GETTOPINDEX));
+
+            Assert.Equal(0, actual); // ScrollIntoView didn't scroll to the tested item because the combobox is disabled
+        }
+
+        public static IEnumerable<object[]> ComboBoxItemAccessibleObject_ScrollIntoView_TestData()
+        {
+            foreach (bool scrollingDown in new[] { true, false })
+            {
+                foreach (ComboBoxStyle comboBoxStyle in Enum.GetValues(typeof(ComboBoxStyle)))
+                {
+                    int itemsCount = 41;
+
+                    for (int index = 0; index < itemsCount; index++)
+                    {
+                        yield return new object[] { comboBoxStyle, scrollingDown, index, itemsCount };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ComboBoxItemAccessibleObject_ScrollIntoView_TestData))]
+        public void ComboBoxItemAccessibleObject_ScrollIntoView_DoExpected(ComboBoxStyle comboBoxStyle, bool scrollingDown, int itemIndex, int itemsCount)
+        {
+            using ComboBox comboBox = new ComboBox();
+            comboBox.IntegralHeight = false;
+            comboBox.DropDownStyle = comboBoxStyle;
+            comboBox.CreateControl();
+
+            for (int i = 0; i < itemsCount; i++)
+            {
+                comboBox.Items.Add(i);
+            }
+
+            if (comboBoxStyle == ComboBoxStyle.Simple)
+            {
+                comboBox.Size = new Drawing.Size(100, 132);
+            }
+            else
+            {
+                comboBox.DropDownHeight = 107;
+                comboBox.DroppedDown = true;
+            }
+
+            ComboBoxAccessibleObject comboBoxAccessibleObject = (ComboBoxAccessibleObject)comboBox.AccessibilityObject;
+            ComboBoxItemAccessibleObjectCollection itemsCollection = comboBoxAccessibleObject.ItemAccessibleObjects;
+            object item = comboBox.Items[itemIndex];
+            ComboBoxItemAccessibleObject itemAccessibleObject = (ComboBoxItemAccessibleObject)comboBoxAccessibleObject.ItemAccessibleObjects[item];
+
+            int expected;
+            Rectangle dropDownRect = comboBox.ChildListAccessibleObject.Bounds;
+            int visibleItemsCount = (int)Math.Ceiling((double)dropDownRect.Height / comboBox.ItemHeight);
+
+            // Get an index of the first item that is visible if dropdown is scrolled to the bottom
+            int lastFirstVisible = itemsCount - visibleItemsCount;
+
+            if (scrollingDown)
+            {
+                if (dropDownRect.IntersectsWith(itemAccessibleObject.Bounds))
+                {
+                    // ScrollIntoView method shouldn't scroll to the item because it is already visible
+                    expected = 0;
+                }
+                else
+                {
+                    //  ScrollIntoView method should scroll to the item or
+                    //  the first item that is visible if dropdown is scrolled to the bottom
+                    expected = itemIndex > lastFirstVisible ? lastFirstVisible : itemIndex;
+                }
+            }
+            else
+            {
+                // Scroll to the bottom and test the method when scrolling up
+                User32.SendMessageW(comboBox, (User32.WM)User32.CB.SETTOPINDEX, (IntPtr)(itemsCount - 1));
+
+                if (dropDownRect.IntersectsWith(itemAccessibleObject.Bounds))
+                {
+                    // ScrollIntoView method shouldn't scroll to the item because it is already visible
+                    expected = lastFirstVisible;
+                }
+                else
+                {
+                    // ScrollIntoView method should scroll to the item
+                    expected = itemIndex;
+                }
+            }
+
+            itemAccessibleObject.ScrollIntoView();
+
+            int actual = unchecked((int)(long)User32.SendMessageW(comboBox, (User32.WM)User32.CB.GETTOPINDEX));
+
+            Assert.Equal(expected, actual);
         }
     }
 }


### PR DESCRIPTION
Fixes #4335
Fixes #4323

Based on changes from #4350

⚠️ A port of a .NET Framework servicing fix 
## Proposed changes:
- Implement `ScrollIntoView `method of `ScrollItemPattern`
- Fix getting of `Bounds`

## Customer Impact:
- Accessibility tools or users can scroll a combo box drop-down list to some item
- A user can see a correct item Bounds position when combobox scrolling
- These 2 bugs were approved for servicing in .NET Framework 4.8 in February release
## Regression?
- Yes (from .NET Framework 4.7.2)
## Risk
- Minimal
## Screenshots
### Before
- ComboBox items don't support `ScrollItemPattern` - `ScrollIntoView` is not available
![image](https://user-images.githubusercontent.com/23376742/104170748-adfb3c80-5412-11eb-827f-9ac9ec022787.png)

### After
- ComboBox items support `ScrollItemPattern` - ensure that the item is visible when invoking `ScrollIntoView`.
For example, in the gif below I call `ScroolIntoView` for the **9th** item, and the `ComboBox` shows the **9th** item.
![4350](https://user-images.githubusercontent.com/23376742/104171000-05011180-5413-11eb-8078-c3a540451b5d.gif)

## Test methodology
- Unit tests
- Manual testing
- CTI
## Accessibility testing
- Using Inspect
## Test environment(s)
- Microsoft Windows [Version 10.0.19042.685]
- .NET v. 6.0.100-alpha.1.20554.10

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/dotnet/winforms/pull/4452)