### PR TITLE
Use local definition of disabledPackageSources

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -12,5 +12,7 @@
     <!-- Used for the Rich Navigation indexing task -->
     <add key="richnav" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-buildservices/nuget/v3/index.json" />
   </packageSources>
-  <disabledPackageSources />
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
Fixes #4516

## Proposed changes

Clear the `disabledPackageSources` in `nuget.config` to prevent global settings affecting the locally setup sources. In particular it could happen that in Visual Studio UI a package source with the same key was defined but unchecked, in which case the local `nuget.config` would ignore the local definition of that source because it inherited the `disabledPackageSources` from the global settings.

This also matches what other projects like [arcade](https://github.com/dotnet/arcade/blob/8b7ec67401393a062292446cf9602c9a0b64c758/NuGet.config) are doing

## Customer Impact

Allow local builds independent of global nuget settings

## Regression? 

unknown

## Risk

none, other projects like arcarde are doing it too

### Before

local builds fail if a package source with the same key is defined but unchecked in the global Visual Studio settings

### After

local builds succeed independent of global Visual Studio settings

## Test methodology

manual testing (defining a package source with the same key and unchecking it in Visual Studio UI)

You may have to clear your local package cache first if you want to reproduce the failure cases.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4517)