### PR TITLE
Allow set application-wide default font

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using Microsoft.Win32;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -170,6 +171,45 @@ namespace System.Windows.Forms
         ///  if the application opted in the automatic scaling in the .config file.
         /// </summary>
         public static bool IsScalingRequired => DeviceDpi != LogicalDpi;
+
+        /// <summary>
+        /// Retrieve the text scale factor, which is set via Settings > Display > Make Text Bigger.
+        /// The settings are stored in the registry under HKCU\Software\Microsoft\Accessibility in (DWORD)TextScaleFactor.
+        /// </summary>
+        /// <returns>The scaling factor in the range [1.0, 2.25].</returns>
+        /// <seealso href="https://docs.microsoft.com/windows/uwp/design/input/text-scaling">Windows Text scaling</seealso>
+        public static float GetTextScaleFactor()
+        {
+            // The default(100) and max(225) text scale factor is value what Settings display text scale
+            // applies and also clamps the text scale factor value between 100 and 225 value.
+            const short MinTextScaleValue = 100;
+            const short MaxTextScaleValue = 225;
+
+            short textScaleValue = MinTextScaleValue;
+            try
+            {
+                RegistryKey? key = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Accessibility");
+                if (key is not null && key.GetValue("TextScaleFactor") is int _textScaleValue)
+                {
+                    textScaleValue = (short)_textScaleValue;
+                }
+            }
+            catch
+            {
+                // Failed to read the registry for whatever reason.
+#if DEBUG
+                throw;
+#endif
+            }
+
+            // Restore the text scale if it isn't the default value in the valid text scale factor value
+            if (textScaleValue > MinTextScaleValue && textScaleValue <= MaxTextScaleValue)
+            {
+                return (float)textScaleValue / MinTextScaleValue;
+            }
+
+            return 1.0f;
+        }
 
         /// <summary>
         /// scale logical pixel to the factor

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/OsVersion.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/OsVersion.cs
@@ -21,6 +21,12 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///  Is Windows 10 first release or later. (Threshold 1, build 10240, version 1507)
+        /// </summary>
+        public static bool IsWindows10_1507OrGreater
+            => s_versionInfo.dwMajorVersion >= 10 && s_versionInfo.dwBuildNumber >= 10240;
+
+        /// <summary>
         ///  Is Windows 10 Anniversary Update or later. (Redstone 1, build 14393, version 1607)
         /// </summary>
         public static bool IsWindows10_1607OrGreater

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ~override System.Windows.Forms.MonthCalendar.OnResize(System.EventArgs e) -> void
+~static System.Windows.Forms.Application.SetDefaultFont(System.Drawing.Font font) -> void

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6495,7 +6495,7 @@ Stack trace where the illegal operation occurred was:
     <value>Width must be greater than MinWidth.</value>
   </data>
   <data name="Win32WindowAlreadyCreated" xml:space="preserve">
