### PR TITLE
Fix issue with showing groups in the Inspector when groups are disabled

### DIFF
--- a/CodeMaid.config
+++ b/CodeMaid.config
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="SteveCadwallader.CodeMaid.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+        </sectionGroup>
+    </configSections>
+    <userSettings>
+        <SteveCadwallader.CodeMaid.Properties.Settings>
+            <setting name="Reorganizing_MemberTypeConstructors" serializeAs="String">
+                <value>Constructors||3||Constructors</value>
+            </setting>
+            <setting name="Reorganizing_MemberTypeMethods" serializeAs="String">
+                <value>Methods||8||Methods</value>
+            </setting>
+            <setting name="Reorganizing_MemberTypeProperties" serializeAs="String">
+                <value>Properties||5||Properties</value>
+            </setting>
+            <setting name="Reorganizing_MemberTypeEnums" serializeAs="String">
+                <value>Enums||9||Enums</value>
+            </setting>
+            <setting name="Reorganizing_MemberTypeDestructors" serializeAs="String">
+                <value>Destructors||4||Destructors</value>
+            </setting>
+            <setting name="Reorganizing_MemberTypeDelegates" serializeAs="String">
+                <value>Delegates||2||Delegates</value>
+            </setting>
+            <setting name="Reorganizing_RegionsRemoveExistingRegions" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="Reorganizing_MemberTypeIndexers" serializeAs="String">
+                <value>Indexers||6||Indexers</value>
+            </setting>
+            <setting name="Reorganizing_MemberTypeInterfaces" serializeAs="String">
+                <value>Interfaces||10||Interfaces</value>
+            </setting>
+            <setting name="Reorganizing_MemberTypeEvents" serializeAs="String">
+                <value>Events||7||Events</value>
+            </setting>
+        </SteveCadwallader.CodeMaid.Properties.Settings>
+    </userSettings>
+</configuration>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -51,7 +51,7 @@ namespace System.Windows.Forms
             }
 
             private bool OwnerHasGroups
-                => _owningListView.IsHandleCreated && _owningListView.Groups.Count > 0;
+                => _owningListView.IsHandleCreated && ShowGroupAccessibleObject;
 
             internal override int RowCount
                 => _owningListView.Items.Count;
@@ -74,6 +74,9 @@ namespace System.Windows.Forms
                     return runtimeId;
                 }
             }
+
+            // ListViewGroup are not displayed when the ListView is in "List" view
+            private bool ShowGroupAccessibleObject => _owningListView.View != View.List && _owningListView.GroupsEnabled;
 
             internal override UiaCore.IRawElementProviderFragment? ElementProviderFromPoint(double x, double y)
             {
@@ -136,7 +139,7 @@ namespace System.Windows.Forms
                     return 0;
                 }
 
