### PR TITLE
Removed CA1838 warning suppressions on p/invokes for StringBuilders.

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.FormatMessageW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.FormatMessageW.cs
@@ -3,21 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal partial class Interop
 {
     internal partial class Kernel32
     {
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
-        public static extern uint FormatMessageW(
+        public static extern unsafe uint FormatMessageW(
             FormatMessageOptions dwFlags,
             IntPtr lpSource,
             uint dwMessageId,
             uint dwLanguageId,
-#pragma warning disable CA1838 // Avoid 'StringBuilder' parameters for P/Invokes
-            StringBuilder lpBuffer,
-#pragma warning restore CA1838 // Avoid 'StringBuilder' parameters for P/Invokes
+            char* lpBuffer,
             int nSize,
             IntPtr arguments);
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Shlwapi/Interop.SHLoadIndirectString.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Shlwapi/Interop.SHLoadIndirectString.cs
@@ -3,15 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using System.Text;
 
 internal static partial class Interop
 {
     internal static partial class Shlwapi
     {
         [DllImport(Libraries.Shlwapi, ExactSpelling = true, CharSet = CharSet.Unicode)]
-#pragma warning disable CA1838 // Avoid 'StringBuilder' parameters for P/Invokes
-        public static extern HRESULT SHLoadIndirectString(string pszSource, StringBuilder pszOutBuf, uint cchOutBuf, IntPtr ppvReserved);
-#pragma warning restore CA1838 // Avoid 'StringBuilder' parameters for P/Invokes
+        public static extern unsafe HRESULT SHLoadIndirectString(string pszSource, char* psZOutBuf, uint cchOutBuf, IntPtr ppvReserved);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/UnsafeNativeMethods.cs
@@ -2,18 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Runtime.InteropServices;
-using System.Text;
 using static Interop;
 
 namespace System.Windows.Forms
 {
     internal static class UnsafeNativeMethods
     {
-        [DllImport(Libraries.User32)]
-#pragma warning disable CA1838 // Avoid 'StringBuilder' parameters for P/Invokes
-        public static extern int GetClassName(HandleRef hwnd, StringBuilder lpClassName, int nMaxCount);
-#pragma warning restore CA1838 // Avoid 'StringBuilder' parameters for P/Invokes
+        [DllImport(Libraries.User32, CharSet = CharSet.Unicode)]
+        public static extern unsafe int GetClassName(HandleRef hwnd, char* lpClassName, int nMaxCount);
 
         [DllImport(Libraries.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern HRESULT PrintDlgEx([In, Out] NativeMethods.PRINTDLGEX lppdex);
@@ -22,39 +20,47 @@ namespace System.Windows.Forms
         public static extern bool GetOpenFileName([In, Out] NativeMethods.OPENFILENAME_I ofn);
 
         [DllImport(Libraries.Kernel32, CharSet = CharSet.Auto, SetLastError = true)]
-#pragma warning disable CA1838 // Avoid 'StringBuilder' parameters for P/Invokes
-        public static extern int GetModuleFileName(HandleRef hModule, StringBuilder buffer, int length);
-#pragma warning restore CA1838 // Avoid 'StringBuilder' parameters for P/Invokes
+        public static extern unsafe int GetModuleFileName(HandleRef hModule, char* buffer, int length);
 
-        public static StringBuilder GetModuleFileNameLongPath(HandleRef hModule)
+        public static unsafe string GetModuleFileNameLongPath(HandleRef hModule)
         {
-            StringBuilder buffer = new StringBuilder(Kernel32.MAX_PATH);
+            Span<char> buffer = new char[Kernel32.MAX_PATH];
             int noOfTimes = 1;
-            int length = 0;
+            int length;
+            int error = 0;
+
             // Iterating by allocating chunk of memory each time we find the length is not sufficient.
             // Performance should not be an issue for current MAX_PATH length due to this change.
-            while (((length = GetModuleFileName(hModule, buffer, buffer.Capacity)) == buffer.Capacity)
-                && Marshal.GetLastWin32Error() == ERROR.INSUFFICIENT_BUFFER
-                && buffer.Capacity < Kernel32.MAX_UNICODESTRING_LEN)
+            while (((length = GetModuleFileName(hModule, buffer)) == buffer.Length)
+                && (error = Marshal.GetLastWin32Error()) == ERROR.INSUFFICIENT_BUFFER
+                && buffer.Length < Kernel32.MAX_UNICODESTRING_LEN)
             {
                 noOfTimes += 2; // Increasing buffer size by 520 in each iteration.
                 int capacity = noOfTimes * Kernel32.MAX_PATH < Kernel32.MAX_UNICODESTRING_LEN ? noOfTimes * Kernel32.MAX_PATH : Kernel32.MAX_UNICODESTRING_LEN;
-                buffer.EnsureCapacity(capacity);
+                buffer = new char[capacity];
             }
 
-            buffer.Length = length;
-            return buffer;
+            if (error == ERROR.INSUFFICIENT_BUFFER)
+            {
+                // probably should localize this.
+                throw new Win32Exception("Error getting the module file names.");
+            }
+
+            return buffer.Slice(0, length).SliceAtFirstNull().ToString();
         }
 
         [DllImport(Libraries.Comdlg32, SetLastError = true, CharSet = CharSet.Auto)]
         public static extern bool GetSaveFileName([In, Out] NativeMethods.OPENFILENAME_I ofn);
 
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Auto)]
-#pragma warning disable CA1838 // Avoid 'StringBuilder' parameters for P/Invokes
-        public static extern void GetTempFileName(string tempDirName, string prefixName, int unique, StringBuilder sb);
-#pragma warning restore CA1838 // Avoid 'StringBuilder' parameters for P/Invokes
-
         [DllImport(Libraries.Oleacc, ExactSpelling = true, CharSet = CharSet.Auto)]
         public static extern int CreateStdAccessibleObject(HandleRef hWnd, int objID, ref Guid refiid, [In, Out, MarshalAs(UnmanagedType.Interface)] ref object? pAcc);
+
+        private static unsafe int GetModuleFileName(HandleRef hModule, Span<char> buffer)
+        {
+            fixed (char* pBuffer = buffer)
+            {
+                return GetModuleFileName(hModule, pBuffer, buffer.Length);
+            }
+        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -289,8 +289,8 @@ namespace System.Windows.Forms
             {
                 if (s_executablePath is null)
                 {
-                    StringBuilder sb = UnsafeNativeMethods.GetModuleFileNameLongPath(NativeMethods.NullHandleRef);
-                    s_executablePath = Path.GetFullPath(sb.ToString());
+                    string path = UnsafeNativeMethods.GetModuleFileNameLongPath(NativeMethods.NullHandleRef);
+                    s_executablePath = Path.GetFullPath(path);
                 }
 
                 return s_executablePath;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -391,24 +391,24 @@ namespace System.Windows.Forms
             /// </summary>
             private static string[]? ReadFileListFromHandle(IntPtr hdrop)
             {
-                uint count = Shell32.DragQueryFileW(hdrop, 0xFFFFFFFF, null);
+                string? fileName = null;
+                uint count = Shell32.DragQueryFileW(hdrop, 0xFFFFFFFF, ref fileName);
                 if (count == 0)
                 {
                     return null;
                 }
 
-                var sb = new StringBuilder(Kernel32.MAX_PATH);
                 var files = new string[count];
                 for (uint i = 0; i < count; i++)
                 {
-                    uint charlen = Shell32.DragQueryFileW(hdrop, i, sb);
-                    if (charlen == 0)
+                    uint length = Shell32.DragQueryFileW(hdrop, i, ref fileName);
+                    if (length == 0 || string.IsNullOrEmpty(fileName))
                     {
                         continue;
                     }
 
-                    string s = sb.ToString(0, (int)charlen);
-                    files[i] = s;
+                    string fullPath = Path.GetFullPath(fileName);
+                    files[i] = fileName;
                 }
 
                 return files;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5162,9 +5162,7 @@ namespace System.Windows.Forms
             {
                 // save the image to a temporary file name
                 _backgroundImageFileName = Path.GetTempFileName();
-
                 BackgroundImage.Save(_backgroundImageFileName, System.Drawing.Imaging.ImageFormat.Bmp);
-
                 lvbkImage.cchImageMax = (uint)(_backgroundImageFileName.Length + 1);
                 lvbkImage.ulFlags = LVBKIF.SOURCE_URL;
                 if (BackgroundImageTiled)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -300,8 +300,7 @@ namespace System.Windows.Forms
                         throw new Win32Exception(lastWin32Error, string.Format(SR.LoadDLLError, richEditControlDllVersion));
                     }
 
-                    StringBuilder pathBuilder = UnsafeNativeMethods.GetModuleFileNameLongPath(new HandleRef(null, moduleHandle));
-                    string path = pathBuilder.ToString();
+                    string path = UnsafeNativeMethods.GetModuleFileNameLongPath(new HandleRef(null, moduleHandle));
                     FileVersionInfo versionInfo = FileVersionInfo.GetVersionInfo(path);
 
                     Debug.Assert(versionInfo is not null && !string.IsNullOrEmpty(versionInfo.ProductVersion), "Couldn't get the version info for the richedit dll");
@@ -3395,22 +3394,22 @@ namespace System.Windows.Forms
                         break;
                     case EN.DROPFILES:
                         ENDROPFILES* endropfiles = (ENDROPFILES*)m.LParamInternal;
+                        string path = string.Empty;
 
                         // Only look at the first file.
-                        var path = new StringBuilder(Kernel32.MAX_PATH);
-                        if (Shell32.DragQueryFileW(endropfiles->hDrop, 0, path) != 0)
+                        if (Shell32.DragQueryFileW(endropfiles->hDrop, 0, ref path) != 0)
                         {
                             // Try to load the file as an RTF
                             try
                             {
-                                LoadFile(path.ToString(), RichTextBoxStreamType.RichText);
+                                LoadFile(path, RichTextBoxStreamType.RichText);
                             }
                             catch
                             {
                                 // we failed to load as rich text so try it as plain text
                                 try
                                 {
-                                    LoadFile(path.ToString(), RichTextBoxStreamType.PlainText);
+                                    LoadFile(path, RichTextBoxStreamType.PlainText);
                                 }
                                 catch
                                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TaskDialog.cs
@@ -794,8 +794,7 @@ namespace System.Windows.Forms
             if (TaskDialogPage.IsNativeStringNullOrEmpty(caption))
             {
                 caption = Path.GetFileName(
-                    UnsafeNativeMethods.GetModuleFileNameLongPath(NativeMethods.NullHandleRef)
-                                       .ToString());
+                    UnsafeNativeMethods.GetModuleFileNameLongPath(NativeMethods.NullHandleRef));
             }
 
             User32.SetWindowTextW(_handle, caption);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/Com2PropertyDescriptorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/Com2PropertyDescriptorTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Reflection;
-using System.Text;
 using Xunit;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop.Tests
@@ -33,7 +32,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop.Tests
         [InlineData("bla bla bla\r\n\nr\n\r\n\r\n", "bla bla bla\r\n\nr")]
         public void TrimNewline_should_remove_all_trailing_CR_LF(string message, string expected)
         {
-            string result = (string)s_miVersionInfo.Invoke(null, new[] { new StringBuilder(message) });
+            string result = (string)s_miVersionInfo.Invoke(null, new[] { message });
 
             Assert.Equal(expected, result);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -10732,12 +10732,15 @@ namespace System.Windows.Forms.Tests
             public new void WndProc(ref Message m) => base.WndProc(ref m);
         }
 
-        private static string GetClassName(IntPtr hWnd)
+        private static unsafe string GetClassName(IntPtr hWnd)
         {
-            const int MaxClassName = 256;
-            StringBuilder sb = new StringBuilder(MaxClassName);
-            UnsafeNativeMethods.GetClassName(new HandleRef(null, hWnd), sb, MaxClassName);
-            return sb.ToString();
+            Span<char> buf = stackalloc char[256];
+            fixed (char* valueChars = buf)
+            {
+                _ = UnsafeNativeMethods.GetClassName(new HandleRef(null, hWnd), valueChars, buf.Length);
+            }
+
+            return buf.SliceAtFirstNull().ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3983


## Proposed changes

- Fixes rule violations on CA1838 on the p/invokes.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Minimal, the changed code should be to the p/invokes only.

## Regression? 

- Yes / No
No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

TODO: Test.
- 
- 
- 
 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->

```
.NET SDK (reflecting any global.json):
 Version:   6.0.100-preview.2.21155.3
 Commit:    1a9103db2d

Runtime Environment:
 OS Name:     Mac OS X
 OS Version:  11.3
 OS Platform: Darwin
 RID:         osx.11.0-x64
 Base Path:   /usr/local/share/dotnet/sdk/6.0.100-preview.2.21155.3/

Host (useful for support):
  Version: 6.0.0-preview.2.21154.6
  Commit:  3eaf1f316b

.NET SDKs installed:
  6.0.100-preview.2.21155.3 [/usr/local/share/dotnet/sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 6.0.0-preview.2.21154.6 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 6.0.0-preview.2.21154.6 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]

To install additional .NET runtimes or SDKs:
  https://aka.ms/dotnet-download
```
(used my browser on my mac this time to make changes)

Note: the code to the StringBuilders was attempted to try to be a minimal change, however it may require changing all the callsites too and simply not having StringBuilder parameters for the methods that wrap the actual p/invokes, this is due to the fact that StringBuilder was used for the buffers instead of string.

Also VB still needs done on it however.

This is opened as a draft because I think it may require a bit more work and testing on a windows system.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4751)