### PR TITLE
Don't use Marshal.SizeOf for SCROLLINFO

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -7803,15 +7803,16 @@ namespace System.Windows.Forms
             OnInvokedSetScrollPosition(sender, e);
         }
 
-        internal virtual void OnInvokedSetScrollPosition(object sender, EventArgs e)
+        internal unsafe virtual void OnInvokedSetScrollPosition(object sender, EventArgs e)
         {
             if (!(this is ScrollableControl) && !IsMirrored)
             {
-                var si = new User32.SCROLLINFO
+                User32.SCROLLINFO si = new()
                 {
-                    cbSize = (uint)Marshal.SizeOf<User32.SCROLLINFO>(),
+                    cbSize = (uint)sizeof(User32.SCROLLINFO),
                     fMask = User32.SIF.RANGE
                 };
+
                 if (User32.GetScrollInfo(this, User32.SB.HORZ, ref si).IsTrue())
                 {
                     si.nPos = (RightToLeft == RightToLeft.Yes) ? si.nMax : si.nMin;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -751,7 +751,7 @@ namespace System.Windows.Forms
             virtualSize = value;
             SetPositionNoInvalidate(position); // Make sure it's within range
 
-            User32.SCROLLINFO si = new()
+            User32.SCROLLINFO info = new()
             {
                 cbSize = (uint)sizeof(User32.SCROLLINFO),
                 fMask = User32.SIF.RANGE | User32.SIF.PAGE,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -310,17 +310,18 @@ namespace System.Windows.Forms
             }
         }
 
-        private int AdjustScroll(Message m, int pos, int maxPos, bool horizontal)
+        private unsafe int AdjustScroll(Message m, int pos, int maxPos, bool horizontal)
         {
             switch ((User32.SBH)PARAM.LOWORD(m.WParam))
             {
                 case User32.SBH.THUMBPOSITION:
                 case User32.SBH.THUMBTRACK:
-                    var si = new User32.SCROLLINFO
+                    User32.SCROLLINFO si = new()
                     {
-                        cbSize = (uint)Marshal.SizeOf<User32.SCROLLINFO>(),
+                        cbSize = (uint)sizeof(User32.SCROLLINFO),
                         fMask = User32.SIF.TRACKPOS
                     };
+
                     User32.SB direction = horizontal ? User32.SB.HORZ : User32.SB.VERT;
                     if (User32.GetScrollInfo(m.HWnd, direction, ref si).IsTrue())
                     {
@@ -745,19 +746,20 @@ namespace System.Windows.Forms
             User32.SetScrollPos(this, User32.SB.VERT, position.Y, BOOL.TRUE);
         }
 
-        internal void SetVirtualSizeNoInvalidate(Size value)
+        internal unsafe void SetVirtualSizeNoInvalidate(Size value)
         {
             virtualSize = value;
             SetPositionNoInvalidate(position); // Make sure it's within range
 
-            var info = new User32.SCROLLINFO
+            User32.SCROLLINFO si = new()
             {
-                cbSize = (uint)Marshal.SizeOf<User32.SCROLLINFO>(),
+                cbSize = (uint)sizeof(User32.SCROLLINFO),
                 fMask = User32.SIF.RANGE | User32.SIF.PAGE,
                 nMin = 0,
                 nMax = Math.Max(Height, virtualSize.Height) - 1,
                 nPage = (uint)Height
             };
+
             User32.SetScrollInfo(this, User32.SB.VERT, ref info, BOOL.TRUE);
 
             info.fMask = User32.SIF.RANGE | User32.SIF.PAGE;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollProperties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollProperties.cs
@@ -269,13 +269,13 @@ namespace System.Windows.Forms
             }
         }
 
-        internal void UpdateScrollInfo()
+        internal unsafe void UpdateScrollInfo()
         {
             if (_parent is not null && _parent.IsHandleCreated && _visible)
             {
-                var si = new User32.SCROLLINFO
+                User32.SCROLLINFO si = new()
                 {
-                    cbSize = (uint)Marshal.SizeOf<User32.SCROLLINFO>(),
+                    cbSize = (uint)sizeof(User32.SCROLLINFO),
                     fMask = User32.SIF.ALL,
                     nMin = _minimum,
                     nMax = _maximum,
@@ -283,6 +283,7 @@ namespace System.Windows.Forms
                     nPos = _value,
                     nTrackPos = 0
                 };
+
                 User32.SetScrollInfo(_parent, Orientation, ref si, BOOL.TRUE);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
@@ -927,13 +927,14 @@ namespace System.Windows.Forms
             return new Point(xCalc, yCalc);
         }
 
-        private int ScrollThumbPosition(User32.SB fnBar)
+        private unsafe int ScrollThumbPosition(User32.SB fnBar)
         {
-            var si = new User32.SCROLLINFO
+            User32.SCROLLINFO si = new()
             {
-                cbSize = (uint)Marshal.SizeOf<User32.SCROLLINFO>(),
+                cbSize = (uint)sizeof(User32.SCROLLINFO),
                 fMask = User32.SIF.TRACKPOS
             };
+
             User32.GetScrollInfo(this, fnBar, ref si);
             return si.nTrackPos;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2778,11 +2778,12 @@ namespace System.Windows.Forms
                         {
                             Rectangle bounds = node.RowBounds;
 
-                            var si = new User32.SCROLLINFO
+                            User32.SCROLLINFO si = new()
                             {
-                                cbSize = (uint)Marshal.SizeOf<User32.SCROLLINFO>(),
+                                cbSize = (uint)sizeof(User32.SCROLLINFO),
                                 fMask = User32.SIF.POS
                             };
+
                             if (User32.GetScrollInfo(this, User32.SB.HORZ, ref si).IsTrue())
                             {
                                 // need to get the correct bounds if horizontal scroll bar is shown.


### PR DESCRIPTION
`sizeof` is a compile time constant and as a result, much faster.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4819)