### PR TITLE
Enable nullability in DrawToolTipEventArgs and DrawTreeNodeEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -9837,15 +9837,15 @@ System.Windows.Forms.DrawListViewSubItemEventArgs.Graphics.get -> System.Drawing
 System.Windows.Forms.DrawListViewSubItemEventArgs.Header.get -> System.Windows.Forms.ColumnHeader?
 System.Windows.Forms.DrawListViewSubItemEventArgs.Item.get -> System.Windows.Forms.ListViewItem?
 System.Windows.Forms.DrawListViewSubItemEventArgs.SubItem.get -> System.Windows.Forms.ListViewItem.ListViewSubItem?
-~System.Windows.Forms.DrawToolTipEventArgs.AssociatedControl.get -> System.Windows.Forms.Control
-~System.Windows.Forms.DrawToolTipEventArgs.AssociatedWindow.get -> System.Windows.Forms.IWin32Window
-~System.Windows.Forms.DrawToolTipEventArgs.DrawToolTipEventArgs(System.Drawing.Graphics graphics, System.Windows.Forms.IWin32Window associatedWindow, System.Windows.Forms.Control associatedControl, System.Drawing.Rectangle bounds, string toolTipText, System.Drawing.Color backColor, System.Drawing.Color foreColor, System.Drawing.Font font) -> void
-~System.Windows.Forms.DrawToolTipEventArgs.Font.get -> System.Drawing.Font
-~System.Windows.Forms.DrawToolTipEventArgs.Graphics.get -> System.Drawing.Graphics
-~System.Windows.Forms.DrawToolTipEventArgs.ToolTipText.get -> string
-~System.Windows.Forms.DrawTreeNodeEventArgs.DrawTreeNodeEventArgs(System.Drawing.Graphics graphics, System.Windows.Forms.TreeNode node, System.Drawing.Rectangle bounds, System.Windows.Forms.TreeNodeStates state) -> void
-~System.Windows.Forms.DrawTreeNodeEventArgs.Graphics.get -> System.Drawing.Graphics
-~System.Windows.Forms.DrawTreeNodeEventArgs.Node.get -> System.Windows.Forms.TreeNode
+System.Windows.Forms.DrawToolTipEventArgs.AssociatedControl.get -> System.Windows.Forms.Control?
+System.Windows.Forms.DrawToolTipEventArgs.AssociatedWindow.get -> System.Windows.Forms.IWin32Window?
+System.Windows.Forms.DrawToolTipEventArgs.DrawToolTipEventArgs(System.Drawing.Graphics! graphics, System.Windows.Forms.IWin32Window? associatedWindow, System.Windows.Forms.Control? associatedControl, System.Drawing.Rectangle bounds, string? toolTipText, System.Drawing.Color backColor, System.Drawing.Color foreColor, System.Drawing.Font? font) -> void
+System.Windows.Forms.DrawToolTipEventArgs.Font.get -> System.Drawing.Font?
+System.Windows.Forms.DrawToolTipEventArgs.Graphics.get -> System.Drawing.Graphics!
+System.Windows.Forms.DrawToolTipEventArgs.ToolTipText.get -> string?
+System.Windows.Forms.DrawTreeNodeEventArgs.DrawTreeNodeEventArgs(System.Drawing.Graphics! graphics, System.Windows.Forms.TreeNode? node, System.Drawing.Rectangle bounds, System.Windows.Forms.TreeNodeStates state) -> void
+System.Windows.Forms.DrawTreeNodeEventArgs.Graphics.get -> System.Drawing.Graphics!
+System.Windows.Forms.DrawTreeNodeEventArgs.Node.get -> System.Windows.Forms.TreeNode?
 ~System.Windows.Forms.ErrorProvider.BindToDataAndErrors(object newDataSource, string newDataMember) -> void
 ~System.Windows.Forms.ErrorProvider.CanExtend(object extendee) -> bool
 ~System.Windows.Forms.ErrorProvider.ContainerControl.get -> System.Windows.Forms.ContainerControl

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawToolTipEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawToolTipEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms
@@ -19,8 +17,15 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Creates a new DrawToolTipEventArgs with the given parameters.
         /// </summary>
