### PR TITLE
Fix inspector crash moving cursor inside the `DataGridView` with `AllowUserToAddRows=false`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
@@ -225,7 +225,12 @@ namespace System.Windows.Forms
                     case UiaCore.NavigateDirection.NextSibling:
                         if (Parent.GetChildCount() > 1)
                         {
-                            return Parent.GetChild(1);
+                            if (_ownerDataGridView is null)
+                            {
+                                throw new InvalidOperationException(SR.DataGridViewTopRowAccessibleObject_OwnerNotSet);
+                            }
+
+                            return _ownerDataGridView.Rows.Count == 0 ? null : Parent.GetChild(1);
                         }
                         break;
                     case UiaCore.NavigateDirection.FirstChild:

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewTopRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewTopRowAccessibleObjectTests.cs
@@ -1,0 +1,65 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class DataGridViewTopRowAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_ReturnsExpected_AllowUserToAddRowsEnabled()
+        {
+            using DataGridView dataGridView = new();
+            DataGridViewTextBoxColumn dataGridViewColumn = new(){Name = "Col 1", HeaderText = "Col 1" };
+
+            dataGridView.Columns.Add(dataGridViewColumn);
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject expectedNextSibling = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject expectedFirstChild = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject expectedLastChild = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(dataGridView.AccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.Parent));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(expectedNextSibling, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(expectedFirstChild, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(expectedLastChild, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_ReturnsExpected_AllowUserToAddRowsDisabled()
+        {
+            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+            DataGridViewTextBoxColumn dataGridViewColumn = new() { Name = "Col 1", HeaderText = "Col 1" };
+
+            dataGridView.Columns.Add(dataGridViewColumn);
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject expectedFirstChild = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject expectedLastChild = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(dataGridView.AccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.Parent));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(expectedFirstChild, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(expectedLastChild, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_ReturnsExpected_WithoutColumns()
+        {
+            using DataGridView dataGridView = new();
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+
+            Assert.Equal(dataGridView.AccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.Parent));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4242


## Proposed changes
- Fixed issue with getting of the non-existing item
- Added unit tests

## Customer Impact
Before fix:
![99368341-fc4dfc80-28f5-11eb-9615-9db023a3e2b1](https://user-images.githubusercontent.com/23376742/111172724-1dc6a880-85b7-11eb-953c-a52e721bf5ac.gif)

After fix:
![Issue-4242](https://user-images.githubusercontent.com/23376742/111172815-320aa580-85b7-11eb-9425-5c8cbb48ca7d.png)

## Regression? 
- No

## Risk
- Minimal
## Test methodology <!-- How did you ensure quality? -->
- CTI team 
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspector

## Test environment(s)
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core Version: 5.0.200-preview.20614.14


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4686)