-                if (_owningListView.Groups.Count > 0)
+                if (ShowGroupAccessibleObject)
                 {
                     return OwnerHasDefaultGroup ? _owningListView.Groups.Count + 1 : _owningListView.Groups.Count;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3156,7 +3156,7 @@ namespace System.Windows.Forms
 
         private void EnsureDefaultGroup()
         {
-            if (IsHandleCreated && Application.ComCtlSupportsVisualStyles && GroupsEnabled)
+            if (IsHandleCreated && GroupsEnabled)
             {
                 if (User32.SendMessageW(this, (User32.WM)LVM.HASGROUP, (IntPtr)DefaultGroup.ID) == IntPtr.Zero)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -77,7 +77,7 @@ namespace System.Windows.Forms
             _headerAlignment = headerAlignment;
         }
 
-        internal AccessibleObject? AccessibilityObject
+        internal AccessibleObject AccessibilityObject
         {
             get
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms
                 => string.Format("{0}-{1}", typeof(ListViewItem).Name, CurrentIndex);
 
             public override Rectangle Bounds
-                => _owningGroup?.CollapsedState == ListViewGroupCollapsedState.Collapsed
+                => ShowGroupAccessibleObject && _owningGroup?.CollapsedState == ListViewGroupCollapsedState.Collapsed
                     ? Rectangle.Empty
                     : new Rectangle(
                         _owningListView.AccessibilityObject.Bounds.X + _owningItem.Bounds.X,
@@ -71,6 +71,9 @@ namespace System.Windows.Forms
             public override AccessibleRole Role
                 => AccessibleRole.ListItem;
 
+            // ListViewGroup are not displayed when the ListView is in "List" view
+            private bool ShowGroupAccessibleObject => _owningListView.View != View.List && _owningListView.GroupsEnabled;
+
             /// <summary>
             ///  Gets the accessible state.
             /// </summary>
@@ -106,7 +109,9 @@ namespace System.Windows.Forms
 
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
-                ListViewGroupAccessibleObject? owningGroupAccessibleObject = (ListViewGroupAccessibleObject?)_owningGroup?.AccessibilityObject;
+                ListViewGroupAccessibleObject? owningGroupAccessibleObject = ShowGroupAccessibleObject && _owningGroup is not null
+                    ? (ListViewGroupAccessibleObject)_owningGroup.AccessibilityObject
+                    : null;
                 switch (direction)
                 {
                     case UiaCore.NavigateDirection.Parent:
@@ -149,7 +154,7 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetChild(int index)
             {
-                if (index < 0 || index >= _owningItem.SubItems.Count || _owningGroup != null)
+                if (index < 0 || index >= _owningItem.SubItems.Count)
                 {
                     return null;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -238,7 +238,6 @@ namespace System.Windows.Forms
                 if (_accessibilityObject is null)
                 {
                     bool inDefaultGroup = listView?.GroupsEnabled == true && Group is null;
-
                     _accessibilityObject = new ListViewItemAccessibleObject(
                         this, inDefaultGroup ? listView.DefaultGroup : Group);
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
@@ -96,8 +96,44 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true, 2)]
         [InlineData(false, 0)]
-        public void ListViewAccessibleObject_ListWithTwoGroups_GetChildCount_ReturnsCorrectValue(bool createdControl, int expectedChildCount)
+        public void ListViewAccessibleObject_ListWithTwoGroups_GetChildCount_ReturnsCorrectValue_UseVisualStylesEnabled(bool createdControl, int expectedChildCount)
         {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = new ListView();
+            if (createdControl)
+            {
+                listView.CreateControl();
+            }
+
+            listView.Items.Add(new ListViewItem());
+            ListViewItem item = new ListViewItem();
+            ListViewItem item2 = new ListViewItem();
+            ListViewGroup group = new ListViewGroup();
+            item2.Group = group;
+            item.Group = group;
+            listView.Groups.Add(group);
+            listView.Items.Add(item);
+            listView.Items.Add(item2);
+
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+            Assert.Equal(expectedChildCount, accessibleObject.GetChildCount()); // Default group and one specified group
+            Assert.Equal(createdControl, listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, 3)]
+        [InlineData(false, 0)]
+        public void ListViewAccessibleObject_ListWithTwoGroups_GetChildCount_ReturnsCorrectValue_UseVisualStylesDisabled(bool createdControl, int expectedChildCount)
+        {
+            if (Application.UseVisualStyles)
+            {
+                return;
+            }
+
             using ListView listView = new ListView();
             if (createdControl)
             {
@@ -120,8 +156,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ListViewAccessibleObject_ListWithTwoGroups_FragmentNavigateWorkCorrectly_IfHandleIsCreated()
+        public void ListViewAccessibleObject_ListWithTwoGroups_FragmentNavigateWorkCorrectly_IfHandleIsCreated_VisualStylesEnabled()
         {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
             using ListView listView = new ListView();
             listView.CreateControl();
             listView.Items.Add(new ListViewItem());
@@ -140,6 +181,36 @@ namespace System.Windows.Forms.Tests
             AccessibleObject lastChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
             Assert.IsType<ListViewGroupAccessibleObject>(firstChild);
             Assert.IsType<ListViewGroupAccessibleObject>(lastChild);
+            Assert.NotEqual(firstChild, lastChild);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewAccessibleObject_ListWithTwoGroups_FragmentNavigateWorkCorrectly_IfHandleIsCreated_VisualStylesDisabled()
+        {
+            if (Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = new ListView();
+            listView.CreateControl();
+            listView.Items.Add(new ListViewItem());
+            ListViewItem item = new ListViewItem();
+            ListViewItem item2 = new ListViewItem();
+            ListViewGroup group = new ListViewGroup();
+            item2.Group = group;
+            item.Group = group;
+            listView.Groups.Add(group);
+            listView.Items.Add(item);
+            listView.Items.Add(item2);
+
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            AccessibleObject firstChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewItemAccessibleObject>(firstChild);
+            Assert.IsType<ListViewItemAccessibleObject>(lastChild);
             Assert.NotEqual(firstChild, lastChild);
             Assert.True(listView.IsHandleCreated);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -74,8 +74,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ListViewGroupAccessibleObject_ListWithTwoGroups_FragmentNavigateWorkCorrectly_IfHandleIsCreated()
+        public void ListViewGroupAccessibleObject_ListWithTwoGroups_FragmentNavigateWorkCorrectly_IfHandleIsCreated_VisualStylesEnabled()
         {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
             using ListView list = new ListView();
             list.CreateControl();
             ListViewGroup listGroup = new ListViewGroup("Group1");

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -124,8 +124,14 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_TestData))]
-        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleCreated(View view, bool showGroups)
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleCreated_VisualStylesDisabled(View view, bool showGroups)
         {
+            if (Application.UseVisualStyles && showGroups)
+            {
+                // This case is tested in the "ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleCreated_GroupsEnabled_VisualStylesEnabled" test.
+                return;
+            }
+
             using ListView listView = new ListView
             {
                 View = view,
@@ -148,61 +154,217 @@ namespace System.Windows.Forms.Tests
             AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
             AccessibleObject accessibleObject4 = listItem4.AccessibilityObject;
 
+            // Testing the "FragmentNavigate" method for "listItem1"
             Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
             Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(listViewGroup.AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem1);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem1);
+            Assert.Equal(listItem1.SubItems[0].AccessibilityObject, firstChildItem1);
+            Assert.Equal(listItem1.SubItems[1].AccessibilityObject, lastChildItem1);
 
+            // Testing the "FragmentNavigate" method for "listItem2"
             Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(listViewGroup.AccessibilityObject, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, firstChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, lastChildItem2);
 
-            if (Application.UseVisualStyles && showGroups)
-            {
-                Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-                Assert.Equal(accessibleObject4, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-                Assert.Equal(listView.DefaultGroup.AccessibilityObject, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-                Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-                Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            // Testing the "FragmentNavigate" method for "listItem3"
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject4, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, firstChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, lastChildItem3);
 
-                Assert.Equal(accessibleObject3, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-                Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-                Assert.Equal(listView.DefaultGroup.AccessibilityObject, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-                Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-                Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
-            }
-            else
-            {
-                // Behavior in this block should be fixed in scope of https://github.com/dotnet/winforms/issues/4205
-                Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-                Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-                Assert.Equal(listView.AccessibilityObject, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-                AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
-                AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
-                Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
-                Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
-                Assert.Equal(firstChildItem3, lastChildItem3);
-
-                Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-                Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-                Assert.Equal(listView.AccessibilityObject, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-                AccessibleObject firstChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
-                AccessibleObject lastChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
-                Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
-                Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
-                Assert.NotEqual(firstChildItem2, lastChildItem2);
-            }
+            // Testing the "FragmentNavigate" method for "listItem4"
+            Assert.Equal(accessibleObject3, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem4);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem4);
+            Assert.Equal(listItem4.SubItems[0].AccessibilityObject, firstChildItem4);
+            Assert.Equal(listItem4.SubItems[1].AccessibilityObject, lastChildItem4);
 
             Assert.True(listView.IsHandleCreated);
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_TestData))]
-        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleNotCreated(View view, bool showGroups)
+        [InlineData(View.Details)]
+        [InlineData(View.Tile)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.LargeIcon)]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleCreated_GroupsEnabled_VisualStylesEnabled(View view)
         {
+            if (!Application.UseVisualStyles)
+            {
+                // Other cases are tested in the "ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleCreated_VisualStylesDisabled" test.
+                return;
+            }
+
+            using ListView listView = new ListView
+            {
+                View = view,
+                ShowGroups = true
+            };
+
+            Assert.NotEqual(IntPtr.Zero, listView.Handle);
+
+            ListViewGroup listViewGroup = new ListViewGroup("Test");
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.Groups.Add(listViewGroup);
+            listView.Items.AddRange(new ListViewItem[] { listItem1, listItem2, listItem3, listItem4 });
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+            AccessibleObject accessibleObject4 = listItem4.AccessibilityObject;
+
+            // Testing the "FragmentNavigate" method for "listItem1"
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(listViewGroup.AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem1);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem1);
+            Assert.Equal(listItem1.SubItems[0].AccessibilityObject, firstChildItem1);
+            Assert.Equal(listItem1.SubItems[1].AccessibilityObject, lastChildItem1);
+
+            // Testing the "FragmentNavigate" method for "listItem2"
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listViewGroup.AccessibilityObject, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, firstChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, lastChildItem2);
+
+            // Testing the "FragmentNavigate" method for "listItem3"
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject4, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.DefaultGroup.AccessibilityObject, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, firstChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, lastChildItem3);
+
+            // Testing the "FragmentNavigate" method for "listItem4"
+            Assert.Equal(accessibleObject3, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.DefaultGroup.AccessibilityObject, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem4);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem4);
+            Assert.Equal(listItem4.SubItems[0].AccessibilityObject, firstChildItem4);
+            Assert.Equal(listItem4.SubItems[1].AccessibilityObject, lastChildItem4);
+
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleCreated_List_View(bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = View.List,
+                ShowGroups = showGroups
+            };
+
+            ListViewGroup listViewGroup = new ListViewGroup("Test");
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.Groups.Add(listViewGroup);
+            listView.Items.AddRange(new ListViewItem[] { listItem1, listItem2, listItem3, listItem4 });
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+            AccessibleObject accessibleObject4 = listItem4.AccessibilityObject;
+
+            // Testing the "FragmentNavigate" method for "listItem1"
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem1);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem1);
+            Assert.Equal(listItem1.SubItems[0].AccessibilityObject, firstChildItem1);
+            Assert.Equal(listItem1.SubItems[1].AccessibilityObject, lastChildItem1);
+
+            // Testing the "FragmentNavigate" method for "listItem2"
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, firstChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, lastChildItem2);
+
+            // Testing the "FragmentNavigate" method for "listItem3"
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, firstChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, lastChildItem3);
+
+            // Testing the "FragmentNavigate" method for "listItem4"
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem4);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem4);
+            Assert.Equal(listItem4.SubItems[0].AccessibilityObject, firstChildItem4);
+            Assert.Equal(listItem4.SubItems[1].AccessibilityObject, lastChildItem4);
+
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_TestData))]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleNotCreated_VisualStylesDisabled(View view, bool showGroups)
+        {
+            if (Application.UseVisualStyles && showGroups)
+            {
+                // This case is tested in the "ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleNotCreated_GroupsEnabled_VisualStylesEnabled" test.
+                return;
+            }
+
             using ListView listView = new ListView
             {
                 View = view,
@@ -223,77 +385,208 @@ namespace System.Windows.Forms.Tests
             AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
             AccessibleObject accessibleObject4 = listItem4.AccessibilityObject;
 
+            // Testing the "FragmentNavigate" method for "listItem1"
             Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
             Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(listViewGroup.AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem1);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem1);
+            Assert.Equal(listItem1.SubItems[0].AccessibilityObject, firstChildItem1);
+            Assert.Equal(listItem1.SubItems[1].AccessibilityObject, lastChildItem1);
 
+            // Testing the "FragmentNavigate" method for "listItem2"
             Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(listViewGroup.AccessibilityObject, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, firstChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, lastChildItem2);
 
+            // Testing the "FragmentNavigate" method for "listItem3"
             Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, firstChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, lastChildItem3);
 
