### PR TITLE
Add a new virtual property StatusStripBorder to ToolStripProfessional…

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -5164,6 +5164,7 @@ static System.Windows.Forms.ProfessionalColors.RaftingContainerGradientBegin.get
 static System.Windows.Forms.ProfessionalColors.RaftingContainerGradientEnd.get -> System.Drawing.Color
 static System.Windows.Forms.ProfessionalColors.SeparatorDark.get -> System.Drawing.Color
 static System.Windows.Forms.ProfessionalColors.SeparatorLight.get -> System.Drawing.Color
+static System.Windows.Forms.ProfessionalColors.StatusStripBorder.get -> System.Drawing.Color
 static System.Windows.Forms.ProfessionalColors.StatusStripGradientBegin.get -> System.Drawing.Color
 static System.Windows.Forms.ProfessionalColors.StatusStripGradientEnd.get -> System.Drawing.Color
 static System.Windows.Forms.ProfessionalColors.ToolStripBorder.get -> System.Drawing.Color
@@ -13266,6 +13267,7 @@ virtual System.Windows.Forms.ProfessionalColorTable.RaftingContainerGradientBegi
 virtual System.Windows.Forms.ProfessionalColorTable.RaftingContainerGradientEnd.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.SeparatorDark.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.SeparatorLight.get -> System.Drawing.Color
+virtual System.Windows.Forms.ProfessionalColorTable.StatusStripBorder.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.StatusStripGradientBegin.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.StatusStripGradientEnd.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.ToolStripBorder.get -> System.Drawing.Color

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -5164,7 +5164,6 @@ static System.Windows.Forms.ProfessionalColors.RaftingContainerGradientBegin.get
 static System.Windows.Forms.ProfessionalColors.RaftingContainerGradientEnd.get -> System.Drawing.Color
 static System.Windows.Forms.ProfessionalColors.SeparatorDark.get -> System.Drawing.Color
 static System.Windows.Forms.ProfessionalColors.SeparatorLight.get -> System.Drawing.Color
-static System.Windows.Forms.ProfessionalColors.StatusStripBorder.get -> System.Drawing.Color
 static System.Windows.Forms.ProfessionalColors.StatusStripGradientBegin.get -> System.Drawing.Color
 static System.Windows.Forms.ProfessionalColors.StatusStripGradientEnd.get -> System.Drawing.Color
 static System.Windows.Forms.ProfessionalColors.ToolStripBorder.get -> System.Drawing.Color
@@ -13267,7 +13266,6 @@ virtual System.Windows.Forms.ProfessionalColorTable.RaftingContainerGradientBegi
 virtual System.Windows.Forms.ProfessionalColorTable.RaftingContainerGradientEnd.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.SeparatorDark.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.SeparatorLight.get -> System.Drawing.Color
-virtual System.Windows.Forms.ProfessionalColorTable.StatusStripBorder.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.StatusStripGradientBegin.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.StatusStripGradientEnd.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.ToolStripBorder.get -> System.Drawing.Color

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
+~override System.Windows.Forms.TrackBar.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
+static System.Windows.Forms.ProfessionalColors.StatusStripBorder.get -> System.Drawing.Color
+virtual System.Windows.Forms.ProfessionalColorTable.StatusStripBorder.get -> System.Drawing.Color
 System.Windows.Forms.Control.IsAncestorSiteInDesignMode.get -> bool
 System.Windows.Forms.Form.MdiChildrenMinimizedAnchorBottom.get -> bool
 System.Windows.Forms.Form.MdiChildrenMinimizedAnchorBottom.set -> void

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,3 @@
-~override System.Windows.Forms.TrackBar.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 static System.Windows.Forms.ProfessionalColors.StatusStripBorder.get -> System.Drawing.Color
 virtual System.Windows.Forms.ProfessionalColorTable.StatusStripBorder.get -> System.Drawing.Color
 System.Windows.Forms.Control.IsAncestorSiteInDesignMode.get -> bool

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6776,4 +6776,7 @@ Stack trace where the illegal operation occurred was:
   <data name="TrackBarPositionButtonName" xml:space="preserve">
     <value>Position</value>
   </data>
