### PR TITLE
Enable nullability in some DataGridViewRow EventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -9931,9 +9931,9 @@ virtual System.Windows.Forms.UpDownBase.ValidateEditText() -> void
 ~System.Windows.Forms.DataGridViewRow.HeaderCell.get -> System.Windows.Forms.DataGridViewRowHeaderCell
 ~System.Windows.Forms.DataGridViewRow.HeaderCell.set -> void
 ~System.Windows.Forms.DataGridViewRow.SetValues(params object[] values) -> bool
-~System.Windows.Forms.DataGridViewRowCancelEventArgs.DataGridViewRowCancelEventArgs(System.Windows.Forms.DataGridViewRow dataGridViewRow) -> void
-~System.Windows.Forms.DataGridViewRowCancelEventArgs.Row.get -> System.Windows.Forms.DataGridViewRow
-~System.Windows.Forms.DataGridViewRowCancelEventArgs.Row.set -> void
+System.Windows.Forms.DataGridViewRowCancelEventArgs.DataGridViewRowCancelEventArgs(System.Windows.Forms.DataGridViewRow? dataGridViewRow) -> void
+System.Windows.Forms.DataGridViewRowCancelEventArgs.Row.get -> System.Windows.Forms.DataGridViewRow?
+System.Windows.Forms.DataGridViewRowCancelEventArgs.Row.set -> void
 ~System.Windows.Forms.DataGridViewRowCollection.CopyTo(System.Windows.Forms.DataGridViewRow[] array, int index) -> void
 ~System.Windows.Forms.DataGridViewRowCollection.DataGridView.get -> System.Windows.Forms.DataGridView
 ~System.Windows.Forms.DataGridViewRowCollection.DataGridViewRowCollection(System.Windows.Forms.DataGridView dataGridView) -> void
@@ -9941,23 +9941,23 @@ virtual System.Windows.Forms.UpDownBase.ValidateEditText() -> void
 ~System.Windows.Forms.DataGridViewRowCollection.List.get -> System.Collections.ArrayList
 ~System.Windows.Forms.DataGridViewRowCollection.SharedRow(int rowIndex) -> System.Windows.Forms.DataGridViewRow
 ~System.Windows.Forms.DataGridViewRowCollection.this[int index].get -> System.Windows.Forms.DataGridViewRow
