### PR TITLE
Move sub-classes of "ToolTip" and "TabPage" classes to their own files

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -10597,7 +10597,7 @@ System.Windows.Forms.TabControlEventArgs.TabPage.get -> System.Windows.Forms.Tab
 ~System.Windows.Forms.TabPage.ImageKey.get -> string
 ~System.Windows.Forms.TabPage.ImageKey.set -> void
 ~System.Windows.Forms.TabPage.TabPage(string text) -> void
-~System.Windows.Forms.TabPage.TabPageControlCollection.TabPageControlCollection(System.Windows.Forms.TabPage owner) -> void
+System.Windows.Forms.TabPage.TabPageControlCollection.TabPageControlCollection(System.Windows.Forms.TabPage! owner) -> void
 ~System.Windows.Forms.TabPage.ToolTipText.get -> string
 ~System.Windows.Forms.TabPage.ToolTipText.set -> void
 ~System.Windows.Forms.TableLayoutCellPaintEventArgs.TableLayoutCellPaintEventArgs(System.Drawing.Graphics g, System.Drawing.Rectangle clipRectangle, System.Drawing.Rectangle cellBounds, int column, int row) -> void
@@ -11898,7 +11898,7 @@ override System.Windows.Forms.ScrollBar.ToString() -> string!
 ~override System.Windows.Forms.TabPage.OnEnter(System.EventArgs e) -> void
 ~override System.Windows.Forms.TabPage.OnLeave(System.EventArgs e) -> void
 ~override System.Windows.Forms.TabPage.OnPaintBackground(System.Windows.Forms.PaintEventArgs e) -> void
