### PR TITLE
Fixing IndexOutOfRangeException throwing by DGV when disposing its DataSource

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
@@ -768,6 +768,14 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///  Refresh tool strip items when the BindingSource is disposed.
+        /// </summary>
+        private void OnBindingSourceDisposed(object sender, EventArgs e)
+        {
+            BindingSource = null;
+        }
+
+        /// <summary>
         ///  Refresh tool strip items when something changes in the BindingSource's list.
         /// </summary>
         private void OnBindingSourceListChanged(object sender, ListChangedEventArgs e)
@@ -895,6 +903,7 @@ namespace System.Windows.Forms
                     oldBindingSource.DataSourceChanged -= new EventHandler(OnBindingSourceStateChanged);
                     oldBindingSource.DataMemberChanged -= new EventHandler(OnBindingSourceStateChanged);
                     oldBindingSource.ListChanged -= new ListChangedEventHandler(OnBindingSourceListChanged);
+                    oldBindingSource.Disposed -= new EventHandler(OnBindingSourceDisposed);
                 }
 
                 if (newBindingSource is not null)
@@ -905,6 +914,7 @@ namespace System.Windows.Forms
                     newBindingSource.DataSourceChanged += new EventHandler(OnBindingSourceStateChanged);
                     newBindingSource.DataMemberChanged += new EventHandler(OnBindingSourceStateChanged);
                     newBindingSource.ListChanged += new ListChangedEventHandler(OnBindingSourceListChanged);
+                    newBindingSource.Disposed += new EventHandler(OnBindingSourceDisposed);
                 }
 
                 oldBindingSource = newBindingSource;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -14861,6 +14861,14 @@ namespace System.Windows.Forms
             }
         }
 
