### PR TITLE
DGV throws `IndexOutOfRangeException` whenever its datasource is disposed (servicing)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
@@ -768,6 +768,14 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///  Refresh tool strip items when the BindingSource is disposed.
+        /// </summary>
+        private void OnBindingSourceDisposed(object sender, EventArgs e)
+        {
+            BindingSource = null;
+        }
+
+        /// <summary>
         ///  Refresh tool strip items when something changes in the BindingSource's list.
         /// </summary>
         private void OnBindingSourceListChanged(object sender, ListChangedEventArgs e)
@@ -895,6 +903,7 @@ namespace System.Windows.Forms
                     oldBindingSource.DataSourceChanged -= new EventHandler(OnBindingSourceStateChanged);
                     oldBindingSource.DataMemberChanged -= new EventHandler(OnBindingSourceStateChanged);
                     oldBindingSource.ListChanged -= new ListChangedEventHandler(OnBindingSourceListChanged);
+                    oldBindingSource.Disposed -= new EventHandler(OnBindingSourceDisposed);
                 }
 
                 if (newBindingSource != null)
@@ -905,6 +914,7 @@ namespace System.Windows.Forms
                     newBindingSource.DataSourceChanged += new EventHandler(OnBindingSourceStateChanged);
                     newBindingSource.DataMemberChanged += new EventHandler(OnBindingSourceStateChanged);
                     newBindingSource.ListChanged += new ListChangedEventHandler(OnBindingSourceListChanged);
+                    newBindingSource.Disposed += new EventHandler(OnBindingSourceDisposed);
                 }
 
                 oldBindingSource = newBindingSource;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -14903,6 +14903,14 @@ namespace System.Windows.Forms
             }
         }
 
