### PR TITLE
Fixing GridEntry padding

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
@@ -163,7 +163,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 PropertyGridView gridHost = GridEntryHost;
 
                 // we call base.PropertyDepth here because we don't want the subratction to happen.
-                return 1 + gridHost.GetOutlineIconSize() + OUTLINE_ICON_PADDING + (base.PropertyDepth * gridHost.GetDefaultOutlineIndent());
+                return 1 + gridHost.GetOutlineIconSize() + OutlineIconPadding + (base.PropertyDepth * gridHost.GetDefaultOutlineIndent());
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -155,7 +155,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <summary>
         ///  Outline Icon padding
         /// </summary>
-        private int OutlineIconPadding
+        internal int OutlineIconPadding
         {
             get
             {
@@ -874,7 +874,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                int borderWidth = GridEntryHost.GetOutlineIconSize() + OUTLINE_ICON_PADDING;
+                int borderWidth = GridEntryHost.GetOutlineIconSize() + OutlineIconPadding;
                 return ((propertyDepth + 1) * borderWidth) + 1;
             }
         }
@@ -2040,7 +2040,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.Assert(gridHost is not null, "No propEntryHost");
             string strLabel = PropertyLabel;
 
-            int borderWidth = gridHost.GetOutlineIconSize() + OUTLINE_ICON_PADDING;
+            int borderWidth = gridHost.GetOutlineIconSize() + OutlineIconPadding;
 
             // fill the background if necessary
             Color backColor = selected ? gridHost.GetSelectedItemWithFocusBackColor() : GetBackgroundColor();


### PR DESCRIPTION
Fixes #4475 

Related  #4945 

## Proposed changes
GridEntry was using the constant defined for 96% DPI. Replaced it with the scaled for DPI property.


## Customer Impact

Property grid at runtime will not render as expected.


## Regression? 

- Yes from .NET framework.

## Risk

None.


## Screenshots 

### Before

![image](https://user-images.githubusercontent.com/36968667/112223116-b330f080-8be6-11eb-91e8-7b74db79925e.png)


### After


![image](https://user-images.githubusercontent.com/36968667/112223154-c348d000-8be6-11eb-8017-47b3fc1b8a84.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4717)