### PR TITLE
Add link span to LinkClickedEventArgs

### DIFF
--- a/Winforms.sln
+++ b/Winforms.sln
@@ -147,6 +147,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Windows.Forms.Primit
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MauiTabControlTests", "src\System.Windows.Forms\tests\IntegrationTests\MauiTests\MauiTabControlTests\MauiTabControlTests.csproj", "{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiRichTextBoxTests", "src\System.Windows.Forms\tests\IntegrationTests\MauiTests\MauiRichTextBoxTests\MauiRichTextBoxTests.csproj", "{4DC0426D-E4B6-4D83-BB96-38A017A92E47}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -321,6 +323,10 @@ Global
 		{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4DC0426D-E4B6-4D83-BB96-38A017A92E47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4DC0426D-E4B6-4D83-BB96-38A017A92E47}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4DC0426D-E4B6-4D83-BB96-38A017A92E47}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4DC0426D-E4B6-4D83-BB96-38A017A92E47}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -371,6 +377,7 @@ Global
 		{1976540D-65A6-45D7-95D2-13106DE6D5BB} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
 		{6EE57002-9965-46E7-A48B-B449969738BB} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
 		{B8FD66E7-BD6F-4E6F-8199-7CE6149FBE48} = {8F20A905-BD37-4D80-B8DF-FA45276FC23F}
+		{4DC0426D-E4B6-4D83-BB96-38A017A92E47} = {8F20A905-BD37-4D80-B8DF-FA45276FC23F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B1B0433-F612-4E5A-BE7E-FCF5B9F6E136}

