### PR TITLE
Fixing the problem with forced creation of a handle when resizing a ComboBox

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -2241,6 +2241,11 @@ namespace System.Windows.Forms
         // Invalidate the entire control, including child HWNDs and non-client areas
         private unsafe void InvalidateEverything()
         {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
             // Control.Invalidate(true) doesn't invalidate the non-client region
             RedrawWindow(
                 new HandleRef(this, Handle),

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -1824,6 +1824,16 @@ namespace System.Windows.Forms.Tests
             }
         }
 
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDown)]
+        [InlineData(ComboBoxStyle.DropDownList)]
+        [InlineData(ComboBoxStyle.Simple)]
+        public void Combobox_SetCustomSize_DoesNotCreateHandle(ComboBoxStyle dropDownStyle)
+        {
+            using ComboBox comboBox = new ComboBox() { DropDownStyle = dropDownStyle, Size = new Size(100, 50) };
+            Assert.False(comboBox.IsHandleCreated);
+        }
+
         private class SubComboBox : ComboBox
         {
             public SubComboBox()


### PR DESCRIPTION
Fixes #4541 


## Proposed changes
- The issue is reproduced because the resize triggers the "OnResize" event which triggers the "InvalidateEverything" where we get the "Handle" property. As a fix, added "IsHandleCreated" check, before calling the "InvalidateEverything" method.
- Added unit tests


## Customer Impact
- No 

## Regression? 

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 5.0.200-preview.20614.14


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4542)