### PR TITLE
Enable nullability in TreeViewHitTestInfo

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -10982,8 +10982,8 @@ System.Windows.Forms.ToolStripControlHost.ToolStripHostedControlAccessibleObject
 ~System.Windows.Forms.TreeViewEventArgs.Node.get -> System.Windows.Forms.TreeNode
 ~System.Windows.Forms.TreeViewEventArgs.TreeViewEventArgs(System.Windows.Forms.TreeNode node) -> void
 ~System.Windows.Forms.TreeViewEventArgs.TreeViewEventArgs(System.Windows.Forms.TreeNode node, System.Windows.Forms.TreeViewAction action) -> void
-~System.Windows.Forms.TreeViewHitTestInfo.Node.get -> System.Windows.Forms.TreeNode
-~System.Windows.Forms.TreeViewHitTestInfo.TreeViewHitTestInfo(System.Windows.Forms.TreeNode hitNode, System.Windows.Forms.TreeViewHitTestLocations hitLocation) -> void
+System.Windows.Forms.TreeViewHitTestInfo.Node.get -> System.Windows.Forms.TreeNode?
+System.Windows.Forms.TreeViewHitTestInfo.TreeViewHitTestInfo(System.Windows.Forms.TreeNode? hitNode, System.Windows.Forms.TreeViewHitTestLocations hitLocation) -> void
 ~System.Windows.Forms.TypeValidationEventArgs.Message.get -> string
 ~System.Windows.Forms.TypeValidationEventArgs.ReturnValue.get -> object
 ~System.Windows.Forms.TypeValidationEventArgs.TypeValidationEventArgs(System.Type validatingType, bool isValidInput, object returnValue, string message) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewHitTestInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewHitTestInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -12,12 +10,12 @@ namespace System.Windows.Forms
     public class TreeViewHitTestInfo
     {
         private readonly TreeViewHitTestLocations loc;
-        private readonly TreeNode node;
+        private readonly TreeNode? node;
 
         /// <summary>
         ///  Creates a TreeViewHitTestInfo instance.
         /// </summary>
-        public TreeViewHitTestInfo(TreeNode hitNode, TreeViewHitTestLocations hitLocation)
+        public TreeViewHitTestInfo(TreeNode? hitNode, TreeViewHitTestLocations hitLocation)
         {
             node = hitNode;
             loc = hitLocation;
@@ -37,7 +35,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This gives the node returned by hit test on treeview.
         /// </summary>
-        public TreeNode Node
+        public TreeNode? Node
         {
             get
             {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in TreeViewHitTestInfo.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4588)