### PR TITLE
Enable nullability in TreeViewCancelEventArgs and TreeViewEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -10977,11 +10977,11 @@ System.Windows.Forms.ToolStripControlHost.ToolStripHostedControlAccessibleObject
 ~System.Windows.Forms.TreeView.TopNode.set -> void
 ~System.Windows.Forms.TreeView.TreeViewNodeSorter.get -> System.Collections.IComparer
 ~System.Windows.Forms.TreeView.TreeViewNodeSorter.set -> void
-~System.Windows.Forms.TreeViewCancelEventArgs.Node.get -> System.Windows.Forms.TreeNode
-~System.Windows.Forms.TreeViewCancelEventArgs.TreeViewCancelEventArgs(System.Windows.Forms.TreeNode node, bool cancel, System.Windows.Forms.TreeViewAction action) -> void
-~System.Windows.Forms.TreeViewEventArgs.Node.get -> System.Windows.Forms.TreeNode
-~System.Windows.Forms.TreeViewEventArgs.TreeViewEventArgs(System.Windows.Forms.TreeNode node) -> void
-~System.Windows.Forms.TreeViewEventArgs.TreeViewEventArgs(System.Windows.Forms.TreeNode node, System.Windows.Forms.TreeViewAction action) -> void
+System.Windows.Forms.TreeViewCancelEventArgs.Node.get -> System.Windows.Forms.TreeNode?
+System.Windows.Forms.TreeViewCancelEventArgs.TreeViewCancelEventArgs(System.Windows.Forms.TreeNode? node, bool cancel, System.Windows.Forms.TreeViewAction action) -> void
+System.Windows.Forms.TreeViewEventArgs.Node.get -> System.Windows.Forms.TreeNode?
+System.Windows.Forms.TreeViewEventArgs.TreeViewEventArgs(System.Windows.Forms.TreeNode? node) -> void
+System.Windows.Forms.TreeViewEventArgs.TreeViewEventArgs(System.Windows.Forms.TreeNode? node, System.Windows.Forms.TreeViewAction action) -> void
 System.Windows.Forms.TreeViewHitTestInfo.Node.get -> System.Windows.Forms.TreeNode?
 System.Windows.Forms.TreeViewHitTestInfo.TreeViewHitTestInfo(System.Windows.Forms.TreeNode? hitNode, System.Windows.Forms.TreeViewHitTestLocations hitLocation) -> void
 ~System.Windows.Forms.TypeValidationEventArgs.Message.get -> string

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewCancelEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewCancelEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms
@@ -16,30 +14,15 @@ namespace System.Windows.Forms
     /// </summary>
     public class TreeViewCancelEventArgs : CancelEventArgs
     {
-        private readonly TreeNode node;
-        private readonly TreeViewAction action;
-
-        public TreeViewCancelEventArgs(TreeNode node, bool cancel, TreeViewAction action)
-        : base(cancel)
+        public TreeViewCancelEventArgs(TreeNode? node, bool cancel, TreeViewAction action)
+            : base(cancel)
         {
-            this.node = node;
-            this.action = action;
+            Node = node;
+            Action = action;
         }
 
-        public TreeNode Node
-        {
-            get
-            {
-                return node;
-            }
-        }
+        public TreeNode? Node { get; }
 
-        public TreeViewAction Action
-        {
-            get
-            {
-                return action;
-            }
-        }
+        public TreeViewAction Action { get; }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewEventArgs.cs
@@ -2,46 +2,33 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>
-    ///  Provides data for the <see cref='TreeView.OnAfterCheck'/>, <see cref='TreeView.AfterCollapse'/>, <see cref='TreeView.AfterExpand'/>, or <see cref='TreeView.AfterSelect'/> event.
+    ///  Provides data for the <see cref='TreeView.OnAfterCheck'/>,
+    ///  <see cref='TreeView.AfterCollapse'/>,
+    ///  <see cref='TreeView.AfterExpand'/>,
+    ///  or <see cref='TreeView.AfterSelect'/> event.
     /// </summary>
     public class TreeViewEventArgs : EventArgs
     {
-        readonly TreeNode node;
-        readonly TreeViewAction action = TreeViewAction.Unknown;
-
-        public TreeViewEventArgs(TreeNode node)
+        public TreeViewEventArgs(TreeNode? node)
         {
-            this.node = node;
+            Node = node;
+            Action = TreeViewAction.Unknown;
         }
 
-        public TreeViewEventArgs(TreeNode node, TreeViewAction action)
+        public TreeViewEventArgs(TreeNode? node, TreeViewAction action)
         {
-            this.node = node;
-            this.action = action;
+            Node = node;
+            Action = action;
         }
 
-        public TreeNode Node
-        {
-            get
-            {
-                return node;
-            }
-        }
+        public TreeNode? Node { get; }
 
         /// <summary>
         ///  An event specific action-flag.
         /// </summary>
-        public TreeViewAction Action
-        {
-            get
-            {
-                return action;
-            }
-        }
+        public TreeViewAction Action { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in TreeViewCancelEventArgs and TreeViewEventArgs.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4658)