-            if (Application.UseVisualStyles && showGroups)
-            {
-                Assert.Equal(listView.DefaultGroup.AccessibilityObject, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-                Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-                Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
-
-                Assert.Equal(listView.DefaultGroup.AccessibilityObject, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-                Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-                Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
-            }
-            else
-            {
-                // Behavior in this block should be fixed in scope of https://github.com/dotnet/winforms/issues/4205
-                Assert.Equal(listView.AccessibilityObject, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-                AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
-                AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
-                Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
-                Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
-                Assert.Equal(firstChildItem3, lastChildItem3);
-
-                Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-                Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-                Assert.Equal(listView.AccessibilityObject, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-                AccessibleObject firstChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
-                AccessibleObject lastChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
-                Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
-                Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
-                Assert.NotEqual(firstChildItem2, lastChildItem2);
-            }
+            // Testing the "FragmentNavigate" method for "listItem4"
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem4);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem4);
+            Assert.Equal(listItem4.SubItems[0].AccessibilityObject, firstChildItem4);
+            Assert.Equal(listItem4.SubItems[1].AccessibilityObject, lastChildItem4);
 
             Assert.False(listView.IsHandleCreated);
         }
 
-        public static IEnumerable<object[]> ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_VirtualMode_TestData()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleNotCreated_List_View(bool showGroups)
         {
-            foreach (View view in Enum.GetValues(typeof(View)))
+            using ListView listView = new ListView
             {
-                // View.Tile is not supported by ListView in virtual mode
-                if (view == View.Tile)
-                {
-                    continue;
-                }
+                View = View.List,
+                ShowGroups = showGroups
+            };
 
-                foreach (bool showGroups in new[] { true, false })
-                {
-                    foreach (bool createHandle in new[] { true, false })
-                    {
-                        yield return new object[] { view, showGroups, createHandle };
-                    }
-                }
-            }
+            ListViewGroup listViewGroup = new ListViewGroup("Test");
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.Groups.Add(listViewGroup);
+            listView.Items.AddRange(new ListViewItem[] { listItem1, listItem2, listItem3, listItem4 });
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+            AccessibleObject accessibleObject4 = listItem4.AccessibilityObject;
+
+            // Testing the "FragmentNavigate" method for "listItem1"
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem1);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem1);
+            Assert.Equal(listItem1.SubItems[0].AccessibilityObject, firstChildItem1);
+            Assert.Equal(listItem1.SubItems[1].AccessibilityObject, lastChildItem1);
+
+            // Testing the "FragmentNavigate" method for "listItem2"
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, firstChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, lastChildItem2);
+
+            // Testing the "FragmentNavigate" method for "listItem3"
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, firstChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, lastChildItem3);
+
+            // Testing the "FragmentNavigate" method for "listItem4"
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.AccessibilityObject, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem4);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem4);
+            Assert.Equal(listItem4.SubItems[0].AccessibilityObject, firstChildItem4);
+            Assert.Equal(listItem4.SubItems[1].AccessibilityObject, lastChildItem4);
+
+            Assert.False(listView.IsHandleCreated);
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_VirtualMode_TestData))]
-        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_VirtualMode_ReturnsExpected(View view, bool showGroups, bool createHandle)
+        [InlineData(View.Details)]
+        [InlineData(View.Tile)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.LargeIcon)]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleNotCreated_GroupsEnabled_VisualStylesEnabled(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                // Other cases are tested in the "ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_ReturnsExpected_IfHandleNotCreated_VisualStylesDisabled" test.
+                return;
+            }
+
+            using ListView listView = new ListView
+            {
+                View = view,
+                ShowGroups = true
+            };
+
+            ListViewGroup listViewGroup = new ListViewGroup("Test");
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.Groups.Add(listViewGroup);
+            listView.Items.AddRange(new ListViewItem[] { listItem1, listItem2, listItem3, listItem4 });
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+            AccessibleObject accessibleObject4 = listItem4.AccessibilityObject;
+
+            // Testing the "FragmentNavigate" method for "listItem1"
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(listViewGroup.AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem1);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem1);
+            Assert.Equal(listItem1.SubItems[0].AccessibilityObject, firstChildItem1);
+            Assert.Equal(listItem1.SubItems[1].AccessibilityObject, lastChildItem1);
+
+            // Testing the "FragmentNavigate" method for "listItem2"
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listViewGroup.AccessibilityObject, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, firstChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, lastChildItem2);
+
+            // Testing the "FragmentNavigate" method for "listItem3"
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.DefaultGroup.AccessibilityObject, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, firstChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, lastChildItem3);
+
+            // Testing the "FragmentNavigate" method for "listItem4"
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(listView.DefaultGroup.AccessibilityObject, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            AccessibleObject firstChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem4);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem4);
+            Assert.Equal(listItem4.SubItems[0].AccessibilityObject, firstChildItem4);
+            Assert.Equal(listItem4.SubItems[1].AccessibilityObject, lastChildItem4);
+
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_View_ShowGroups_VirtualMode_TestData))]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_VirtualMode_ReturnsExpected_IfHandleNotCreated(View view, bool showGroups)
         {
             using ListView listView = new ListView
             {
@@ -323,11 +616,6 @@ namespace System.Windows.Forms.Tests
                 };
             };
 