+  <data name="ProfessionalColorsStatusStripBorderDescr" xml:space="preserve">
+    <value>Border color to use on the top edge of the StatusStrip.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -7941,6 +7941,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Barva, která se má použít pro efekty zvýraznění na oddělovači</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">Počáteční barva přechodu použitá v ovládacím prvku StatusStrip</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -7941,6 +7941,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Die für Hervorhebungseffekte im Trennzeichen zu verwendende Farbe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">Die im StatusStrip verwendete Anfangsfarbe des Farbverlaufs.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -7941,6 +7941,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Color que se utiliza para los efectos de resaltado en el separador.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">Color inicial del gradiente que se utiliza en StatusStrip.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -7941,6 +7941,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Couleur à utiliser pour les effets de surbrillance sur le séparateur.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">Couleur de début du dégradé utilisé dans le StatusStrip.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -7941,6 +7941,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Colore da utilizzare per effetti di evidenziazione sul separatore.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">Colore iniziale della sfumatura da utilizzare in StatusStrip.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -7941,6 +7941,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">区切り記号に強調表示効果で使用する色です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">StatusStrip で使用されるグラデーションの開始色です。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -7941,6 +7941,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">구분 기호에 대한 강조 효과에 사용할 색입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">StatusStrip에 사용하는 그라데이션의 시작 색입니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -7941,6 +7941,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Kolor używany przez efekty wyróżnienia w separatorze.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">Kolor początkowy gradientu używany w elemencie StatusStrip.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -7941,6 +7941,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">Cor a ser usada para efeitos de realce no separador.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">A cor inicial do gradiente usada em StatusStrip.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -7942,6 +7942,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Цвет для эффекта подсветки на разделителе.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">Начальный цвет градиента, используемый в StatusStrip.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -7941,6 +7941,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Ayırıcıdaki vurgu efektleri için kullanılacak renk.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">StatusStrip'te kullanılan geçişin başlangıç rengi.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7941,6 +7941,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">用于分隔条上的突出显示效果的颜色。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">在 StatusStrip 中使用的渐变的开始颜色。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7941,6 +7941,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">分隔符號醒目提示效果所使用的色彩。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ProfessionalColorsStatusStripBorderDescr">
+        <source>Border color to use on the top edge of the StatusStrip.</source>
+        <target state="new">Border color to use on the top edge of the StatusStrip.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProfessionalColorsStatusStripGradientBeginDescr">
         <source>Starting color of the gradient used in the StatusStrip.</source>
         <target state="translated">StatusStrip 中所使用漸層的開始色彩。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColorTable.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColorTable.cs
@@ -230,7 +230,8 @@ namespace System.Windows.Forms
         public virtual Color SeparatorLight => FromKnownColor(KnownColors.msocbvcrCBSplitterLineLight);
 
         [SRDescription(nameof(SR.ProfessionalColorsStatusStripBorderDescr))]
-        public virtual Color StatusStripBorder => FromKnownColor(KnownColors.msocbvcrCBShadow);
+        // Note: the color is retained for backwards compatibility
+        public virtual Color StatusStripBorder => SystemColors.ButtonHighlight;
 
         [SRDescription(nameof(SR.ProfessionalColorsStatusStripGradientBeginDescr))]
         public virtual Color StatusStripGradientBegin => FromKnownColor(KnownColors.msocbvcrCBGradMainMenuHorzBegin);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColorTable.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColorTable.cs
@@ -229,6 +229,9 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ProfessionalColorsSeparatorLightDescr))]
         public virtual Color SeparatorLight => FromKnownColor(KnownColors.msocbvcrCBSplitterLineLight);
 
+        [SRDescription(nameof(SR.ProfessionalColorsStatusStripBorderDescr))]
+        public virtual Color StatusStripBorder => FromKnownColor(KnownColors.msocbvcrCBShadow);
+
         [SRDescription(nameof(SR.ProfessionalColorsStatusStripGradientBeginDescr))]
         public virtual Color StatusStripGradientBegin => FromKnownColor(KnownColors.msocbvcrCBGradMainMenuHorzBegin);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColors.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProfessionalColors.cs
@@ -159,6 +159,9 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ProfessionalColorsSeparatorLightDescr))]
         public static Color SeparatorLight => ColorTable.SeparatorLight;
 
