### PR TITLE
Collapsed ListBox in the PropertyGrid has invalid rectangle

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -75,7 +75,8 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (!_owningListBox.IsHandleCreated)
+                    if (!_owningListBox.IsHandleCreated
+                        || (_owningListBox.AccessibilityObject.State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen)
                     {
                         return Rectangle.Empty;
                     }


### PR DESCRIPTION
Fixes #3655 

## Proposed changes
- Issue is reproduced because we get the rectangle for the ListBox, whether the ListBox is expanded or not. Unfortunately, we cannot return an empty rectangle, it is replaced with a native rectangle. Therefore, we return the rectangle with the maximum offset to the invisible zone.

- Added check for "Bounds" property of ListBox items. If the ListBox is not visible (it has an "OffScreen" state), then we return an empty rectangle.

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/117311853-43707f80-ae8d-11eb-8d4a-b04b2e4fa115.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/117313408-8c750380-ae8e-11eb-819b-58ab6d37dfb2.png)

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.100-preview.3.21202.5


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4875)