-            if (createHandle)
-            {
-                listView.CreateControl();
-            }
-
             listItem1.SetItemIndex(listView, 0);
             listItem2.SetItemIndex(listView, 1);
             listItem3.SetItemIndex(listView, 2);
@@ -340,15 +628,23 @@ namespace System.Windows.Forms.Tests
 
             Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
             Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewGroup.AccessibilityObject);
-            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem1);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem1);
+            Assert.Equal(listItem1.SubItems[0].AccessibilityObject, firstChildItem1);
+            Assert.Equal(listItem1.SubItems[1].AccessibilityObject, lastChildItem1);
 
             Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listViewGroup.AccessibilityObject);
-            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, firstChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, lastChildItem2);
 
             Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
@@ -357,18 +653,107 @@ namespace System.Windows.Forms.Tests
             AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
             Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
             Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
-            Assert.Equal(firstChildItem3, lastChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, firstChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, lastChildItem3);
 
             Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
             Assert.Equal(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
-            AccessibleObject firstChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
-            AccessibleObject lastChildItem2 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            AccessibleObject firstChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem4);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem4);
+            Assert.Equal(listItem4.SubItems[0].AccessibilityObject, firstChildItem4);
+            Assert.Equal(listItem4.SubItems[1].AccessibilityObject, lastChildItem4);
+
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_View_ShowGroups_VirtualMode_TestData))]
+        public void ListViewItemAccessibleObject_FragmentNavigate_ListGroupWithItems_VirtualMode_ReturnsExpected_IfHandleCreated(View view, bool showGroups)
+        {
+            using ListView listView = new ListView
+            {
+                View = view,
+                VirtualMode = true,
+                ShowGroups = showGroups,
+                VirtualListSize = 4
+            };
+
+            ListViewGroup listViewGroup = new ListViewGroup("Test");
+            listView.Groups.Add(listViewGroup);
+
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup);
+            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup);
+            ListViewItem listItem3 = new ListViewItem("Item 3");
+            ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
+
+            listView.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => listItem1,
+                    1 => listItem2,
+                    2 => listItem3,
+                    3 => listItem4,
+                    _ => throw new NotImplementedException()
+                };
+            };
+
+            listItem1.SetItemIndex(listView, 0);
+            listItem2.SetItemIndex(listView, 1);
+            listItem3.SetItemIndex(listView, 2);
+            listItem4.SetItemIndex(listView, 3);
+
+            listView.CreateControl();
+
+            AccessibleObject accessibleObject1 = listItem1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = listItem2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = listItem3.AccessibilityObject;
+            AccessibleObject accessibleObject4 = listItem4.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem1 = accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem1);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem1);
+            Assert.Equal(listItem1.SubItems[0].AccessibilityObject, firstChildItem1);
+            Assert.Equal(listItem1.SubItems[1].AccessibilityObject, lastChildItem1);
+
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem2 = accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
             Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem2);
             Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem2);
