### PR TITLE
Porting: Fixing missing 'TypeForwardedFrom' attribute

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Padding.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Padding.cs
@@ -10,6 +10,7 @@ namespace System.Windows.Forms
 {
     [TypeConverter(typeof(PaddingConverter))]
     [Serializable] // This type is participating in resx serialization scenarios.
+    [Runtime.CompilerServices.TypeForwardedFrom("System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public struct Padding
     {
         private bool _all; // Do NOT rename (binary serialization).


### PR DESCRIPTION
Fixes #4561 (a cherrypick of  #4715)


## Proposed changes

Padding is serialized in to Resx file and any serializable type that was 'TypeForwardedTo' should have 'TypeForwarededFrom' attribute to help is de-serialize it.
And also, we recently added dependency on this attribute, in core designer, while writing types in to Resx file.

## Customer Impact

Any resource file that has Padding serialized will fail to load it while de-serializing the type for the application. This attribute was missed while moving this type from System.Windows.Forms.dll

## Regression? 

- Yes from .NET core 3.1 and .NET framework.

## Risk

None

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4753)