### PR TITLE
Fix issue with announcing RTB content by Narrator

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+~override System.Windows.Forms.RichTextBox.OnGotFocus(System.EventArgs e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -2507,6 +2507,16 @@ namespace System.Windows.Forms
             ((ContentsResizedEventHandler)Events[EVENT_REQUESTRESIZE])?.Invoke(this, e);
         }
 
+        protected override void OnGotFocus(EventArgs e)
+        {
+            base.OnGotFocus(e);
+
+            AccessibilityObject.RaiseAutomationNotification(
+                Automation.AutomationNotificationKind.Other,
+                Automation.AutomationNotificationProcessing.MostRecent,
+                Text);
+        }
+
         protected override void OnHandleCreated(EventArgs e)
         {
             // base.OnHandleCreated is called somewhere in the middle of this


### PR DESCRIPTION
Fixes #3455

## Proposed changes
- Added logic for forced announcement of RichTextBox text

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/112454590-e6e85380-8d69-11eb-9e1c-c4dbc250f4ac.png)

**After fix:**
![4723](https://user-images.githubusercontent.com/23376742/112454635-f23b7f00-8d69-11eb-943c-90991c2c58ab.png)

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspector
 
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows: Version 10.0.19041.388
- .NET Core SDK: 6.0.0-preview.2.21154.2

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4723)