### PR TITLE
Use new GetContext overloads

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextHdcScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextHdcScope.cs
@@ -146,58 +146,61 @@ namespace System.Windows.Forms
             bool applyTransform = applyGraphicsState.HasFlag(ApplyGraphicsProperties.TranslateTransform);
             bool applyClipping = applyGraphicsState.HasFlag(ApplyGraphicsProperties.Clipping);
 
-#pragma warning disable SYSLIB0016 // Type or member is obsolete
-            // This API is very expensive and cannot be called after GetHdc()
-            object[]? data = applyTransform || applyClipping ? (object[])graphics.GetContextInfo() : null;
-#pragma warning restore SYSLIB0016 // Type or member is obsolete
-
-            using Region? clipRegion = (Region?)data?[0];
-            using Matrix? worldTransform = (Matrix?)data?[1];
-
-            // elements (XFORM) = [eM11, eM12, eM21, eM22, eDx, eDy], eDx/eDy specify the translation offset.
-            float[]? elements = applyTransform ? worldTransform?.Elements : null;
-            int dx = elements is not null ? (int)elements[4] : 0;
-            int dy = elements is not null ? (int)elements[5] : 0;
-            applyTransform = applyTransform && elements is not null && (dx != 0 || dy != 0);
-
-            using var graphicsRegion = applyClipping ? new Gdi32.RegionScope(clipRegion!, graphics) : default;
-            applyClipping = applyClipping && !graphicsRegion!.Region.IsNull;
-
-            HDC = (Gdi32.HDC)graphics.GetHdc();
-
-            if (saveHdcState || applyClipping || applyTransform)
-            {
-                _savedHdcState = Gdi32.SaveDC(HDC);
-            }
-
+            Region? clipRegion = null;
+            PointF offset = default;
             if (applyClipping)
             {
-                // If the Graphics object was created from a native DC the actual clipping region is the intersection
-                // beteween the original DC clip region and the GDI+ one - for display Graphics it is the same as
-                // Graphics.VisibleClipBounds.
+                graphics.GetContextInfo(out offset, out clipRegion);
+            }
+            else if (applyTransform)
+            {
+                graphics.GetContextInfo(out offset);
+            }
 
-                RegionType type;
+            using (clipRegion)
+            {
+                applyTransform = applyTransform && !offset.IsEmpty;
+                applyClipping = clipRegion is not null;
 
-                using var dcRegion = new Gdi32.RegionScope(HDC);
-                if (!dcRegion.IsNull)
+                using var graphicsRegion = applyClipping ? new Gdi32.RegionScope(clipRegion!, graphics) : default;
+                applyClipping = applyClipping && !graphicsRegion!.Region.IsNull;
+
+                HDC = (Gdi32.HDC)graphics.GetHdc();
+
+                if (saveHdcState || applyClipping || applyTransform)
                 {
-                    type = Gdi32.CombineRgn(graphicsRegion!, dcRegion, graphicsRegion!, Gdi32.RGN.AND);
+                    _savedHdcState = Gdi32.SaveDC(HDC);
+                }
+
+                if (applyClipping)
+                {
+                    // If the Graphics object was created from a native DC the actual clipping region is the intersection
+                    // beteween the original DC clip region and the GDI+ one - for display Graphics it is the same as
+                    // Graphics.VisibleClipBounds.
+
+                    RegionType type;
+
+                    using var dcRegion = new Gdi32.RegionScope(HDC);
+                    if (!dcRegion.IsNull)
+                    {
+                        type = Gdi32.CombineRgn(graphicsRegion!, dcRegion, graphicsRegion!, Gdi32.RGN.AND);
+                        if (type == RegionType.ERROR)
+                        {
+                            throw new Win32Exception();
+                        }
+                    }
+
+                    type = Gdi32.SelectClipRgn(HDC, graphicsRegion!);
                     if (type == RegionType.ERROR)
                     {
                         throw new Win32Exception();
                     }
                 }
 
-                type = Gdi32.SelectClipRgn(HDC, graphicsRegion!);
-                if (type == RegionType.ERROR)
+                if (applyTransform)
                 {
-                    throw new Win32Exception();
+                    Gdi32.OffsetViewportOrgEx(HDC, (int)offset.X, (int)offset.Y, null);
                 }
-            }
-
-            if (applyTransform)
-            {
-                Gdi32.OffsetViewportOrgEx(HDC, dx, dy, null);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/DrawingEventArgs.cs
@@ -156,18 +156,15 @@ namespace System.Windows.Forms
                 return;
             }
 
-#pragma warning disable SYSLIB0016 // Type or member is obsolete
             // Check to see if we've actually corrupted the state
-            object[] data = (object[])graphics.GetContextInfo();
-#pragma warning restore SYSLIB0016 // Type or member is obsolete
+            graphics.GetContextInfo(out PointF offset, out Region? clip);
 
-            using Region clipRegion = (Region)data[0];
-            using Matrix worldTransform = (Matrix)data[1];
-
-            float[] elements = worldTransform?.Elements!;
-            bool isInfinite = clipRegion.IsInfinite(graphics);
-            Debug.Assert((int)elements[4] == 0 && (int)elements[5] == 0, "transform has been modified");
-            Debug.Assert(isInfinite, "clipping as been applied");
+            using (clip)
+            {
+                bool isInfinite = clip?.IsInfinite(graphics) ?? true;
+                Debug.Assert(offset.IsEmpty, "transform has been modified");
+                Debug.Assert(isInfinite, "clipping as been applied");
+            }
         }
     }
 }


### PR DESCRIPTION
Use new Graphics.GetContext overloads that minimize allocations and remove warning suppression.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4814)