### PR TITLE
Separating ListViewItemAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6758,4 +6758,10 @@ Stack trace where the illegal operation occurred was:
   <data name="MonthCalendarWeekNumberDescription" xml:space="preserve">
     <value>Week {0}</value>
   </data>
+  <data name="ListViewItemAccessbilityObjectInvalidViewException" xml:space="preserve">
+    <value>The current accessibility object is only for the ListView in {0} view</value>
+  </data>
+  <data name="ListViewItemAccessbilityObjectInvalidViewsException" xml:space="preserve">
+    <value>The current accessibility object is only for the ListView in {0}, {1} or {2} view</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -6481,6 +6481,16 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Umožňuje změnit atributy značky vložení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Událost aktivovaná v případě změny zaškrtnuté vlastnosti položky ListView</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -6481,6 +6481,16 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Ermöglicht das Ändern von Einfügemarkenattributen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Das ausgelöste Ereignis, wenn sich die aktivierte Eigenschaft für ein ListView-Element ändert.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -6481,6 +6481,16 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Permite que se cambien los atributos de marca de inserción.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Evento que se desencadena cuando cambia la propiedad checked de un elemento ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -6481,6 +6481,16 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Autorise la modification des attributs des marques d'insertion.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Événement déclenché lorsque la propriété Checked d'un élément ListView est modifiée.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -6481,6 +6481,16 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Consente la modifica di attributi dei segni di inserimento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Evento generato quando la proprietà checked di un elemento di ListView cambia.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -6481,6 +6481,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">挿入マーク属性を変更できるようにします。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView アイテムのチェックされたプロパティが変更するときに発生するイベントです。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -6481,6 +6481,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">삽입 표시 특성의 변경을 허용합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView 항목의 Checked 속성이 변경되면 이벤트가 발생합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -6481,6 +6481,16 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Zezwala na zmianę atrybutów znacznika wstawiania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Zdarzenie wywoływane, gdy zostanie zmieniona zaznaczona właściwość elementu ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -6481,6 +6481,16 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">Permite a alteração dos atributos de marca de inserção.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Evento gerado quando a propriedade de ativação de um item ListView é alterada.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -6482,6 +6482,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Позволяет изменение атрибутов метки вставки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Событие возникает при изменении отмеченного свойства элемента ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -6481,6 +6481,16 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Ekleme işareti özniteliklerinin değiştirilmesine olanak tanır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView öğesinin Checked özelliği değiştiğinde harekete geçirilen olay.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -6481,6 +6481,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">允许更改插入标记特性。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">当 ListView 项的 Checked 属性更改时引发的事件。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -6481,6 +6481,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">允許變更插入標記屬性。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewException">
+        <source>The current accessibility object is only for the ListView in {0} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0} view</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListViewItemAccessbilityObjectInvalidViewsException">
+        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
+        <target state="new">The current accessibility object is only for the ListView in {0}, {1} or {2} view</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView 項目的核取屬性變更時引發的事件。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -316,10 +316,8 @@ namespace System.Windows.Forms
                         };
                     }
 