--- a/src/System.Windows.Forms.Primitives/src/Properties/AssemblyInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/Properties/AssemblyInfo.cs
@@ -21,6 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("System.Windows.Forms.IntegrationTests.Common, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.Maui.IntegrationTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiMonthCalendarTests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("MauiRichTextBoxTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiTestsHelper, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiTabControlTests, PublicKey=00000000000000000400000000000000")]
 

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 ~override System.Windows.Forms.RichTextBox.OnGotFocus(System.EventArgs e) -> void
+System.Windows.Forms.LinkClickedEventArgs.LinkClickedEventArgs(string? linkText, int linkStart, int linkLength) -> void
+System.Windows.Forms.LinkClickedEventArgs.LinkLength.get -> int
+System.Windows.Forms.LinkClickedEventArgs.LinkStart.get -> int

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
@@ -22,9 +22,9 @@ namespace System.Windows.Forms
         /// <param name="linkStart">The start of the link span being clicked.</param>
         /// <param name="linkLength">The length of the link span being clicked.</param>
         /// <exception cref="ArgumentOutOfRangeException">
-        /// The value for <paramref name="linkStart"/> or <paramref name="linkLength"/> is negative.
-        /// -or-
-        /// The values for <paramref name="linkStart"/> and <paramref name="linkLength"/> would overflow addition.
+        /// <para>The value for <paramref name="linkStart"/> or <paramref name="linkLength"/> is negative.</para>
+        /// <para>-or-</para>
+        /// <para>The values for <paramref name="linkStart"/> and <paramref name="linkLength"/> would overflow addition.</para>
         /// </exception>
         public LinkClickedEventArgs(string? linkText, int linkStart, int linkLength)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
@@ -21,6 +21,11 @@ namespace System.Windows.Forms
         /// <param name="linkText">The text of the link being clicked.</param>
         /// <param name="linkStart">The start of the link span being clicked.</param>
         /// <param name="linkLength">The length of the link span being clicked.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The value for <paramref name="linkStart"/> or <paramref name="linkLength"/> is negative.
+        /// -or-
+        /// The values for <paramref name="linkStart"/> and <paramref name="linkLength"/> would overflow addition.
+        /// </exception>
         public LinkClickedEventArgs(string? linkText, int linkStart, int linkLength)
         {
             if (linkStart < 0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
@@ -12,14 +12,41 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Initializes a new instance of the <see cref='LinkClickedEventArgs'/> class.
         /// </summary>
-        public LinkClickedEventArgs(string? linkText)
+        /// <param name="linkText">The text of the link being clicked.</param>
+        public LinkClickedEventArgs(string? linkText) : this(linkText, 0, 0) { }
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref='LinkClickedEventArgs'/> class.
+        /// </summary>
+        /// <param name="linkText">The text of the link being clicked.</param>
+        /// <param name="linkStart">The start of the link span being clicked.</param>
+        /// <param name="linkLength">The length of the link span being clicked.</param>
+        public LinkClickedEventArgs(string? linkText, int linkStart, int linkLength)
         {
+            if (linkStart < 0)
+                throw new ArgumentOutOfRangeException(nameof(linkStart));
+
+            if (linkLength < 0 || linkStart + linkLength < 0)
+                throw new ArgumentOutOfRangeException(nameof(linkLength));
+
             LinkText = linkText;
+            LinkStart = linkStart;
+            LinkLength = linkLength;
         }
 
         /// <summary>
         ///  Gets the text of the link being clicked.
         /// </summary>
         public string? LinkText { get; }
+
+        /// <summary>
+        /// Gets the start of the link span being clicked.
+        /// </summary>
+        public int LinkStart { get; }
+
+        /// <summary>
+        /// Gets the length of the link span being clicked.
+        /// </summary>
+        public int LinkLength { get; }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkClickedEventArgs.cs
@@ -35,9 +35,9 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Gets the text of the link being clicked.
+        /// Gets the length of the link span being clicked.
         /// </summary>
-        public string? LinkText { get; }
+        public int LinkLength { get; }
 
         /// <summary>
         /// Gets the start of the link span being clicked.
@@ -45,8 +45,8 @@ namespace System.Windows.Forms
         public int LinkStart { get; }
 
         /// <summary>
-        /// Gets the length of the link span being clicked.
+        ///  Gets the text of the link being clicked.
         /// </summary>
-        public int LinkLength { get; }
+        public string? LinkText { get; }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3314,7 +3314,7 @@ namespace System.Windows.Forms
                     string linktext = CharRangeToString(enlink.charrange);
                     if (!string.IsNullOrEmpty(linktext))
                     {
-                        OnLinkClicked(new LinkClickedEventArgs(linktext));
+                        OnLinkClicked(new LinkClickedEventArgs(linktext, enlink.charrange.cpMin, enlink.charrange.cpMax - enlink.charrange.cpMin));
                     }
 
                     m.Result = (IntPtr)1;

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.cs
@@ -16,8 +16,8 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
 {
     public class MauiRichTextBoxTests : ReflectBase
     {
-        private const int tomLink = unchecked((int)0x80000020);
-        private const int tomHidden = unchecked((int)0x80000100);
+        private const int TomLink = unchecked((int)0x80000020);
+        private const int TomHidden = unchecked((int)0x80000100);
 
         private readonly RichTextBox _control;
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.cs
@@ -189,7 +189,6 @@ This is a custom link\v #link3#\v0  which is followed by hidden text.\par
         {
             IntPtr pOleInterface = IntPtr.Zero;
             object oleInterface = null;
-            Guid textDocumentIID = typeof(Richedit.ITextDocument).GUID;
 
             try
             {

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.cs
@@ -65,10 +65,10 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             var displayText = GetTextFromRange(e.LinkStart, e.LinkLength, range =>
             {
                 // Move the cursor to the end of the hidden area we are currently located in.
-                range.EndOf(tomHidden, 0);
+                range.EndOf(TomHidden, 0);
 
                 // Extend the cursor to the end of the display text of the link.
-                range.EndOf(tomLink, 1);
+                range.EndOf(TomLink, 1);
             });
 
             if (displayText != "Click link #2")
@@ -109,10 +109,10 @@ This is hidden text preceeding a \v #link3#\v0 custom link.\par
             var hiddenText = GetTextFromRange(e.LinkStart, e.LinkLength, range =>
             {
                 // Move the cursor to the start of the link we are currently located in.
-                range.StartOf(tomLink, 0);
+                range.StartOf(TomLink, 0);
 
                 // Extend the cursor to the start of the hidden area preceeding the link.
-                range.StartOf(tomHidden, 1);
+                range.StartOf(TomHidden, 1);
             });
 
             if (hiddenText != "#link2#")
@@ -155,10 +155,10 @@ This is a custom link\v #link3#\v0  which is followed by hidden text.\par
             var hiddenText = GetTextFromRange(e.LinkStart, e.LinkLength, range =>
             {
                 // Move the cursor to the end of link we are currently located in.
-                range.EndOf(tomLink, 0);
+                range.EndOf(TomLink, 0);
 
                 // Extend the cursor to the end of the hidden area following the link.
-                range.EndOf(tomHidden, 1);
+                range.EndOf(TomHidden, 1);
             });
 
             if (hiddenText != "#link2#")

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.cs
@@ -1,0 +1,274 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Windows.Forms.IntegrationTests.Common;
+using ReflectTools;
+using WFCTestLib.Log;
+using static Interop;
+using static Interop.User32;
+
+namespace System.Windows.Forms.IntegrationTests.MauiTests
+{
+    public class MauiRichTextBoxTests : ReflectBase
+    {
+        private const int tomLink = unchecked((int)0x80000020);
+        private const int tomHidden = unchecked((int)0x80000100);
+
+        private readonly RichTextBox _control;
+
+        public MauiRichTextBoxTests(string[] args) : base(args)
+        {
+            this.BringToForeground();
+            _control = new RichTextBox { Size = new Size(439, 103), DetectUrls = false };
+            Controls.Add(_control);
+        }
+
+        public static void Main(string[] args)
+        {
+            Thread.CurrentThread.SetCulture("en-US");
+            Application.Run(new MauiRichTextBoxTests(args));
+        }
+
+        [Scenario(true)]
+        public ScenarioResult RichTextBox_Click_On_Friendly_Name_Link_Provides_Hidden_Link_Span(TParams p)
+        {
+            _control.Rtf = @"{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang4105{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+{\*\generator Riched20 10.0.17134}\viewkind4\uc1 
+{\field{\*\fldinst { HYPERLINK ""http://www.google.com"" }}{\fldrslt {Click link #1}}}
+\pard\sa200\sl276\slmult1\f0\fs22\lang9  for more information.\par
+{\field{\*\fldinst { HYPERLINK ""http://www.google.com"" }}{\fldrslt {Click link #2}}}
+\pard\sa200\sl276\slmult1\f0\fs22\lang9  for more information.\par
+{\field{\*\fldinst { HYPERLINK ""http://www.google.com"" }}{\fldrslt {Click link #3}}}
+\pard\sa200\sl276\slmult1\f0\fs22\lang9  for more information.\par
+}";
+
+            var e = ExecuteClickOnLink(_control.Text.IndexOf("Click link #2"));
+
+            if (e is null)
+            {
+                return new ScenarioResult(false, "Click on link did not raise event.");
+            }
+
+            if (e.LinkStart + e.LinkLength > _control.Text.Length || e.LinkText != _control.Text.Substring(e.LinkStart, e.LinkLength))
+            {
+                return new ScenarioResult(false, "Click on link provided span which did not match the provided text.");
+            }
+
+            // This assumes the input span is the hidden text of a "friendly name" URL,
+            // which is what the native control will pass to the LinkClicked event instead
+            // of the actual span of the clicked display text.
+            var displayText = GetTextFromRange(e.LinkStart, e.LinkLength, range =>
+            {
+                // Move the cursor to the end of the hidden area we are currently located in.
+                range.EndOf(tomHidden, 0);
+
+                // Extend the cursor to the end of the display text of the link.
+                range.EndOf(tomLink, 1);
+            });
+
+            if (displayText != "Click link #2")
+            {
+                return new ScenarioResult(false, "Click on link provided wrong link.");
+            }
+
+            return new ScenarioResult(true);
+        }
+
+        [Scenario(true)]
+        public ScenarioResult RichTextBox_Click_On_Custom_Link_Preceeded_By_Hidden_Text_Provides_Displayed_Link_Span(TParams p)
+        {
+            _control.Rtf = @"{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang4105{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+{\*\generator Riched20 10.0.17134}\viewkind4\uc1\pard\sa200\sl276\slmult1\f0\fs22\lang9
+This is hidden text preceeding a \v #link1#\v0 custom link.\par
+This is hidden text preceeding a \v #link2#\v0 custom link.\par
+This is hidden text preceeding a \v #link3#\v0 custom link.\par
+}";
+
+            MakeLink("#link1#custom link");
+            MakeLink("#link2#custom link");
+            MakeLink("#link3#custom link");
+
+            var e = ExecuteClickOnLink(_control.Text.IndexOf("#link2#custom link"));
+
+            if (e is null)
+            {
+                return new ScenarioResult(false, "Click on link did not raise event.");
+            }
+
+            if (e.LinkStart + e.LinkLength > _control.Text.Length || e.LinkText != _control.Text.Substring(e.LinkStart, e.LinkLength))
+            {
+                return new ScenarioResult(false, "Click on link provided span which did not match the provided text.");
+            }
+
+            // This assumes the input span is a custom link preceeded by hidden text.
+            var hiddenText = GetTextFromRange(e.LinkStart, e.LinkLength, range =>
+            {
+                // Move the cursor to the start of the link we are currently located in.
+                range.StartOf(tomLink, 0);
+
+                // Extend the cursor to the start of the hidden area preceeding the link.
+                range.StartOf(tomHidden, 1);
+            });
+
+            if (hiddenText != "#link2#")
+            {
+                return new ScenarioResult(false, "Click on link provided wrong link");
+            }
+
+            return new ScenarioResult(true);
+        }
+
+        [Scenario(true)]
+        public ScenarioResult RichTextBox_Click_On_Custom_Link_Followed_By_Hidden_Text_Provides_Displayed_Link_Span(TParams p)
+        {
+            // This needs to be sufficiently different from the previous test so we don't click on the same location twice,
+            // otherwise the tests may execute fast enough for the second test to register as a double click.
+            _control.Rtf = @"{\rtf1\ansi\ansicpg1252\deff0\nouicompat\deflang4105{\fonttbl{\f0\fnil\fcharset0 Calibri;}}
+{\*\generator Riched20 10.0.17134}\viewkind4\uc1\pard\sa200\sl276\slmult1\f0\fs22\lang9
+This is a custom link\v #link1#\v0  which is followed by hidden text.\par
+This is a custom link\v #link2#\v0  which is followed by hidden text.\par
+This is a custom link\v #link3#\v0  which is followed by hidden text.\par
+}";
+
+            MakeLink("custom link#link1#");
+            MakeLink("custom link#link2#");
+            MakeLink("custom link#link3#");
+
+            var e = ExecuteClickOnLink(_control.Text.IndexOf("custom link#link2#"));
+
+            if (e is null)
+            {
+                return new ScenarioResult(false, "Click on link did not raise event.");
+            }
+
+            if (e.LinkStart + e.LinkLength > _control.Text.Length || e.LinkText != _control.Text.Substring(e.LinkStart, e.LinkLength))
+            {
+                return new ScenarioResult(false, "Click on link provided span which did not match the provided text.");
+            }
+
+            // This assumes the input span is a custom link followed by hidden text.
+            var hiddenText = GetTextFromRange(e.LinkStart, e.LinkLength, range =>
+            {
+                // Move the cursor to the end of link we are currently located in.
+                range.EndOf(tomLink, 0);
+
+                // Extend the cursor to the end of the hidden area following the link.
+                range.EndOf(tomHidden, 1);
+            });
+
+            if (hiddenText != "#link2#")
+            {
+                return new ScenarioResult(false, "Click on link provided wrong link");
+            }
+
+            return new ScenarioResult(true);
+        }
+
+        private unsafe void MakeLink(string text)
+        {
+            _control.Select(_control.Text.IndexOf(text), text.Length);
+
+            var format = new Richedit.CHARFORMAT2W
+            {
+                cbSize = (uint)sizeof(Richedit.CHARFORMAT2W),
+                dwMask = Richedit.CFM.LINK,
+                dwEffects = Richedit.CFE.LINK,
+            };
+
+            SendMessageW(_control, (WM)Richedit.EM.SETCHARFORMAT, (IntPtr)Richedit.SCF.SELECTION, ref format);
+
+            _control.Select(0, 0);
+        }
+
+        private unsafe string GetTextFromRange(int start, int length, Action<Richedit.ITextRange> transform)
+        {
+            IntPtr pOleInterface = IntPtr.Zero;
+            object oleInterface = null;
+            Guid textDocumentIID = typeof(Richedit.ITextDocument).GUID;
+
+            try
+            {
+                if (SendMessageW(_control, (WM)Richedit.EM.GETOLEINTERFACE, IntPtr.Zero, ref pOleInterface) != IntPtr.Zero && pOleInterface != IntPtr.Zero)
+                {
+                    // This increments the RCW reference count, further casts do not increment it. It is important
+                    // to capture the initial reference to the RCW so we can release it even if casts fail.
+                    oleInterface = Marshal.GetObjectForIUnknown(pOleInterface);
+
+                    if (oleInterface is Richedit.ITextDocument textDocument)
+                    {
+                        // This method returns a COM object, thus increments the RCW reference count and we want to release it later.
+                        var range = textDocument.Range(start, start + length);
+                        if (range != null)
+                        {
+                            try
+                            {
+                                transform?.Invoke(range);
+                                return range.GetText();
+                            }
+                            finally
+                            {
+                                // release RCW reference count
+                                Marshal.ReleaseComObject(range);
+                            }
+                        }
+                    }
+                }
+
+                return null;
+            }
+            finally
+            {
+                // release RCW reference count
+                if (oleInterface != null)
+                {
+                    Marshal.ReleaseComObject(oleInterface);
+                }
+
+                // release COM reference count
+                if (pOleInterface != IntPtr.Zero)
+                {
+                    Marshal.Release(pOleInterface);
+                }
+            }
+        }
+
+        private LinkClickedEventArgs ExecuteClickOnLink(int characterIndex)
+        {
+            Point previousPosition = new Point();
+            BOOL setOldCursorPos = GetPhysicalCursorPos(ref previousPosition);
+
+            LinkClickedEventArgs result = null;
+            LinkClickedEventHandler handler = (sender, e) => result = e;
+            _control.LinkClicked += handler;
+
+            try
+            {
+                Point pt = _control.PointToScreen(_control.GetPositionFromCharIndex(characterIndex));
+
+                // Adjust point a bit to make sure we are clicking inside the character cell instead of on its edge.
+                MouseHelper.SendClick(pt.X + 2, pt.Y + 2);
+
+                // Let the event queue drain after clicking, before moving the cursor back to the old position.
+                Application.DoEvents();
+            }
+            finally
+            {
+                _control.LinkClicked -= handler;
+
+                if (setOldCursorPos.IsTrue())
+                {
+                    // Move cursor to old position
+                    MouseHelper.ChangeMousePosition(previousPosition.X, previousPosition.Y);
+                    Application.DoEvents();
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\References.targets"/>
+  
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MauiTestsHelper\MauiTestsHelper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
@@ -37,7 +37,7 @@ This is a custom link\v #data#\v0  with hidden text after the link.\par
 
         private unsafe void MakeLink(RichTextBox control, string text)
         {
-            richTextBox2.Select(control.Text.IndexOf(text), text.Length);
+            control.Select(control.Text.IndexOf(text), text.Length);
 
             var format = new Interop.Richedit.CHARFORMAT2W
             {
@@ -46,9 +46,9 @@ This is a custom link\v #data#\v0  with hidden text after the link.\par
                 dwEffects = Interop.Richedit.CFE.LINK,
             };
 
-            Interop.User32.SendMessageW(richTextBox2, (Interop.User32.WM)Interop.Richedit.EM.SETCHARFORMAT, (IntPtr)Interop.Richedit.SCF.SELECTION, ref format);
+            Interop.User32.SendMessageW(control, (Interop.User32.WM)Interop.Richedit.EM.SETCHARFORMAT, (IntPtr)Interop.Richedit.SCF.SELECTION, ref format);
 
-            richTextBox2.Select(0, 0);
+            control.Select(0, 0);
         }
 
         private string ReportLinkClickedEventArgs(object sender, LinkClickedEventArgs e)

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
@@ -24,17 +24,64 @@ namespace WinformsControlsTest
 {\*\generator Riched20 10.0.17134}\viewkind4\uc1 
 {\field{\*\fldinst { HYPERLINK ""http://www.google.com"" }}{\fldrslt {Click here}}}
 \pard\sa200\sl276\slmult1\f0\fs22\lang9  for more information.\par
+This is a \v #data#\v0 custom link with hidden text before the link.\par
+This is a custom link\v #data#\v0  with hidden text after the link.\par
 }";
+
+            // Allow setting custom links.
+            richTextBox2.DetectUrls = false;
+
+            MakeLink(richTextBox2, "#data#custom link");
+            MakeLink(richTextBox2, "custom link#data#");
+        }
+
+        private unsafe void MakeLink(RichTextBox control, string text)
+        {
+            richTextBox2.Select(control.Text.IndexOf(text), text.Length);
+
+            var format = new Interop.Richedit.CHARFORMAT2W
+            {
+                cbSize = (uint)sizeof(Interop.Richedit.CHARFORMAT2W),
+                dwMask = Interop.Richedit.CFM.LINK,
+                dwEffects = Interop.Richedit.CFE.LINK,
+            };
+
+            Interop.User32.SendMessageW(richTextBox2, (Interop.User32.WM)Interop.Richedit.EM.SETCHARFORMAT, (IntPtr)Interop.Richedit.SCF.SELECTION, ref format);
+
+            richTextBox2.Select(0, 0);
+        }
+
+        private string ReportLinkClickedEventArgs(object sender, LinkClickedEventArgs e)
+        {
+            var control = (RichTextBox)sender;
+            var prefix = control.Text.Remove(e.LinkStart);
+            var content = control.Text.Substring(e.LinkStart, e.LinkLength);
+            var suffix = control.Text.Substring(e.LinkStart + e.LinkLength);
+
+            var index = prefix.LastIndexOf('\n');
+            if (index >= 0)
+            {
+                prefix = prefix.Substring(index + 1);
+            }
+
+            index = suffix.IndexOf('\n');
+            if (index >= 0)
+            {
+                suffix = suffix.Remove(index);
+            }
+
+            return $"LinkText: {e.LinkText}\nLinkStart: {e.LinkStart}\nLinkLength: {e.LinkLength}\n\n"
+                + $"Span prefix: {prefix}\nSpan content: {content}\nSpan suffix: {suffix}";
         }
 
         private void richTextBox1_LinkClicked(object sender, LinkClickedEventArgs e)
         {
-            MessageBox.Show(this, e.LinkText, "link clicked");
+            MessageBox.Show(this, ReportLinkClickedEventArgs(sender, e), "link clicked");
         }
 
         private void richTextBox2_LinkClicked(object sender, LinkClickedEventArgs e)
         {
-            MessageBox.Show(this, e.LinkText, "link clicked");
+            MessageBox.Show(this, ReportLinkClickedEventArgs(sender, e), "link clicked");
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
@@ -9,6 +9,7 @@
     <ApplicationManifest>app1.manifest</ApplicationManifest>
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^netcoreapp\d'))">

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -9183,6 +9183,8 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { new LinkClickedEventArgs(null) };
             yield return new object[] { new LinkClickedEventArgs("") };
             yield return new object[] { new LinkClickedEventArgs("text") };
+            yield return new object[] { new LinkClickedEventArgs("", 10, 0) };
+            yield return new object[] { new LinkClickedEventArgs("text", 10, 4) };
         }
 
         [WinFormsTheory]
@@ -9209,6 +9211,21 @@ namespace System.Windows.Forms.Tests
             control.OnLinkClicked(eventArgs);
             Assert.Equal(1, callCount);
             Assert.False(control.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> RichTextBox_InvalidLinkClickedEventArgs_TestData()
+        {
+            yield return new object[] { -1, 0 };
+            yield return new object[] { 0, -1 };
+            yield return new object[] { int.MaxValue, 1 };
+            yield return new object[] { 1, int.MaxValue };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(RichTextBox_InvalidLinkClickedEventArgs_TestData))]
+        public void RichTextBox_InvalidLinkClickedEventArgs(int linkStart, int linkLength)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new LinkClickedEventArgs("text", linkStart, linkLength));
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -9223,7 +9223,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(RichTextBox_InvalidLinkClickedEventArgs_TestData))]
-        public void RichTextBox_InvalidLinkClickedEventArgs(int linkStart, int linkLength)
+        public void RichTextBox_InvalidLinkClickedEventArgs_ThrowsArgumentOutOfRangeException(int linkStart, int linkLength)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new LinkClickedEventArgs("text", linkStart, linkLength));
         }


### PR DESCRIPTION
Resolves #4431

## Proposed changes

Pass link span to `LinkClickedEventArgs` as they are not otherwise obtainable.

## Customer Impact

The clicked link span is available to user code, which is vital information if you use hidden text adjacent to the link for storing additional information. This was a common strategy for the old RTF textbox control and helps porting old code.

## Regression? 

no

## Risk

none, this is adding new API

### Before

link span was not available

### After

link span is available and adjacent hidden text can be retrieved easily

## Test methodology

added new unit tests to cover the usage scenarios of retrieving adjacent hidden text

## Accessibility testing

not necessary, this API does not change the UI

## Test environment(s)

unit tests


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4708)