-    <value>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</value>
+    <value>{0} must be called before the first IWin32Window object is created in the application.</value>
   </data>
   <data name="WindowsFormsSetEvent" xml:space="preserve">
     <value>Setting event '{0}'</value>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -11052,8 +11052,8 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">Před vytvořením prvního objektu IWin32Window v aplikaci je nutné volat metodu SetCompatibleTextRenderingDefault.</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -11052,8 +11052,8 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">SetCompatibleTextRenderingDefault muss aufgerufen werden, bevor das erste IWin32Window-Objekt in der Anwendung erstellt wird.</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -11052,8 +11052,8 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">SetCompatibleTextRenderingDefault se debe llamar antes de crear el primer objeto IWin32Window en la aplicación.</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -11052,8 +11052,8 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">SetCompatibleTextRenderingDefault doit être appelé avant la création du premier objet IWin32Window dans l'application.</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -11052,8 +11052,8 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">SetCompatibleTextRenderingDefault deve essere chiamato prima della creazione del primo oggetto IWin32Window nell'applicazione.</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -11052,8 +11052,8 @@ Stack trace where the illegal operation occurred was:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">最初の IWin32Window オブジェクトがアプリケーションで作成される前に、SetCompatibleTextRenderingDefault が呼び出されなければなりません。</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -11052,8 +11052,8 @@ Stack trace where the illegal operation occurred was:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">SetCompatibleTextRenderingDefault는 애플리케이션에 첫 번째 IWin32Window 개체가 만들어지기 전에 호출해야 합니다.</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -11052,8 +11052,8 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">Należy wywołać element SetCompatibleTextRenderingDefault, aby pierwszy obiekt IWin32Window został utworzony w aplikacji.</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -11052,8 +11052,8 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">É necessário chamar SetCompatibleTextRenderingDefault antes da criação do primeiro objeto IWin32Window no aplicativo.</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -11053,8 +11053,8 @@ Stack trace where the illegal operation occurred was:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">До создания первого объекта IWin32Window в приложении необходимо вызвать SetCompatibleTextRenderingDefault.</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -11052,8 +11052,8 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">Uygulamada ilk IWin32Window nesnesi oluşturulmadan önce SetCompatibleTextRenderingDefault çağrılmalıdır.</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -11052,8 +11052,8 @@ Stack trace where the illegal operation occurred was:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">在应用程序中创建第一个 IWin32Window 对象之前，必须调用 SetCompatibleTextRenderingDefault。</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -11052,8 +11052,8 @@ Stack trace where the illegal operation occurred was:
         <note />
       </trans-unit>
       <trans-unit id="Win32WindowAlreadyCreated">
-        <source>SetCompatibleTextRenderingDefault must be called before the first IWin32Window object is created in the application.</source>
-        <target state="translated">在應用程式中建立第一個 IWin32Window 物件之前，必須先呼叫 SetCompatibleTextRenderingDefault。</target>
+        <source>{0} must be called before the first IWin32Window object is created in the application.</source>
+        <target state="new">{0} must be called before the first IWin32Window object is created in the application.</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowSubclassHandlerWndProcIsNotExceptedOne">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1810,7 +1810,7 @@ namespace System.Windows.Forms
             {
                 if (s_defaultFont is null)
                 {
-                    s_defaultFont = SystemFonts.MessageBoxFont;
+                    s_defaultFont = Application.DefaultFont ?? SystemFonts.MessageBoxFont;
                     Debug.Assert(s_defaultFont is not null, "defaultFont wasn't set!");
                 }
 
@@ -11603,6 +11603,7 @@ namespace System.Windows.Forms
             if (pref.Category == UserPreferenceCategory.Color)
             {
                 s_defaultFont = null;
+                Application.ScaleDefaultFont();
                 OnSystemColorsChanged(EventArgs.Empty);
             }
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.Designer.cs
@@ -47,7 +47,7 @@ namespace WinformsControlsTest
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(570, 30);
             this.Controls.Add(this.flowLayoutPanelUITypeEditors);
             this.Name = "MainForm";

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -4,10 +4,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using System.Windows.Forms.IntegrationTests.Common;
+using Microsoft.Win32;
 using WindowsFormsApp1;
 using WinformsControlsTest.UserControls;
 
@@ -29,8 +31,8 @@ namespace WinformsControlsTest
                 InitInfo info = buttonsInitInfo[item];
                 Button button = new Button
                 {
+                    AutoSizeMode = AutoSizeMode.GrowAndShrink,
                     Name = info.Name,
-                    Size = new Size(259, 23),
                     TabIndex = (int)item,
                     Text = info.Name,
                     UseVisualStyleBackColor = true
@@ -40,15 +42,17 @@ namespace WinformsControlsTest
                 flowLayoutPanelUITypeEditors.Controls.Add(button);
             }
 
-            // Calculate the form size.
-            ClientSize = new Size(545, 18 + (mainFormControlsTabOrderItems.Length + 1) / 2 * 29);
-            MinimumSize = Size;
-
-            // Force the panel to show all buttons
-            flowLayoutPanelUITypeEditors.PerformLayout();
-            flowLayoutPanelUITypeEditors.Controls[(int)MainFormControlsTabOrder.ButtonsButton].Focus();
-
             Text = RuntimeInformation.FrameworkDescription;
+
+            SystemEvents.UserPreferenceChanged += (s, e) =>
+            {
+                // The default font gets reset for UserPreferenceCategory.Color
+                // though perhaps it should've been done for UserPreferenceCategory.Window
+                if (e.Category == UserPreferenceCategory.Color)
+                {
+                    UpdateLayout();
+                }
+            };
         }
 
         private IReadOnlyDictionary<MainFormControlsTabOrder, InitInfo> GetButtonsInitInfo() => new Dictionary<MainFormControlsTabOrder, InitInfo>
