### PR TITLE
Fix issue with displaying empty ListViewGroups

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
@@ -760,6 +760,307 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(listView.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNavigate_ReturnExpected_InvisibleGroups(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            ListViewGroup listViewGroupWithItems1 = listView.Groups[1];
+            ListViewGroup listViewGroupWithItems2 = listView.Groups[2];
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            Assert.Equal(listViewGroupWithItems1.AccessibilityObject,
+                accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+
+            Assert.Equal(listViewGroupWithItems2.AccessibilityObject,
+                accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNavigate_ReturnExpected_InvisibleGroups_AfterAddingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            Assert.Equal(listView.Groups[1].AccessibilityObject,
+                accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+
+            Assert.Equal(listView.Groups[2].AccessibilityObject,
+                accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            ListViewItem listViewItem1 = new();
+            ListViewItem listViewItem2 = new();
+            listView.Items.Add(listViewItem1);
+            listView.Items.Add(listViewItem2);
+            listView.Groups[0].Items.Add(listViewItem1);
+            listView.Groups[3].Items.Add(listViewItem2);
+
+            Assert.Equal(listView.Groups[0].AccessibilityObject,
+                accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+
+            Assert.Equal(listView.Groups[3].AccessibilityObject,
+                accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNavigate_ReturnExpected_InvisibleGroups_AfterRemovingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            Assert.Equal(listView.Groups[1].AccessibilityObject,
+                accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+
+            Assert.Equal(listView.Groups[2].AccessibilityObject,
+                accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            listView.Groups[1].Items.RemoveAt(0);
+            listView.Groups[2].Items.RemoveAt(0);
+
+            Assert.Equal(listView.DefaultGroup.AccessibilityObject,
+                accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+
+            Assert.Equal(listView.DefaultGroup.AccessibilityObject,
+                accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChildCount_ReturnExpected_InvisibleGroups(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            Assert.Equal(2, accessibleObject.GetChildCount());
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChildCount_ReturnExpected_InvisibleGroups_AfterAddingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            Assert.Equal(2, accessibleObject.GetChildCount());
+
+            ListViewItem listViewItem1 = new();
+            ListViewItem listViewItem2 = new();
+            listView.Items.Add(listViewItem1);
+            listView.Items.Add(listViewItem2);
+            listView.Groups[0].Items.Add(listViewItem1);
+            listView.Groups[3].Items.Add(listViewItem2);
+
+            Assert.Equal(4, accessibleObject.GetChildCount());
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChildCount_ReturnExpected_InvisibleGroups_AfterRemovingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            Assert.Equal(2, accessibleObject.GetChildCount());
+
+            listView.Groups[1].Items.RemoveAt(0);
+            listView.Groups[2].Items.RemoveAt(0);
+
+            Assert.Equal(1, accessibleObject.GetChildCount());
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChildCount_ReturnExpected_GroupWithInvalidAccessibleObject(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+            Assert.Equal(2, accessibleObject.GetChildCount());
+
+            listView.Groups[1].TestAccessor().Dynamic._accessibilityObject = new AccessibleObject();
+
+            Assert.Equal(1, accessibleObject.GetChildCount());
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChild_ReturnExpected_InvisibleGroups(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            ListViewGroup listViewGroupWithItems1 = listView.Groups[1];
+            ListViewGroup listViewGroupWithItems2 = listView.Groups[2];
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            Assert.Equal(listViewGroupWithItems1.AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(listViewGroupWithItems2.AccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Null(accessibleObject.GetChild(2));
+            Assert.Null(accessibleObject.GetChild(3));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChild_ReturnExpected_InvisibleGroups_AfterAddingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            Assert.Equal(listView.Groups[1].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(listView.Groups[2].AccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Null(accessibleObject.GetChild(2));
+            Assert.Null(accessibleObject.GetChild(3));
+
+            ListViewItem listViewItem1 = new();
+            ListViewItem listViewItem2 = new();
+            listView.Items.Add(listViewItem1);
+            listView.Items.Add(listViewItem2);
+            listView.Groups[0].Items.Add(listViewItem1);
+            listView.Groups[3].Items.Add(listViewItem2);
+
+            Assert.Equal(listView.Groups[0].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(listView.Groups[1].AccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Equal(listView.Groups[2].AccessibilityObject, accessibleObject.GetChild(2));
+            Assert.Equal(listView.Groups[3].AccessibilityObject, accessibleObject.GetChild(3));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChild_ReturnExpected_InvisibleGroups_AfterRemovingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            Assert.Equal(listView.Groups[1].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(listView.Groups[2].AccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Null(accessibleObject.GetChild(2));
+            Assert.Null(accessibleObject.GetChild(3));
+
+            listView.Groups[1].Items.RemoveAt(0);
+            listView.Groups[2].Items.RemoveAt(0);
+
+            Assert.Equal(listView.DefaultGroup.AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Null(accessibleObject.GetChild(1));
+            Assert.Null(accessibleObject.GetChild(2));
+            Assert.Null(accessibleObject.GetChild(3));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        private ListView GetListViewItemWithEmptyGroups(View view)
+        {
+            ListView listView = new ListView() { View = view};
+            listView.CreateControl();
+            ListViewGroup listViewGroupWithoutItems = new("Group without items");
+            ListViewGroup listViewGroupWithItems1 = new("Group with item 1");
+            ListViewGroup listViewGroupWithItems2 = new("Group with item 2");
+            ListViewGroup listViewGroupWithInvisibleItems = new("Group with invisible item");
+            listView.Groups.Add(listViewGroupWithoutItems);
+            listView.Groups.Add(listViewGroupWithItems1);
+            listView.Groups.Add(listViewGroupWithItems2);
+            listView.Groups.Add(listViewGroupWithInvisibleItems);
+            ListViewItem listViewItem1 = new();
+            ListViewItem listViewItem2 = new();
+            ListViewItem listViewItem3 = new();
+            listView.Items.Add(listViewItem1);
+            listView.Items.Add(listViewItem2);
+            listViewGroupWithItems1.Items.Add(listViewItem1);
+            listViewGroupWithItems2.Items.Add(listViewItem2);
+            listViewGroupWithInvisibleItems.Items.Add(listViewItem3);
+
+            return listView;
+        }
     }
 }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -640,5 +640,353 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(ExpandCollapseState.Expanded, listView.DefaultGroup.AccessibilityObject.ExpandCollapseState);
             Assert.Equal(createHandle, listView.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleGroups(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+            AccessibleObject listViewGroupWithItems1 = listView.Groups[1].AccessibilityObject;
+            AccessibleObject listViewGroupWithItems2 = listView.Groups[2].AccessibilityObject;
+
+            Assert.Null(listViewGroupWithItems1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(listViewGroupWithItems2, listViewGroupWithItems1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(listViewGroupWithItems1, listViewGroupWithItems2.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(listViewGroupWithItems2.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNaviage_ReturnsExpected_Sibling_InvisibleGroups_AfterAddingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+
+            Assert.Null(GetAccessibleObject(1).FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(GetAccessibleObject(2), GetAccessibleObject(1).FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(GetAccessibleObject(1), GetAccessibleObject(2).FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(GetAccessibleObject(2).FragmentNavigate(NavigateDirection.NextSibling));
+
+            ListViewItem listViewItem1 = new();
+            ListViewItem listViewItem2 = new();
+            listView.Items.Add(listViewItem1);
+            listView.Items.Add(listViewItem2);
+            listView.Groups[0].Items.Add(listViewItem1);
+            listView.Groups[3].Items.Add(listViewItem2);
+
+            Assert.Null(GetAccessibleObject(0).FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(GetAccessibleObject(1), GetAccessibleObject(0).FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(GetAccessibleObject(0), GetAccessibleObject(1).FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(GetAccessibleObject(2), GetAccessibleObject(1).FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(GetAccessibleObject(1), GetAccessibleObject(2).FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(GetAccessibleObject(3), GetAccessibleObject(2).FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(GetAccessibleObject(2), GetAccessibleObject(3).FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(GetAccessibleObject(3).FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.True(listView.IsHandleCreated);
+
+            AccessibleObject GetAccessibleObject(int index) => listView.Groups[index].AccessibilityObject;
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleGroups_AfterRemovingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithEmptyGroups(view);
+            AccessibleObject accessibleObject = listView.AccessibilityObject;
+            AccessibleObject listViewGroupWithItems1 = listView.Groups[1].AccessibilityObject;
+            AccessibleObject listViewGroupWithItems2 = listView.Groups[2].AccessibilityObject;
+
+            Assert.Null(listViewGroupWithItems1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(listViewGroupWithItems2, listViewGroupWithItems1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(listViewGroupWithItems1, listViewGroupWithItems2.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(listViewGroupWithItems2.FragmentNavigate(NavigateDirection.NextSibling));
+
+            listView.Groups[2].Items.RemoveAt(0);
+
+            Assert.Equal(listView.DefaultGroup.AccessibilityObject, listViewGroupWithItems1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(listViewGroupWithItems1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNaviage_Child_ReturnsExpected_InvisibleItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+            AccessibleObject accessibleObject = listView.Groups[0].AccessibilityObject;
+
+            Assert.Equal(listView.Groups[0].Items[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(listView.Groups[0].Items[2].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNaviage_Child_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+            AccessibleObject accessibleObject = listView.Groups[0].AccessibilityObject;
+
+            Assert.Equal(listView.Groups[0].Items[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(listView.Groups[0].Items[2].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            listView.Items.Add(listView.Groups[0].Items[0]);
+            listView.Items.Add(listView.Groups[0].Items[3]);
+
+            Assert.Equal(listView.Groups[0].Items[0].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(listView.Groups[0].Items[3].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNaviage_Child_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+            AccessibleObject accessibleObject = listView.Groups[0].AccessibilityObject;
+
+            Assert.Equal(listView.Groups[0].Items[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(listView.Groups[0].Items[2].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            listView.Items.RemoveAt(1);
+
+            Assert.Equal(listView.Groups[0].Items[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(listView.Groups[0].Items[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChildCount_ReturnsExpected_InvisibleItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+            AccessibleObject accessibleObject = listView.Groups[0].AccessibilityObject;
+
+            Assert.Equal(2, accessibleObject.GetChildCount());
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChildCount_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+            AccessibleObject accessibleObject = listView.Groups[0].AccessibilityObject;
+
+            Assert.Equal(2, accessibleObject.GetChildCount());
+
+            listView.Items.Add(listView.Groups[0].Items[0]);
+            listView.Items.Add(listView.Groups[0].Items[3]);
+
+            Assert.Equal(4, accessibleObject.GetChildCount());
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChildCount_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+            AccessibleObject accessibleObject = listView.Groups[0].AccessibilityObject;
+
+            Assert.Equal(2, accessibleObject.GetChildCount());
+
+            listView.Items.RemoveAt(1);
+
+            Assert.Equal(1, accessibleObject.GetChildCount());
+
+            listView.Items.RemoveAt(0);
+
+            Assert.Equal(0, accessibleObject.GetChildCount());
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChild_ReturnsExpected_InvisibleItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+            AccessibleObject accessibleObject = listView.Groups[0].AccessibilityObject;
+
+            Assert.Equal(listView.Groups[0].Items[1].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(listView.Groups[0].Items[2].AccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Null(accessibleObject.GetChild(2));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChild_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+            AccessibleObject accessibleObject = listView.Groups[0].AccessibilityObject;
+
+            listView.Items.Add(listView.Groups[0].Items[0]);
+            listView.Items.Add(listView.Groups[0].Items[3]);
+
+            Assert.Equal(listView.Groups[0].Items[0].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(listView.Groups[0].Items[1].AccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Equal(listView.Groups[0].Items[2].AccessibilityObject, accessibleObject.GetChild(2));
+            Assert.Equal(listView.Groups[0].Items[3].AccessibilityObject, accessibleObject.GetChild(3));
+            Assert.Null(accessibleObject.GetChild(4));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_GetChild_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+            AccessibleObject accessibleObject = listView.Groups[0].AccessibilityObject;
+
+            listView.Items.RemoveAt(1);
+
+            Assert.Equal(listView.Groups[0].Items[1].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Null(accessibleObject.GetChild(1));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        private ListView GetListViewItemWithEmptyGroups(View view)
+        {
+            ListView listView = new ListView() { View = view };
+            listView.CreateControl();
+            ListViewGroup listViewGroupWithoutItems = new("Group without items");
+            ListViewGroup listViewGroupWithItems1 = new("Group with item 1");
+            ListViewGroup listViewGroupWithItems2 = new("Group with item 2");
+            ListViewGroup listViewGroupWithInvisibleItems = new("Group with invisible item");
+            listView.Groups.Add(listViewGroupWithoutItems);
+            listView.Groups.Add(listViewGroupWithItems1);
+            listView.Groups.Add(listViewGroupWithItems2);
+            listView.Groups.Add(listViewGroupWithInvisibleItems);
+            ListViewItem listViewItem1 = new();
+            ListViewItem listViewItem2 = new();
+            ListViewItem listViewItem3 = new();
+            listView.Items.Add(listViewItem1);
+            listView.Items.Add(listViewItem2);
+            listViewGroupWithItems1.Items.Add(listViewItem1);
+            listViewGroupWithItems2.Items.Add(listViewItem2);
+            listViewGroupWithInvisibleItems.Items.Add(listViewItem3);
+
+            return listView;
+        }
+
+        private ListView GetListViewItemWithInvisibleItems(View view)
+        {
+            ListView listView = new ListView() { View = view };
+            listView.CreateControl();
+            ListViewGroup listViewGroup = new("Test group");
+            ListViewItem listViewInvisibleItem1 = new ListViewItem("Invisible item 1");
+            ListViewItem listViewVisibleItem1 = new ListViewItem("Visible item 1");
+            ListViewItem listViewInvisibleItem2 = new ListViewItem("Invisible item 1");
+            ListViewItem listViewVisibleItem2 = new ListViewItem("Visible item 1");
+
+            listView.Groups.Add(listViewGroup);
+            listView.Items.AddRange(new ListViewItem[] { listViewVisibleItem1, listViewVisibleItem2 });
+            listViewGroup.Items.AddRange(new ListViewItem[]
+            {
+                listViewInvisibleItem1, listViewVisibleItem1,
+                listViewVisibleItem2, listViewInvisibleItem2
+            });
+
+            return listView;
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -1482,5 +1482,112 @@ namespace System.Windows.Forms.Tests
             Assert.False(listViewItem.Checked);
             Assert.Equal(createHandle, listView.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+
+            Assert.Null(GetAccessibleObject(1).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(GetAccessibleObject(2), GetAccessibleObject(1).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(GetAccessibleObject(1), GetAccessibleObject(2).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(GetAccessibleObject(2).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.True(listView.IsHandleCreated);
+
+            AccessibleObject GetAccessibleObject(int index) => listView.Groups[0].Items[index].AccessibilityObject;
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+
+            Assert.Null(GetAccessibleObject(1).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(GetAccessibleObject(2), GetAccessibleObject(1).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(GetAccessibleObject(1), GetAccessibleObject(2).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(GetAccessibleObject(2).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            listView.Items.Add(listView.Groups[0].Items[0]);
+            listView.Items.Add(listView.Groups[0].Items[3]);
+
+            Assert.Null(GetAccessibleObject(0).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(GetAccessibleObject(1), GetAccessibleObject(0).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(GetAccessibleObject(0), GetAccessibleObject(1).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(GetAccessibleObject(2), GetAccessibleObject(1).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(GetAccessibleObject(1), GetAccessibleObject(2).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(GetAccessibleObject(3), GetAccessibleObject(2).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(GetAccessibleObject(2), GetAccessibleObject(3).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(GetAccessibleObject(3).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.True(listView.IsHandleCreated);
+
+            AccessibleObject GetAccessibleObject(int index) => listView.Groups[0].Items[index].AccessibilityObject;
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewItemWithInvisibleItems(view);
+
+            Assert.Null(GetAccessibleObject(1).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(GetAccessibleObject(2), GetAccessibleObject(1).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(GetAccessibleObject(1), GetAccessibleObject(2).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(GetAccessibleObject(2).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            listView.Items.RemoveAt(1);
+
+            Assert.Null(GetAccessibleObject(0).FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(GetAccessibleObject(0).FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.True(listView.IsHandleCreated);
+
+            AccessibleObject GetAccessibleObject(int index) => listView.Groups[0].Items[index].AccessibilityObject;
+        }
+
+        private ListView GetListViewItemWithInvisibleItems(View view)
+        {
+            ListView listView = new ListView() { View = view };
+            listView.CreateControl();
+            ListViewGroup listViewGroup = new("Test group");
+            ListViewItem listViewInvisibleItem1 = new ListViewItem("Invisible item 1");
+            ListViewItem listViewVisibleItem1 = new ListViewItem("Visible item 1");
+            ListViewItem listViewInvisibleItem2 = new ListViewItem("Invisible item 1");
+            ListViewItem listViewVisibleItem2 = new ListViewItem("Visible item 1");
+
+            listView.Groups.Add(listViewGroup);
+            listView.Items.AddRange(new ListViewItem[] { listViewVisibleItem1, listViewVisibleItem2 });
+            listViewGroup.Items.AddRange(new ListViewItem[]
+            {
+                listViewInvisibleItem1, listViewVisibleItem1,
+                listViewVisibleItem2, listViewInvisibleItem2
+            });
+
+            return listView;
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4779


## Proposed changes
- An ListViewItem is considered invisible when it is in a ListViewGroup but not added to the ListView. In this case, the ListViewGroup contains data about it, but the ListViewItem is not displayed in the list. To solve this problem, the "VisibleItems" property was added, which contains a list of only displayed ListViewItems, in which the property "ListView" is not empty. Now, when receiving data about the ListViewItems of a ListViewGroup, we use this property and not "Items" property of the ListViewGroup.
- if the ListViewGroup is empty or contains invisible ListViewItems (case above), then this ListViewGroup is also not displayed in the ListView. This issue was solved in the same way as the issue above, by adding the "VisibleGroups" property that contains a list of only the displayed ListViewGroups.
- Added unit tests for ListViewAccessibleObject, ListViewGroupAccessibleObject, ListViewItemAccessibleObject

## Customer Impact
Simple code as an example:
```
ListViewGroup inVisibleListViewGroup = new ListViewGroup("Invisible group");
ListViewGroup visibleListViewGroup = new ListViewGroup("Visible group");
ListViewItem invisibleListViewItem = new ListViewItem("Invisible item");
ListViewItem visibleListViewItem = new ListViewItem("Visible item");

listView.Groups.Add(inVisibleListViewGroup);
listView.Groups.Add(visibleListViewGroup);

visibleListViewGroup.Items.Add(invisibleListViewItem);
visibleListViewGroup.Items.Add(visibleListViewItem);
listView.Items.Add(visibleListViewItem);
```

**Before fix:**
![Issue-4779-before](https://user-images.githubusercontent.com/23376742/114667578-48b43180-9d08-11eb-9a2a-3fbcd16bbd97.png)

**After fix:**
![Issue-4779-after](https://user-images.githubusercontent.com/23376742/114667598-54075d00-9d08-11eb-9b3a-d5cb0bf7c73a.png)

## Regression? 

- Yes (regression from #3224)

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests 
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.100-preview.2.21155.3


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4789)