### PR TITLE
Fix ANE in the "ListViewSubItemAccessibleObjectin" constructor (#4744) (port to 5.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItemCollection.cs
@@ -61,7 +61,13 @@ namespace System.Windows.Forms
                         throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
                     }
 
+                    ListViewSubItem oldSubItem = _owner.subItems[index];
+
                     _owner.subItems[index] = value ?? throw new ArgumentNullException(nameof(value));
+                    value.owner = _owner;
+
+                    oldSubItem.owner = null;
+
                     _owner.UpdateSubItems(index);
                 }
             }
@@ -143,6 +149,7 @@ namespace System.Windows.Forms
                 {
                     if (item != null)
                     {
+                        item.owner = _owner;
                         _owner.subItems[_owner.SubItemCount++] = item;
                     }
                 }
@@ -203,6 +210,11 @@ namespace System.Windows.Forms
                 int oldCount = _owner.SubItemCount;
                 if (oldCount > 0)
                 {
+                    for (int i = 0; i < oldCount; i++)
+                    {
+                        _owner.SubItems[i].owner = null;
+                    }
+
                     _owner.SubItemCount = 0;
                     _owner.UpdateSubItems(-1, oldCount);
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewSubItemCollectionTests.cs
@@ -435,12 +435,12 @@ namespace System.Windows.Forms.Tests
 
             collection.Clear();
             Assert.Empty(collection);
-            Assert.Same(item, subItem.owner);
+            Assert.Null(subItem.owner);
 
             // Clear again.
             collection.Clear();
             Assert.Empty(collection);
-            Assert.Same(item, subItem.owner);
+            Assert.Null(subItem.owner);
         }
 
         [Fact]
@@ -876,6 +876,259 @@ namespace System.Windows.Forms.Tests
             var array = new object[] { 1, 2, 3 };
             collection.CopyTo(array, 0);
             Assert.Equal(new object[] { 1, 2, 3 }, array);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_Add_SetOwner()
