### PR TITLE
Enable nullability in OwnerDrawPropertyBag

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1340,7 +1340,7 @@
 ~static System.Windows.Forms.MessageBox.Show(System.Windows.Forms.IWin32Window owner, string text, string caption, System.Windows.Forms.MessageBoxButtons buttons, System.Windows.Forms.MessageBoxIcon icon, System.Windows.Forms.MessageBoxDefaultButton defaultButton, System.Windows.Forms.MessageBoxOptions options, string helpFilePath, System.Windows.Forms.HelpNavigator navigator, object param) -> System.Windows.Forms.DialogResult
 ~static System.Windows.Forms.NativeWindow.FromHandle(System.IntPtr handle) -> System.Windows.Forms.NativeWindow
 ~static System.Windows.Forms.OSFeature.Feature.get -> System.Windows.Forms.OSFeature
-~static System.Windows.Forms.OwnerDrawPropertyBag.Copy(System.Windows.Forms.OwnerDrawPropertyBag value) -> System.Windows.Forms.OwnerDrawPropertyBag
+static System.Windows.Forms.OwnerDrawPropertyBag.Copy(System.Windows.Forms.OwnerDrawPropertyBag? value) -> System.Windows.Forms.OwnerDrawPropertyBag!
 ~static System.Windows.Forms.ProgressBarRenderer.DrawHorizontalBar(System.Drawing.Graphics g, System.Drawing.Rectangle bounds) -> void
 ~static System.Windows.Forms.ProgressBarRenderer.DrawHorizontalChunks(System.Drawing.Graphics g, System.Drawing.Rectangle bounds) -> void
 ~static System.Windows.Forms.ProgressBarRenderer.DrawVerticalBar(System.Drawing.Graphics g, System.Drawing.Rectangle bounds) -> void
@@ -2550,9 +2550,9 @@
 ~System.Windows.Forms.OpenFileDialog.OpenFile() -> System.IO.Stream
 ~System.Windows.Forms.OpenFileDialog.SafeFileName.get -> string
 ~System.Windows.Forms.OpenFileDialog.SafeFileNames.get -> string[]
-~System.Windows.Forms.OwnerDrawPropertyBag.Font.get -> System.Drawing.Font
-~System.Windows.Forms.OwnerDrawPropertyBag.Font.set -> void
-~System.Windows.Forms.OwnerDrawPropertyBag.OwnerDrawPropertyBag(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) -> void
+System.Windows.Forms.OwnerDrawPropertyBag.Font.get -> System.Drawing.Font?
+System.Windows.Forms.OwnerDrawPropertyBag.Font.set -> void
+System.Windows.Forms.OwnerDrawPropertyBag.OwnerDrawPropertyBag(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 ~System.Windows.Forms.PageSetupDialog.Document.get -> System.Drawing.Printing.PrintDocument
 ~System.Windows.Forms.PageSetupDialog.Document.set -> void
 ~System.Windows.Forms.PageSetupDialog.MinMargins.get -> System.Drawing.Printing.Margins

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OwnerDrawPropertyBag.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OwnerDrawPropertyBag.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.Serialization;
 using static Interop;
@@ -16,24 +15,24 @@ namespace System.Windows.Forms
     [Serializable] // This class is participating in resx serialization scenarios for listview/treeview items.
     public class OwnerDrawPropertyBag : MarshalByRefObject, ISerializable
     {
-        private Control.FontHandleWrapper _fontWrapper;
+        private Control.FontHandleWrapper? _fontWrapper;
         private static readonly object s_internalSyncObject = new object();
 
         protected OwnerDrawPropertyBag(SerializationInfo info, StreamingContext context)
         {
             foreach (SerializationEntry entry in info)
             {
-                if (entry.Name == nameof(Font))
+                if (entry.Name == nameof(Font) && entry.Value is Font font)
                 {
-                    Font = (Font)entry.Value;
+                    Font = font;
                 }
                 else if (entry.Name == nameof(ForeColor))
                 {
-                    ForeColor = (Color)entry.Value;
+                    ForeColor = (Color)entry.Value!;
                 }
                 else if (entry.Name == nameof(BackColor))
                 {
-                    BackColor = (Color)entry.Value;
+                    BackColor = (Color)entry.Value!;
                 }
             }
         }
@@ -42,7 +41,7 @@ namespace System.Windows.Forms
         {
         }
 
-        public Font Font { get; set; }
+        public Font? Font { get; set; }
 
         public Color ForeColor { get; set; }
 
@@ -54,6 +53,7 @@ namespace System.Windows.Forms
             {
                 if (_fontWrapper is null)
                 {
+                    Debug.Assert(Font is not null);
                     _fontWrapper = new Control.FontHandleWrapper(Font);
                 }
 
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Copies the bag. Always returns a valid ODPB object
         /// </summary>
-        public static OwnerDrawPropertyBag Copy(OwnerDrawPropertyBag value)
+        public static OwnerDrawPropertyBag Copy(OwnerDrawPropertyBag? value)
         {
             lock (s_internalSyncObject)
             {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in OwnerDrawPropertyBag.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4653)