-        public DrawToolTipEventArgs(Graphics graphics, IWin32Window associatedWindow, Control associatedControl, Rectangle bounds,
-                                    string toolTipText, Color backColor, Color foreColor, Font font)
+        public DrawToolTipEventArgs(
+            Graphics graphics,
+            IWin32Window? associatedWindow,
+            Control? associatedControl,
+            Rectangle bounds,
+            string? toolTipText,
+            Color backColor,
+            Color foreColor,
+            Font? font)
         {
             Graphics = graphics ?? throw new ArgumentNullException(nameof(graphics));
             AssociatedWindow = associatedWindow;
@@ -40,12 +45,12 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The window for which the tooltip is being painted.
         /// </summary>
-        public IWin32Window AssociatedWindow { get; }
+        public IWin32Window? AssociatedWindow { get; }
 
         /// <summary>
         ///  The control for which the tooltip is being painted.
         /// </summary>
-        public Control AssociatedControl { get; }
+        public Control? AssociatedControl { get; }
 
         /// <summary>
         ///  The rectangle outlining the area in which the painting should be done.
@@ -55,12 +60,12 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The text that should be drawn.
         /// </summary>
-        public string ToolTipText { get; }
+        public string? ToolTipText { get; }
 
         /// <summary>
         ///  The font used to draw tooltip text.
         /// </summary>
-        public Font Font { get; }
+        public Font? Font { get; }
 
         /// <summary>
         ///  Draws the background of the ToolTip.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DrawTreeNodeEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DrawTreeNodeEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms
@@ -16,9 +14,13 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Creates a new DrawTreeNodeEventArgs with the given parameters.
         /// </summary>
-        public DrawTreeNodeEventArgs(Graphics graphics, TreeNode node, Rectangle bounds, TreeNodeStates state)
+        public DrawTreeNodeEventArgs(
+            Graphics graphics,
+            TreeNode? node,
+            Rectangle bounds,
+            TreeNodeStates state)
         {
-            Graphics = graphics;
+            Graphics = graphics ?? throw new ArgumentNullException(nameof(graphics));
             Node = node;
             Bounds = bounds;
             State = state;
@@ -32,7 +34,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The node to be painted.
         /// </summary>
-        public TreeNode Node { get; }
+        public TreeNode? Node { get; }
 
         /// <summary>
         ///  The rectangle outlining the area in which the painting should be done.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawTreeNodeEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DrawTreeNodeEventArgsTests.cs
@@ -13,23 +13,24 @@ namespace System.Windows.Forms.Tests
     {
         public static IEnumerable<object[]> Ctor_Graphics_TreeNode_Rectangle_TreeNodeStates_TestData()
         {
-            var image = new Bitmap(10, 10);
-            Graphics graphics = Graphics.FromImage(image);
-
-            yield return new object[] { null, null, Rectangle.Empty, (TreeNodeStates)(TreeNodeStates.Checked - 1) };
-            yield return new object[] { graphics, new TreeNode(), new Rectangle(1, 2, 3, 4), TreeNodeStates.Checked };
-            yield return new object[] { graphics, new TreeNode(), new Rectangle(-1, -2, -3, -4), TreeNodeStates.Checked };
+            yield return new object[] { null, Rectangle.Empty, (TreeNodeStates)(TreeNodeStates.Checked - 1) };
+            yield return new object[] { new TreeNode(), new Rectangle(1, 2, 3, 4), TreeNodeStates.Checked };
+            yield return new object[] { new TreeNode(), new Rectangle(-1, -2, -3, -4), TreeNodeStates.Checked };
         }
 
         [Theory]
         [MemberData(nameof(Ctor_Graphics_TreeNode_Rectangle_TreeNodeStates_TestData))]
-        public void Ctor_Graphics_TreeNode_Rectangle_TreeNodeStates(Graphics graphics, TreeNode node, Rectangle bounds, TreeNodeStates state)
+        public void Ctor_Graphics_TreeNode_Rectangle_TreeNodeStates(TreeNode node, Rectangle bounds, TreeNodeStates state)
         {
-            var e = new DrawTreeNodeEventArgs(graphics, node, bounds, state);
-            Assert.Equal(graphics, e.Graphics);
-            Assert.Equal(node, e.Node);
-            Assert.Equal(bounds, e.Bounds);
-            Assert.Equal(state, e.State);
+            using (var image = new Bitmap(10, 10))
+            using (Graphics graphics = Graphics.FromImage(image))
+            {
+                var e = new DrawTreeNodeEventArgs(graphics, node, bounds, state);
+                Assert.Equal(graphics, e.Graphics);
+                Assert.Equal(node, e.Node);
+                Assert.Equal(bounds, e.Bounds);
+                Assert.Equal(state, e.State);
+            }
         }
 
         [Theory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -5645,10 +5645,11 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> OnDrawNode_TestData()
         {
             yield return new object[] { null };
-            yield return new object[] { new DrawTreeNodeEventArgs(null, null, Rectangle.Empty, TreeNodeStates.Checked) };
 
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
+            yield return new object[] { new DrawTreeNodeEventArgs(graphics, null, Rectangle.Empty, TreeNodeStates.Checked) };
+
             yield return new object[] { new DrawTreeNodeEventArgs(graphics, new TreeNode(), new Rectangle(1, 2, 3, 4), TreeNodeStates.Checked) };
         }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DrawToolTipEventArgs and DrawTreeNodeEventArgs.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4683)