@@ -158,6 +162,70 @@ namespace WinformsControlsTest
                 new InitInfo("Task Dialog", (obj, e) => new TaskDialogSamples().Show())
             }
         };
+
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+
+            UpdateLayout();
+            flowLayoutPanelUITypeEditors.Controls[(int)MainFormControlsTabOrder.ButtonsButton].Focus();
+        }
+
+        private void UpdateLayout()
+        {
+            MinimumSize = default;
+            Debug.WriteLine($"MessageBoxFont: {SystemFonts.MessageBoxFont}", nameof(MainForm));
+            Debug.WriteLine($"Default font: {Control.DefaultFont}", nameof(MainForm));
+
+            // 1. Auto-size all buttons
+            flowLayoutPanelUITypeEditors.SuspendLayout();
+            foreach (Control c in flowLayoutPanelUITypeEditors.Controls)
+            {
+                if (c is Button button)
+                {
+                    button.AutoSize = true;
+                }
+            }
+
+            flowLayoutPanelUITypeEditors.ResumeLayout(true);
+
+            // 2. Find the biggest button
+            Size biggestButton = default;
+            foreach (Control c in flowLayoutPanelUITypeEditors.Controls)
+            {
+                if (c is Button button)
+                {
+                    if (button.Width > biggestButton.Width)
+                    {
+                        biggestButton = button.Size;
+                    }
+                }
+            }
+
+            Debug.WriteLine($"Biggest button size: {biggestButton}", nameof(MainForm));
+
+            // 3. Size all buttons to the biggest button
+            flowLayoutPanelUITypeEditors.SuspendLayout();
+            foreach (Control c in flowLayoutPanelUITypeEditors.Controls)
+            {
+                if (c is Button button)
+                {
+                    button.AutoSize = false;
+                    button.Size = biggestButton;
+                }
+            }
+
+            flowLayoutPanelUITypeEditors.ResumeLayout(true);
+
+            // 4. Calculate the new form size showing all buttons in two vertical columns
+            int padding = flowLayoutPanelUITypeEditors.Controls[0].Margin.All;
+            ClientSize = new Size(
+                (biggestButton.Width + padding * 2) * 2 + padding * 2,
+                (int)(flowLayoutPanelUITypeEditors.Controls.Count / 2 * (biggestButton.Height + padding * 2) + padding * 2)
+                );
+            MinimumSize = Size;
+            Debug.WriteLine($"Minimum form size: {MinimumSize}", nameof(MainForm));
+        }
 
         private struct InitInfo
         {

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
@@ -83,6 +83,9 @@ namespace WinformsControlsTest
             //
             // label1
             //
+            this.label1.AccessibleDescription = "Test Label AccessibleDescription";
+            this.label1.AccessibleName = "Test Label AccessibleName";
+            this.label1.AccessibleRole = System.Windows.Forms.AccessibleRole.Indicator;
             this.label1.AutoSize = true;
             this.label1.FlatStyle = System.Windows.Forms.FlatStyle.System;
             this.label1.Location = new System.Drawing.Point(13, 73);
@@ -90,9 +93,6 @@ namespace WinformsControlsTest
             this.label1.Size = new System.Drawing.Size(35, 13);
             this.label1.TabIndex = 2;
             this.label1.Text = "label1";
-            this.label1.AccessibleName = "Test Label AccessibleName";
-            this.label1.AccessibleDescription = "Test Label AccessibleDescription";
-            this.label1.AccessibleRole = System.Windows.Forms.AccessibleRole.Indicator;
             //
             // maskedTextBox1
             //
@@ -196,6 +196,9 @@ namespace WinformsControlsTest
             //
             // groupBox1
             //
+            this.groupBox1.AccessibleDescription = "Test GroupBox AccessibleDescription";
+            this.groupBox1.AccessibleName = "Test GroupBox AccessibleName";
+            this.groupBox1.AccessibleRole = System.Windows.Forms.AccessibleRole.Table;
             this.groupBox1.Controls.Add(this.radioButton2);
             this.groupBox1.Controls.Add(this.radioButton1);
             this.groupBox1.Location = new System.Drawing.Point(125, 171);
@@ -204,9 +207,6 @@ namespace WinformsControlsTest
             this.groupBox1.TabIndex = 7;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "groupBox1";
-            this.groupBox1.AccessibleName = "Test GroupBox AccessibleName";
-            this.groupBox1.AccessibleDescription = "Test GroupBox AccessibleDescription";
-            this.groupBox1.AccessibleRole = System.Windows.Forms.AccessibleRole.Table;
             //
             // checkedListBox1
             //
@@ -236,12 +236,12 @@ namespace WinformsControlsTest
             this.domainUpDown1.Size = new System.Drawing.Size(120, 20);
             this.domainUpDown1.TabIndex = 10;
             this.domainUpDown1.Text = "domainUpDown1";
-            //
-            // Test3
-            //
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(629, 269);
+            // 
+            // Form1
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(639, 397);
             this.Controls.Add(this.domainUpDown1);
             this.Controls.Add(this.numericUpDown1);
             this.Controls.Add(this.checkedListBox1);
@@ -253,7 +253,7 @@ namespace WinformsControlsTest
             this.Controls.Add(this.label1);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.progressBar1);
