### PR TITLE
Changing the "ComboBox" control type to "RadioButton" control type for buttons in PropertyGrid

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -2032,21 +2032,24 @@ namespace System.Windows.Forms
             return tab;
         }
 
-        private ToolStripButton CreatePushButton(string toolTipText, int imageIndex, EventHandler eventHandler, bool useCheckButtonRole = false)
+        private ToolStripButton CreatePushButton(string toolTipText, int imageIndex, EventHandler eventHandler, bool useRadioButtonRole = false)
         {
-            PropertyGridToolStripButton button = new PropertyGridToolStripButton
+            PropertyGridToolStripButton button = new PropertyGridToolStripButton(this, useRadioButtonRole)
             {
                 Text = toolTipText,
                 AutoToolTip = true,
                 DisplayStyle = ToolStripItemDisplayStyle.Image,
                 ImageIndex = imageIndex
             };
+
             button.Click += eventHandler;
             button.ImageScaling = ToolStripItemImageScaling.SizeToFit;
 
-            if (useCheckButtonRole)
+            if (useRadioButtonRole)
             {
-                button.AccessibleRole = AccessibleRole.CheckButton;
+                // As discussed in https://github.com/dotnet/winforms/issues/4428 issue, set the accessible role
+                // to "RadioButton" instead of "CheckBox" as it better matches the behavior of the button.
+                button.AccessibleRole = AccessibleRole.RadioButton;
             }
 
             return button;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObject.cs
@@ -1,0 +1,68 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    internal partial class PropertyGridToolStripButton
+    {
+        internal class PropertyGridToolStripButtonAccessibleObject : ToolStripButtonAccessibleObject
+        {
+            private readonly PropertyGrid? _owningPropertyGrid;
+            private readonly PropertyGridToolStripButton _owningPropertyGridToolStripButton;
+
+            public PropertyGridToolStripButtonAccessibleObject(PropertyGridToolStripButton owningToolStripButton) : base(owningToolStripButton)
+            {
+                _owningPropertyGridToolStripButton = owningToolStripButton;
+                _owningPropertyGrid = owningToolStripButton._owningPropertyGrid;
+            }
+
+            internal override bool IsItemSelected
+                => _owningPropertyGridToolStripButton.Checked;
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
+                {
+                    UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.SelectionItemPatternId),
+                    _ => base.GetPropertyValue(propertyID)
+                };
+
+            internal override bool IsPatternSupported(UiaCore.UIA patternId)
+                => patternId switch
+                {
+                    UiaCore.UIA.SelectionItemPatternId => _owningPropertyGridToolStripButton._selectItemEnabled,
+                    _ => base.IsPatternSupported(patternId)
+                };
+
+            internal override void AddToSelection() => SelectItem();
+
+            internal override void Invoke() => SelectItem();
+
+            internal override void RemoveFromSelection()
+            {
+            }
+
+            internal unsafe override void SelectItem()
+            {
+                if (_owningPropertyGrid is null || !_owningPropertyGrid.IsHandleCreated)
+                {
+                    return;
+                }
+
+                bool initialState = _owningPropertyGridToolStripButton.Checked;
+                _owningPropertyGridToolStripButton.PerformClick();
+
+                // This code is required to simulate the behavior in 4.7.1. When we call "Toggle" method on an already
+                // checked button, the focus switches to the ToolStrip. If the button was not checked before the call,
+                // then the focus is switched to the table with properties.
+                AccessibleObject? focusedAccessibleObject = initialState
+                    ? _owningPropertyGridToolStripButton.Parent?.AccessibilityObject
+                    : _owningPropertyGridToolStripButton._owningPropertyGrid.GridViewAccessibleObject.GetFocused();
+
+                focusedAccessibleObject?.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.cs
@@ -8,35 +8,20 @@ using System.Drawing;
 
 namespace System.Windows.Forms
 {
-    internal class PropertyGridToolStripButton : ToolStripButton
+    internal partial class PropertyGridToolStripButton : ToolStripButton
     {
-        /// <summary>
-        ///  Inheriting classes should override this method to handle this event.
-        /// </summary>
-        protected override void OnPaint(PaintEventArgs e)
+        private readonly PropertyGrid _owningPropertyGrid;
+
+        private readonly bool _selectItemEnabled;
+
+        internal PropertyGridToolStripButton(PropertyGrid propertyGrid, bool selectItemEnabled) : base()
         {
-            base.OnPaint(e);
-
-            if (Selected)
-            {
-                var bounds = ClientBounds;
-
-                // It is necessary so that when HighContrast is off, the size of the dotted borders
-                // coincides with the size of the button background
-                // For normal mode we use the "ToolStripSystemRenderer.RenderItemInternal" method
-                // which calls the "VisualStyleRenderer.DrawBackground" method for drawing
-                // For high contrast mode we use the "ToolStripHighContrastRenderer.OnRenderButtonBackground" method
-                // which calls the "Graphics.DrawRectangle" method for drawing
-                if (SystemInformation.HighContrast)
-                {
-                    DrawHightContrastDashedBorer(e.Graphics);
-                }
-                else
-                {
-                    DrawDashedBorer(e.Graphics);
-                }
-            }
+            _owningPropertyGrid = propertyGrid;
+            _selectItemEnabled = selectItemEnabled;
         }
+
+        protected override AccessibleObject CreateAccessibilityInstance()
+            => new PropertyGridToolStripButtonAccessibleObject(this);
 
         private void DrawDashedBorer(Graphics graphics)
         {
@@ -77,6 +62,36 @@ namespace System.Windows.Forms
 
             graphics.DrawRectangle(focusPen1, bounds);
             graphics.DrawRectangle(focusPen2, bounds);
+        }
+
+        /// <summary>
+        ///  Inheriting classes should override this method to handle this event.
+        /// </summary>
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+
+            if (!Selected)
+            {
+                return;
+            }
+
+            var bounds = ClientBounds;
+
+            // It is necessary so that when HighContrast is off, the size of the dotted borders
+            // coincides with the size of the button background
+            // For normal mode we use the "ToolStripSystemRenderer.RenderItemInternal" method
+            // which calls the "VisualStyleRenderer.DrawBackground" method for drawing
+            // For high contrast mode we use the "ToolStripHighContrastRenderer.OnRenderButtonBackground" method
+            // which calls the "Graphics.DrawRectangle" method for drawing
+            if (SystemInformation.HighContrast)
+            {
+                DrawHightContrastDashedBorer(e.Graphics);
+            }
+            else
+            {
+                DrawDashedBorer(e.Graphics);
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObjectTests.cs
@@ -1,0 +1,177 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.Tests
+{
+    public class PropertyGridToolStripButton_PropertyGridToolStripButtonAccessibleObjectTests
+    {
+        [WinFormsFact]
+        public void PropertyGridToolStripButtonAccessibleObject_IsItemSelected_ReturnsExpected()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+            AccessibleObject categoryButtonAccessibleObject = toolStripButtons[0].AccessibilityObject;
+            AccessibleObject alphaButtonAccessibleObject = toolStripButtons[1].AccessibilityObject;
+
+            Assert.True(categoryButtonAccessibleObject.IsItemSelected);
+            Assert.False(alphaButtonAccessibleObject.IsItemSelected);
+
+            alphaButtonAccessibleObject.SelectItem();
+
+            Assert.False(categoryButtonAccessibleObject.IsItemSelected);
+            Assert.True(alphaButtonAccessibleObject.IsItemSelected);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridToolStripButtonAccessibleObject_Role_IsRadiButton()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+            AccessibleObject accessibleObject = toolStripButtons[0].AccessibilityObject;
+
+            Assert.Equal(AccessibleRole.RadioButton, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridToolStripButtonAccessibleObjec_SelectionItemPatternSupported_ReturnsExpected()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+            ToolStripButton propertyPagesButton = propertyGrid.TestAccessor().Dynamic._btnViewPropertyPages;
+            AccessibleObject categoryButtonAccessibleObject = toolStripButtons[0].AccessibilityObject;
+            AccessibleObject alphaButtonAccessibleObject = toolStripButtons[1].AccessibilityObject;
+            AccessibleObject propertyPagesButtonAccessibleObject = propertyPagesButton.AccessibilityObject;
+
+            Assert.True(categoryButtonAccessibleObject.IsPatternSupported(UIA.SelectionItemPatternId));
+            Assert.True(alphaButtonAccessibleObject.IsPatternSupported(UIA.SelectionItemPatternId));
+
+            // In accordance with the behavior of the PropertyGrid, the "Property Page" button does not have
+            // the role of a "RadioButton" and therefore does not support the "SelectionItem" pattern
+            Assert.False(propertyPagesButtonAccessibleObject.IsPatternSupported(UIA.SelectionItemPatternId));
+        }
+
+        [WinFormsFact]
+        public void PropertyGridToolStripButtonAccessibleObject_GetPropertyValue_ControlType_IsRadioButton()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+            AccessibleObject accessibleObject = toolStripButtons[0].AccessibilityObject;
+
+            UiaCore.UIA actual = (UiaCore.UIA)accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
+
+            Assert.Equal(UiaCore.UIA.RadioButtonControlTypeId, actual);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridToolStripButtonAccessibleObject_AddToSelection_UpdatesCheckedStateAndPropertySort()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+            ToolStripButton categoryButton = toolStripButtons[0];
+            ToolStripButton alphaButton = toolStripButtons[1];
+            AccessibleObject alphaButtonAccessibleObject = alphaButton.AccessibilityObject;
+            AccessibleObject categoryButtonAccessibleObject = categoryButton.AccessibilityObject;
+
+            Assert.True(categoryButton.Checked);
+            Assert.False(alphaButton.Checked);
+            Assert.Equal(PropertySort.CategorizedAlphabetical, propertyGrid.PropertySort);
+
+            alphaButtonAccessibleObject.AddToSelection();
+
+            Assert.False(categoryButton.Checked);
+            Assert.True(alphaButton.Checked);
+            Assert.Equal(PropertySort.Alphabetical, propertyGrid.PropertySort);
+
+            categoryButtonAccessibleObject.AddToSelection();
+
+            Assert.True(categoryButton.Checked);
+            Assert.False(alphaButton.Checked);
+            Assert.Equal(PropertySort.CategorizedAlphabetical, propertyGrid.PropertySort);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridToolStripButtonAccessibleObject_Invoke_UpdatesCheckedStateAndPropertySort()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+            ToolStripButton categoryButton = toolStripButtons[0];
+            ToolStripButton alphaButton = toolStripButtons[1];
+            AccessibleObject alphaButtonAccessibleObject = alphaButton.AccessibilityObject;
+            AccessibleObject categoryButtonAccessibleObject = categoryButton.AccessibilityObject;
+
+            Assert.True(categoryButton.Checked);
+            Assert.False(alphaButton.Checked);
+            Assert.Equal(PropertySort.CategorizedAlphabetical, propertyGrid.PropertySort);
+
+            alphaButtonAccessibleObject.Invoke();
+
+            Assert.False(categoryButton.Checked);
+            Assert.True(alphaButton.Checked);
+            Assert.Equal(PropertySort.Alphabetical, propertyGrid.PropertySort);
+
+            categoryButtonAccessibleObject.Invoke();
+
+            Assert.True(categoryButton.Checked);
+            Assert.False(alphaButton.Checked);
+            Assert.Equal(PropertySort.CategorizedAlphabetical, propertyGrid.PropertySort);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridToolStripButtonAccessibleObject_RemoveFromSelection_DoesNotUpdateCheckedStateAndPropertySort()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+            ToolStripButton categoryButton = toolStripButtons[0];
+            ToolStripButton alphaButton = toolStripButtons[1];
+            AccessibleObject alphaButtonAccessibleObject = alphaButton.AccessibilityObject;
+            AccessibleObject categoryButtonAccessibleObject = categoryButton.AccessibilityObject;
+
+            Assert.True(categoryButton.Checked);
+            Assert.False(alphaButton.Checked);
+            Assert.Equal(PropertySort.CategorizedAlphabetical, propertyGrid.PropertySort);
+
+            alphaButtonAccessibleObject.RemoveFromSelection();
+
+            Assert.True(categoryButton.Checked);
+            Assert.False(alphaButton.Checked);
+            Assert.Equal(PropertySort.CategorizedAlphabetical, propertyGrid.PropertySort);
+        }
+
+        [WinFormsFact]
+        public void PropertyGridToolStripButtonAccessibleObject_SelectItem_UpdatesCheckedStateAndPropertySort()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            propertyGrid.CreateControl();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+            ToolStripButton categoryButton = toolStripButtons[0];
+            ToolStripButton alphaButton = toolStripButtons[1];
+            AccessibleObject alphaButtonAccessibleObject = alphaButton.AccessibilityObject;
+            AccessibleObject categoryButtonAccessibleObject = categoryButton.AccessibilityObject;
+
+            Assert.True(categoryButton.Checked);
+            Assert.False(alphaButton.Checked);
+            Assert.Equal(PropertySort.CategorizedAlphabetical, propertyGrid.PropertySort);
+
+            alphaButtonAccessibleObject.SelectItem();
+
+            Assert.False(categoryButton.Checked);
+            Assert.True(alphaButton.Checked);
+            Assert.Equal(PropertySort.Alphabetical, propertyGrid.PropertySort);
+
+            categoryButtonAccessibleObject.SelectItem();
+
+            Assert.True(categoryButton.Checked);
+            Assert.False(alphaButton.Checked);
+            Assert.Equal(PropertySort.CategorizedAlphabetical, propertyGrid.PropertySort);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -3746,6 +3746,18 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void PropertyGrid_Buttons_AccessibleRole_IsRadiButton()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+            ToolStripButton categoryButton = toolStripButtons[0];
+            ToolStripButton alphaButton = toolStripButtons[1];
+
+            Assert.Equal(AccessibleRole.RadioButton, categoryButton.AccessibleRole);
+            Assert.Equal(AccessibleRole.RadioButton, alphaButton.AccessibleRole);
+        }
+
         private class SubToolStripRenderer : ToolStripRenderer
         {
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridToolStripButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridToolStripButtonTests.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class PropertyGridToolStripButtonTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void PropertyGridToolStripButton_AccessibilityObject_ReturnsPropertyGridToolStripButtonAccessibleObject()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            ToolStripButton[] toolStripButtons = propertyGrid.TestAccessor().Dynamic._viewSortButtons;
+
+            Assert.IsType<PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObject>(toolStripButtons[0].AccessibilityObject);
+            Assert.IsType<PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObject>(toolStripButtons[1].AccessibilityObject);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4428

## Proposed changes
- Added logic to use `RadioButton` control type instead of `CheckBox` control type. In 4.7.2 these PropertyGrid buttons were of the `Checkbox` control type, which changed to `Button` from 4.8. After fixing #3618 we returned the behavior that was originally in 4.7.2, but we have lost support for the `Toggle` pattern. Since the buttons do not visually look like checkboxes, we wanted to change the `CheckBox` control type to `Button` control type that supports the `Toggle` pattern. Unfortunately, the "Accessibility Insights" rules prohibit the button to simultaneously support the `Invoke` and `Toggle` patterns. Therefore, based on the fact that the buttons have a behavior similar to radiobutons, as a fix, we decided to assign them a `RadioButton` control type.
- Added `SelectItem` pattern support for a PropertyGrid buttons
- Added unit tests.

## Customer Impact
Before:
![4586-before](https://user-images.githubusercontent.com/23376742/108591403-a451e680-7379-11eb-88ad-d6455b8a6fa0.png)

After:
![Issue-4428-radiobutton](https://user-images.githubusercontent.com/23376742/110606197-fdec4a80-819a-11eb-8db5-0c6b7ac2be0e.png)


## Regression? 

- Yes

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspector 

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 6.0.0-alpha.1.21073.5

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4586)