### PR TITLE
DataGridView throws NRE when Narrator is active

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -2210,8 +2210,6 @@ namespace System.Windows.Forms
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    DataGridView dataGridView = owner.DataGridView;
-
                     switch (direction)
                     {
                         case UiaCore.NavigateDirection.Parent:
@@ -2234,7 +2232,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    return owner.DataGridView.AccessibilityObject;
+                    return ParentPrivate;
                 }
             }
 
@@ -2252,7 +2250,7 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.NamePropertyId:
                         return Name;
                     case UiaCore.UIA.IsEnabledPropertyId:
-                        return Owner.DataGridView.Enabled;
+                        return Owner?.DataGridView?.Enabled ?? false;
                     case UiaCore.UIA.HelpTextPropertyId:
                         return Help ?? string.Empty;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
@@ -2338,7 +2336,7 @@ namespace System.Windows.Forms
 
             public override AccessibleObject GetFocused()
             {
-                if (owner.DataGridView.CurrentCell is not null && owner.DataGridView.CurrentCell.Selected)
+                if (owner.DataGridView?.CurrentCell is not null && owner.DataGridView.CurrentCell.Selected)
                 {
                     return owner.DataGridView.CurrentCell.AccessibilityObject;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Drawing;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -299,6 +300,21 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewRowAccessibleObject_Select_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Select(AccessibleSelection.None));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentRoot_ReturnsNull_WithoutDataGridView()
+        {
+            using DataGridViewRow dataGridViewRow = new();
+            Assert.Null(dataGridViewRow.AccessibilityObject.FragmentRoot);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_IsEnabled_ReturnsFalse_WithoutDataGridView()
+        {
+            using DataGridViewRow dataGridViewRow = new();
+            bool actualValue = (bool)dataGridViewRow.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsEnabledPropertyId);
+            Assert.False(actualValue);
         }
 
         private class SubDataGridViewCell : DataGridViewCell


### PR DESCRIPTION
Fixes #4228

## Proposed changes
- Added skipped checks for null. The issue is reproduced because in some cases the "DataGridView" property may be null. Most of the methods and properties check that the "DataGridView" property is not null. But in some places (including the "FragmentRoot" property) we forgot to add this check and got an exception as a result.
- Added unit tests. 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![101900113-fc24e200-3bbf-11eb-8b72-10c677bcec1e](https://user-images.githubusercontent.com/23376742/111578094-80d95a80-87c4-11eb-88f6-5fd04cdd35c2.gif)

**After fix:**
![Issue-4228-AfterFix](https://user-images.githubusercontent.com/23376742/111578116-8cc51c80-87c4-11eb-8e82-d7eefde188c7.gif)

## Regression? 

- Yes

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests
- CTI team
## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator

 ## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core Version: 6.0.0-preview.2.21154.2


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4693)