+        /// <summary>
+        ///  Refresh items when the DataSource is disposed.
+        /// </summary>
+        private void OnDataSourceDisposed(object sender, EventArgs e)
+        {
+            DataSource = null;
+        }
+
         protected virtual void OnDefaultCellStyleChanged(EventArgs e)
         {
             if (e is DataGridViewCellStyleChangedEventArgs dgvcsce && !dgvcsce.ChangeAffectsPreferredSize)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -2014,6 +2014,16 @@ namespace System.Windows.Forms
             {
                 if (value != DataSource)
                 {
+                    if (DataSource is Component oldDataSource)
+                    {
+                        oldDataSource.Disposed -= OnDataSourceDisposed;
+                    }
+
+                    if (value is Component newDataSource)
+                    {
+                        newDataSource.Disposed += OnDataSourceDisposed;
+                    }
+
                     CurrentCell = null;
                     if (DataConnection is null)
                     {

--- a/src/System.Windows.Forms/tests/UnitTests/BindingNavigatorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/BindingNavigatorTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Data;
 using System.Diagnostics;
 using Moq;
 using Xunit;
@@ -128,6 +129,87 @@ namespace System.Windows.Forms.Tests
             Assert.IsType<ToolStripSeparator>(bn.Items[index++]);
             Assert.Equal(bn.AddNewItem, bn.Items[index++]);
             Assert.Equal(bn.DeleteItem, bn.Items[index++]);
+        }
+
+        [WinFormsFact]
+        public void BindingNavigator_UpdatesItsItems_AfterDataSourceDisposing()
+        {
+            using BindingNavigator control = new BindingNavigator(true);
+            int rowsCount = 5;
+            BindingSource bindingSource = GetTestBindingSource(rowsCount);
+            control.BindingSource = bindingSource;
+
+            Assert.Equal("1", control.PositionItem.Text);
+            Assert.Equal($"of {rowsCount}", control.CountItem.Text);
+
+            bindingSource.Dispose();
+
+            // The BindingNavigator updates its PositionItem and CountItem values
+            // after its BindingSource is disposed
+            Assert.Equal("0", control.PositionItem.Text);
+            Assert.Equal("of 0", control.CountItem.Text);
+        }
+
+        [WinFormsFact]
+        public void BindingNavigator_BindingSource_IsNull_AfterDisposing()
+        {
+            using BindingNavigator control = new BindingNavigator();
+            BindingSource bindingSource = GetTestBindingSource(5);
+            control.BindingSource = bindingSource;
+
+            Assert.Equal(bindingSource, control.BindingSource);
+
+            bindingSource.Dispose();
+
+            Assert.Null(control.BindingSource);
+        }
+
+        [WinFormsFact]
+        public void BindingNavigator_BindingSource_IsActual_AfterOldOneIsDisposed()
+        {
+            using BindingNavigator control = new BindingNavigator(true);
+            int rowsCount1 = 3;
+            BindingSource bindingSource1 = GetTestBindingSource(rowsCount1);
+            int rowsCount2 = 5;
+            BindingSource bindingSource2 = GetTestBindingSource(rowsCount2);
+            control.BindingSource = bindingSource1;
+
+            Assert.Equal(bindingSource1, control.BindingSource);
+            Assert.Equal("1", control.PositionItem.Text);
+            Assert.Equal($"of {rowsCount1}", control.CountItem.Text);
+
+            control.BindingSource = bindingSource2;
+
+            Assert.Equal(bindingSource2, control.BindingSource);
+            Assert.Equal("1", control.PositionItem.Text);
+            Assert.Equal($"of {rowsCount2}", control.CountItem.Text);
+
+            bindingSource1.Dispose();
+
+            // bindingSource2 is actual for the BindingNavigator
+            // so it will contain correct PositionItem and CountItem values
+            // even after bindingSource1 is disposed.
+            // This test checks that Disposed events unsubscribed correctly
+            Assert.Equal(bindingSource2, control.BindingSource);
+            Assert.Equal("1", control.PositionItem.Text);
+            Assert.Equal($"of {rowsCount2}", control.CountItem.Text);
+        }
+
+        private BindingSource GetTestBindingSource(int rowsCount)
+        {
+            DataTable dt = new DataTable();
+            dt.Columns.Add("Name");
+            dt.Columns.Add("Age");
+
+            for (int i = 0; i < rowsCount; i++)
+            {
+                DataRow dr = dt.NewRow();
+                dr[0] = $"User{i}";
+                dr[1] = i * 3;
+                dt.Rows.Add(dr);
+            }
+
+            return new() { DataSource = dt };
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,6 +11,7 @@ using System.Windows.Forms.Metafiles;
 using System.Numerics;
 using static System.Windows.Forms.Metafiles.DataHelpers;
 using static Interop;
+using System.Data;
 
 namespace System.Windows.Forms.Tests
 {
@@ -2799,6 +2800,92 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new SubDataGridView();
             Assert.Throws<NullReferenceException>(() => control.OnRowHeadersWidthSizeModeChanged(null));
+        }
+
+        [WinFormsFact]
+        public void DataGridView_UpdatesItsItems_AfterDataSourceDisposing()
+        {
+            using DataGridView control = new DataGridView();
+            int rowsCount = 5;
+            BindingSource bindingSource = GetTestBindingSource(rowsCount);
+            BindingContext context = new BindingContext();
+            context.Add(bindingSource, bindingSource.CurrencyManager);
+            control.BindingContext = context;
+            control.DataSource = bindingSource;
+
+            // The TestBindingSource table contains 2 columns
+            Assert.Equal(2, control.Columns.Count);
+            // The TestBindingSource table contains some rows + 1 new DGV row (because AllowUserToAddRows is true)
+            Assert.Equal(rowsCount + 1, control.Rows.Count);
+
+            bindingSource.Dispose();
+
+            // The DataGridView updates its Rows and Columns collections after its DataSource is disposed
+            Assert.Empty(control.Columns);
+            Assert.Empty(control.Rows);
+        }
+
+        [WinFormsFact]
+        public void DataGridView_DataSource_IsNull_AfterDisposing()
+        {
+            using DataGridView control = new DataGridView();
+            BindingSource bindingSource = GetTestBindingSource(5);
+            control.DataSource = bindingSource;
+
+            Assert.Equal(bindingSource, control.DataSource);
+
+            bindingSource.Dispose();
+
+            Assert.Null(control.DataSource);
+        }
+
+        [WinFormsFact]
+        public void DataGridView_DataSource_IsActual_AfterOldOneIsDisposed()
+        {
+            using DataGridView control = new DataGridView();
+            int rowsCount1 = 3;
+            BindingSource bindingSource1 = GetTestBindingSource(rowsCount1);
+            int rowsCount2 = 5;
+            BindingSource bindingSource2 = GetTestBindingSource(rowsCount2);
+            BindingContext context = new BindingContext();
+            context.Add(bindingSource1, bindingSource1.CurrencyManager);
+            control.BindingContext = context;
+            control.DataSource = bindingSource1;
+
+            Assert.Equal(bindingSource1, control.DataSource);
+            Assert.Equal(2, control.Columns.Count);
+            Assert.Equal(rowsCount1 + 1, control.Rows.Count); // + 1 is the new DGV row
+
+            control.DataSource = bindingSource2;
+
+            Assert.Equal(bindingSource2, control.DataSource);
+            Assert.Equal(2, control.Columns.Count);
+            Assert.Equal(rowsCount2 + 1, control.Rows.Count); // + 1 is the new DGV row
+
+            bindingSource1.Dispose();
+
+            // bindingSource2 is actual for the DataGridView so it will contain correct Rows and Columns counts
+            // even after bindingSource1 is disposed. This test checks that Disposed events unsubscribed correctly
+            Assert.Equal(bindingSource2, control.DataSource);
+            Assert.Equal(2, control.Columns.Count);
+            Assert.Equal(rowsCount2 + 1, control.Rows.Count); // + 1 is the new DGV row
+        }
+
+        private BindingSource GetTestBindingSource(int rowsCount)
+        {
+            DataTable dt = new DataTable();
+            dt.Columns.Add("Name");
+            dt.Columns.Add("Age");
+
+            for (int i = 0; i < rowsCount; i++)
+            {
+                DataRow dr = dt.NewRow();
+                dr[0] = $"User{i}";
+                dr[1] = i * 3;
+                dt.Rows.Add(dr);
+            }
+
+            return new() { DataSource = dt };
         }
 
         private class SubDataGridViewCell : DataGridViewCell


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4216


## Proposed changes

- Add Dispose event handlers to clear DataSource of DGV and BindingSource of BindingNavigator thereby update their data source actual state

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user won't catch the exception when closing a form or disposing a BindingSource

## Regression? 

- Yes and no. .NET Framework 4.8 throws an exception when closing a form. v.4.7 doesn't throw the exception in this case. But anyway every version throws the exception if to Dispose a BindingSource component

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- A DataGridView doesn't update its Rows and Columns collections after its DataSource is disposed. And the DGV throws the exception when trying to redraw because the DGV is trying to draw items from a DataSource that doesn't already exist (send some index, eg. 4, to the collection that has 0 items, and catch IndexOutOfRangeException)
![vR6xyN1oe6](https://user-images.githubusercontent.com/49272759/107550604-49cec280-6be2-11eb-848d-d137900e1a07.gif)

<!-- TODO -->

### After
- DataGridView and BindingNavigator subscribed on the BindingSource Disposed event and release their DataSource and BindingSource to update internal collections
![mtA3PmfUl4](https://user-images.githubusercontent.com/49272759/107550667-5d7a2900-6be2-11eb-8299-757cc49e73af.gif)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Unit testing
- Manual UI testing
- CTI

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 6.0.100-preview.1.21101.5
- Microsoft Windows [Version 10.0.19042.804]


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4551)