### PR TITLE
Moved sub-classes of "FileDialog", "OpenFileDialog" and "SaveFileDialog" classes to their own files

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -199,63 +199,6 @@ namespace System.Windows.Forms
             return ok;
         }
 
-        private class VistaDialogEvents : IFileDialogEvents
-        {
-            private readonly FileDialog _dialog;
-
-            public VistaDialogEvents(FileDialog dialog)
-            {
-                _dialog = dialog;
-            }
-
-            public HRESULT OnFileOk(IFileDialog pfd)
-            {
-                return _dialog.HandleVistaFileOk(pfd) ? HRESULT.S_OK : HRESULT.S_FALSE;
-            }
-
-            public HRESULT OnFolderChanging(IFileDialog pfd, IShellItem psiFolder)
-            {
-                return HRESULT.S_OK;
-            }
-
-            public HRESULT OnFolderChange(IFileDialog pfd)
-            {
-                return HRESULT.S_OK;
-            }
-
-            public HRESULT OnSelectionChange(IFileDialog pfd)
-            {
-                return HRESULT.S_OK;
-            }
-
-            public unsafe HRESULT OnShareViolation(IFileDialog pfd, IShellItem psi, FDESVR* pResponse)
-            {
-                if (pResponse is null)
-                {
-                    return HRESULT.E_POINTER;
-                }
-
-                *pResponse = FDESVR.DEFAULT;
-                return HRESULT.S_OK;
-            }
-
-            public HRESULT OnTypeChange(IFileDialog pfd)
-            {
-                return HRESULT.S_OK;
-            }
-
-            public unsafe HRESULT OnOverwrite(IFileDialog pfd, IShellItem psi, FDEOR* pResponse)
-            {
-                if (pResponse is null)
-                {
-                    return HRESULT.E_POINTER;
-                }
-
-                *pResponse = FDEOR.DEFAULT;
-                return HRESULT.S_OK;
-            }
-        }
-
         private void SetFileTypes(IFileDialog dialog)
         {
             COMDLG_FILTERSPEC[] filterItems = FilterItems;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.VistaDialogEvents.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.VistaDialogEvents.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 using static Interop.Shell32;
 
@@ -13,16 +11,16 @@ namespace System.Windows.Forms
     {
         private class VistaDialogEvents : IFileDialogEvents
         {
-            private readonly FileDialog _dialog;
+            private readonly FileDialog _ownerDialog;
 
             public VistaDialogEvents(FileDialog dialog)
             {
-                _dialog = dialog;
+                _ownerDialog = dialog;
             }
 
             public HRESULT OnFileOk(IFileDialog pfd)
             {
-                return _dialog.HandleVistaFileOk(pfd) ? HRESULT.S_OK : HRESULT.S_FALSE;
+                return _ownerDialog.HandleVistaFileOk(pfd) ? HRESULT.S_OK : HRESULT.S_FALSE;
             }
 
             public HRESULT OnFolderChanging(IFileDialog pfd, IShellItem psiFolder)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.VistaDialogEvents.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.VistaDialogEvents.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using static Interop;
+using static Interop.Shell32;
+
+namespace System.Windows.Forms
+{
+    public partial class FileDialog
+    {
+        private class VistaDialogEvents : IFileDialogEvents
+        {
+            private readonly FileDialog _dialog;
+
+            public VistaDialogEvents(FileDialog dialog)
+            {
+                _dialog = dialog;
+            }
+
+            public HRESULT OnFileOk(IFileDialog pfd)
+            {
+                return _dialog.HandleVistaFileOk(pfd) ? HRESULT.S_OK : HRESULT.S_FALSE;
+            }
+
+            public HRESULT OnFolderChanging(IFileDialog pfd, IShellItem psiFolder)
+            {
+                return HRESULT.S_OK;
+            }
+
+            public HRESULT OnFolderChange(IFileDialog pfd)
+            {
+                return HRESULT.S_OK;
+            }
+
+            public HRESULT OnSelectionChange(IFileDialog pfd)
+            {
+                return HRESULT.S_OK;
+            }
+
+            public unsafe HRESULT OnShareViolation(IFileDialog pfd, IShellItem psi, FDESVR* pResponse)
+            {
+                if (pResponse is null)
+                {
+                    return HRESULT.E_POINTER;
+                }
+
+                *pResponse = FDESVR.DEFAULT;
+                return HRESULT.S_OK;
+            }
+
+            public HRESULT OnTypeChange(IFileDialog pfd)
+            {
+                return HRESULT.S_OK;
+            }
+
+            public unsafe HRESULT OnOverwrite(IFileDialog pfd, IShellItem psi, FDEOR* pResponse)
+            {
+                if (pResponse is null)
+                {
+                    return HRESULT.E_POINTER;
+                }
+
+                *pResponse = FDEOR.DEFAULT;
+                return HRESULT.S_OK;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.FileOpenDialogRCW.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.FileOpenDialogRCW.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Windows.Forms
+{
+    public sealed partial class OpenFileDialog
+    {
+        [ComImport]
+        [ClassInterface(ClassInterfaceType.None)]
+        [TypeLibType(TypeLibTypeFlags.FCanCreate)]
+        [Guid("DC1C5A9C-E88A-4dde-A5A1-60F82A20AEF7")]
+        internal class FileOpenDialogRCW
+        {
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.NativeFileOpenDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.NativeFileOpenDialog.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using static Interop.Shell32;
+
+namespace System.Windows.Forms
+{
+    public sealed partial class OpenFileDialog
+    {
+        [ComImport]
+        [Guid("d57c7288-d4ad-4768-be02-9d969532d960")]
+        [CoClass(typeof(FileOpenDialogRCW))]
+        internal interface NativeFileOpenDialog : IFileOpenDialog
+        {
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -6,7 +6,6 @@
 
 using System.ComponentModel;
 using System.IO;
-using System.Runtime.InteropServices;
 using static Interop;
 using static Interop.Shell32;
 
@@ -18,7 +17,7 @@ namespace System.Windows.Forms
     ///  cannot be inherited.
     /// </summary>
     [SRDescription(nameof(SR.DescriptionOpenFileDialog))]
-    public sealed class OpenFileDialog : FileDialog
+    public sealed partial class OpenFileDialog : FileDialog
     {
         /// <summary>
         ///  Gets or sets a value indicating whether the dialog box displays a
@@ -183,21 +182,6 @@ namespace System.Windows.Forms
         private protected override bool SettingsSupportVistaDialog
         {
             get => base.SettingsSupportVistaDialog && !ShowReadOnly;
-        }
-
-        [ComImport]
-        [Guid("d57c7288-d4ad-4768-be02-9d969532d960")]
-        [CoClass(typeof(FileOpenDialogRCW))]
-        internal interface NativeFileOpenDialog : IFileOpenDialog
-        {
-        }
-
-        [ComImport]
-        [ClassInterface(ClassInterfaceType.None)]
-        [TypeLibType(TypeLibTypeFlags.FCanCreate)]
-        [Guid("DC1C5A9C-E88A-4dde-A5A1-60F82A20AEF7")]
-        internal class FileOpenDialogRCW
-        {
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.FileSaveDialogRCW.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.FileSaveDialogRCW.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Windows.Forms
+{
+    public sealed partial class SaveFileDialog
+    {
+        [ComImport]
+        [ClassInterface(ClassInterfaceType.None)]
+        [TypeLibType(TypeLibTypeFlags.FCanCreate)]
+        [Guid("C0B4E2F3-BA21-4773-8DBA-335EC946EB8B")]
+        private class FileSaveDialogRCW
+        {
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.NativeFileSaveDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.NativeFileSaveDialog.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using static Interop.Shell32;
+
+namespace System.Windows.Forms
+{
+    public sealed partial class SaveFileDialog
+    {
+        [ComImport]
+        [Guid("84bccd23-5fde-4cdb-aea4-af64b83d78ab")]
+        [CoClass(typeof(FileSaveDialogRCW))]
+        private interface NativeFileSaveDialog : IFileSaveDialog
+        {
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
@@ -6,7 +6,6 @@
 
 using System.ComponentModel;
 using System.IO;
-using System.Runtime.InteropServices;
 using static Interop;
 using static Interop.Shell32;
 
@@ -21,7 +20,7 @@ namespace System.Windows.Forms
     Designer("System.Windows.Forms.Design.SaveFileDialogDesigner, " + AssemblyRef.SystemDesign)]
     [SRDescription(nameof(SR.DescriptionSaveFileDialog))
     ]
-    public sealed class SaveFileDialog : FileDialog
+    public sealed partial class SaveFileDialog : FileDialog
     {
         /// <summary>
         ///  Gets or sets a value indicating whether the dialog box prompts the user for
@@ -153,20 +152,5 @@ namespace System.Windows.Forms
         }
 
         private protected override IFileDialog CreateVistaDialog() => new NativeFileSaveDialog();
-
-        [ComImport]
-        [Guid("84bccd23-5fde-4cdb-aea4-af64b83d78ab")]
-        [CoClass(typeof(FileSaveDialogRCW))]
-        private interface NativeFileSaveDialog : IFileSaveDialog
-        {
-        }
-
-        [ComImport]
-        [ClassInterface(ClassInterfaceType.None)]
-        [TypeLibType(TypeLibTypeFlags.FCanCreate)]
-        [Guid("C0B4E2F3-BA21-4773-8DBA-335EC946EB8B")]
-        private class FileSaveDialogRCW
-        {
-        }
     }
 }


### PR DESCRIPTION
## Proposed changes
- Moved sub-classes of "FileDialog", "OpenFileDialog" and "SaveFileDialog" classes to their own files 
## Customer Impact
- No 

## Regression? 
- No

## Risk
- Minimal

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 6.0.0-alpha.1.21073.5

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4606)