-~override System.Windows.Forms.TabPage.TabPageControlCollection.Add(System.Windows.Forms.Control value) -> void
+override System.Windows.Forms.TabPage.TabPageControlCollection.Add(System.Windows.Forms.Control! value) -> void
 ~override System.Windows.Forms.TabPage.Text.get -> string
 ~override System.Windows.Forms.TabPage.Text.set -> void
 ~override System.Windows.Forms.TabPage.ToString() -> string

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageControlCollection.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    public partial class TabPage
+    {
+        /// <summary>
+        ///  Our control collection will throw an exception if you try to add other tab pages.
+        /// </summary>
+        public class TabPageControlCollection : ControlCollection
+        {
+            /// <summary>
+            ///  Creates a new TabPageControlCollection.
+            /// </summary>
+            public TabPageControlCollection(TabPage owner) : base(owner)
+            {
+            }
+
+            /// <summary>
+            ///  Adds a child control to this control. The control becomes the last control
+            ///  in the child control list. If the control is already a child of another
+            ///  control it is first removed from that control. The tab page overrides
+            ///  this method to ensure that child tab pages are not added to it, as these
+            ///  are illegal.
+            /// </summary>
+            public override void Add(Control value)
+            {
+                if (value is TabPage)
+                {
+                    throw new ArgumentException(SR.TabControlTabPageOnTabPage);
+                }
+
+                base.Add(value);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -22,7 +22,7 @@ namespace System.Windows.Forms
     [DesignTimeVisible(false)]
     [DefaultEvent("Click")]
     [DefaultProperty("Text")]
-    public class TabPage : Panel
+    public partial class TabPage : Panel
     {
         private ImageList.Indexer _imageIndexer;
         private string _toolTipText = string.Empty;
@@ -725,36 +725,6 @@ namespace System.Windows.Forms
             if (ParentInternal is TabControl parent)
             {
                 parent.UpdateTab(this);
-            }
-        }
-
-        /// <summary>
-        ///  Our control collection will throw an exception if you try to add other tab pages.
-        /// </summary>
-        public class TabPageControlCollection : ControlCollection
-        {
-            /// <summary>
-            ///  Creates a new TabPageControlCollection.
-            /// </summary>
-            public TabPageControlCollection(TabPage owner) : base(owner)
-            {
-            }
-
-            /// <summary>
-            ///  Adds a child control to this control. The control becomes the last control
-            ///  in the child control list. If the control is already a child of another
-            ///  control it is first removed from that control. The tab page overrides
-            ///  this method to ensure that child tab pages are not added to it, as these
-            ///  are illegal.
-            /// </summary>
-            public override void Add(Control value)
-            {
-                if (value is TabPage)
-                {
-                    throw new ArgumentException(SR.TabControlTabPageOnTabPage);
-                }
-
-                base.Add(value);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.TipInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.TipInfo.cs
@@ -10,19 +10,8 @@ namespace System.Windows.Forms
     {
         private class TipInfo
         {
-            [Flags]
-            public enum Type
-            {
-                None = 0x0000,
-                Auto = 0x0001,
-                Absolute = 0x0002,
-                SemiAbsolute = 0x0004
-            }
-
-            public Type TipType { get; set; } = Type.Auto;
-            private string? _caption;
             private readonly string? _designerText;
-            public Point Position { get; set; }
+            private string? _caption;
 
             public TipInfo(string caption, Type type)
             {
@@ -38,6 +27,19 @@ namespace System.Windows.Forms
             {
                 get => ((TipType & (Type.Absolute | Type.SemiAbsolute)) != 0) ? _caption : _designerText;
                 set => _caption = value;
+            }
+
+            public Point Position { get; set; }
+
+            public Type TipType { get; set; } = Type.Auto;
+
+            [Flags]
+            public enum Type
+            {
+                None = 0x0000,
+                Auto = 0x0001,
+                Absolute = 0x0002,
+                SemiAbsolute = 0x0004
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.TipInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.TipInfo.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+
+namespace System.Windows.Forms
+{
+    public partial class ToolTip
+    {
+        private class TipInfo
+        {
+            [Flags]
+            public enum Type
+            {
+                None = 0x0000,
+                Auto = 0x0001,
+                Absolute = 0x0002,
+                SemiAbsolute = 0x0004
+            }
+
+            public Type TipType { get; set; } = Type.Auto;
+            private string? _caption;
+            private readonly string? _designerText;
+            public Point Position { get; set; }
+
+            public TipInfo(string caption, Type type)
+            {
+                _caption = caption;
+                TipType = type;
+                if (type == Type.Auto)
+                {
+                    _designerText = caption;
+                }
+            }
+
+            public string? Caption
+            {
+                get => ((TipType & (Type.Absolute | Type.SemiAbsolute)) != 0) ? _caption : _designerText;
+                set => _caption = value;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.ToolTipNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.ToolTipNativeWindow.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    public partial class ToolTip
+    {
+        private class ToolTipNativeWindow : NativeWindow
+        {
+            private readonly ToolTip _control;
+
+            internal ToolTipNativeWindow(ToolTip control)
+            {
+                _control = control;
+            }
+
+            protected override void WndProc(ref Message m) => _control?.WndProc(ref m);
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.ToolTipTimer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.ToolTipTimer.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    public partial class ToolTip
+    {
+        private class ToolTipTimer : Timer
+        {
+            public ToolTipTimer(IWin32Window owner) : base()
+            {
+                Host = owner;
+            }
+
+            public IWin32Window Host { get; }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms
     [DefaultEvent(nameof(Popup))]
     [ToolboxItemFilter("System.Windows.Forms")]
     [SRDescription(nameof(SR.DescriptionToolTip))]
-    public class ToolTip : Component, IExtenderProvider, IHandle
+    public partial class ToolTip : Component, IExtenderProvider, IHandle
     {
         private const int DefaultDelay = 500;
         private const int ReshowRatio = 5;
@@ -2346,61 +2346,6 @@ namespace System.Windows.Forms
                 default:
                     _window?.DefWndProc(ref msg);
                     break;
-            }
-        }
-
-        private class ToolTipNativeWindow : NativeWindow
-        {
-            private readonly ToolTip _control;
-
-            internal ToolTipNativeWindow(ToolTip control)
-            {
-                _control = control;
-            }
-
-            protected override void WndProc(ref Message m) => _control?.WndProc(ref m);
-        }
-
-        private class ToolTipTimer : Timer
-        {
-            public ToolTipTimer(IWin32Window owner) : base()
-            {
-                Host = owner;
-            }
-
-            public IWin32Window Host { get; }
-        }
-
-        private class TipInfo
-        {
-            [Flags]
-            public enum Type
-            {
-                None = 0x0000,
-                Auto = 0x0001,
-                Absolute = 0x0002,
-                SemiAbsolute = 0x0004
-            }
-
-            public Type TipType { get; set; } = Type.Auto;
-            private string _caption;
-            private readonly string _designerText;
-            public Point Position { get; set; }
-
-            public TipInfo(string caption, Type type)
-            {
-                _caption = caption;
-                TipType = type;
-                if (type == Type.Auto)
-                {
-                    _designerText = caption;
-                }
-            }
-
-            public string Caption
-            {
-                get => ((TipType & (Type.Absolute | Type.SemiAbsolute)) != 0) ? _caption : _designerText;
-                set => _caption = value;
             }
         }
     }


### PR DESCRIPTION
## Proposed changes
- Move sub-classes of "ToolTip" and "TabPage" classes to their own files
- Fixed code sorting

## Customer Impact
- No 

## Regression? 
- No

## Risk
- Minimal

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 6.0.100-preview.2.21155.3

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4694)