-                    if (_owningListView.View == View.Details)
+                    if (hitTestInfo.Item.AccessibilityObject is ListViewItem.ListViewItemDetailsAccessibleObject itemAccessibleObject)
                     {
-                        var itemAccessibleObject = (ListViewItem.ListViewItemAccessibleObject)hitTestInfo.Item.AccessibilityObject;
-
                         for (int i = 1; i < _owningListView.Columns.Count; i++)
                         {
                             if (itemAccessibleObject.GetSubItemBounds(i).Contains(point))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -1,0 +1,127 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using Accessibility;
+using static System.Windows.Forms.ListView;
+using static System.Windows.Forms.ListViewGroup;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class ListViewItem
+    {
+        internal class ListViewItemDetailsAccessibleObject : ListViewItemBaseAccessibleObject
+        {
+            private readonly Dictionary<int, AccessibleObject> _listViewSubItemAccessibleObjects;
+
+            public ListViewItemDetailsAccessibleObject(ListViewItem owningItem) : base(owningItem)
+            {
+                _listViewSubItemAccessibleObjects = new Dictionary<int, AccessibleObject>();
+            }
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                switch (direction)
+                {
+                    case UiaCore.NavigateDirection.FirstChild:
+                        return GetChild(0);
+                    case UiaCore.NavigateDirection.LastChild:
+                        return GetChild(_owningListView.Columns.Count - 1);
+                }
+
+                return base.FragmentNavigate(direction);
+            }
+
+            // If the ListView does not support ListViewSubItems, the index is greater than the number of columns
+            // or the index is negative, then we return null
+            public override AccessibleObject? GetChild(int index)
+            {
+                if (_owningListView.View != View.Details)
+                {
+                    throw new InvalidOperationException(string.Format(SR.ListViewItemAccessbilityObjectInvalidViewException, nameof(View.Details)));
+                }
+
+                return !_owningListView.SupportsListViewSubItems || _owningListView.Columns.Count <= index || index < 0
+                    ? null
+                    : GetDetailsSubItemOrFake(index);
+            }
+
+            public override int GetChildCount()
+            {
+                if (_owningListView.View != View.Details)
+                {
+                    throw new InvalidOperationException(string.Format(SR.ListViewItemAccessbilityObjectInvalidViewException, nameof(View.Details)));
+                }
+
+                return !_owningListView.IsHandleCreated || !_owningListView.SupportsListViewSubItems
+                    ? -1
+                    : _owningListView.Columns.Count;
+            }
+
+            internal override int GetChildIndex(AccessibleObject? child)
+            {
+                if (child is null
+                    || !_owningListView.SupportsListViewSubItems
+                    || child is not ListViewSubItem.ListViewSubItemAccessibleObject subItemAccessibleObject)
+                {
+                    return -1;
+                }
+
+                if (subItemAccessibleObject.OwningSubItem is null)
+                {
+                    return GetFakeSubItemIndex(subItemAccessibleObject);
+                }
+
+                int index = _owningItem.SubItems.IndexOf(subItemAccessibleObject.OwningSubItem);
+                return index > _owningListView.Columns.Count - 1 ? -1 : index;
+            }
+
+            // This method returns an accessibility object for an existing ListViewSubItem, or creates a fake one
+            // if the ListViewSubItem does not exist. This is necessary for the "Details" view,
+            // when there is no ListViewSubItem, but the cell for it is displayed and the user can interact with it.
+            internal AccessibleObject? GetDetailsSubItemOrFake(int subItemIndex)
+            {
+                if (subItemIndex < _owningItem.SubItems.Count)
+                {
+                    _listViewSubItemAccessibleObjects.Remove(subItemIndex);
+
+                    return _owningItem.SubItems[subItemIndex].AccessibilityObject;
+                }
+
+                if (_listViewSubItemAccessibleObjects.ContainsKey(subItemIndex))
+                {
+                    return _listViewSubItemAccessibleObjects[subItemIndex];
+                }
+
+                ListViewSubItem.ListViewSubItemAccessibleObject fakeAccessbileObject = new(owningSubItem: null, _owningItem);
+                _listViewSubItemAccessibleObjects.Add(subItemIndex, fakeAccessbileObject);
+                return fakeAccessbileObject;
+            }
+
+            // This method is required to get the index of the fake accessibility object. Since the fake accessibility object
+            // has no ListViewSubItem from which we could get an index, we have to get its index from the dictionary
+            private int GetFakeSubItemIndex(ListViewSubItem.ListViewSubItemAccessibleObject fakeAccessbileObject)
+            {
+                foreach (KeyValuePair<int, AccessibleObject> keyValuePair in _listViewSubItemAccessibleObjects)
+                {
+                    if (keyValuePair.Value == fakeAccessbileObject)
+                    {
+                        return keyValuePair.Key;
+                    }
+                }
+
+                return -1;
+            }
+
+            internal override Rectangle GetSubItemBounds(int subItemIndex)
+                => _owningListView.IsHandleCreated
+                    ? _owningListView.GetSubItemRect(_owningItem.Index, subItemIndex)
+                    : Rectangle.Empty;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemListAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemListAccessibleObject.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using Accessibility;
+using static System.Windows.Forms.ListView;
+using static System.Windows.Forms.ListViewGroup;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class ListViewItem
+    {
+        internal class ListViewItemListAccessibleObject : ListViewItemBaseAccessibleObject
+        {
+            public ListViewItemListAccessibleObject(ListViewItem owningItem) : base(owningItem)
+            {
+            }
+
+            public override Rectangle Bounds
+                => !_owningListView.IsHandleCreated
+                    ? Rectangle.Empty
+                    : new Rectangle(
+                        _owningListView.AccessibilityObject.Bounds.X + _owningItem.Bounds.X,
+                        _owningListView.AccessibilityObject.Bounds.Y + _owningItem.Bounds.Y,
+                        _owningItem.Bounds.Width,
+                        _owningItem.Bounds.Height);
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                AccessibleObject _parentInternal = _owningListView.AccessibilityObject;
+
+                switch (direction)
+                {
+                    case UiaCore.NavigateDirection.Parent:
+                        return _parentInternal;
+                    case UiaCore.NavigateDirection.NextSibling:
+                        int childIndex = _parentInternal.GetChildIndex(this);
+                        return childIndex == -1 ? null : _parentInternal.GetChild(childIndex + 1);
+                    case UiaCore.NavigateDirection.PreviousSibling:
+                        return _parentInternal.GetChild(_parentInternal.GetChildIndex(this) - 1);
+                }
+
+                return base.FragmentNavigate(direction);
+            }
+
+            internal override int[]? RuntimeId
+            {
+                get
+                {
+                    int[] runtimeId;
+                    var owningListViewRuntimeId = _owningListView.AccessibilityObject.RuntimeId;
+                    if (owningListViewRuntimeId is null)
+                    {
+                        return base.RuntimeId;
+                    }
+
+                    runtimeId = new int[4];
+                    runtimeId[0] = owningListViewRuntimeId[0];
+                    runtimeId[1] = owningListViewRuntimeId[1];
+                    runtimeId[2] = 4; // Win32-control specific RuntimeID constant.
+                    runtimeId[3] = CurrentIndex;
+
+                    return runtimeId;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemTileAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemTileAccessibleObject.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using Accessibility;
+using static System.Windows.Forms.ListView;
+using static System.Windows.Forms.ListViewGroup;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class ListViewItem
+    {
+        internal class ListViewItemTileAccessibleObject : ListViewItemBaseAccessibleObject
+        {
+            public ListViewItemTileAccessibleObject(ListViewItem owningItem) : base(owningItem)
+            {
+            }
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                switch (direction)
+                {
+                    case UiaCore.NavigateDirection.FirstChild:
+                        return GetChildInternal(1);
+                    case UiaCore.NavigateDirection.LastChild:
+                        return GetChildInternal(GetLastChildIndex());
+                }
+
+                return base.FragmentNavigate(direction);
+            }
+
+            // Only additional ListViewSubItem are displayed in the accessibility tree if the ListView
+            // in the "Tile" view (the first ListViewSubItem is responsible for the ListViewItem)
+            public override AccessibleObject? GetChild(int index)
+            {
+                if (_owningListView.View != View.Tile)
+                {
+                    throw new InvalidOperationException(string.Format(SR.ListViewItemAccessbilityObjectInvalidViewException, nameof(View.Tile)));
+                }
+
+                return GetChildInternal(index + 1);
+            }
+
+            internal override AccessibleObject? GetChildInternal(int index)
+            {
+                // If the ListView does not support ListViewSubItems, the index is greater than the number of columns
+                // or the index is negative, then we return null
+                if (!_owningListView.SupportsListViewSubItems
+                    || index <= 0
+                    || _owningListView.Columns.Count <= index
+                    || _owningItem.SubItems.Count <= index
+                    || GetSubItemBounds(index).IsEmpty)
+                {
+                    return null;
+                }
+
+                return _owningItem.SubItems[index].AccessibilityObject;
+            }
+
+            public override int GetChildCount()
+            {
+                if (_owningListView.View != View.Tile)
+                {
+                    throw new InvalidOperationException(string.Format(SR.ListViewItemAccessbilityObjectInvalidViewException, nameof(View.Tile)));
+                }
+
+                if (!_owningListView.IsHandleCreated || !_owningListView.SupportsListViewSubItems)
+                {
+                    return -1;
+                }
+
+                if (_owningItem.SubItems.Count == 1)
+                {
+                    return 0;
+                }
+
+                return GetLastChildIndex();
+            }
+
+            internal override int GetChildIndex(AccessibleObject? child)
+            {
+                if (child is null
+                    || !_owningListView.SupportsListViewSubItems
+                    || child == _owningItem.SubItems[0].AccessibilityObject
+                    || child is not ListViewSubItem.ListViewSubItemAccessibleObject subItemAccessibleObject
+                    || subItemAccessibleObject.OwningSubItem is null)
+                {
+                    return -1;
+                }
+
+                int index = _owningItem.SubItems.IndexOf(subItemAccessibleObject.OwningSubItem);
+                return index == -1 || index > GetLastChildIndex() ? -1 : index;
+            }
+
+            private int GetLastChildIndex()
+            {
+                // Data about the first ListViewSubItem is displayed in the ListViewItem.
+                // Therefore, it is not displayed in the ListViewSubItems list
+                if (_owningItem.SubItems.Count == 1)
+                {
+                    return -1;
+                }
+
+                // Only ListViewSubItems with the corresponding columns are displayed in the ListView
+                int subItemCount = Math.Min(_owningListView.Columns.Count, _owningItem.SubItems.Count);
+
+                // The ListView can be of limited TileSize, so some of the ListViewSubItems can be hidden.
+                // sListViewSubItems that do not have enough space to display have an empty bounds
+                for (int i = 1; i < subItemCount; i++)
+                {
+                    if (GetSubItemBounds(i).IsEmpty)
+                    {
+                        return i - 1;
+                    }
+                }
+
+                return subItemCount - 1;
+            }
+
+            internal override Rectangle GetSubItemBounds(int subItemIndex)
+                => _owningListView.IsHandleCreated
+                    ? _owningListView.GetSubItemRect(_owningItem.Index, subItemIndex)
+                    : Rectangle.Empty;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -94,8 +94,8 @@ namespace System.Windows.Forms
 
                 public override AccessibleObject Parent => ParentInternal;
 
-                private ListViewItemAccessibleObject ParentInternal
-                    => (ListViewItemAccessibleObject)_owningItem.AccessibilityObject;
+                private ListViewItemBaseAccessibleObject ParentInternal
+                    => (ListViewItemBaseAccessibleObject)_owningItem.AccessibilityObject;
 
                 internal override int[]? RuntimeId
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -58,6 +58,7 @@ namespace System.Windows.Forms
         private object userData;
 
         private AccessibleObject _accessibilityObject;
+        private View _accessibilityObjectView;
 
         public ListViewItem()
         {
@@ -235,9 +236,19 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_accessibilityObject is null)
+                ListView owningListView = listView ?? Group.ListView ?? throw new InvalidOperationException(nameof(listView));
+                if (_accessibilityObject is null || owningListView.View != _accessibilityObjectView)
                 {
-                    _accessibilityObject = new ListViewItemAccessibleObject(this);
+                    _accessibilityObjectView = owningListView.View;
+                    _accessibilityObject = _accessibilityObjectView switch
+                    {
+                        View.Details => new ListViewItem.ListViewItemDetailsAccessibleObject(this),
+                        View.LargeIcon => new ListViewItem.ListViewItemBaseAccessibleObject(this),
+                        View.List => new ListViewItemListAccessibleObject(this),
+                        View.SmallIcon => new ListViewItem.ListViewItemBaseAccessibleObject(this),
+                        View.Tile => new ListViewItemTileAccessibleObject(this),
+                        _ => throw new Exception()
+                    };
                 }
 
                 return _accessibilityObject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
@@ -130,8 +130,8 @@ namespace System.Windows.Forms.Tests
 
             AccessibleObject firstChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
             AccessibleObject lastChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
-            Assert.IsType<ListViewItemAccessibleObject>(firstChild);
-            Assert.IsType<ListViewItemAccessibleObject>(lastChild);
+            Assert.IsType<ListViewItemBaseAccessibleObject>(firstChild);
+            Assert.IsType<ListViewItemBaseAccessibleObject>(lastChild);
             Assert.NotEqual(firstChild, lastChild);
             Assert.True(listView.IsHandleCreated);
         }
@@ -171,8 +171,8 @@ namespace System.Windows.Forms.Tests
 
             AccessibleObject firstChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
             AccessibleObject lastChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
-            Assert.IsType<ListViewItemAccessibleObject>(firstChild);
-            Assert.IsType<ListViewItemAccessibleObject>(lastChild);
+            Assert.IsType<ListViewItemBaseAccessibleObject>(firstChild);
+            Assert.IsType<ListViewItemBaseAccessibleObject>(lastChild);
             Assert.NotEqual(firstChild, lastChild);
             Assert.True(listView.IsHandleCreated);
         }
@@ -931,9 +931,9 @@ namespace System.Windows.Forms.Tests
             listView.Items[3].Selected = true;
 
             var listSelection = listView.AccessibilityObject.GetSelection();
-            Assert.Equal(listItem1.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[0]);
-            Assert.Equal(listItem2.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[1]);
-            Assert.Equal(listItem4.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[2]);
+            Assert.Equal(listItem1.AccessibilityObject, listSelection[0]);
+            Assert.Equal(listItem2.AccessibilityObject, listSelection[1]);
+            Assert.Equal(listItem4.AccessibilityObject, listSelection[2]);
             Assert.True(listView.IsHandleCreated);
         }
 
@@ -1037,9 +1037,9 @@ namespace System.Windows.Forms.Tests
             listView.Items[3].Selected = true;
 
             var listSelection = listView.AccessibilityObject.GetSelection();
-            Assert.Equal(listItem1.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[0]);
-            Assert.Equal(listItem2.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[1]);
-            Assert.Equal(listItem4.AccessibilityObject, (ListViewItemAccessibleObject)listSelection[2]);
+            Assert.Equal(listItem1.AccessibilityObject, listSelection[0]);
+            Assert.Equal(listItem2.AccessibilityObject, listSelection[1]);
+            Assert.Equal(listItem4.AccessibilityObject, listSelection[2]);
             Assert.True(listView.IsHandleCreated);
         }
 
@@ -1225,7 +1225,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(GetDetailsSubItemOrFake(1, 2), HitTest(listView, GetDetailsSubItemOrFake(1, 2).Bounds.Location));
 
             AccessibleObject GetDetailsSubItemOrFake(int itemIndex, int subItemIndex) =>
-                ((ListViewItemAccessibleObject)listView.Items[itemIndex].AccessibilityObject).GetDetailsSubItemOrFake(subItemIndex);
+                ((ListViewItemDetailsAccessibleObject)listView.Items[itemIndex].AccessibilityObject).GetDetailsSubItemOrFake(subItemIndex);
         }
 
         public static IEnumerable<object[]> ListViewAccessibleObject_GetChild_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -669,7 +669,7 @@ namespace System.Windows.Forms.Tests
             ListViewItem listItem1 = new ListViewItem(new string[] { "Test A", "Alpha" }, -1);
             listView.Items.Add(listItem1);
             listView.Items[0].Selected = selected;
-            ListViewItemAccessibleObject accessibleObject = (ListViewItemAccessibleObject)listView.Items[0].AccessibilityObject;
+            AccessibleObject accessibleObject = listView.Items[0].AccessibilityObject;
 
             Assert.Equal(expectedAcessibleStates, accessibleObject.State);
             Assert.Equal(createHandle, listView.IsHandleCreated);
@@ -733,7 +733,7 @@ namespace System.Windows.Forms.Tests
                 listView.Items[0].Selected = true;
             }
 
-            ListViewItemAccessibleObject accessibleObject = (ListViewItemAccessibleObject)listView.Items[0].AccessibilityObject;
+            AccessibleObject accessibleObject = listView.Items[0].AccessibilityObject;
 
             Assert.Equal(expectedAcessibleStates, accessibleObject.State);
             Assert.Equal(createHandle, listView.IsHandleCreated);
@@ -1062,8 +1062,8 @@ namespace System.Windows.Forms.Tests
         public void ListViewItemAccessibleObject_GetChild_ReturnsExpected(View view, bool createControl, bool virtualMode, bool showGroups)
         {
             using ListView listView = GetListViewWithSubItemData(view, createControl, virtualMode, showGroups, columnCount: 3, subItemCount: 1);
-            ListViewItemAccessibleObject accessibleObject1 = (ListViewItemAccessibleObject)listView.Items[0].AccessibilityObject;
-            ListViewItemAccessibleObject accessibleObject2 = (ListViewItemAccessibleObject)listView.Items[1].AccessibilityObject;
+            AccessibleObject accessibleObject1 = listView.Items[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = listView.Items[1].AccessibilityObject;
 
             Assert.Null(accessibleObject1.GetChild(-1));
             Assert.Null(accessibleObject2.GetChild(-1));
@@ -1071,11 +1071,15 @@ namespace System.Windows.Forms.Tests
             {
                 Assert.Equal(listView.Items[0].SubItems[0].AccessibilityObject, accessibleObject1.GetChild(0));
                 Assert.Equal(listView.Items[0].SubItems[1].AccessibilityObject, accessibleObject1.GetChild(1));
-                Assert.Equal(accessibleObject1.GetDetailsSubItemOrFake(2), accessibleObject1.GetChild(2));
+                Assert.Equal(
+                    ((ListViewItem.ListViewItemDetailsAccessibleObject)accessibleObject1).GetDetailsSubItemOrFake(2),
+                    accessibleObject1.GetChild(2));
 
                 Assert.Equal(listView.Items[1].SubItems[0].AccessibilityObject, accessibleObject2.GetChild(0));
                 Assert.Equal(listView.Items[1].SubItems[1].AccessibilityObject, accessibleObject2.GetChild(1));
-                Assert.Equal(accessibleObject2.GetDetailsSubItemOrFake(2), accessibleObject2.GetChild(2));
+                Assert.Equal(
+                    ((ListViewItem.ListViewItemDetailsAccessibleObject)accessibleObject2).GetDetailsSubItemOrFake(2),
+                    accessibleObject2.GetChild(2));
             }
             else
             {
@@ -1098,8 +1102,8 @@ namespace System.Windows.Forms.Tests
         public void ListViewItemAccessibleObject_GetChild_ReturnsExpected_ForManySubItems(View view, bool createControl, bool virtualMode, bool showGroups)
         {
             using ListView listView = GetListViewWithSubItemData(view, createControl, virtualMode, showGroups, columnCount: 3, subItemCount: 10);
-            ListViewItemAccessibleObject accessibleObject1 = (ListViewItemAccessibleObject)listView.Items[0].AccessibilityObject;
-            ListViewItemAccessibleObject accessibleObject2 = (ListViewItemAccessibleObject)listView.Items[1].AccessibilityObject;
+            AccessibleObject accessibleObject1 = listView.Items[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = listView.Items[1].AccessibilityObject;
 
             Assert.Null(accessibleObject1.GetChild(-1));
             Assert.Null(accessibleObject2.GetChild(-1));
@@ -1557,7 +1561,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.Tile)]
         public void ListViewItemAccessibleObject_GetChildIndex_ReturnsMinusOne_IfChildIsNull(View view)
         {
-            using ListView listView = new() { View = view};
+            using ListView listView = new() { View = view };
             listView.Items.Add(new ListViewItem(new string[] { "Item 1", "SubItem 1", "SubItem 2" }));
 
             Assert.Equal(-1, listView.Items[0].AccessibilityObject.GetChildIndex(null));
@@ -1591,8 +1595,8 @@ namespace System.Windows.Forms.Tests
             listView.Columns.Add(new ColumnHeader());
             listView.Columns.Add(new ColumnHeader());
             listView.Columns.Add(new ColumnHeader());
-            listView.Items.Add(new ListViewItem(new string[] { "Item 1"}));
-            ListViewItemAccessibleObject accessibleObject = (ListViewItemAccessibleObject)listView.Items[0].AccessibilityObject;
+            listView.Items.Add(new ListViewItem(new string[] { "Item 1" }));
+            ListViewItemDetailsAccessibleObject accessibleObject = (ListViewItemDetailsAccessibleObject)listView.Items[0].AccessibilityObject;
 
             Assert.Equal(0, accessibleObject.GetChildIndex(listView.Items[0].SubItems[0].AccessibilityObject));
             Assert.Equal(1, accessibleObject.GetChildIndex(accessibleObject.GetDetailsSubItemOrFake(1)));
@@ -1617,6 +1621,174 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(-1, listView.Items[0].AccessibilityObject.GetChildIndex(listView.AccessibilityObject));
             Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.List)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewItemAccessibleObject_ReturnExpectedType(View view)
+        {
+            using ListView listView = new() { View = view };
+            listView.Items.Add(new ListViewItem("Test"));
+
+            switch (view)
+            {
+                case View.Details:
+                    Assert.IsType<ListViewItemDetailsAccessibleObject>(listView.Items[0].AccessibilityObject);
+                    break;
+                case View.LargeIcon:
+                case View.SmallIcon:
+                    Assert.IsType<ListViewItemBaseAccessibleObject>(listView.Items[0].AccessibilityObject);
+                    break;
+                case View.List:
+                    Assert.IsType<ListViewItemListAccessibleObject>(listView.Items[0].AccessibilityObject);
+                    break;
+                case View.Tile:
+                    Assert.IsType<ListViewItemTileAccessibleObject>(listView.Items[0].AccessibilityObject);
+                    break;
+            }
+        }
+
+        public static IEnumerable<object[]> ListViewItemAccessibleObject_ReturnExpectedType_TestData()
+        {
+            foreach (View oldView in Enum.GetValues(typeof(View)))
+            {
+                foreach (View newView in Enum.GetValues(typeof(View)))
+                {
+                    if(oldView != newView)
+                    {
+                        yield return new object[] { oldView, newView };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewItemAccessibleObject_ReturnExpectedType_TestData))]
+        public void ListViewItemAccessibleObject_ReturnExpectedType_AfterChaningView(View oldView, View newView)
+        {
+            using ListView listView = new() { View = oldView };
+            listView.Items.Add(new ListViewItem("Test"));
+            CheckAccessibleObject();
+
+            listView.View = newView;
+
+            CheckAccessibleObject();
+
+            void CheckAccessibleObject()
+            {
+                switch (listView.View)
+                {
+                    case View.Details:
+                        Assert.IsType<ListViewItemDetailsAccessibleObject>(listView.Items[0].AccessibilityObject);
+                        break;
+                    case View.LargeIcon:
+                    case View.SmallIcon:
+                        Assert.IsType<ListViewItemBaseAccessibleObject>(listView.Items[0].AccessibilityObject);
+                        break;
+                    case View.List:
+                        Assert.IsType<ListViewItemListAccessibleObject>(listView.Items[0].AccessibilityObject);
+                        break;
+                    case View.Tile:
+                        Assert.IsType<ListViewItemTileAccessibleObject>(listView.Items[0].AccessibilityObject);
+                        break;
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details, View.LargeIcon)]
+        [InlineData(View.Details, View.List)]
+        [InlineData(View.Details, View.SmallIcon)]
+        [InlineData(View.Details, View.Tile)]
+        [InlineData(View.LargeIcon, View.Details)]
+        [InlineData(View.LargeIcon, View.Tile)]
+        [InlineData(View.List, View.Details)]
+        [InlineData(View.List, View.Tile)]
+        [InlineData(View.SmallIcon, View.Details)]
+        [InlineData(View.SmallIcon, View.Tile)]
+        [InlineData(View.Tile, View.Details)]
+        [InlineData(View.Tile, View.LargeIcon)]
+        [InlineData(View.Tile, View.List)]
+        [InlineData(View.Tile, View.SmallIcon)]
+        public void ListViewItemAccessibleObject_GetChild_ReturnException_AfterChaningView(View oldView, View newView)
+        {
+            using ListView listView = new() { View = oldView };
+            listView.Items.Add(new ListViewItem(new string[] { "1", "2" }));
+            AccessibleObject accessibleObject = listView.Items[0].AccessibilityObject;
+            Assert.Null(accessibleObject.GetChild(0));
+
+            listView.View = newView;
+
+            Assert.Throws<InvalidOperationException>(() => accessibleObject.GetChild(0));
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.LargeIcon, View.List)]
+        [InlineData(View.LargeIcon, View.SmallIcon)]
+        [InlineData(View.List, View.LargeIcon)]
+        [InlineData(View.List, View.SmallIcon)]
+        [InlineData(View.SmallIcon, View.LargeIcon)]
+        [InlineData(View.SmallIcon, View.List)]
+        public void ListViewItemAccessibleObject_GetChild_DoesNotReturnException_AfterChaningView(View oldView, View newView)
+        {
+            using ListView listView = new() { View = oldView };
+            listView.Items.Add(new ListViewItem(new string[] { "1", "2" }));
+            AccessibleObject accessibleObject = listView.Items[0].AccessibilityObject;
+            Assert.Null(accessibleObject.GetChild(0));
+
+            listView.View = newView;
+
+            Assert.Null(accessibleObject.GetChild(0));
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details, View.LargeIcon)]
+        [InlineData(View.Details, View.List)]
+        [InlineData(View.Details, View.SmallIcon)]
+        [InlineData(View.Details, View.Tile)]
+        [InlineData(View.LargeIcon, View.Details)]
+        [InlineData(View.LargeIcon, View.Tile)]
+        [InlineData(View.List, View.Details)]
+        [InlineData(View.List, View.Tile)]
+        [InlineData(View.SmallIcon, View.Details)]
+        [InlineData(View.SmallIcon, View.Tile)]
+        [InlineData(View.Tile, View.Details)]
+        [InlineData(View.Tile, View.LargeIcon)]
+        [InlineData(View.Tile, View.List)]
+        [InlineData(View.Tile, View.SmallIcon)]
+        public void ListViewItemAccessibleObject_GetChildCount_ReturnException_AfterChaningView(View oldView, View newView)
+        {
+            using ListView listView = new() { View = oldView };
+            listView.Items.Add(new ListViewItem(new string[] { "1" }));
+            AccessibleObject accessibleObject = listView.Items[0].AccessibilityObject;
+            Assert.NotEqual(2, accessibleObject.GetChildCount());
+
+            listView.View = newView;
+
+            Assert.Throws<InvalidOperationException>(() => accessibleObject.GetChildCount());
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.LargeIcon, View.List)]
+        [InlineData(View.LargeIcon, View.SmallIcon)]
+        [InlineData(View.List, View.LargeIcon)]
+        [InlineData(View.List, View.SmallIcon)]
+        [InlineData(View.SmallIcon, View.LargeIcon)]
+        [InlineData(View.SmallIcon, View.List)]
+        public void ListViewItemAccessibleObject_GetChildCount_DoesNotReturnException_AfterChaningView(View oldView, View newView)
+        {
+            using ListView listView = new() { View = oldView };
+            listView.Items.Add(new ListViewItem(new string[] { "1", "2" }));
+            AccessibleObject accessibleObject = listView.Items[0].AccessibilityObject;
+            Assert.NotEqual(2, accessibleObject.GetChildCount());
+
+            listView.View = newView;
+
+            Assert.NotEqual(2, accessibleObject.GetChildCount());
         }
 
         private ListView GetBoundsListView(View view, bool showGroups, bool virtualMode)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5251,6 +5251,9 @@ namespace System.Windows.Forms.Tests
         {
             using SubListView listView = GetSubListViewWithData(view, virtualMode, showGroups, withinGroup);
             ListViewItem listViewItem = listView.Items[0];
+
+            Assert.NotNull(listViewItem.AccessibilityObject);
+
             SubListViewItemAccessibleObject accessibleObject = new SubListViewItemAccessibleObject(listViewItem);
             listViewItem.TestAccessor().Dynamic._accessibilityObject = accessibleObject;
             listView.CreateControl();
@@ -5275,7 +5278,7 @@ namespace System.Windows.Forms.Tests
             internal override AccessibleObject AccessibilityObject => CustomAccessibleObject;
         }
 
-        private class SubListViewItemAccessibleObject : ListViewItemAccessibleObject
+        private class SubListViewItemAccessibleObject : ListViewItemBaseAccessibleObject
         {
             public int RaiseAutomationEventCalls;
 


### PR DESCRIPTION
Fixes #4748 

## Proposed changes
During the separating of `ListViewAccessibilityObject`, two ways of separating were considered: `View` and `ListViewGroup` presence. 
Unfortunately, it makes no sense to separate `ListViewAccessibilityObject` by `View`, since the class contains almost no code specific to any `View`.
A `ListViewAccessibilityObject`  has code specific to the presence or absence of `ListViewGroups`, but the display of a `ListViewGroup` depends on many factors:
`ShowGroups` property;
`VirtualMode` property;
`View` property;
`Groups` property;
`Visual styles`.
Keeping track of all of these factors will lead to the need to add changes that will be much more difficult to support than the current code. Therefore, it was decided to leave the current code for the `ListViewAccessibilityObject`.

When separating the `ListViewItemAccessibleObject`, we took into account how the `ListViewItemAccessibleObject` works with `ListViewGroups` and `ListViewItems` depending on the view.

**ListViewItemBaseAccessibleObject**
The `ListViewItemBaseAccessibleObject` class has been added. It contains the implementation for most of the properties and methods of the `ListViewItemAccessibleObject` class. In addition, its implementation fully corresponds to the behavior of elements when the tree is in `LargeIcon` or `SmallIcon` view.

**ListViewItemListAccessibleObject**
For the `List` view, an `ListViewItemListAccessibleObject` class has been added. It contains an overridden implementation for the `Bounds` and `RuntimeId` properties and the `FragmentNavigate` method. Since this view does not support `ListViewGroup`, it allows us to remove some unnecessary checks.

**ListViewItemTileAccessibleObject**
For the `Tile` mode, an `ListViewItemTileAccessibleObject` class has been added. It contains implementations for methods such as `FragmentNavigate`, `GetChild`, `GetChildInternal`, `GetChildCount`, `GetChildIndex` and `GetSubItemBounds` methods. This is necessary because this mode supports `ListViewSubItems` and has complex logic to work with them. In addition, we have a special method `GetChildInternal`, which is necessary because inside the classes we operate with real indexes of `ListViewSubItems` , and not visible to the user.

**ListViewItemDetailsAccessibleObject**
For `Details` mode, the `ListViewItemDetailsAccessibleObject` class has been added. It does not have such overloaded logic for working with `ListViewSubItems` as the `ListViewItemTileAccessibleObject` class, but it has special functionality for working with fake accessibility objects. This is necessary because the user sees the cell and can interact with it, whether there is a `ListViewSubItem` for it or not.

Since `ListViewSubItems` do not support descendants, and all the logic for interacting with each other is taken from the `ListViewItemAccessibleObjects`, there is no point in separating the `ListViewSubItemAccessibleObject` of the class.

## Customer Impact
- No

## Regression? 
-  No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect 

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 6.0.100-preview.3.21202.5


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4910)