+        {
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem subItem = new();
+
+            Assert.Null(subItem.owner);
+
+            listViewItem.SubItems.Add(subItem);
+
+            Assert.Same(listViewItem, subItem.owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_Add_String_SetOwner()
+        {
+            ListViewItem listViewItem = new();
+
+            listViewItem.SubItems.Add("Test");
+
+            Assert.Same(listViewItem, listViewItem.SubItems[1].owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_Add_String_Color_SetOwner()
+        {
+            ListViewItem listViewItem = new();
+
+            listViewItem.SubItems.Add("Test", Color.White, Color.Black, SystemFonts.MenuFont);
+
+            Assert.Same(listViewItem, listViewItem.SubItems[1].owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_AddRange_SetOwner()
+        {
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem subItem1 = new();
+            ListViewItem.ListViewSubItem subItem2 = new();
+
+            Assert.Null(subItem1.owner);
+            Assert.Null(subItem2.owner);
+
+            listViewItem.SubItems.AddRange(new ListViewItem.ListViewSubItem[] { subItem1, subItem2 });
+
+            Assert.Same(listViewItem, subItem1.owner);
+            Assert.Same(listViewItem, subItem2.owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_AddRange_String_SetOwner()
+        {
+            ListViewItem listViewItem = new();
+
+            listViewItem.SubItems.AddRange(new string[] { "Test 1", "Test 2" });
+
+            Assert.Same(listViewItem, listViewItem.SubItems[1].owner);
+            Assert.Same(listViewItem, listViewItem.SubItems[2].owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_AddRange_String_Color_SetOwner()
+        {
+            ListViewItem listViewItem = new();
+
+            listViewItem.SubItems.AddRange(new string[] { "Test 1", "Test 2" }, Color.White, Color.Black, SystemFonts.MenuFont);
+
+            Assert.Same(listViewItem, listViewItem.SubItems[1].owner);
+            Assert.Same(listViewItem, listViewItem.SubItems[2].owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItem_Clear_RemoveOwner()
+        {
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem subItem1 = new();
+            ListViewItem.ListViewSubItem subItem2 = new();
+            ListViewItem.ListViewSubItem oldSubItem = listViewItem.SubItems[0];
+
+            listViewItem.SubItems.Add(subItem1);
+            listViewItem.SubItems.Add(subItem2);
+
+            Assert.Same(listViewItem, oldSubItem.owner);
+            Assert.Same(listViewItem, subItem1.owner);
+            Assert.Same(listViewItem, subItem1.owner);
+
+            listViewItem.SubItems.Clear();
+
+            Assert.Same(listViewItem, listViewItem.SubItems[0].owner);
+            Assert.Null(oldSubItem.owner);
+            Assert.Null(subItem1.owner);
+            Assert.Null(subItem1.owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_IList_Add_SetOwner()
+        {
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem subItem = new();
+
+            Assert.Null(subItem.owner);
+
+            ((IList)listViewItem.SubItems).Add(subItem);
+
+            Assert.Same(listViewItem, subItem.owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_IList_Insert_AddOwner()
+        {
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem subItem1 = new();
+            ListViewItem.ListViewSubItem subItem2 = new();
+            ListViewItem.ListViewSubItem oldSubItem1 = listViewItem.SubItems[0];
+            ListViewItem.ListViewSubItem oldSubItem2 = new();
+            listViewItem.SubItems.Add(oldSubItem2);
+
+            Assert.Null(subItem1.owner);
+            Assert.Null(subItem2.owner);
+            Assert.Same(listViewItem, oldSubItem1.owner);
+            Assert.Same(listViewItem, oldSubItem2.owner);
+
+            ((IList)listViewItem.SubItems).Insert(0, subItem1);
+            ((IList)listViewItem.SubItems).Insert(1, subItem2);
+
+            Assert.Equal(4, listViewItem.SubItems.Count);
+
+            Assert.Same(subItem1, listViewItem.SubItems[0]);
+            Assert.Same(subItem2, listViewItem.SubItems[1]);
+            Assert.Same(oldSubItem1, listViewItem.SubItems[2]);
+            Assert.Same(oldSubItem2, listViewItem.SubItems[3]);
+
+            Assert.Same(listViewItem, oldSubItem1.owner);
+            Assert.Same(listViewItem, oldSubItem2.owner);
+            Assert.Same(listViewItem, subItem1.owner);
+            Assert.Same(listViewItem, subItem2.owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_IList_Remove_RemoveOwner()
+        {
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem oldSubItem = listViewItem.SubItems[0];
+            ListViewItem.ListViewSubItem subItem = new();
+            listViewItem.SubItems.Add(subItem);
+
+            Assert.Same(listViewItem, subItem.owner);
+            Assert.Same(listViewItem, oldSubItem.owner);
+
+            listViewItem.SubItems.Remove(subItem);
+            listViewItem.SubItems.Remove(oldSubItem);
+
+            Assert.Same(listViewItem, listViewItem.SubItems[0].owner);
+            Assert.Null(subItem.owner);
+            Assert.Null(oldSubItem.owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_IList_Set_UpdateOwner()
+        {
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem subItem = new();
+            ListViewItem.ListViewSubItem oldSubItem = listViewItem.SubItems[0];
+
+            Assert.Same(listViewItem, oldSubItem.owner);
+            Assert.Null(subItem.owner);
+
+            ((IList)listViewItem.SubItems)[0] = subItem;
+
+            Assert.Null(oldSubItem.owner);
+            Assert.Same(listViewItem, subItem.owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_Insert_UpdateOwner()
+        {
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem subItem1 = new();
+            ListViewItem.ListViewSubItem subItem2 = new();
+            ListViewItem.ListViewSubItem defaultSubItem = listViewItem.SubItems[0];
+
+            Assert.Null(subItem1.owner);
+            Assert.Null(subItem2.owner);
+            Assert.Same(listViewItem, defaultSubItem.owner);
+
+            listViewItem.SubItems.Insert(0, subItem1);
+            listViewItem.SubItems.Insert(1, subItem2);
+
+            Assert.Equal(3, listViewItem.SubItems.Count);
+
+            Assert.Same(listViewItem, defaultSubItem.owner);
+            Assert.Same(listViewItem, subItem1.owner);
+            Assert.Same(listViewItem, subItem2.owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_Remove_RemoveOwner()
+        {
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem oldSubItem = listViewItem.SubItems[0];
+            ListViewItem.ListViewSubItem subItem = new();
+            listViewItem.SubItems.Add(subItem);
+
+            Assert.Same(listViewItem, subItem.owner);
+            Assert.Same(listViewItem, oldSubItem.owner);
+
+            listViewItem.SubItems.Remove(subItem);
+            listViewItem.SubItems.Remove(oldSubItem);
+
+            Assert.Null(subItem.owner);
+            Assert.Null(oldSubItem.owner);
+            Assert.Same(listViewItem, listViewItem.SubItems[0].owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_RemoveAt_RemoveOwner()
+        {
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem oldSubItem = listViewItem.SubItems[0];
+            ListViewItem.ListViewSubItem subItem = new();
+            listViewItem.SubItems.Add(subItem);
+
+            Assert.Same(listViewItem, subItem.owner);
+            Assert.Same(listViewItem, oldSubItem.owner);
+
+            listViewItem.SubItems.RemoveAt(1);
+            listViewItem.SubItems.RemoveAt(0);
+
+            Assert.Null(subItem.owner);
+            Assert.Null(oldSubItem.owner);
+            Assert.Same(listViewItem, listViewItem.SubItems[0].owner);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemCollection_RemoveByKey_RemoveOwner()
+        {
+            ListViewItem listViewItem = new("Test 1");
+            ListViewItem.ListViewSubItem oldSubItem = listViewItem.SubItems[0];
+            oldSubItem.Name = "Test 1";
+            ListViewItem.ListViewSubItem subItem = new(listViewItem, "Test 2") { Name = "Test 2"  };
+            listViewItem.SubItems.Add(subItem);
+
+            Assert.Same(listViewItem, subItem.owner);
+            Assert.Same(listViewItem, oldSubItem.owner);
+
+            listViewItem.SubItems.RemoveByKey("Test 2");
+            listViewItem.SubItems.RemoveByKey("Test 1");
+
+            Assert.Null(subItem.owner);
+            Assert.Null(oldSubItem.owner);
+            Assert.Same(listViewItem, listViewItem.SubItems[0].owner);
         }
     }
 }


### PR DESCRIPTION
Fixes #4742


## Proposed changes
- Added missing logic for adding and removing owner. The problem is reproduced because when getting an accessibility object for a `ListViewSubItem`, the `ListViewSubItem` may not have an owner. This is because we have several ways to create and add an unowned `ListViewSubItem` to an `ListViewItem`.
- Added/updated unit tests

## Customer Impact

An app crash upon clicking on a listview subitem.

* **Before fix:**
  ![Issue-4742-BeforeFix](https://user-images.githubusercontent.com/23376742/113000113-34086300-9178-11eb-8378-4990c11449c8.gif)

* **After fix:**
  ![Issue-4742-AfterFix](https://user-images.githubusercontent.com/23376742/113000176-3f5b8e80-9178-11eb-88d6-23780f2697b3.gif)

## Regression? 
- Yes

## Risk
- Minimal
## Test methodology <!-- How did you ensure quality? -->
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows: Version 10.0.19041.388
- .NET Core SDK: 5.0.100


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4744)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4764)