### PR TITLE
fixes #3686: just insert the tabpage if the handle isn't created

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1220,6 +1220,10 @@ namespace System.Windows.Forms
                     Insert(retIndex, tabPage);
                 }
             }
+            else
+            {
+                Insert(index, tabPage);
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
@@ -4895,6 +4895,33 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(new TabPage[] { child1, child2, child3 }, collection.Cast<TabPage>());
         }
 
+        [WinFormsFact]
+        public void TabPageCollection_Insert_By_Index()
+        {
+            using var TabControl = new TabControl();
+
+            using var page1 = new TabPage();
+            using var page2 = new TabPage();
+            using var page3 = new TabPage();
+
+            page1.Text = "First works";
+            TabControl.TabPages.Add(page1);
+
+            page2.Text = "Second fails";
+            TabControl.TabPages.Insert(1, page2);
+            Assert.Equal(2, TabControl.TabPages.Count);
+            Assert.Equal(page2, TabControl.TabPages[1]);
+            Assert.Equal(page2, TabControl.Controls[1]);
+
+            page3.Text = "Third works";
+            TabControl.TabPages.Insert(1, page3);
+            Assert.Equal(3, TabControl.TabPages.Count);
+            Assert.Equal(page3, TabControl.TabPages[1]);
+            Assert.Equal(page3, TabControl.Controls[1]);
+            Assert.Equal(page2, TabControl.TabPages[2]);
+            Assert.Equal(page2, TabControl.Controls[2]);
+        }
+
         private class NullGetItemsTabControl : TabControl
         {
             protected override object[] GetItems() => null;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3686


## Proposed changes

- Insert the tabpage in the controls list and in the tabpages list

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The user can now insert tab pages without creating the Handle.


## Regression? 

- No

## Risk

- None

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- unit test
- manual testing