### PR TITLE
Fix handle creation on DateTimePicker.Enabled change

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -1200,7 +1200,7 @@ namespace System.Windows.Forms
         {
             base.OnEnabledChanged(e);
 
-            if (Application.RenderWithVisualStyles)
+            if (IsHandleCreated && Application.RenderWithVisualStyles)
             {
                 // The SysDateTimePick32 control caches the style and uses that directly to determine whether the
                 // border should be drawn disabled when theming (VisualStyles) is enabled. Setting the window


### PR DESCRIPTION
This PR fixes an incorrect code in PR #4374. 

This code is using GetWindowLong and SetWindowLong on OnEnabledChanged. This could cause a handle creation before the control is displayed.

See discussion here : https://github.com/dotnet/winforms/pull/4374#discussion_r621914769

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4855)