-~System.Windows.Forms.DataGridViewRowContextMenuStripNeededEventArgs.ContextMenuStrip.get -> System.Windows.Forms.ContextMenuStrip
-~System.Windows.Forms.DataGridViewRowContextMenuStripNeededEventArgs.ContextMenuStrip.set -> void
-~System.Windows.Forms.DataGridViewRowDividerDoubleClickEventArgs.DataGridViewRowDividerDoubleClickEventArgs(int rowIndex, System.Windows.Forms.HandledMouseEventArgs e) -> void
-~System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs.ErrorText.get -> string
-~System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs.ErrorText.set -> void
-~System.Windows.Forms.DataGridViewRowEventArgs.DataGridViewRowEventArgs(System.Windows.Forms.DataGridViewRow dataGridViewRow) -> void
-~System.Windows.Forms.DataGridViewRowEventArgs.Row.get -> System.Windows.Forms.DataGridViewRow
-~System.Windows.Forms.DataGridViewRowPostPaintEventArgs.DataGridViewRowPostPaintEventArgs(System.Windows.Forms.DataGridView dataGridView, System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle rowBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates rowState, string errorText, System.Windows.Forms.DataGridViewCellStyle inheritedRowStyle, bool isFirstDisplayedRow, bool isLastVisibleRow) -> void
-~System.Windows.Forms.DataGridViewRowPostPaintEventArgs.ErrorText.get -> string
-~System.Windows.Forms.DataGridViewRowPostPaintEventArgs.Graphics.get -> System.Drawing.Graphics
-~System.Windows.Forms.DataGridViewRowPostPaintEventArgs.InheritedRowStyle.get -> System.Windows.Forms.DataGridViewCellStyle
-~System.Windows.Forms.DataGridViewRowPrePaintEventArgs.DataGridViewRowPrePaintEventArgs(System.Windows.Forms.DataGridView dataGridView, System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle rowBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates rowState, string errorText, System.Windows.Forms.DataGridViewCellStyle inheritedRowStyle, bool isFirstDisplayedRow, bool isLastVisibleRow) -> void
-~System.Windows.Forms.DataGridViewRowPrePaintEventArgs.ErrorText.get -> string
-~System.Windows.Forms.DataGridViewRowPrePaintEventArgs.Graphics.get -> System.Drawing.Graphics
-~System.Windows.Forms.DataGridViewRowPrePaintEventArgs.InheritedRowStyle.get -> System.Windows.Forms.DataGridViewCellStyle
-~System.Windows.Forms.DataGridViewRowStateChangedEventArgs.DataGridViewRowStateChangedEventArgs(System.Windows.Forms.DataGridViewRow dataGridViewRow, System.Windows.Forms.DataGridViewElementStates stateChanged) -> void
-~System.Windows.Forms.DataGridViewRowStateChangedEventArgs.Row.get -> System.Windows.Forms.DataGridViewRow
+System.Windows.Forms.DataGridViewRowContextMenuStripNeededEventArgs.ContextMenuStrip.get -> System.Windows.Forms.ContextMenuStrip?
+System.Windows.Forms.DataGridViewRowContextMenuStripNeededEventArgs.ContextMenuStrip.set -> void
+System.Windows.Forms.DataGridViewRowDividerDoubleClickEventArgs.DataGridViewRowDividerDoubleClickEventArgs(int rowIndex, System.Windows.Forms.HandledMouseEventArgs! e) -> void
+System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs.ErrorText.get -> string?
+System.Windows.Forms.DataGridViewRowErrorTextNeededEventArgs.ErrorText.set -> void
+System.Windows.Forms.DataGridViewRowEventArgs.DataGridViewRowEventArgs(System.Windows.Forms.DataGridViewRow! dataGridViewRow) -> void
+System.Windows.Forms.DataGridViewRowEventArgs.Row.get -> System.Windows.Forms.DataGridViewRow!
+System.Windows.Forms.DataGridViewRowPostPaintEventArgs.DataGridViewRowPostPaintEventArgs(System.Windows.Forms.DataGridView! dataGridView, System.Drawing.Graphics! graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle rowBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates rowState, string? errorText, System.Windows.Forms.DataGridViewCellStyle! inheritedRowStyle, bool isFirstDisplayedRow, bool isLastVisibleRow) -> void
+System.Windows.Forms.DataGridViewRowPostPaintEventArgs.ErrorText.get -> string?
+System.Windows.Forms.DataGridViewRowPostPaintEventArgs.Graphics.get -> System.Drawing.Graphics!
+System.Windows.Forms.DataGridViewRowPostPaintEventArgs.InheritedRowStyle.get -> System.Windows.Forms.DataGridViewCellStyle!
+System.Windows.Forms.DataGridViewRowPrePaintEventArgs.DataGridViewRowPrePaintEventArgs(System.Windows.Forms.DataGridView! dataGridView, System.Drawing.Graphics! graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle rowBounds, int rowIndex, System.Windows.Forms.DataGridViewElementStates rowState, string? errorText, System.Windows.Forms.DataGridViewCellStyle! inheritedRowStyle, bool isFirstDisplayedRow, bool isLastVisibleRow) -> void
+System.Windows.Forms.DataGridViewRowPrePaintEventArgs.ErrorText.get -> string?
+System.Windows.Forms.DataGridViewRowPrePaintEventArgs.Graphics.get -> System.Drawing.Graphics!
+System.Windows.Forms.DataGridViewRowPrePaintEventArgs.InheritedRowStyle.get -> System.Windows.Forms.DataGridViewCellStyle!
+System.Windows.Forms.DataGridViewRowStateChangedEventArgs.DataGridViewRowStateChangedEventArgs(System.Windows.Forms.DataGridViewRow! dataGridViewRow, System.Windows.Forms.DataGridViewElementStates stateChanged) -> void
+System.Windows.Forms.DataGridViewRowStateChangedEventArgs.Row.get -> System.Windows.Forms.DataGridViewRow!
 ~System.Windows.Forms.DataGridViewSelectedCellCollection.Contains(System.Windows.Forms.DataGridViewCell dataGridViewCell) -> bool
 ~System.Windows.Forms.DataGridViewSelectedCellCollection.CopyTo(System.Windows.Forms.DataGridViewCell[] array, int index) -> void
 ~System.Windows.Forms.DataGridViewSelectedCellCollection.Insert(int index, System.Windows.Forms.DataGridViewCell dataGridViewCell) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCancelEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCancelEventArgs.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms
 {
     public class DataGridViewRowCancelEventArgs : CancelEventArgs
     {
-        public DataGridViewRowCancelEventArgs(DataGridViewRow dataGridViewRow)
+        public DataGridViewRowCancelEventArgs(DataGridViewRow? dataGridViewRow)
         {
             Row = dataGridViewRow;
         }
 
-        public DataGridViewRow Row { get; set; }
+        public DataGridViewRow? Row { get; set; }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowContextMenuStripNeededEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowContextMenuStripNeededEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewRowContextMenuStripNeededEventArgs : EventArgs
@@ -18,13 +16,14 @@ namespace System.Windows.Forms
             RowIndex = rowIndex;
         }
 
-        internal DataGridViewRowContextMenuStripNeededEventArgs(int rowIndex, ContextMenuStrip contextMenuStrip) : this(rowIndex)
+        internal DataGridViewRowContextMenuStripNeededEventArgs(int rowIndex, ContextMenuStrip? contextMenuStrip)
+            : this(rowIndex)
         {
             ContextMenuStrip = contextMenuStrip;
         }
 
         public int RowIndex { get; }
 
-        public ContextMenuStrip ContextMenuStrip { get; set; }
+        public ContextMenuStrip? ContextMenuStrip { get; set; }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowDividerDoubleClickEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowDividerDoubleClickEventArgs.cs
@@ -2,22 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewRowDividerDoubleClickEventArgs : HandledMouseEventArgs
     {
-        public DataGridViewRowDividerDoubleClickEventArgs(int rowIndex, HandledMouseEventArgs e) : base(e?.Button ?? MouseButtons.None, e?.Clicks ?? 0, e?.X ?? 0, e?.Y ?? 0, e?.Delta ?? 0, e?.Handled ?? false)
+        public DataGridViewRowDividerDoubleClickEventArgs(int rowIndex, HandledMouseEventArgs e)
+            : base((e ?? throw new ArgumentNullException(nameof(e))).Button, e.Clicks, e.X, e.Y, e.Delta, e.Handled)
         {
             if (rowIndex < -1)
             {
                 throw new ArgumentOutOfRangeException(nameof(rowIndex));
-            }
-
-            if (e is null)
-            {
-                throw new ArgumentNullException(nameof(e));
             }
 
             RowIndex = rowIndex;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowErrorTextNeededEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowErrorTextNeededEventArgs.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 
 namespace System.Windows.Forms
 {
     public class DataGridViewRowErrorTextNeededEventArgs : EventArgs
     {
-        internal DataGridViewRowErrorTextNeededEventArgs(int rowIndex, string errorText)
+        internal DataGridViewRowErrorTextNeededEventArgs(int rowIndex, string? errorText)
         {
             Debug.Assert(rowIndex >= -1);
             RowIndex = rowIndex;
@@ -19,6 +17,6 @@ namespace System.Windows.Forms
 
         public int RowIndex { get; }
 
-        public string ErrorText { get; set; }
+        public string? ErrorText { get; set; }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewRowEventArgs : EventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowPostPaintEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowPostPaintEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Drawing;
 
@@ -13,16 +11,17 @@ namespace System.Windows.Forms
     {
         private readonly DataGridView _dataGridView;
 
-        public DataGridViewRowPostPaintEventArgs(DataGridView dataGridView,
-                                                 Graphics graphics,
-                                                 Rectangle clipBounds,
-                                                 Rectangle rowBounds,
-                                                 int rowIndex,
-                                                 DataGridViewElementStates rowState,
-                                                 string errorText,
-                                                 DataGridViewCellStyle inheritedRowStyle,
-                                                 bool isFirstDisplayedRow,
-                                                 bool isLastVisibleRow)
+        public DataGridViewRowPostPaintEventArgs(
+            DataGridView dataGridView,
+            Graphics graphics,
+            Rectangle clipBounds,
+            Rectangle rowBounds,
+            int rowIndex,
+            DataGridViewElementStates rowState,
+            string? errorText,
+            DataGridViewCellStyle inheritedRowStyle,
+            bool isFirstDisplayedRow,
+            bool isLastVisibleRow)
         {
             _dataGridView = dataGridView ?? throw new ArgumentNullException(nameof(dataGridView));
             Graphics = graphics ?? throw new ArgumentNullException(nameof(graphics));
@@ -40,6 +39,8 @@ namespace System.Windows.Forms
         {
             Debug.Assert(dataGridView is not null);
             _dataGridView = dataGridView;
+            Graphics = null!;
+            InheritedRowStyle = null!;
         }
 
         public Graphics Graphics { get; private set; }
@@ -52,7 +53,7 @@ namespace System.Windows.Forms
 
         public DataGridViewElementStates State { get; private set; }
 
-        public string ErrorText { get; private set; }
+        public string? ErrorText { get; private set; }
 
         public DataGridViewCellStyle InheritedRowStyle { get; private set; }
 
@@ -67,13 +68,14 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewElementPaintingEventArgs_RowIndexOutOfRange);
             }
 
-            _dataGridView.Rows.SharedRow(RowIndex).DrawFocus(Graphics,
-                                                             ClipBounds,
-                                                             bounds,
-                                                             RowIndex,
-                                                             State,
-                                                             InheritedRowStyle,
-                                                             cellsPaintSelectionBackground);
+            _dataGridView.Rows.SharedRow(RowIndex).DrawFocus(
+                Graphics,
+                ClipBounds,
+                bounds,
+                RowIndex,
+                State,
+                InheritedRowStyle,
+                cellsPaintSelectionBackground);
         }
 
         public void PaintCells(Rectangle clipBounds, DataGridViewPaintParts paintParts)
@@ -83,14 +85,15 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewElementPaintingEventArgs_RowIndexOutOfRange);
             }
 
-            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(Graphics,
-                                                              clipBounds,
-                                                              RowBounds,
-                                                              RowIndex,
-                                                              State,
-                                                              IsFirstDisplayedRow,
-                                                              IsLastVisibleRow,
-                                                              paintParts);
+            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(
+                Graphics,
+                clipBounds,
+                RowBounds,
+                RowIndex,
+                State,
+                IsFirstDisplayedRow,
+                IsLastVisibleRow,
+                paintParts);
         }
 
         public void PaintCellsBackground(Rectangle clipBounds, bool cellsPaintSelectionBackground)
@@ -106,14 +109,15 @@ namespace System.Windows.Forms
                 paintParts |= DataGridViewPaintParts.SelectionBackground;
             }
 
-            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(Graphics,
-                                                              clipBounds,
-                                                              RowBounds,
-                                                              RowIndex,
-                                                              State,
-                                                              IsFirstDisplayedRow,
-                                                              IsLastVisibleRow,
-                                                              paintParts);
+            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(
+                Graphics,
+                clipBounds,
+                RowBounds,
+                RowIndex,
+                State,
+                IsFirstDisplayedRow,
+                IsLastVisibleRow,
+                paintParts);
         }
 
         public void PaintCellsContent(Rectangle clipBounds)
