### PR TITLE
Add MetadataUpdateHandler to WinForms to repaint all open forms

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/WinFormsMetadataUpdateHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/WinFormsMetadataUpdateHandler.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection.Metadata;
+using System.Windows.Forms;
+
+[assembly: MetadataUpdateHandler(typeof(WinFormsMetadataUpdateHandler))]
+
+namespace System.Windows.Forms
+{
+    /// <summary>Handle notifications of metadata updates being applied.</summary>
+    internal static class WinFormsMetadataUpdateHandler
+    {
+        /// <summary>Invoked after a metadata update is applied.</summary>
+        /// <param name="types">The list of types known to be updated, or null if it couldn't be determined.</param>
+        internal static void AfterUpdate(Type[]? types)
+        {
+            // Repaint all open forms.
+            foreach (Form openForm in Application.OpenForms)
+            {
+                openForm.BeginInvoke((MethodInvoker)(() => openForm.Refresh()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

.NET hot reload enables changes to be made to an app while it's running.  If you were to patch a control's OnPaint routine, for example, the next time that was invoked, it would end up running the newly patched code.  However, nothing at the runtime level applying updates automatically triggers Windows Forms to refresh its controls.  Instead, a notification mechanism is used to invoke any interested listeners about an update.  Windows Forms can have its own listener, which it can use to do anything it would like in response to the update notification.  This PR adds such a listener, and uses it to refresh every open form in the application.  Future updates to it could be used to do other things, like request that data bound controls rebind, in case the thing they're bound to has changed in some way. (Note that TypeDescriptor.Refresh is invoked via the same mechanism, so any control's listening to TypeDescriptor.Refreshed will automatically be notified as well; this appears to only be the case for PropertyGrid today.)

## Customer Impact

Windows Forms apps being used with hot reload automatically refresh in response to a hot reload update.

## Regression? 

No

## Risk

The hot reload work is still in flight and the pattern employed by this loosely-coupled mechanism is still in development; the pattern may evolve, in which case we'll need to update it along with all the other handlers we've added / are adding in .NET 6.

## Test methodology

Build the changes locally and patched my installed nightly .NET 6 build.  Then use hot reload with several apps, including some that had custom OnPaint overrides, which I could change to see that hot reload edits forced a repaint.

cc: @KlausLoeffelmann, @JeremyKuhne, @pranavkm, @tommcdon, @mikem8361, @LyalinDotCom 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4831)