### PR TITLE
Fix `ListView` detaches shared `ImageList`  twice

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -250,6 +250,10 @@ namespace System.Windows.Forms
                 }
             }
         }
+
+#if DEBUG
+        internal bool IsDisposed { get; private set; }
+#endif
 
         [SRCategory(nameof(SR.CatData))]
         [Localizable(false)]
@@ -523,6 +527,11 @@ namespace System.Windows.Forms
 
                 DestroyHandle();
             }
+
+#if DEBUG
+            // At this stage we've released all resources, and the component is essentially disposed
+            IsDisposed = true;
+#endif
 
             base.Dispose(disposing);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -2938,11 +2938,12 @@ namespace System.Windows.Forms
             try
             {
 #if DEBUG
-                if (sender != _imageListSmall && sender != _imageListState && sender != _imageListLarge && sender != _imageListGroup)
+                if (sender is ImageList imageList && !imageList.IsDisposed &&
+                    sender != _imageListSmall && sender != _imageListState && sender != _imageListLarge && sender != _imageListGroup)
                 {
                     Debug.Fail("ListView sunk dispose event from unknown component");
                 }
-#endif // DEBUG
+#endif
                 if (sender == _imageListSmall)
                 {
                     SmallImageList = null;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageListTests.cs
@@ -905,6 +905,18 @@ namespace System.Windows.Forms.Tests
             Assert.False(list.HandleCreated);
         }
 
+#if DEBUG
+        [WinFormsFact]
+        public void ImageList_Dispose_SetsIsDisposed()
+        {
+            using var list = new ImageList();
+            Assert.False(list.IsDisposed);
+
+            list.Dispose();
+            Assert.True(list.IsDisposed);
+        }
+#endif
+
         public static IEnumerable<object[]> Draw_Point_TestData()
         {
             yield return new object[] { Point.Empty };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -1125,6 +1125,24 @@ namespace System.Windows.Forms.Tests
             Assert.False(listViewRef.IsAlive);
         }
 
+#if DEBUG
+        [WinFormsFact]
+        public void ListView_Dispose_shared_ImageList_doesnt_assert()
+        {
+            using ListView listView = new();
+            ImageList imageList = new();
+            listView.LargeImageList = imageList;
+            listView.SmallImageList = imageList;
+
+            // Initiate DetachImageList sequence
+            imageList.Dispose();
+
+            // Unless we track whether an imagelist was disposed, we would hit Debug.Fail assertion
+            // and never reach this line
+            Assert.True(true);
+        }
+#endif
+
         [WinFormsTheory]
         [CommonMemberData(nameof(CommonTestHelper.GetBoolTheoryData))]
         public void ListView_DoubleBuffered_Get_ReturnsExpected(bool value)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Resolves #4265


## Proposed changes

- Prevent `ListView` detaching a shared `ImageList` multiple times



## Test methodology <!-- How did you ensure quality? -->

-  manual
- unit tests

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4526)