+        /// <summary>
+        ///  Refresh items when the DataSource is disposed.
+        /// </summary>
+        private void OnDataSourceDisposed(object sender, EventArgs e)
+        {
+            DataSource = null;
+        }
+
         protected virtual void OnDefaultCellStyleChanged(EventArgs e)
         {
             if (e is DataGridViewCellStyleChangedEventArgs dgvcsce && !dgvcsce.ChangeAffectsPreferredSize)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -2029,6 +2029,16 @@ namespace System.Windows.Forms
             {
                 if (value != DataSource)
                 {
+                    if (DataSource is Component oldDataSource)
+                    {
+                        oldDataSource.Disposed -= OnDataSourceDisposed;
+                    }
+
+                    if (value is Component newDataSource)
+                    {
+                        newDataSource.Disposed += OnDataSourceDisposed;
+                    }
+
                     CurrentCell = null;
                     if (DataConnection is null)
                     {

--- a/src/System.Windows.Forms/tests/UnitTests/BindingNavigatorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/BindingNavigatorTests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Data;
 using System.Diagnostics;
 using Moq;
 using Xunit;
@@ -128,6 +129,87 @@ namespace System.Windows.Forms.Tests
             Assert.IsType<ToolStripSeparator>(bn.Items[index++]);
             Assert.Equal(bn.AddNewItem, bn.Items[index++]);
             Assert.Equal(bn.DeleteItem, bn.Items[index++]);
+        }
+
+        [WinFormsFact]
+        public void BindingNavigator_UpdatesItsItems_AfterDataSourceDisposing()
+        {
+            using BindingNavigator control = new BindingNavigator(true);
+            int rowsCount = 5;
+            BindingSource bindingSource = GetTestBindingSource(rowsCount);
+            control.BindingSource = bindingSource;
+
+            Assert.Equal("1", control.PositionItem.Text);
+            Assert.Equal($"of {rowsCount}", control.CountItem.Text);
+
+            bindingSource.Dispose();
+
+            // The BindingNavigator updates its PositionItem and CountItem values
+            // after its BindingSource is disposed
+            Assert.Equal("0", control.PositionItem.Text);
+            Assert.Equal("of 0", control.CountItem.Text);
+        }
+
+        [WinFormsFact]
+        public void BindingNavigator_BindingSource_IsNull_AfterDisposing()
+        {
+            using BindingNavigator control = new BindingNavigator();
+            BindingSource bindingSource = GetTestBindingSource(5);
+            control.BindingSource = bindingSource;
+
+            Assert.Equal(bindingSource, control.BindingSource);
+
+            bindingSource.Dispose();
+
+            Assert.Null(control.BindingSource);
+        }
+
+        [WinFormsFact]
+        public void BindingNavigator_BindingSource_IsActual_AfterOldOneIsDisposed()
+        {
+            using BindingNavigator control = new BindingNavigator(true);
+            int rowsCount1 = 3;
+            BindingSource bindingSource1 = GetTestBindingSource(rowsCount1);
+            int rowsCount2 = 5;
+            BindingSource bindingSource2 = GetTestBindingSource(rowsCount2);
+            control.BindingSource = bindingSource1;
+
+            Assert.Equal(bindingSource1, control.BindingSource);
+            Assert.Equal("1", control.PositionItem.Text);
+            Assert.Equal($"of {rowsCount1}", control.CountItem.Text);
+
+            control.BindingSource = bindingSource2;
+
+            Assert.Equal(bindingSource2, control.BindingSource);
+            Assert.Equal("1", control.PositionItem.Text);
+            Assert.Equal($"of {rowsCount2}", control.CountItem.Text);
+
+            bindingSource1.Dispose();
+
+            // bindingSource2 is actual for the BindingNavigator
+            // so it will contain correct PositionItem and CountItem values
+            // even after bindingSource1 is disposed.
+            // This test checks that Disposed events unsubscribed correctly
+            Assert.Equal(bindingSource2, control.BindingSource);
+            Assert.Equal("1", control.PositionItem.Text);
+            Assert.Equal($"of {rowsCount2}", control.CountItem.Text);
+        }
+
+        private BindingSource GetTestBindingSource(int rowsCount)
+        {
+            DataTable dt = new DataTable();
+            dt.Columns.Add("Name");
+            dt.Columns.Add("Age");
+
+            for (int i = 0; i < rowsCount; i++)
+            {
+                DataRow dr = dt.NewRow();
+                dr[0] = $"User{i}";
+                dr[1] = i * 3;
+                dt.Rows.Add(dr);
+            }
+
+            return new() { DataSource = dt };
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4216


## Proposed changes

- Add Dispose event handlers to clear DataSource of DGV and BindingSource of BindingNavigator thereby update their data source actual state

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user won't catch the exception when closing a form or disposing a BindingSource

## Regression? 

- Yes and no. .NET Framework 4.8 throws an exception when closing a form. v.4.7 doesn't throw the exception in this case. But anyway every version throws the exception if to Dispose a BindingSource component

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- A DataGridView doesn't update its Rows and Columns collections after its DataSource is disposed. And the DGV throws the exception when trying to redraw because the DGV is trying to draw items from a DataSource that doesn't already exist (send some index, eg. 4, to the collection that has 0 items, and catch IndexOutOfRangeException)
![vR6xyN1oe6](https://user-images.githubusercontent.com/49272759/107550604-49cec280-6be2-11eb-848d-d137900e1a07.gif)

<!-- TODO -->

### After
- `DataGridView` and `BindingNavigator` subscribed on the `BindingSource.Disposed` event and release their `DataSource` and `BindingSource` to update internal collections
![mtA3PmfUl4](https://user-images.githubusercontent.com/49272759/107550667-5d7a2900-6be2-11eb-8299-757cc49e73af.gif)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Unit testing
- Manual UI testing
- CTI

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 6.0.100-preview.1.21101.5
- Microsoft Windows [Version 10.0.19042.804]


<!-- Mention language, UI scaling, or anything else that might be relevant -->