@@ -123,14 +127,15 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewElementPaintingEventArgs_RowIndexOutOfRange);
             }
 
-            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(Graphics,
-                                                              clipBounds,
-                                                              RowBounds,
-                                                              RowIndex,
-                                                              State,
-                                                              IsFirstDisplayedRow,
-                                                              IsLastVisibleRow,
-                                                              DataGridViewPaintParts.ContentBackground | DataGridViewPaintParts.ContentForeground | DataGridViewPaintParts.ErrorIcon);
+            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(
+                Graphics,
+                clipBounds,
+                RowBounds,
+                RowIndex,
+                State,
+                IsFirstDisplayedRow,
+                IsLastVisibleRow,
+                DataGridViewPaintParts.ContentBackground | DataGridViewPaintParts.ContentForeground | DataGridViewPaintParts.ErrorIcon);
         }
 
         public void PaintHeader(bool paintSelectionBackground)
@@ -151,25 +156,27 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewElementPaintingEventArgs_RowIndexOutOfRange);
             }
 
-            _dataGridView.Rows.SharedRow(RowIndex).PaintHeader(Graphics,
-                                                               ClipBounds,
-                                                               RowBounds,
-                                                               RowIndex,
-                                                               State,
-                                                               IsFirstDisplayedRow,
-                                                               IsLastVisibleRow,
-                                                               paintParts);
+            _dataGridView.Rows.SharedRow(RowIndex).PaintHeader(
+                Graphics,
+                ClipBounds,
+                RowBounds,
+                RowIndex,
+                State,
+                IsFirstDisplayedRow,
+                IsLastVisibleRow,
+                paintParts);
         }
 
