### PR TITLE
Mdicontainer iconchanges

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -5815,7 +5815,7 @@ namespace System.Windows.Forms
                     User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
                 }
 
-                if (WindowState == FormWindowState.Maximized && MdiParent != null && MdiParent.MdiControlStrip != null)
+                if (WindowState == FormWindowState.Maximized && MdiParent?.MdiControlStrip != null)
                 {
                     MdiParent.MdiControlStrip.updateIcon();
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -5815,6 +5815,11 @@ namespace System.Windows.Forms
                     User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
                 }
 
+                if (WindowState == FormWindowState.Maximized && MdiParent != null && MdiParent.MdiControlStrip != null)
+                {
+                    MdiParent.MdiControlStrip.updateIcon();
+                }
+
                 if (redrawFrame)
                 {
                     User32.RedrawWindow(new HandleRef(this, Handle), null, IntPtr.Zero, User32.RDW.INVALIDATE | User32.RDW.FRAME);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
@@ -76,7 +76,7 @@ namespace System.Windows.Forms
             _system.DoubleClick += new EventHandler(OnSystemMenuDoubleClick);
             _system.Padding = Padding.Empty;
             _system.ShortcutKeys = Keys.Alt | Keys.OemMinus;
-                ResumeLayout(false);
+            ResumeLayout(false);
         }
 
         public ToolStripMenuItem Close

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
@@ -68,6 +68,7 @@ namespace System.Windows.Forms
             // set up the sytem menu
 
             _system.Image = GetTargetWindowIcon();
+            _system.Visible = GetTargetWindowIconVisibility();
             _system.Alignment = ToolStripItemAlignment.Left;
             _system.DropDownOpening += new EventHandler(OnSystemMenuDropDownOpening);
             _system.ImageScaling = ToolStripItemImageScaling.None;
@@ -75,7 +76,7 @@ namespace System.Windows.Forms
             _system.DoubleClick += new EventHandler(OnSystemMenuDoubleClick);
             _system.Padding = Padding.Empty;
             _system.ShortcutKeys = Keys.Alt | Keys.OemMinus;
-            ResumeLayout(false);
+                ResumeLayout(false);
         }
 
         public ToolStripMenuItem Close
@@ -105,6 +106,23 @@ namespace System.Windows.Forms
             smallIcon.Dispose();
 
             return systemIcon;
+        }
+        private bool GetTargetWindowIconVisibility()
+        {
+            if (_target is Form formTarget)
+            {
+                return formTarget.ShowIcon;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        public void updateIcon()
+        {
+            _system.Image = GetTargetWindowIcon();
+            _system.Visible = GetTargetWindowIconVisibility();
         }
 
         protected internal override void OnItemAdded(ToolStripItemEventArgs e)
@@ -144,6 +162,7 @@ namespace System.Windows.Forms
             }
 
             _system.Image = GetTargetWindowIcon();
+            _system.Visible = GetTargetWindowIconVisibility();
         }
 
         private void OnSystemMenuDropDownOpening(object sender, EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
@@ -107,17 +107,7 @@ namespace System.Windows.Forms
 
             return systemIcon;
         }
-        private bool GetTargetWindowIconVisibility()
-        {
-            if (_target is Form formTarget)
-            {
-                return formTarget.ShowIcon;
-            }
-            else
-            {
-                return true;
-            }
-        }
+        private bool GetTargetWindowIconVisibility() => _target is not Form formTarget || formTarget.ShowIcon;
 
         public void updateIcon()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -1170,6 +1170,46 @@ namespace System.Windows.Forms.Tests
             Assert.Same(oldParent, control.MdiParent);
         }
 
+        [WinFormsFact]
+        public void Form_Parent_ShowIconInMaximized()
+        {
+            using var parent = new Form();
+            using var menuStrip = new MenuStrip();
+            menuStrip.Location = new System.Drawing.Point(0, 0);
+            menuStrip.Size = new System.Drawing.Size(parent.Width, 24);
+            parent.Controls.Add(menuStrip);
+            parent.IsMdiContainer = true;
+            parent.MainMenuStrip = menuStrip;
+            parent.Show();
+            Assert.True(parent.Handle != IntPtr.Zero);
+            using var control = new Form();
+            control.MdiParent = parent;
+            control.Icon = Form.DefaultIcon;
+            Assert.True(control.Handle != IntPtr.Zero);
+            control.Show();
+
+            control.ShowIcon = false;
+            IntPtr hSmallIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            Assert.True(hSmallIcon == IntPtr.Zero);
+            IntPtr hLargeIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+            Assert.True(hLargeIcon == IntPtr.Zero);
+
+            control.WindowState = FormWindowState.Maximized;
+            control.ShowIcon = false;
+            hSmallIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            Assert.True(hSmallIcon == IntPtr.Zero);
+            hLargeIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+            Assert.True(hLargeIcon == IntPtr.Zero);
+            Assert.True(!menuStrip.Items[0].Visible);
+
+            control.ShowIcon = true;
+            hSmallIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            Assert.True(hSmallIcon != IntPtr.Zero);
+            hLargeIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+            Assert.True(hLargeIcon != IntPtr.Zero);
+            Assert.True(menuStrip.Items[0].Visible);
+        }
+
         public static IEnumerable<object[]> TransparencyKey_Set_TestData()
         {
             foreach (bool allowTransparency in new bool[] { true, false })

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -1175,8 +1175,6 @@ namespace System.Windows.Forms.Tests
         {
             using var parent = new Form();
             using var menuStrip = new MenuStrip();
-            menuStrip.Location = new System.Drawing.Point(0, 0);
-            menuStrip.Size = new System.Drawing.Size(parent.Width, 24);
             parent.Controls.Add(menuStrip);
             parent.IsMdiContainer = true;
             parent.MainMenuStrip = menuStrip;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4621


## Proposed changes

- The visibility of the Icon in the MDIControlStrip is dependent on the ShowIcon property on the target MDI child.
- When the icon gets updated in the target MDI child, the icon gets updated in the MDIControlStrip and its visibility is checked.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The icon will now change dependent on ShowIcon and the icon in the target MDI child.

## Regression? 

- No

## Risk

- Icon can not be used to open context menu when icon is hidden.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

With showicon = false and the icon set to error icon after it is maximized.
![image](https://user-images.githubusercontent.com/155535/110207129-c66f5c80-7e81-11eb-94f2-a93c6bb3c01d.png)

### After

the icon set to error icon after it is maximized.
![image](https://user-images.githubusercontent.com/155535/110207294-db98bb00-7e82-11eb-8be3-da652464e89e.png)

With showicon = false
![image](https://user-images.githubusercontent.com/155535/110207319-f834f300-7e82-11eb-83e0-04ca92fb7dcb.png)



## Test methodology <!-- How did you ensure quality? -->

- manual testing
- Unit test 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->





###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4650)