### PR TITLE
Fix rectangle of the ListViewGroup

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVGGR.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVGGR.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class ComCtl32
+    {
+        public enum LVGGR
+        {
+            GROUP = 0,
+            HEADER = 1,
+            LABEL = 2,
+            SUBSETLINK = 3
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -26,11 +26,11 @@ namespace System.Windows.Forms
             internal override int ColumnCount
                 => _owningListView.Columns.Count;
 
-            private bool OwnerHasDefaultGroup
+            internal bool OwnerHasDefaultGroup
             {
                 get
                 {
-                    if (!_owningListView.IsHandleCreated || !_owningListView.ShowGroups || _owningListView.VirtualMode)
+                    if (!_owningListView.ShowGroups || _owningListView.VirtualMode)
                     {
                         return false;
                     }
@@ -77,7 +77,7 @@ namespace System.Windows.Forms
             }
 
             // ListViewGroup are not displayed when the ListView is in "List" view
-            private bool ShowGroupAccessibleObject => _owningListView.View != View.List && _owningListView.GroupsEnabled;
+            internal bool ShowGroupAccessibleObject => _owningListView.View != View.List && _owningListView.GroupsEnabled;
 
             internal override UiaCore.IRawElementProviderFragment? ElementProviderFromPoint(double x, double y)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3501,22 +3501,6 @@ namespace System.Windows.Forms
             return -1;
         }
 
-        internal int GetGroupIndex(ListViewGroup owningGroup)
-        {
-            if (Groups.Count == 0)
-            {
-                return -1;
-            }
-
-            // Default group it's last group in accessibility and not specified in Groups collection, therefore default group index = Groups.Count
-            if (DefaultGroup == owningGroup)
-            {
-                return Groups.Count;
-            }
-
-            return Groups.IndexOf(owningGroup);
-        }
-
         /// <summary>
         ///  Returns the current ListViewItem corresponding to the specific
         ///  x,y co-ordinate.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
@@ -179,7 +179,10 @@ namespace System.Windows.Forms
                         runtimeId[0] = owningListViewRuntimeId[0];
                         runtimeId[1] = owningListViewRuntimeId[1];
                         runtimeId[2] = 4; // Win32-control specific RuntimeID constant, is used in similar Win32 controls and is used in WinForms controls for consistency.
-                        runtimeId[3] = _owningListView.GetGroupIndex(_owningGroup);
+                        runtimeId[3] = _owningGroup.AccessibilityObject is ListViewGroupAccessibleObject listViewGroupAccessibleObject
+                                        ? listViewGroupAccessibleObject.CurrentIndex
+                                        : -1;
+
                         runtimeId[4] = CurrentIndex;
 
                         return runtimeId;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
@@ -424,7 +424,7 @@ namespace System.Windows.Forms.Tests
                 {
                     foreach (bool createHandle in new[] { true, false })
                     {
-                        bool expected = showGroups && createHandle;
+                        bool expected = showGroups;
                         yield return new object[] { showGroups, createHandle, expected };
                     }
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -50,7 +50,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ListViewGroupAccessibleObject_GetPropertyValue_returns_correct_values()
+        public void ListViewGroupAccessibleObject_GetPropertyValue_ReturnsExpected_WithoutDefaultGroup()
         {
             using ListView list = new ListView();
             ListViewGroup listGroup = new ListViewGroup("Group1");
@@ -71,6 +71,34 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, controlType);
 
             Assert.True((bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+            Assert.False(list.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewGroupAccessibleObject_GetPropertyValue_ReturnsExpected_WithDefaultGroup()
+        {
+            using ListView list = new ListView();
+            ListViewGroup listGroup = new ListViewGroup("Group1");
+            listGroup.Items.Add(new ListViewItem());
+            list.Items.Add(new ListViewItem());
+            list.Groups.Add(listGroup);
+
+            AccessibleObject defaultGroupAccessibleObject = list.DefaultGroup.AccessibilityObject;
+            AccessibleObject groupAccessibleObject = listGroup.AccessibilityObject;
+
+            Assert.Equal(list.DefaultGroup.Header, defaultGroupAccessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
+            Assert.Equal("Group1", groupAccessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
+
+            Assert.Equal("ListViewGroup-0", defaultGroupAccessibleObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
+            Assert.Equal("ListViewGroup-1", groupAccessibleObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
+
+            Assert.Equal(UiaCore.UIA.GroupControlTypeId, groupAccessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+            Assert.Equal(UiaCore.UIA.GroupControlTypeId, defaultGroupAccessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+
+            Assert.True((bool)defaultGroupAccessibleObject.GetPropertyValue(UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+            Assert.True((bool)groupAccessibleObject.GetPropertyValue(UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+
+            Assert.False(list.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -646,7 +674,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleGroups(View view)
+        public void ListViewGroupAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleGroups(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -670,7 +698,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_FragmentNaviage_ReturnsExpected_Sibling_InvisibleGroups_AfterAddingItems(View view)
+        public void ListViewGroupAccessibleObject_FragmentNaviage_ReturnsExpected_Sibling_InvisibleGroups_AfterAddingItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -710,7 +738,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleGroups_AfterRemovingItems(View view)
+        public void ListViewGroupAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleGroups_AfterRemovingItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -739,7 +767,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_FragmentNaviage_Child_ReturnsExpected_InvisibleItems(View view)
+        public void ListViewGroupAccessibleObject_FragmentNaviage_Child_ReturnsExpected_InvisibleItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -759,7 +787,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_FragmentNaviage_Child_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
+        public void ListViewGroupAccessibleObject_FragmentNaviage_Child_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -785,7 +813,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_FragmentNaviage_Child_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
+        public void ListViewGroupAccessibleObject_FragmentNaviage_Child_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -810,7 +838,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_GetChildCount_ReturnsExpected_InvisibleItems(View view)
+        public void ListViewGroupAccessibleObject_GetChildCount_ReturnsExpected_InvisibleItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -829,7 +857,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_GetChildCount_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
+        public void ListViewGroupAccessibleObject_GetChildCount_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -853,7 +881,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_GetChildCount_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
+        public void ListViewGroupAccessibleObject_GetChildCount_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -880,7 +908,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_GetChild_ReturnsExpected_InvisibleItems(View view)
+        public void ListViewGroupAccessibleObject_GetChild_ReturnsExpected_InvisibleItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -901,7 +929,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_GetChild_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
+        public void ListViewGroupAccessibleObject_GetChild_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -927,7 +955,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_GetChild_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
+        public void ListViewGroupAccessibleObject_GetChild_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -941,6 +969,85 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(listView.Groups[0].Items[1].AccessibilityObject, accessibleObject.GetChild(0));
             Assert.Null(accessibleObject.GetChild(1));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_FragmentRoot_Returns_ListViewAccessibleObject(View view, bool showGroups, bool createHandle)
+        {
+            using ListView listView = new()
+            {
+                View = view,
+                ShowGroups = showGroups,
+            };
+
+            ListViewGroup listViewGroup = new();
+            listView.Groups.Add(listViewGroup);
+
+            if (createHandle)
+            {
+                listView.CreateControl();
+            }
+
+            Assert.Equal(listView.AccessibilityObject, listViewGroup.AccessibilityObject.FragmentRoot);
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroup_GroupAddedWithItem_AccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_Bounds_ReturnsExpected(View view, bool showGroups, bool createHandle, bool virtualMode)
+        {
+            using ListView listView = GetListViewWithGroups(view, showGroups, createHandle, virtualMode);
+            ListView.ListViewAccessibleObject accessibleObject = listView.AccessibilityObject as ListView.ListViewAccessibleObject;
+            bool showBounds = listView.IsHandleCreated && accessibleObject.ShowGroupAccessibleObject;
+
+            Assert.Equal(showBounds, !listView.DefaultGroup.AccessibilityObject.Bounds.IsEmpty);
+            Assert.Equal(showBounds, !listView.Groups[0].AccessibilityObject.Bounds.IsEmpty);
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewGroupAccessibleObject_Bounds_LocatedInsideListViewBounds(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = GetListViewWithGroups(view, showGroups: true, createHandle: true, virtualMode: false);
+            ListView.ListViewAccessibleObject accessibleObject = listView.AccessibilityObject as ListView.ListViewAccessibleObject;
+            Rectangle listViewBounds = listView.AccessibilityObject.Bounds;
+
+            Assert.True(listViewBounds.Contains(listView.DefaultGroup.AccessibilityObject.Bounds));
+            Assert.True(listViewBounds.Contains(listView.Groups[0].AccessibilityObject.Bounds));
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewGroupAccessibleObject_Bounds_ReturnEmptyRectangle_ForEmptyGroup(View view)
+        {
+            if (!Application.UseVisualStyles)
+            {
+                return;
+            }
+
+            using ListView listView = new ListView() { View = view, ShowGroups = true };
+            listView.Columns.Add(new ColumnHeader());
+            listView.CreateControl();
+            listView.Groups.Add(new ListViewGroup());
+            listView.Items.Add(new ListViewItem());
+
+            Assert.False(listView.DefaultGroup.AccessibilityObject.Bounds.IsEmpty);
+            Assert.True(listView.Groups[0].AccessibilityObject.Bounds.IsEmpty);
             Assert.True(listView.IsHandleCreated);
         }
 
@@ -985,6 +1092,53 @@ namespace System.Windows.Forms.Tests
                 listViewInvisibleItem1, listViewVisibleItem1,
                 listViewVisibleItem2, listViewInvisibleItem2
             });
+
+            return listView;
+        }
+
+        private ListView GetListViewWithGroups(View view, bool showGroups, bool createHandle, bool virtualMode)
+        {
+            ListView listView = new()
+            {
+                View = view,
+                ShowGroups = showGroups,
+                VirtualListSize = 2,
+                VirtualMode = virtualMode,
+                Size = new Size(200, 200)
+            };
+
+            listView.Columns.Add(new ColumnHeader());
+
+            var listViewGroup = new ListViewGroup("Test Group");
+            listView.Groups.Add(listViewGroup);
+            var listViewItem1 = new ListViewItem("Test item 1", listViewGroup);
+            var listViewItem2 = new ListViewItem("Test item 2");
+
+            if (virtualMode)
+            {
+                listView.RetrieveVirtualItem += (s, e) =>
+                {
+                    e.Item = e.ItemIndex switch
+                    {
+                        0 => listViewItem1,
+                        1 => listViewItem2,
+                        _ => throw new NotImplementedException()
+                    };
+                };
+
+                listViewItem1.SetItemIndex(listView, 0);
+                listViewItem2.SetItemIndex(listView, 1);
+            }
+            else
+            {
+                listView.Items.Add(listViewItem1);
+                listView.Items.Add(listViewItem2);
+            }
+
+            if (createHandle)
+            {
+                Assert.NotEqual(IntPtr.Zero, listView.Handle);
+            }
 
             return listView;
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -1488,7 +1488,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleItems(View view)
+        public void ListViewItemAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -1511,7 +1511,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
+        public void ListViewItemAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleItems_AfterAddingItems(View view)
         {
             if (!Application.UseVisualStyles)
             {
@@ -1546,7 +1546,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]
         [InlineData(View.Tile)]
-        public void ListViewAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
+        public void ListViewItemAccessibleObject_FragmentNaviage_Sibling_ReturnsExpected_InvisibleItems_AfterRemovingItems(View view)
         {
             if (!Application.UseVisualStyles)
             {


### PR DESCRIPTION
Fixes #4778


## Proposed changes
- The issue with the incorrect rectangle is reproduced because the "FragmentRoot" property was not overridden. Added an override for the "FragmentRoot" property.
- Fixed issue with getting a rectangle for a ListViewGroup. Now, instead of the ListViewGroup index, we use the group ID. Fixed a issue with getting an incorrect ListViewGroup index.
- Added unit tests. Fixed typos in unit-tests naming


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
### Case 1
**Before fix:**
![Issue-4778-case1-before](https://user-images.githubusercontent.com/23376742/114997193-41c42500-9ea8-11eb-9d8d-dd2fed7be588.png)

**After fix:**
![Issue-4778-case1-after](https://user-images.githubusercontent.com/23376742/114997486-8e0f6500-9ea8-11eb-8e14-0aae753335ac.png)

### Case 2
**Before fix:**
![Issue-4778-case2-before](https://user-images.githubusercontent.com/23376742/114997915-0bd37080-9ea9-11eb-8203-d76619915de9.png)

**After fix:**
![Issue-4778-case2-after](https://user-images.githubusercontent.com/23376742/114997927-1130bb00-9ea9-11eb-80fe-bee59783f3cf.png)

## Regression? 

- Yes (from #3224)

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team
- unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspector

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.100-preview.2.21155.3


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4800)