-        internal void SetProperties(Graphics graphics,
-                                    Rectangle clipBounds,
-                                    Rectangle rowBounds,
-                                    int rowIndex,
-                                    DataGridViewElementStates rowState,
-                                    string errorText,
-                                    DataGridViewCellStyle inheritedRowStyle,
-                                    bool isFirstDisplayedRow,
-                                    bool isLastVisibleRow)
+        internal void SetProperties(
+            Graphics graphics,
+            Rectangle clipBounds,
+            Rectangle rowBounds,
+            int rowIndex,
+            DataGridViewElementStates rowState,
+            string errorText,
+            DataGridViewCellStyle inheritedRowStyle,
+            bool isFirstDisplayedRow,
+            bool isLastVisibleRow)
         {
             Debug.Assert(graphics is not null);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowPrePaintEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowPrePaintEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -15,16 +13,17 @@ namespace System.Windows.Forms
         private readonly DataGridView _dataGridView;
         private DataGridViewPaintParts _paintParts;
 
-        public DataGridViewRowPrePaintEventArgs(DataGridView dataGridView,
-                                                Graphics graphics,
-                                                Rectangle clipBounds,
-                                                Rectangle rowBounds,
-                                                int rowIndex,
-                                                DataGridViewElementStates rowState,
-                                                string errorText,
-                                                DataGridViewCellStyle inheritedRowStyle,
-                                                bool isFirstDisplayedRow,
-                                                bool isLastVisibleRow)
+        public DataGridViewRowPrePaintEventArgs(
+            DataGridView dataGridView,
+            Graphics graphics,
+            Rectangle clipBounds,
+            Rectangle rowBounds,
+            int rowIndex,
+            DataGridViewElementStates rowState,
+            string? errorText,
+            DataGridViewCellStyle inheritedRowStyle,
+            bool isFirstDisplayedRow,
+            bool isLastVisibleRow)
         {
             _dataGridView = dataGridView ?? throw new ArgumentNullException(nameof(dataGridView));
             Graphics = graphics ?? throw new ArgumentNullException(nameof(graphics));
@@ -43,6 +42,8 @@ namespace System.Windows.Forms
         {
             Debug.Assert(dataGridView is not null);
             _dataGridView = dataGridView;
+            Graphics = null!;
+            InheritedRowStyle = null!;
         }
 
         public Graphics Graphics { get; private set; }
@@ -55,7 +56,7 @@ namespace System.Windows.Forms
 
         public DataGridViewElementStates State { get; private set; }
 
-        public string ErrorText { get; private set; }
+        public string? ErrorText { get; private set; }
 
         public DataGridViewCellStyle InheritedRowStyle { get; private set; }
 
@@ -84,13 +85,14 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewElementPaintingEventArgs_RowIndexOutOfRange);
             }
 