-            this.Name = "Test3";
+            this.Name = "Form1";
             this.Text = "These look ok";
             this.Load += new System.EventHandler(this.Test3_Load);
             this.tabControl1.ResumeLayout(false);

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Drawing;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -14,6 +15,107 @@ namespace WinformsControlsTest
         public MultipleControls()
         {
             InitializeComponent();
+            CreateMyListView();
+        }
+
+        private void CreateMyListView()
+        {
+            // Create a new ListView control.
+            ListView listView2 = new ListView
+            {
+                Bounds = new Rectangle(new Point(0, 0), new Size(400, 200)),
+
+                // Set the view to show details.
+                View = View.Details,
+                // Allow the user to edit item text.
+                LabelEdit = true,
+                // Allow the user to rearrange columns.
+                AllowColumnReorder = true,
+                // Display check boxes.
+                CheckBoxes = true,
+                // Select the item and subitems when selection is made.
+                FullRowSelect = true,
+                // Display grid lines.
+                GridLines = true,
+                // Sort the items in the list in ascending order.
+                Sorting = SortOrder.Ascending,
+
+                VirtualMode = true,
+                VirtualListSize = 3,
+            };
+
+            ListViewGroup listViewGroup1 = new("ListViewGroup", HorizontalAlignment.Left)
+            {
+                Header = "ListViewGroup",
+                Name = "listViewGroup1"
+            };
+            listView2.Groups.AddRange(new ListViewGroup[] { listViewGroup1 });
+
+            // Create three items and three sets of subitems for each item.
+            ListViewItem item1 = new("item1", 0)
+            {
+                // Place a check mark next to the item.
+                Checked = true
+            };
+            item1.SubItems.Add("sub1");
+            item1.SubItems.Add("sub2");
+            item1.SubItems.Add("sub3");
+            ListViewItem item2 = new("item2", 1);
+            item2.SubItems.Add("sub4");
+            item2.SubItems.Add("sub5");
+            item2.SubItems.Add("sub6");
+            ListViewItem item3 = new("item3", 0)
+            {
+                // Place a check mark next to the item.
+                Checked = true
+            };
+            item3.SubItems.Add("sub7");
+            item3.SubItems.Add("sub8");
+            item3.SubItems.Add("sub9");
+
+            // Add the items to the ListView, but because the listview is in Virtual Mode, we have to manage items ourselves
+            // and thus, we can't call the following:
+            //      listView2.Items.AddRange(new ListViewItem[] { item1, item2, item3 });
+            listView2.RetrieveVirtualItem += (s, e) =>
+            {
+                e.Item = e.ItemIndex switch
+                {
+                    0 => item1,
+                    1 => item2,
+                    2 => item3,
+                    _ => throw new IndexOutOfRangeException(),
+                };
+            };
+
+            // Create columns for the items and subitems.
+            // Width of -2 indicates auto-size.
+            listView2.Columns.Add("column1", "Item Column", -2, HorizontalAlignment.Left, 0);
+            listView2.Columns.Add("Column 2", -2, HorizontalAlignment.Left);
+            listView2.Columns.Add("Column 3", -2, HorizontalAlignment.Left);
+            listView2.Columns.Add("Column 4", -2, HorizontalAlignment.Center);
+            listView2.AutoResizeColumns(ColumnHeaderAutoResizeStyle.HeaderSize);
+
+            // Create two ImageList objects.
+            ImageList imageListSmall = new();
+            ImageList imageListLarge = new();
+
+            // Initialize the ImageList objects with bitmaps.
+            imageListSmall.Images.Add(Bitmap.FromFile("Images\\SmallA.bmp"));
+            imageListSmall.Images.Add(Bitmap.FromFile("Images\\SmallABlue.bmp"));
+            imageListLarge.Images.Add(Bitmap.FromFile("Images\\LargeA.bmp"));
+            imageListLarge.Images.Add(Bitmap.FromFile("Images\\LargeABlue.bmp"));
+
+            // Assign the ImageList objects to the ListView.
+            listView2.LargeImageList = imageListLarge;
+            listView2.SmallImageList = imageListSmall;
+
+            // Add the ListView to the control collection.
+            Controls.Add(listView2);
+            listView2.Dock = DockStyle.Bottom;
+
+            // Change a ListViewGroup's header.
+            listView2.Groups[0].HeaderAlignment = HorizontalAlignment.Center;
+            listView2.Groups[0].Header = "NewText";
         }
 
         private void Test3_Load(object sender, EventArgs e)

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Program.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Program.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
+using System.Drawing;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -18,6 +18,12 @@ namespace WinformsControlsTest
         static void Main()
         {
             Application.EnableVisualStyles();
+            Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
+
+            //Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8f));
+            //Application.SetDefaultFont(new Font(new FontFamily("Chiller"), 12f));
+            Application.SetDefaultFont(new Font(new FontFamily("Calibri"), 11f));
+
             Application.SetCompatibleTextRenderingDefault(false);
             Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException); //UnhandledExceptionMode.ThrowException
             Thread.CurrentThread.CurrentUICulture = Thread.CurrentThread.CurrentCulture;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -1,9 +1,10 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Threading;
