### PR TITLE
Fix HtmlDocument tests

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs
@@ -413,6 +413,10 @@ namespace System.Windows.Forms.Tests
             HtmlDocument document = await GetDocument(control, Html);
             IHTMLDocument2 iHTMLDocument2 = (IHTMLDocument2)document.DomDocument;
 
+            // Cleanup!
+            // WebBrowser is notorious for not cleaning after itself - clean all cookies before we set new ones
+            document.ExecCommand("ClearAuthenticationCache", false, null);
+
             document.Cookie = value;
             Assert.Equal(expected, document.Cookie);
             Assert.Equal(expected, iHTMLDocument2.GetCookie());
@@ -641,7 +645,7 @@ namespace System.Windows.Forms.Tests
 
             // Have to do it again.
             iHTMLDocument4.Focus();
-            Assert.False(document.Focused);
+            Assert.True(document.Focused);
         }
 
         [WinFormsFact]
@@ -1563,11 +1567,11 @@ namespace System.Windows.Forms.Tests
             const string Html = "<html></html>";
             HtmlDocument document = await GetDocument(control, Html);
             document.Focus();
-            Assert.False(document.Focused);
+            Assert.True(document.Focused);
 
             // Call again.
             document.Focus();
-            Assert.False(document.Focused);
+            Assert.True(document.Focused);
         }
 
         [WinFormsFact]


### PR DESCRIPTION
Currently all public CI builds are failing with
```
    System.Windows.Forms.Tests.HtmlDocumentTests.HtmlDocument_Focus_Invoke_Success [FAIL]
      Assert.False() Failure
      Expected: False
      Actual:   True
      Stack Trace:
        /_/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs(1566,0): at System.Windows.Forms.Tests.HtmlDocumentTests.HtmlDocument_Focus_Invoke_Success()
        --- End of stack trace from previous location ---
    System.Windows.Forms.Tests.HtmlDocumentTests.HtmlDocument_Focused_GetFocused_ReturnsExpected [FAIL]
      Assert.False() Failure
      Expected: False
      Actual:   True
      Stack Trace:
        /_/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HtmlDocumentTests.cs(644,0): at System.Windows.Forms.Tests.HtmlDocumentTests.HtmlDocument_Focused_GetFocused_ReturnsExpected()
        --- End of stack trace from previous location ---
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4904)