### PR TITLE
Disable SYSLIB0016 warning

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextHdcScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextHdcScope.cs
@@ -146,8 +146,10 @@ namespace System.Windows.Forms
             bool applyTransform = applyGraphicsState.HasFlag(ApplyGraphicsProperties.TranslateTransform);
             bool applyClipping = applyGraphicsState.HasFlag(ApplyGraphicsProperties.Clipping);
 
+#pragma warning disable SYSLIB0016 // Type or member is obsolete
             // This API is very expensive and cannot be called after GetHdc()
             object[]? data = applyTransform || applyClipping ? (object[])graphics.GetContextInfo() : null;
+#pragma warning restore SYSLIB0016 // Type or member is obsolete
 
             using Region? clipRegion = (Region?)data?[0];
             using Matrix? worldTransform = (Matrix?)data?[1];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
@@ -156,8 +156,10 @@ namespace System.Windows.Forms
                 return;
             }
 
+#pragma warning disable SYSLIB0016 // Type or member is obsolete
             // Check to see if we've actually corrupted the state
             object[] data = (object[])graphics.GetContextInfo();
+#pragma warning restore SYSLIB0016 // Type or member is obsolete
 
             using Region clipRegion = (Region)data[0];
             using Matrix worldTransform = (Matrix)data[1];


### PR DESCRIPTION
This is a new obsoletion in System.Drawing. Disabling so we can consume the new build. Will follow this change with another that consumes the newer API.

Unblocks https://github.com/dotnet/winforms/pull/4802

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4811)