-            _dataGridView.Rows.SharedRow(RowIndex).DrawFocus(Graphics,
-                                                             ClipBounds,
-                                                             bounds,
-                                                             RowIndex,
-                                                             State,
-                                                             InheritedRowStyle,
-                                                             cellsPaintSelectionBackground);
+            _dataGridView.Rows.SharedRow(RowIndex).DrawFocus(
+                Graphics,
+                ClipBounds,
+                bounds,
+                RowIndex,
+                State,
+                InheritedRowStyle,
+                cellsPaintSelectionBackground);
         }
 
         public void PaintCells(Rectangle clipBounds, DataGridViewPaintParts paintParts)
@@ -100,14 +102,15 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewElementPaintingEventArgs_RowIndexOutOfRange);
             }
 
-            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(Graphics,
-                                                              clipBounds,
-                                                              RowBounds,
-                                                              RowIndex,
-                                                              State,
-                                                              IsFirstDisplayedRow,
-                                                              IsLastVisibleRow,
-                                                              paintParts);
+            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(
+                Graphics,
+                clipBounds,
+                RowBounds,
+                RowIndex,
+                State,
+                IsFirstDisplayedRow,
+                IsLastVisibleRow,
+                paintParts);
         }
 
         public void PaintCellsBackground(Rectangle clipBounds, bool cellsPaintSelectionBackground)
@@ -123,14 +126,15 @@ namespace System.Windows.Forms
                 paintParts |= DataGridViewPaintParts.SelectionBackground;
             }
 
-            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(Graphics,
-                                                              clipBounds,
-                                                              RowBounds,
-                                                              RowIndex,
-                                                              State,
-                                                              IsFirstDisplayedRow,
-                                                              IsLastVisibleRow,
-                                                              paintParts);
+            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(
+                Graphics,
+                clipBounds,
+                RowBounds,
+                RowIndex,
+                State,
+                IsFirstDisplayedRow,
+                IsLastVisibleRow,
+                paintParts);
         }
 
         public void PaintCellsContent(Rectangle clipBounds)
