### PR TITLE
Properly apply translation and clipping in TextRenderer

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.HENHMETAFILE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.HENHMETAFILE.cs
@@ -17,6 +17,7 @@ internal static partial class Interop
             public bool IsNull => Handle == IntPtr.Zero;
 
             public static explicit operator IntPtr(HENHMETAFILE hmetafile) => hmetafile.Handle;
+            public static explicit operator HENHMETAFILE(IntPtr hmetafile) => new HENHMETAFILE(hmetafile);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfScope.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfScope.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms.Metafiles
     internal class EmfScope : DisposalTracking.Tracker, IDisposable
     {
         public Gdi32.HDC HDC { get; }
-        private Gdi32.HENHMETAFILE _hmf;
+        private Gdi32.HENHMETAFILE _hemf;
 
         public unsafe EmfScope()
             : this (Gdi32.CreateEnhMetaFileW(hdc: default, lpFilename: null, lprc: null, lpDesc: null))
@@ -24,7 +24,12 @@ namespace System.Windows.Forms.Metafiles
         public EmfScope(Gdi32.HDC hdc)
         {
             HDC = hdc;
-            _hmf = default;
+            _hemf = default;
+        }
+
+        public EmfScope(Gdi32.HENHMETAFILE hemf)
+        {
+            _hemf = hemf;
         }
 
         public unsafe static EmfScope Create() => new EmfScope();
@@ -33,17 +38,17 @@ namespace System.Windows.Forms.Metafiles
         {
             get
             {
-                if (HDC.IsNull)
+                if (_hemf.IsNull)
                 {
-                    return default;
+                    if (HDC.IsNull)
+                    {
+                        return default;
+                    }
+
+                    _hemf = Gdi32.CloseEnhMetaFile(HDC);
                 }
 
-                if (_hmf.IsNull)
-                {
-                    _hmf = Gdi32.CloseEnhMetaFile(HDC);
-                }
-
-                return _hmf;
+                return _hemf;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextRenderer.cs
@@ -4,7 +4,6 @@
 
 using System.Drawing;
 using System.Drawing.Text;
-using System.Windows.Forms.Internal;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -301,7 +300,7 @@ namespace System.Windows.Forms
             // This MUST come before retreiving the HDC, which locks the Graphics object
             Gdi32.QUALITY quality = FontQualityFromTextRenderingHint(dc);
 
-            using var hdc = new DeviceContextHdcScope(dc);
+            using var hdc = new DeviceContextHdcScope(dc, GetApplyStateFlags(dc, flags));
 
             DrawTextInternal(hdc, text, font, bounds, foreColor, quality, backColor, flags);
         }
@@ -534,7 +533,9 @@ namespace System.Windows.Forms
             // This MUST come before retreiving the HDC, which locks the Graphics object
             Gdi32.QUALITY quality = FontQualityFromTextRenderingHint(dc);
 
-            using var hdc = new DeviceContextHdcScope(dc);
+            // Applying state may not impact text size measurements. Rather than risk missing some
+            // case we'll apply as we have historically to avoid suprise regressions.
+            using var hdc = new DeviceContextHdcScope(dc, GetApplyStateFlags(dc, flags));
             using var hfont = GdiCache.GetHFONT(font, quality, hdc);
             return hdc.HDC.MeasureText(text, hfont, proposedSize, flags);
         }
@@ -595,6 +596,30 @@ namespace System.Windows.Forms
             // FE_FONTSMOOTHINGCLEARTYPE = 0x0002
             return SystemInformation.FontSmoothingType == 0x0002
                 ? Gdi32.QUALITY.CLEARTYPE : Gdi32.QUALITY.ANTIALIASED;
+        }
+
+        /// <summary>
+        ///  Gets the proper <see cref="ApplyGraphicsProperties"/> flags for the given <paramref name="textFormatFlags"/>.
+        /// </summary>
+        private static ApplyGraphicsProperties GetApplyStateFlags(IDeviceContext deviceContext, TextFormatFlags textFormatFlags)
+        {
+            if (deviceContext is not Graphics)
+            {
+                return ApplyGraphicsProperties.None;
+            }
+
+            var apply = ApplyGraphicsProperties.None;
+            if (textFormatFlags.HasFlag(TextFormatFlags.PreserveGraphicsClipping))
+            {
+                apply |= ApplyGraphicsProperties.Clipping;
+            }
+
+            if (textFormatFlags.HasFlag(TextFormatFlags.PreserveGraphicsTranslateTransform))
+            {
+                apply |= ApplyGraphicsProperties.TranslateTransform;
+            }
+
+            return apply;
         }
     }
 }


### PR DESCRIPTION
Translation and clipping should only be applied from Graphics objects when they are explicitly asked for in the TextFormatFlags.

Adds regression tests.

Fixes #4524


## Proposed changes

- Apply graphics properties only when requested
- Add regression tests

## Customer Impact

- This causes rendering to not work correctly when transforms and clipping are in play.
- This shows up in 3rd party control libraries, such as Telerik's. It can cause text to "vanish" as it isn't rendered in the clipped area.
- Workarounds are difficult, particularly when this shows up in 3rd party control libraries.

## Regression? 

- Yes

## Risk

- Very low

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/8184940/106831203-5bddbd80-6644-11eb-8086-ec71b09ff9ba.png)

### After

![image](https://user-images.githubusercontent.com/8184940/106831163-48325700-6644-11eb-9cad-8e80748912a9.png)


## Test methodology

- Test Telerik provided repro
- Audit of legacy code
- Add regression tests



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4525)