@@ -149,6 +150,121 @@ namespace System.Windows.Forms.Tests
             using Stream stream = typeof(Application).Module.Assembly.GetManifestResourceStream(
                 "System.Windows.Forms.XPThemes.manifest");
             Assert.NotNull(stream);
+        }
+
+        [WinFormsFact]
+        public void Application_DefaultFont_ReturnsNull_IfNoFontSet()
+        {
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+            Assert.Null(applicationTestAccessor.s_defaultFont);
+            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+            Assert.Null(Application.DefaultFont);
+        }
+
+        [WinFormsFact]
+        public void Application_DefaultFont_Returns_DefaultFont_IfNotScaled()
+        {
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+            Assert.Null(applicationTestAccessor.s_defaultFont);
+            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+
+            Font customFont = (Font)SystemFonts.CaptionFont.Clone();
+            try
+            {
+                applicationTestAccessor.s_defaultFont = customFont;
+
+                AreFontEqual(customFont, Application.DefaultFont);
+            }
+            finally
+            {
+                customFont.Dispose();
+                applicationTestAccessor.s_defaultFont = null;
+                applicationTestAccessor.s_defaultFontScaled?.Dispose();
+                applicationTestAccessor.s_defaultFontScaled = null;
+            }
+        }
+
+        [WinFormsFact]
+        public void Application_DefaultFont_Returns_ScaledDefaultFont_IfScaled()
+        {
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+            Assert.Null(applicationTestAccessor.s_defaultFont);
+            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+
+            Font font = new Font(new FontFamily("Arial"), 12f);
+            Font scaled = new Font(new FontFamily("Arial"), 16f);
+            try
+            {
+                applicationTestAccessor.s_defaultFont = font;
+                applicationTestAccessor.s_defaultFontScaled = scaled;
+
+                AreFontEqual(scaled, Application.DefaultFont);
+            }
+            finally
+            {
+                applicationTestAccessor.s_defaultFont = null;
+                applicationTestAccessor.s_defaultFontScaled = null;
+                font.Dispose();
+                scaled.Dispose();
+            }
+        }
+
+        private static void AreFontEqual(Font expected, Font actual)
+        {
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.SizeInPoints, actual.SizeInPoints);
+            Assert.Equal(expected.GdiCharSet, actual.GdiCharSet);
+            Assert.Equal(expected.Style, actual.Style);
+        }
+
+        [WinFormsFact]
+        public void Application_SetDefaultFont_SetNull_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("font", () => Application.SetDefaultFont(null));
+        }
+
+        [WinFormsFact]
+        public void Application_SetDefaultFont_AfterHandleCreated_InvalidOperationException()
+        {
+            using var control = new Control();
+            var window = new NativeWindow();
+            window.AssignHandle(control.Handle);
+
+            Assert.Throws<InvalidOperationException>(() => Application.SetDefaultFont(SystemFonts.CaptionFont));
+        }
+
+        [WinFormsFact]
+        public void Application_SetDefaultFont_MustCloseSystemFont()
+        {
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+            Assert.Null(applicationTestAccessor.s_defaultFont);
+            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+
+            Assert.True(SystemFonts.CaptionFont.IsSystemFont);
+
+            // This a unholy, but generally at this stage NativeWindow.AnyHandleCreated=true,
+            // And we won't be able to set the font, unless we flip the bit
+            var nativeWindowTestAccessor = typeof(NativeWindow).TestAccessor().Dynamic;
+            bool currentAnyHandleCreated = nativeWindowTestAccessor.t_anyHandleCreated;
+
+            try
+            {
+                nativeWindowTestAccessor.t_anyHandleCreated = false;
+
+                Application.SetDefaultFont(SystemFonts.CaptionFont);
+
+                Assert.False(applicationTestAccessor.s_defaultFont.IsSystemFont);
+            }
+            finally
+            {
+                // Flip the bit back
+                nativeWindowTestAccessor.t_anyHandleCreated = currentAnyHandleCreated;
+
+                applicationTestAccessor.s_defaultFont.Dispose();
+                applicationTestAccessor.s_defaultFontScaled?.Dispose();
+                applicationTestAccessor.s_defaultFont = null;
+                applicationTestAccessor.s_defaultFontScaled = null;
+            }
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
Resolves #3001



## Proposed changes

The default font has been updated in .NET Core 3.0 (#656) and documented. However for some users who built their apps in pixel-perfect manner this change has proved to be a significant hurdle in migrating their apps to .NET.

Allow setting application-wide default font in a similar manner we set high dpi or visual styles:

```diff
class Program
{
    [STAThread]
    static void Main()
    {
        Application.SetHighDpiMode(HighDpiMode.SystemAware);
        Application.EnableVisualStyles();
        Application.SetCompatibleTextRenderingDefault(false);

+       Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8f));

        Application.Run(new Form1());
    }
}
```

* The application-wide default font can only be set before the first window is created by an application.
* The font will be scaled by the system text scale factor, whenever it is getting changed.



## Screenshots <!-- Remove this section if PR does not change UI -->

* Microsoft Sans Serif, 8pt
![image](https://user-images.githubusercontent.com/4403806/118235486-29abe980-b4d8-11eb-9a57-b7e559201a83.png)

* Chiller, 12pt
![image](https://user-images.githubusercontent.com/4403806/118235457-2153ae80-b4d8-11eb-9183-2a1cc5aa82a1.png)

* Calibri, 11pt
![image](https://user-images.githubusercontent.com/4403806/118235357-ff5a2c00-b4d7-11eb-83b0-15aa572731d9.png)

* System text scale factor changes
![default-font1](https://user-images.githubusercontent.com/4403806/118394599-01172180-b689-11eb-8591-a9eb2acc10a4.gif)


<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- several new unit tests
- manual - see below



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4911)