@@ -140,14 +144,15 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewElementPaintingEventArgs_RowIndexOutOfRange);
             }
 
-            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(Graphics,
-                                                              clipBounds,
-                                                              RowBounds,
-                                                              RowIndex,
-                                                              State,
-                                                              IsFirstDisplayedRow,
-                                                              IsLastVisibleRow,
-                                                              DataGridViewPaintParts.ContentBackground | DataGridViewPaintParts.ContentForeground | DataGridViewPaintParts.ErrorIcon);
+            _dataGridView.Rows.SharedRow(RowIndex).PaintCells(
+                Graphics,
+                clipBounds,
+                RowBounds,
+                RowIndex,
+                State,
+                IsFirstDisplayedRow,
+                IsLastVisibleRow,
+                DataGridViewPaintParts.ContentBackground | DataGridViewPaintParts.ContentForeground | DataGridViewPaintParts.ErrorIcon);
         }
 
         public void PaintHeader(bool paintSelectionBackground)
@@ -168,25 +173,27 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridViewElementPaintingEventArgs_RowIndexOutOfRange);
             }
 
-            _dataGridView.Rows.SharedRow(RowIndex).PaintHeader(Graphics,
-                                                               ClipBounds,
-                                                               RowBounds,
-                                                               RowIndex,
-                                                               State,
-                                                               IsFirstDisplayedRow,
-                                                               IsLastVisibleRow,
-                                                               paintParts);
+            _dataGridView.Rows.SharedRow(RowIndex).PaintHeader(
+                Graphics,
+                ClipBounds,
+                RowBounds,
+                RowIndex,
+                State,
+                IsFirstDisplayedRow,
+                IsLastVisibleRow,
+                paintParts);
         }
 
-        internal void SetProperties(Graphics graphics,
-                                    Rectangle clipBounds,
-                                    Rectangle rowBounds,
-                                    int rowIndex,
-                                    DataGridViewElementStates rowState,
-                                    string errorText,
-                                    DataGridViewCellStyle inheritedRowStyle,
-                                    bool isFirstDisplayedRow,
-                                    bool isLastVisibleRow)
+        internal void SetProperties(
+            Graphics graphics,
+            Rectangle clipBounds,
+            Rectangle rowBounds,
+            int rowIndex,
+            DataGridViewElementStates rowState,
+            string errorText,
+            DataGridViewCellStyle inheritedRowStyle,
+            bool isFirstDisplayedRow,
+            bool isLastVisibleRow)
         {
             Debug.Assert(graphics is not null);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowStateChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowStateChangedEventArgs.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewRowStateChangedEventArgs : EventArgs
     {
         public DataGridViewRowStateChangedEventArgs(DataGridViewRow dataGridViewRow, DataGridViewElementStates stateChanged)
         {
-            Row = dataGridViewRow;
+            Row = dataGridViewRow ?? throw new ArgumentNullException(nameof(dataGridViewRow));
             StateChanged = stateChanged;
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowDividerDoubleClickEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowDividerDoubleClickEventArgsTests.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void DataGridViewRowDividerDoubleClickEventArgs_Ctor_NegativeRowIndex_ThrowsArgumentOutOfRangeException()
         {
-            Assert.Throws<ArgumentOutOfRangeException>("rowIndex", () => new DataGridViewRowDividerDoubleClickEventArgs(-2, null));
+            Assert.Throws<ArgumentNullException>("e", () => new DataGridViewRowDividerDoubleClickEventArgs(-2, null));
             Assert.Throws<ArgumentOutOfRangeException>("rowIndex", () => new DataGridViewRowDividerDoubleClickEventArgs(-2, new HandledMouseEventArgs(MouseButtons.Left, 1, 2, 3, 4, true)));
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowStateChangedEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowStateChangedEventArgsTests.cs
@@ -12,7 +12,7 @@ namespace System.Windows.Forms.Tests
     {
         public static IEnumerable<object[]> Ctor_DataGridViewRow_DataGridViewElementStates_TestData()
         {
-            yield return new object[] { null, (DataGridViewElementStates)7 };
+            yield return new object[] { new DataGridViewRow(), (DataGridViewElementStates)7 };
             yield return new object[] { new DataGridViewRow(), DataGridViewElementStates.Displayed };
         }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in some DataGridView EventArgs.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4676)