### PR TITLE
Fix infinite accessibility loop when using ToolStripControlHost 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -451,6 +451,8 @@ namespace System.Windows.Forms
 
         internal virtual UiaCore.ToggleState ToggleState => UiaCore.ToggleState.Indeterminate;
 
+        private protected virtual UiaCore.IRawElementProviderFragmentRoot? ToolStripFragmentRoot => null;
+
         internal virtual UiaCore.IRawElementProviderSimple[]? GetRowHeaders() => null;
 
         internal virtual UiaCore.IRawElementProviderSimple[]? GetColumnHeaders() => null;
@@ -657,7 +659,13 @@ namespace System.Windows.Forms
 
         UiaCore.UiaRect UiaCore.IRawElementProviderFragment.BoundingRectangle => new UiaCore.UiaRect(BoundingRectangle);
 
-        UiaCore.IRawElementProviderFragmentRoot? UiaCore.IRawElementProviderFragment.FragmentRoot => FragmentRoot;
+        // An accessible object should provide info about its correct root object,
+        // even its owner is used like a ToolStrip item via ToolStripControlHost.
+        // This change was made here to not to rework FragmentRoot implementations
+        // for all accessible object. Moreover, this change will work for new accessible object
+        // classes, where it is enough to implement FragmentRoot for a common case.
+        UiaCore.IRawElementProviderFragmentRoot? UiaCore.IRawElementProviderFragment.FragmentRoot
+            => ToolStripFragmentRoot ?? FragmentRoot;
 
         object? UiaCore.IRawElementProviderFragmentRoot.ElementProviderFromPoint(double x, double y) => ElementProviderFromPoint(x, y);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -37,6 +37,26 @@ namespace System.Windows.Forms
                 InitHandle(ownerControl);
             }
 
+            // If the control is used as an item of a ToolStrip via ToolStripControlHost,
+            // its accessible object should provide info about the owning ToolStrip and items-siblings
+            // to build a correct ToolStrip accessibility tree.
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                if (Owner.ToolStripControlHost is not ToolStripControlHost host)
+                {
+                    return base.FragmentNavigate(direction);
+                }
+
+                if (direction == UiaCore.NavigateDirection.Parent
+                    || direction == UiaCore.NavigateDirection.PreviousSibling
+                    || direction == UiaCore.NavigateDirection.NextSibling)
+                {
+                    return host.AccessibilityObject.FragmentNavigate(direction);
+                }
+
+                return base.FragmentNavigate(direction);
+            }
+
             private void InitHandle(Control ownerControl)
             {
                 if (ownerControl.IsHandleCreated)
@@ -540,6 +560,12 @@ namespace System.Windows.Forms
                     return provider;
                 }
             }
+
+            // If the control is used as an item of a ToolStrip via ToolStripControlHost,
+            // its accessible object should provide info about the owning ToolStrip
+            // to build a correct ToolStrip accessibility tree.
+            private protected override UiaCore.IRawElementProviderFragmentRoot? ToolStripFragmentRoot
+                => Owner.ToolStripControlHost?.Owner?.AccessibilityObject;
 
             public override string ToString()
                 => $"{nameof(ControlAccessibleObject)}: Owner = {Owner?.ToString() ?? "null"}";

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -409,7 +409,7 @@ namespace System.Windows.Forms
                         break;
                 }
 
-                return null;
+                return base.FragmentNavigate(direction);
             }
 
             internal override void SetFocus()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Forms
                         return _ownerDataGridView.EditingControlAccessibleObject;
                 }
 