-            Assert.NotEqual(firstChildItem2, lastChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, firstChildItem2);
+            Assert.Equal(listItem2.SubItems[0].AccessibilityObject, lastChildItem2);
 
-            Assert.Equal(createHandle, listView.IsHandleCreated);
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject4, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem3 = accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem3);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, firstChildItem3);
+            Assert.Equal(listItem3.SubItems[0].AccessibilityObject, lastChildItem3);
+
+            Assert.Equal(accessibleObject3, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.Parent), listView.AccessibilityObject);
+            AccessibleObject firstChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
+            AccessibleObject lastChildItem4 = accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
+            Assert.IsType<ListViewSubItemAccessibleObject>(firstChildItem4);
+            Assert.IsType<ListViewSubItemAccessibleObject>(lastChildItem4);
+            Assert.Equal(listItem4.SubItems[0].AccessibilityObject, firstChildItem4);
+            Assert.Equal(listItem4.SubItems[1].AccessibilityObject, lastChildItem4);
+
+            Assert.True(listView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -917,7 +1302,16 @@ namespace System.Windows.Forms.Tests
             }
 
             Assert.NotEqual(Rectangle.Empty, listViewItem1.AccessibilityObject.Bounds);
-            Assert.Equal(Rectangle.Empty, listViewItem2.AccessibilityObject.Bounds);
+
+            if (listView.GroupsEnabled && listView.View != View.List)
+            {
+                Assert.Equal(Rectangle.Empty, listViewItem2.AccessibilityObject.Bounds);
+            }
+            else
+            {
+                Assert.NotEqual(Rectangle.Empty, listViewItem2.AccessibilityObject.Bounds);
+            }
+
             Assert.NotEqual(Rectangle.Empty, listViewItem3.AccessibilityObject.Bounds);
         }
 


### PR DESCRIPTION
Fixes #4205

## Proposed changes
- Added conditions to ignore `ListViewGroupAccessibleObject` when groups or visual styles are disabled
- Updated unit tests. 

## Customer Impact

## Regression? 
- Yes (from #3223) 

## Risk
- Minimal


## Test methodology <!-- How did you ensure quality? -->
- Unit tests
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspector

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4677)