+        [SRDescription(nameof(SR.ProfessionalColorsStatusStripBorderDescr))]
+        public static Color StatusStripBorder => ColorTable.StatusStripBorder;
+
         [SRDescription(nameof(SR.ProfessionalColorsStatusStripGradientBeginDescr))]
         public static Color StatusStripGradientBegin => ColorTable.StatusStripGradientBegin;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
@@ -1029,7 +1029,8 @@ namespace System.Windows.Forms
 
         private void RenderStatusStripBorder(ToolStripRenderEventArgs e)
         {
-            e.Graphics.DrawLine(ColorTable.StatusStripBorder, 0, 0, e.ToolStrip.Width, 0);
+            using Pen p = new Pen(ColorTable.StatusStripBorder);
+            e.Graphics.DrawLine(p, 0, 0, e.ToolStrip.Width, 0);
         }
 
         private void RenderStatusStripBackground(ToolStripRenderEventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolstripProfessionalRenderer.cs
@@ -1029,7 +1029,7 @@ namespace System.Windows.Forms
 
         private void RenderStatusStripBorder(ToolStripRenderEventArgs e)
         {
-            e.Graphics.DrawLine(SystemPens.ButtonHighlight, 0, 0, e.ToolStrip.Width, 0);
+            e.Graphics.DrawLine(ColorTable.StatusStripBorder, 0, 0, e.ToolStrip.Width, 0);
         }
 
         private void RenderStatusStripBackground(ToolStripRenderEventArgs e)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.Rendering.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.Rendering.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Windows.Forms.Metafiles;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Tests
+{
+    public partial class StatusStripTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void StatusStrip_RendersBorderCorrectly()
+        {
+            using Form form = new Form();
+            using StatusStrip statusStrip = new StatusStrip
+            {
+                BackColor = Color.Blue,
+                SizingGrip = false,
+                Renderer = new ToolStripProfessionalRenderer(new CustomColorTable()),
+                Size = new Size(200, 38)
+            };
+            form.Controls.Add(statusStrip);
+
+            // Force the handle creation
+            Assert.NotEqual(IntPtr.Zero, form.Handle);
+            Assert.NotEqual(IntPtr.Zero, statusStrip.Handle);
+
+            // Create an Enhance Metafile into which we will render the control
+            using var emf = new EmfScope();
+            DeviceContextState state = new DeviceContextState(emf);
+
+            // Render the control
+            statusStrip.PrintToMetafile(emf);
+
+            Rectangle bounds = statusStrip.Bounds;
+            Rectangle bitBltBounds = new Rectangle(bounds.X, 0, bounds.Width - 1, bounds.Height - 1);
+            Rectangle polylineBounds = new Rectangle(bounds.X, 0, bounds.Width - 1, 15);
+
+            // This is the default pen style GDI+ renders polylines with
+            Gdi32.PS penStyle = Gdi32.PS.SOLID | Gdi32.PS.JOIN_ROUND | Gdi32.PS.COSMETIC | Gdi32.PS.ENDCAP_FLAT | Gdi32.PS.JOIN_MITER | Gdi32.PS.GEOMETRIC;
+
+            emf.Validate(
+               state,
+               Validate.BitBltValidator(bitBltBounds, State.BrushColor(Color.Blue)),
+               Validate.Polyline16(polylineBounds, null, State.Pen(16, Color.Green, penStyle))
+               );
+
+            var details = emf.RecordsToString();
+        }
+
+        private sealed class CustomColorTable : ProfessionalColorTable
+        {
+            public override Color StatusStripBorder => Color.Green;
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
@@ -12,7 +12,7 @@ namespace System.Windows.Forms.Tests
     using Point = System.Drawing.Point;
     using Size = System.Drawing.Size;
 
-    public class StatusStripTests : IClassFixture<ThreadExceptionFixture>
+    public partial class StatusStripTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
         public void StatusStrip_Ctor_Default()


### PR DESCRIPTION
<!-- Read https://github.com/dotnet/winforms/blob/main/docs/issue-guide.md -->

Resolves  #4643

# Summary

Currently, if you want to theme your application with a `ToolStripProfessionalRenderer`, there is an issue with the `StatusStrip` border, as the drawing routine uses a hardcoded value for the border color. A new virtual property is added to the `ProfessionalColorTable` to customize that color.