### PR TITLE
[NO MERGE] use a hacky way to run all the tests using new FileStream implementation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,6 +51,7 @@
   <!-- workaround for package downgrade in Microsoft.NetCore.Platforms -->
   <PropertyGroup>
     <DisableImplicitNETCorePlatformsReference>true</DisableImplicitNETCorePlatformsReference>
+    <UserRuntimeConfig Condition="'$(IsTestProject)' == 'true'">$(RepoRoot)eng\runtimeconfig.template.json</UserRuntimeConfig>
   </PropertyGroup>
 
 </Project>

--- a/eng/runtimeconfig.template.json
+++ b/eng/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+    "configProperties": {
+        "System.IO.UseNet5CompatFileStream": false
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Net5CompatSwitchTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Net5CompatSwitchTests.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if NET6_0
+using System.Reflection;
+using Xunit;
+
+namespace System.IO.Tests
+{
+    public class Net5CompatSwitchTests
+    {
+        [Fact]
+        public static void LegacySwitchIsHonored()
+        {
+            string filePath = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+
+            using (FileStream fileStream = File.Create(filePath))
+            {
+                object? strategy = fileStream?
+                        .GetType()?
+                        .GetField("_strategy", BindingFlags.NonPublic | BindingFlags.Instance)?
+                        .GetValue(fileStream)
+                    ?? null;
+
+                if (OperatingSystem.IsWindows())
+                {
+                    if (strategy == null)
+                    {
+                        throw new Exception("using an old build");
+                    }
+
+                    Assert.DoesNotContain("Net5Compat", strategy.GetType().FullName);
+                    Assert.DoesNotContain("Legacy", strategy.GetType().FullName);
+                }
+            }
+
+            File.Delete(filePath);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Please ignore this PR, I just want to check if the most recent changes have not broken anything in WinForms before we enable them by default.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4756)