### PR TITLE
Fix NRE when instantiating UserControl as ActiveX object

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -838,7 +838,7 @@ namespace System.Windows.Forms
 
                     // We are entering a secure context here.
                     IntPtr hwndParent = IntPtr.Zero;
-                    HRESULT hr = _inPlaceUiWindow.GetWindow(&hwndParent);
+                    HRESULT hr = inPlaceSite.GetWindow(&hwndParent);
                     if (!hr.Succeeded())
                     {
                         ThrowHr(hr);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4370

## Proposed changes

The issue fixes some code that was probably erroneously copied & pasted when porting from .NET framework here:
https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Control.cs,17065


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- quite critical, as in certain situation .NET Core is totally unusable due to this. E.g. when using Core inside Office Add-Ins, it was not possible at all to use the task pane for building addins. This is a showstopper for our go-live.

## Regression? 

- None introduced, hopefully

## Risk

- unknown

<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- run build and test
- sorry, this project is quite tangential for me, and it is an obvious fix, once you confirmed this successfully for the main branch, it would be awesome to backport to 5.x, let me know if I should create a PR as well for that.

## Accessibility testing  

## Test environment(s) 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4626)