### PR TITLE
ListViewItemAccessibleObject doesn't respect updating a group

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -1009,6 +1009,8 @@ namespace System.Windows.Forms
             }
         }
 
+        internal bool GroupsDisplayed => View != View.List && GroupsEnabled;
+
         // this essentially means that the version of CommCtl supports list view grouping
         // and that the user wants to make use of list view groups
         internal bool GroupsEnabled

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -237,9 +237,7 @@ namespace System.Windows.Forms
             {
                 if (_accessibilityObject is null)
                 {
-                    bool inDefaultGroup = listView?.GroupsEnabled == true && Group is null;
-                    _accessibilityObject = new ListViewItemAccessibleObject(
-                        this, inDefaultGroup ? listView.DefaultGroup : Group);
+                    _accessibilityObject = new ListViewItemAccessibleObject(this);
                 }
 
                 return _accessibilityObject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5112,7 +5112,7 @@ namespace System.Windows.Forms.Tests
         {
             public int RaiseAutomationEventCalls;
 
-            public SubListViewItemAccessibleObject(ListViewItem owningItem) : base(owningItem, null)
+            public SubListViewItemAccessibleObject(ListViewItem owningItem) : base(owningItem)
             {
             }
 


### PR DESCRIPTION
Fixes #4839


## Proposed changes
- The issue is reproduced because during the creation of the ListViewItemAccessibilityObject, we save the current value of the ListViewGroup and it is no longer updated. This is not the right approach because the user can change the ListViewGroup of a ListViewItem or remove ListViewGroups from the ListView. Currently we use the "OwningGroup" property, which, on each call, calculates whether the ListView has ListViewGroups and which ListViewGroup the ListViewItem is in.

- Also, an issue with an attempt to get "Bounds" property when the Handle is not created has been fixed. Now, in the absence of a Handle, we immediately return an empty rectangle

- Added and updated unit tests 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
Before fix:
![Issue-4839-before](https://user-images.githubusercontent.com/23376742/115868973-e82e9e00-a445-11eb-83ac-5a9a35bae963.png)

After fix:
![Issue-4839-after](https://user-images.githubusercontent.com/23376742/115869001-ef55ac00-a445-11eb-86fd-40efcaa03e05.png)

## Regression? 

- Yes (from #3223)

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspector
 
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows Version 10.0.19041.388
- .NET Core SDK: 6.0.100-preview.2.21155.3

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4841)