-                return null;
+                return base.FragmentNavigate(direction);
             }
 
             internal override void SetFocus()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.NavigateDirection.Parent:
                         if (Owner is IDataGridViewEditingControl owner
-                            && owner.EditingControlDataGridView.EditingControl == owner
+                            && owner.EditingControlDataGridView?.EditingControl == owner
                             && Owner.ToolStripControlHost is null)
                         {
                             return _parentAccessibleObject;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
@@ -40,12 +40,14 @@ namespace System.Windows.Forms
                 switch (direction)
                 {
                     case UiaCore.NavigateDirection.Parent:
-                        if (Owner is IDataGridViewEditingControl owner && owner.EditingControlDataGridView.EditingControl == owner)
+                        if (Owner is IDataGridViewEditingControl owner
+                            && owner.EditingControlDataGridView.EditingControl == owner
+                            && Owner.ToolStripControlHost is null)
                         {
                             return _parentAccessibleObject;
                         }
 
-                        return null;
+                        break;
                 }
 
                 return base.FragmentNavigate(direction);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
@@ -36,13 +36,22 @@ namespace System.Windows.Forms
             }
 
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
-                => direction switch
+            {
+                switch (direction)
                 {
-                    UiaCore.NavigateDirection.Parent => (Owner is IDataGridViewEditingControl owner && owner.EditingControlDataGridView.EditingControl == owner)
-                                               ? _parentAccessibleObject
-                                               : null,
-                    _ => base.FragmentNavigate(direction),
-                };
+                    case UiaCore.NavigateDirection.Parent:
+                        if (Owner is IDataGridViewEditingControl owner
+                            && owner.EditingControlDataGridView.EditingControl == owner
+                            && Owner.ToolStripControlHost is null)
+                        {
+                            return _parentAccessibleObject;
+                        }
+
+                        break;
+                }
+
+                return base.FragmentNavigate(direction);
+            }
 
             internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
                 => (Owner as IDataGridViewEditingControl)?.EditingControlDataGridView?.AccessibilityObject;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.NavigateDirection.Parent:
                         if (Owner is IDataGridViewEditingControl owner
-                            && owner.EditingControlDataGridView.EditingControl == owner
+                            && owner.EditingControlDataGridView?.EditingControl == owner
                             && Owner.ToolStripControlHost is null)
                         {
                             return _parentAccessibleObject;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
@@ -107,7 +107,7 @@ namespace System.Windows.Forms
 
                 if (childCount == 0)
                 {
-                    return null;
+                    return base.FragmentNavigate(direction);
                 }
 
                 return direction switch

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.PropertyGridAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.PropertyGridAccessibleObject.cs
@@ -66,8 +66,6 @@ namespace System.Windows.Forms
             {
                 switch (direction)
                 {
-                    case UiaCore.NavigateDirection.Parent:
-                        return null;
                     case UiaCore.NavigateDirection.FirstChild:
                         return GetChildFragment(0);
                     case UiaCore.NavigateDirection.LastChild:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObject.cs
@@ -50,7 +50,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
             {
                 if (direction == UiaCore.NavigateDirection.Parent &&
-                    _owningPropertyGrid.SelectedGridEntry is not null &&
+                    _owningPropertyGrid?.SelectedGridEntry is not null &&
                     _owningDropDownButton.Visible)
                 {
                     return _owningPropertyGrid.SelectedGridEntry?.AccessibilityObject;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.StatusStripAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.StatusStripAccessibleObject.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms
             {
                 if (!(Owner is StatusStrip statusStrip) || statusStrip.Items.Count == 0)
                 {
-                    return null;
+                    return base.FragmentNavigate(direction);
                 }
 
                 switch (direction)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.ToolStripAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.ToolStripAccessibleObject.cs
@@ -157,53 +157,59 @@ namespace System.Windows.Forms
 
             internal AccessibleObject GetChildFragment(int fragmentIndex, UiaCore.NavigateDirection direction, bool getOverflowItem = false)
             {
-                ToolStripItemCollection items = getOverflowItem ? _owningToolStrip.OverflowItems : _owningToolStrip.DisplayedItems;
-                int childFragmentCount = items.Count;
+                if (fragmentIndex < 0)
+                {
+                    return null;
+                }
 
-                if (!getOverflowItem && _owningToolStrip.CanOverflow && _owningToolStrip.OverflowButton.Visible && fragmentIndex == childFragmentCount - 1)
+                ToolStripItemCollection items = getOverflowItem
+                    ? _owningToolStrip.OverflowItems
+                    : _owningToolStrip.DisplayedItems;
+
+                if (!getOverflowItem
+                    && _owningToolStrip.CanOverflow
+                    && _owningToolStrip.OverflowButton.Visible
+                    && fragmentIndex == items.Count - 1)
                 {
                     return _owningToolStrip.OverflowButton.AccessibilityObject;
                 }
 
-                for (int index = 0; index < childFragmentCount; index++)
+                if (fragmentIndex < items.Count)
                 {
-                    ToolStripItem item = items[index];
-                    if (item.Available && item.Alignment == ToolStripItemAlignment.Left && fragmentIndex == index)
+                    ToolStripItem item = items[fragmentIndex];
+                    if (item.Available && item.Alignment == ToolStripItemAlignment.Left)
                     {
-                        if (item is ToolStripControlHost controlHostItem)
-                        {
-                            if (ShouldItemBeSkipped(controlHostItem.Control))
-                            {
-                                return GetFollowingChildFragment(fragmentIndex, items, direction);
-                            }
-
-                            return controlHostItem.ControlAccessibilityObject;
-                        }
-
-                        return item.AccessibilityObject;
+                        return GetItemAccessibleObject(item);
                     }
                 }
 
-                for (int index = 0; index < childFragmentCount; index++)
+                items = _owningToolStrip.Items;
+
+                if (fragmentIndex < items.Count)
                 {
-                    ToolStripItem item = _owningToolStrip.Items[index];
-                    if (item.Available && item.Alignment == ToolStripItemAlignment.Right && fragmentIndex == index)
+                    ToolStripItem item = items[fragmentIndex];
+                    if (item.Available && item.Alignment == ToolStripItemAlignment.Right)
                     {
-                        if (item is ToolStripControlHost controlHostItem)
-                        {
-                            if (ShouldItemBeSkipped(controlHostItem.Control))
-                            {
-                                return GetFollowingChildFragment(fragmentIndex, items, direction);
-                            }
-
-                            return controlHostItem.ControlAccessibilityObject;
-                        }
-
-                        return item.AccessibilityObject;
+                        return GetItemAccessibleObject(item);
                     }
                 }
 
                 return null;
+
+                AccessibleObject GetItemAccessibleObject(ToolStripItem item)
+                {
+                    if (item is ToolStripControlHost controlHostItem)
+                    {
+                        if (ShouldItemBeSkipped(controlHostItem.Control))
+                        {
+                            return GetFollowingChildFragment(fragmentIndex, items, direction);
+                        }
+
+                        return controlHostItem.ControlAccessibilityObject;
+                    }
+
+                    return item.AccessibilityObject;
+                }
             }
 
             internal int GetChildOverflowFragmentCount()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItemAccessibleObject.cs
@@ -171,11 +171,11 @@ namespace System.Windows.Forms
             return count;
         }
 
-        internal AccessibleObject GetChildFragment(int index)
+        internal AccessibleObject GetChildFragment(int index, UiaCore.NavigateDirection direction)
         {
             if (owner.DropDown.AccessibilityObject is ToolStrip.ToolStripAccessibleObject toolStripAccessibleObject)
             {
-                return toolStripAccessibleObject.GetChildFragment(index);
+                return toolStripAccessibleObject.GetChildFragment(index, direction);
             }
 
             return null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -389,7 +389,7 @@ namespace System.Windows.Forms
                         int itemsCount = GetChildFragmentCount();
                         if (index >= 0 && index < itemsCount)
                         {
-                            sibling = GetChildFragment(index);
+                            sibling = GetChildFragment(index, direction);
                         }
 
                         return sibling;
@@ -398,11 +398,11 @@ namespace System.Windows.Forms
                 return base.FragmentNavigate(direction);
             }
 
-            private AccessibleObject GetChildFragment(int index)
+            private AccessibleObject GetChildFragment(int index, UiaCore.NavigateDirection direction)
             {
                 if (Parent is ToolStrip.ToolStripAccessibleObject toolStripParent)
                 {
-                    return toolStripParent.GetChildFragment(index);
+                    return toolStripParent.GetChildFragment(index, direction);
                 }
 
                 // ToolStripOverflowButtonAccessibleObject is derived from ToolStripDropDownItemAccessibleObject
@@ -412,13 +412,13 @@ namespace System.Windows.Forms
                 {
                     if (toolStripOverflowButtonParent.Parent is ToolStrip.ToolStripAccessibleObject toolStripGrandParent)
                     {
-                        return toolStripGrandParent.GetChildFragment(index, true);
+                        return toolStripGrandParent.GetChildFragment(index, direction, true);
                     }
                 }
 
                 if (Parent is ToolStripDropDownItemAccessibleObject dropDownItemParent)
                 {
-                    return dropDownItemParent.GetChildFragment(index);
+                    return dropDownItemParent.GetChildFragment(index, direction);
                 }
 
                 return null;

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
@@ -32,6 +32,7 @@ namespace System.Windows.Forms.IntegrationTests.Common
         FileDialogButton,
         ErrorProviderButton,
         TaskDialogButton,
-        MessageBoxButton
+        MessageBoxButton,
+        ToolStripsButton
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -164,6 +164,10 @@ namespace WinformsControlsTest
             {
                 MainFormControlsTabOrder.MessageBoxButton,
                 new InitInfo("MessageBox", (obj, e) => new MessageBoxes().Show())
+            },
+            {
+                MainFormControlsTabOrder.ToolStripsButton,
+                new InitInfo("ToolStrips", (obj, e) => new ToolStripTests().Show())
             }
         };
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
@@ -1,0 +1,130 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace WinformsControlsTest
+{
+    partial class ToolStripTests
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
+            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.label1 = new System.Windows.Forms.Label();
+            this.toolStripProgressBar1 = new System.Windows.Forms.ToolStripProgressBar();
+            this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
+            this.toolStripProgressBar2 = new System.Windows.Forms.ToolStripProgressBar();
+            this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStrip1.SuspendLayout();
+            this.statusStrip1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // toolStrip1
+            // 
+            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripProgressBar1,
+            this.toolStripLabel1});
+            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
+            this.toolStrip1.Name = "toolStrip1";
+            this.toolStrip1.Size = new System.Drawing.Size(481, 22);
+            this.toolStrip1.TabIndex = 0;
+            this.toolStrip1.Text = "toolStrip1";
+            // 
+            // statusStrip1
+            // 
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripProgressBar2,
+            this.toolStripStatusLabel1});
+            this.statusStrip1.Location = new System.Drawing.Point(0, 101);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(481, 22);
+            this.statusStrip1.TabIndex = 1;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 56);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(78, 13);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "Test ToolStrips";
+            // 
+            // toolStripProgressBar1
+            // 
+            this.toolStripProgressBar1.Name = "toolStripProgressBar1";
+            this.toolStripProgressBar1.Size = new System.Drawing.Size(100, 22);
+            this.toolStripProgressBar1.Value = 30;
+            // 
+            // toolStripLabel1
+            // 
+            this.toolStripLabel1.Name = "toolStripLabel1";
+            this.toolStripLabel1.Size = new System.Drawing.Size(86, 22);
+            this.toolStripLabel1.Text = "ToolStripLabel";
+            // 
+            // toolStripProgressBar2
+            // 
+            this.toolStripProgressBar2.Name = "toolStripProgressBar2";
+            this.toolStripProgressBar2.Size = new System.Drawing.Size(100, 16);
+            this.toolStripProgressBar2.Value = 30;
+            // 
+            // toolStripStatusLabel1
+            // 
+            this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(118, 17);
+            this.toolStripStatusLabel1.Text = "ToolStripStatusLabel";
+            // 
+            // Form1
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(481, 123);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.statusStrip1);
+            this.Controls.Add(this.toolStrip1);
+            this.Name = "ToolStripTests";
+            this.Text = "ToolStripTests";
+            this.toolStrip1.ResumeLayout(false);
+            this.toolStrip1.PerformLayout();
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ToolStrip toolStrip1;
+        private System.Windows.Forms.ToolStripLabel toolStripLabel1;
+        private System.Windows.Forms.ToolStripProgressBar toolStripProgressBar1;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
+        private System.Windows.Forms.ToolStripProgressBar toolStripProgressBar2;
+        private System.Windows.Forms.Label label1;
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    public partial class ToolStripTests : Form
+    {
+        public ToolStripTests()
+        {
+            InitializeComponent();
+
+            toolStrip1.Items.Add(new ToolStripControlHost(new RadioButton() { Text = "RadioButton" })); // RadioButton supports UIA
+            toolStrip1.Items.Add(new ToolStripControlHost(new HScrollBar() { Value = 30 })); // HScrollBar doesn't support UIA
+            statusStrip1.Items.Add(new ToolStripControlHost(new RadioButton() { Text = "RadioButton" })); // RadioButton supports UIA
+            statusStrip1.Items.Add(new ToolStripControlHost(new HScrollBar() { Value = 30 })); // HScrollBar doesn't support UIA
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.resx
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.resx
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -13,7 +13,7 @@ using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
-    public class ControlControlAccessibleObject : IClassFixture<ThreadExceptionFixture>
+    public class Control_ControlAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
         public void ControlAccessibleObject_Ctor_ControlWithoutHandle()
@@ -1312,6 +1312,205 @@ namespace System.Windows.Forms.Tests
             // Check if the method returns an exist UIA_ControlTypeId
             Assert.True(actual >= UiaCore.UIA.ButtonControlTypeId && actual <= UiaCore.UIA.AppBarControlTypeId);
         }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_FragmentRoot_IsNullOrOwnObject(Type type)
+        {
+            using NoAssertContext context = new();
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+
+            Assert.False(control.IsHandleCreated);
+            Assert.True(control.AccessibilityObject is Control.ControlAccessibleObject);
+
+            UiaCore.IRawElementProviderFragment actual = control.AccessibilityObject.FragmentRoot;
+
+            Assert.True(actual is null || actual == control.AccessibilityObject);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_FragmentRoot_IsToolStrip_IfControlIsUsedAsToolStripItem(Type type)
+        {
+            using NoAssertContext context = new();
+            using ToolStrip toolStrip = new();
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+            using ToolStripControlHost host = new(control);
+
+            toolStrip.CreateControl();
+            control.CreateControl();
+
+            if (!CanBeAddedToToolStrip(control))
+            {
+                // A number of controls can't be added to ToolStrip. Double verify it is still the case, and exit.
+                Assert.Throws<ArgumentException>(() => toolStrip.Items.Add(host));
+
+                return;
+            }
+
+            toolStrip.Items.Add(host);
+
+            Assert.True(control.AccessibilityObject is Control.ControlAccessibleObject);
+
+            UiaCore.IRawElementProviderFragment actual = ((UiaCore.IRawElementProviderFragment)control.AccessibilityObject).FragmentRoot;
+
+            Assert.Equal(toolStrip.AccessibilityObject, actual);
+            Assert.True(control.IsHandleCreated);
+            Assert.True(toolStrip.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_FragmentNavigate_Parent_IsNull(Type type)
+        {
+            using NoAssertContext context = new();
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+
+            Assert.True(control.AccessibilityObject is Control.ControlAccessibleObject);
+
+            UiaCore.IRawElementProviderFragment parent
+                = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent);
+
+            Assert.True(parent is null);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_FragmentNavigate_Siblings_AreNull(Type type)
+        {
+            using NoAssertContext context = new();
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+
+            Assert.True(control.AccessibilityObject is Control.ControlAccessibleObject);
+
+            UiaCore.IRawElementProviderFragment nextSibling
+                = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            UiaCore.IRawElementProviderFragment previousSibling
+                = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+
+            Assert.True(nextSibling is null);
+            Assert.True(previousSibling is null);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_FragmentNavigate_ParentIsToolStrip_IfControlIsUsedAsToolStripItem(Type type)
+        {
+            using NoAssertContext noAssertContext = new();
+            using ToolStrip toolStrip = new() { Size = new Drawing.Size(1000, 25) };
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+            using ToolStripControlHost host = new(control);
+
+            toolStrip.CreateControl();
+            control.CreateControl();
+
+            if (!CanBeAddedToToolStrip(control))
+            {
+                // A number of controls can't be added to ToolStrip. Double verify it is still the case, and exit.
+                Assert.Throws<ArgumentException>(() => toolStrip.Items.Add(host));
+
+                return;
+            }
+
+            toolStrip.Items.Add(host);
+            ((ToolStripItem)host).TestAccessor().Dynamic._parent = toolStrip;
+            host.SetPlacement(ToolStripItemPlacement.Main);
+
+            Assert.True(control.AccessibilityObject is Control.ControlAccessibleObject);
+
+            UiaCore.IRawElementProviderFragment actual = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent);
+            AccessibleObject expected = toolStrip.AccessibilityObject;
+
+            Assert.Equal(expected, actual);
+            Assert.True(control.IsHandleCreated);
+            Assert.True(toolStrip.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_FragmentNavigate_NextSibling_IsNextItem_IfControlIsUsedAsToolStripItem(Type type)
+        {
+            using NoAssertContext noAssertContext = new();
+            using ToolStrip toolStrip = new() { Size = new Drawing.Size(1000, 25) };
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+            using ToolStripControlHost host = new(control);
+            using ToolStripLabel label = new();
+            using ToolStripButton button = new();
+
+            toolStrip.CreateControl();
+            control.CreateControl();
+            toolStrip.Items.Add(label);
+
+            if (!CanBeAddedToToolStrip(control))
+            {
+                // A number of controls can't be added to ToolStrip. Double verify it is still the case, and exit.
+                Assert.Throws<ArgumentException>(() => toolStrip.Items.Add(host));
+
+                return;
+            }
+
+            toolStrip.Items.Add(host);
+            toolStrip.Items.Add(button);
+            ((ToolStripItem)host).TestAccessor().Dynamic._parent = toolStrip;
+            host.SetPlacement(ToolStripItemPlacement.Main);
+
+            Assert.True(control.AccessibilityObject is Control.ControlAccessibleObject);
+
+            UiaCore.IRawElementProviderFragment actual = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            AccessibleObject expected = button.AccessibilityObject;
+
+            Assert.Equal(expected, actual);
+            Assert.True(control.IsHandleCreated);
+            Assert.True(toolStrip.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ControlAccessibleObject_TestData))]
+        public void ControlAccessibleObject_FragmentNavigate_PreviousSibling_IsPreviousItem_IfControlIsUsedAsToolStripItem(Type type)
+        {
+            using NoAssertContext noAssertContext = new();
+            using ToolStrip toolStrip = new() { Size = new Drawing.Size(1000, 25) };
+            using Control control = ReflectionHelper.InvokePublicConstructor<Control>(type);
+            using ToolStripControlHost host = new(control);
+            using ToolStripLabel label = new();
+
+            toolStrip.CreateControl();
+            control.CreateControl();
+            toolStrip.Items.Add(label);
+
+            if (!CanBeAddedToToolStrip(control))
+            {
+                // A number of controls can't be added to ToolStrip. Double verify it is still the case, and exit.
+                Assert.Throws<ArgumentException>(() => toolStrip.Items.Add(host));
+
+                return;
+            }
+
+            toolStrip.Items.Add(host);
+            ((ToolStripItem)host).TestAccessor().Dynamic._parent = toolStrip;
+            host.SetPlacement(ToolStripItemPlacement.Main);
+
+            Assert.True(control.AccessibilityObject is Control.ControlAccessibleObject);
+
+            UiaCore.IRawElementProviderFragment actual = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+            AccessibleObject expected = label.AccessibilityObject;
+
+            Assert.Equal(expected, actual);
+            Assert.True(control.IsHandleCreated);
+            Assert.True(toolStrip.IsHandleCreated);
+        }
+
+        // ContextMenuStrip, From, ToolStripDropDown, ToolStripDropDownMenu
+        // are Top level controls that can't be added to a ToolStrip.
+        // A TabPage can be added to a TabControl only (see TabPage.AssignParent method).
+        private bool CanBeAddedToToolStrip(Control control)
+            => !(control is ContextMenuStrip
+                || control is Form
+                || control is ToolStripDropDown
+                || control is ToolStripDropDownMenu
+                || control is TabPage);
 
         private class AutomationLiveRegionControl : Control, IAutomationLiveRegion
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObjectTests.cs
@@ -118,5 +118,40 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(textCellControl.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.NavigateDirection.NextSibling)]
+        [InlineData((int)UiaCore.NavigateDirection.PreviousSibling)]
+        [InlineData((int)UiaCore.NavigateDirection.FirstChild)]
+        [InlineData((int)UiaCore.NavigateDirection.LastChild)]
+        public void DataGridViewTextBoxEditingControlAccessibleObject_FragmentNavigate_SiblingsAndChildrenAreNull(int direction)
+        {
+            using DataGridViewTextBoxEditingControl control = new();
+
+            object actual = control.AccessibilityObject.FragmentNavigate((UiaCore.NavigateDirection)direction);
+
+            Assert.Null(actual);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTextBoxEditingControlAccessibleObject_FragmentNavigate_ParentIsCell()
+        {
+            using DataGridView control = new();
+            control.Columns.Add(new DataGridViewTextBoxColumn());
+            control.Rows.Add();
+
+            control.CreateControl();
+            control.CurrentCell = control.Rows[0].Cells[0];
+            control.BeginEdit(false);
+
+            object actual = control.EditingControlAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent);
+
+            control.EndEdit();
+
+            Assert.Null(control.EditingControl);
+            Assert.Equal(control.CurrentCell.AccessibilityObject, actual);
+            Assert.True(control.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObjectTests.cs
@@ -43,5 +43,57 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             Assert.Equal(AccessibleRole.PushButton, actual);
             Assert.False(dropDownButton.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void DropDownButtonAccessibleObject_FragmentNavigate_SiblingsAreExpected()
+        {
+            using PropertyGrid control = new();
+            using Button button = new();
+            control.SelectedObject = button;
+            control.SelectedGridItem = control.GetPropEntries()[1].GridItems[5]; // FlatStyle property
+
+            PropertyGridView gridView = control.TestAccessor().GridView;
+            DropDownButton dropDownButton = gridView.DropDownButton;
+
+            object nextSibling = dropDownButton.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            object previousSibling = dropDownButton.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+
+            Assert.Null(nextSibling);
+            Assert.Equal(gridView.EditAccessibleObject, previousSibling);
+            Assert.False(control.IsHandleCreated);
+            Assert.False(dropDownButton.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.NavigateDirection.FirstChild)]
+        [InlineData((int)UiaCore.NavigateDirection.LastChild)]
+        public void DropDownButtonAccessibleObject_FragmentNavigate_ChildrenAreNull(int direction)
+        {
+            using DropDownButton dropDownButton = new();
+
+            object actual = dropDownButton.AccessibilityObject.FragmentNavigate((UiaCore.NavigateDirection)direction);
+
+            Assert.Null(actual);
+            Assert.False(dropDownButton.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DropDownButtonAccessibleObject_FragmentNavigate_ParentIsGridEntry()
+        {
+            using PropertyGrid control = new();
+            using Button button = new();
+            control.SelectedObject = button;
+            control.SelectedGridItem = control.GetPropEntries()[1].GridItems[5]; // FlatStyle property
+
+            PropertyGridView gridView = control.TestAccessor().GridView;
+            DropDownButton dropDownButton = gridView.DropDownButton;
+            dropDownButton.Visible = true;
+
+            object actual = dropDownButton.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent);
+
+            Assert.Equal(gridView.SelectedGridEntry.AccessibilityObject, actual);
+            Assert.False(control.IsHandleCreated);
+            Assert.True(dropDownButton.IsHandleCreated); // Setting Visible property forces Handle creation
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxControlAccessibleObjectTests.cs
@@ -71,5 +71,36 @@ namespace System.Windows.Forms.Tests
             UiaCore.UIA expected = AccessibleRoleControlTypeMap.GetControlType(role);
             Assert.Equal(expected, actual);
         }
+
+        [WinFormsFact]
+        public void ToolStripComboBoxControlAccessibleObject_FragmentNavigate_ChildrenAreExpected()
+        {
+            using ToolStripComboBoxControl control = new();
+            control.CreateControl();
+
+            object firstChild = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
+            object lastChild = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild);
+
+            Assert.Equal(control.ChildEditAccessibleObject, firstChild);
+            Assert.Equal(((ToolStripComboBoxControlAccessibleObject)control.AccessibilityObject).DropDownButtonUiaProvider, lastChild);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ToolStripComboBoxControlAccessibleObject_FragmentNavigate_ParentIsToolStrip()
+        {
+            using NoAssertContext noAssertContext = new();
+            using ToolStripComboBoxControl control = new();
+            using ToolStripComboBox item = new();
+            using ToolStrip toolStrip = new();
+            control.Owner = item;
+            item.Parent = toolStrip;
+
+            object actual = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent);
+
+            Assert.Equal(toolStrip.AccessibilityObject, actual);
+            Assert.False(control.IsHandleCreated);
+            Assert.False(toolStrip.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripProgressBar.ToolStripProgressBarControl.ToolStripProgressBarControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripProgressBar.ToolStripProgressBarControl.ToolStripProgressBarControlAccessibleObjectTests.cs
@@ -82,5 +82,61 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(toolStripProgressBarControl.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.NavigateDirection.FirstChild)]
+        [InlineData((int)UiaCore.NavigateDirection.LastChild)]
+        public void ToolStripProgressBarControlAccessibleObject_FragmentNavigate_ChildrenAreNull(int direction)
+        {
+            using ToolStripProgressBarControl control = new();
+
+            object actual = control.AccessibilityObject.FragmentNavigate((UiaCore.NavigateDirection)direction);
+
+            Assert.Null(actual);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ToolStripProgressBarControlAccessibleObject_FragmentNavigate_ParentIsToolStrip()
+        {
+            using NoAssertContext noAssertContext = new();
+            using ToolStripProgressBarControl control = new();
+            using ToolStripProgressBar item = new();
+            using ToolStrip toolStrip = new();
+            control.Owner = item;
+            item.Parent = toolStrip;
+
+            object actual = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent);
+
+            Assert.Equal(toolStrip.AccessibilityObject, actual);
+            Assert.False(control.IsHandleCreated);
+            Assert.False(toolStrip.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ToolStripProgressBarControlAccessibleObject_FragmentNavigate_SiblingsAreExpected()
+        {
+            using NoAssertContext noAssertContext = new();
+            using ToolStripProgressBarControl control = new();
+            using ToolStripProgressBar item = new();
+            using ToolStrip toolStrip = new() { Size = new Drawing.Size(500, 25)};
+            using ToolStripLabel label = new() { Text = "Label"};
+            using ToolStripButton button = new() { Text = "Button"};
+
+            toolStrip.CreateControl();
+            control.Owner = item;
+            item.Parent = toolStrip;
+            toolStrip.Items.Add(label);
+            toolStrip.Items.Add(item);
+            toolStrip.Items.Add(button);
+
+            object nextSibling = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            object previousSibling = control.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+
+            Assert.Equal(button.AccessibilityObject, nextSibling);
+            Assert.Equal(label.AccessibilityObject, previousSibling);
+            Assert.False(control.IsHandleCreated);
+            Assert.True(toolStrip.IsHandleCreated);
+        }
     }
 }


### PR DESCRIPTION
Fixes #4835
Original bug: [1313197](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1313197?src=WorkItemMention&src-action=artifact_link)

## Proposed changes

- Add a test app for ToolStrips 
- Implement FragmentRoot and FragmentNavigate for all controls to return correct value if a control is part of a ToolStrip
- Remove duplicate accessibility instances of native controls (that don't support UIA) from an accessibility tree 

## Customer Impact

- Accessibility tools don't freeze when navigate through a ToolStrip with a ToolStripControlHost 

## Regression? 

- Yes (from .NET Framework 4.7.2)

## Risk

- Minimal


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- An accessibility tool (eg. Inspect) freezes on a ToolStrip if it has a ToolStripControlHost:
![hMfSttv4cb](https://user-images.githubusercontent.com/49272759/116204419-6d1aff80-a745-11eb-93fa-1cde4b04d47e.gif)


### After

- An accessibility tool (eg. Inspect) works correctly and see the correct accessibility tree:
![image](https://user-images.githubusercontent.com/49272759/116204778-c2efa780-a745-11eb-8252-b9493bb6c44e.png)




## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manual
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using Inspect and Narrator


## Test environment(s) <!-- Remove any that don't apply -->

- dotnet SDK Version: 6.0.100-preview.1.21101.5
- Microsoft Windows [Version 10.0.19042.928]


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4850)