### PR TITLE
Fix PropertyGrid leaking ImageList

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -4424,6 +4424,7 @@ namespace System.Windows.Forms
 
                 if (_imageList[NormalButtonSize] is null || fullRebuild)
                 {
+                    _imageList[NormalButtonSize]?.Dispose();
                     _imageList[NormalButtonSize] = new ImageList();
                     if (DpiHelper.IsScalingRequired)
                     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -3759,6 +3759,36 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AccessibleRole.RadioButton, alphaButton.AccessibleRole);
         }
 
+        [WinFormsFact]
+        public void PropertyGrid_SystemColorsChanged_DoesNotLeakImageList()
+        {
+            using SubPropertyGrid propertyGrid = new SubPropertyGrid();
+
+            var imageLists = propertyGrid.TestAccessor().Dynamic._imageList as ImageList[];
+
+            Assert.NotNull(imageLists);
+            Assert.Equal(2, imageLists.Length);
+            var imageList1 = imageLists[0];
+            Assert.NotNull(imageList1);
+
+            propertyGrid.OnSystemColorsChanged(EventArgs.Empty);
+
+            imageLists = propertyGrid.TestAccessor().Dynamic._imageList as ImageList[];
+
+            Assert.NotNull(imageLists);
+            Assert.Equal(2, imageLists.Length);
+            var imageList2 = imageLists[0];
+            Assert.NotNull(imageList2);
+            Assert.NotSame(imageList1, imageList2);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+#if DEBUG
+            Assert.True(imageList1.IsDisposed);
+#endif
+        }
+
         private class SubToolStripRenderer : ToolStripRenderer
         {
         }
@@ -3882,6 +3912,8 @@ namespace System.Windows.Forms.Tests
             public new void OnMouseMove(MouseEventArgs eventargs) => base.OnMouseMove(eventargs);
 
             public new void OnMouseUp(MouseEventArgs eventargs) => base.OnMouseUp(eventargs);
+
+            public new void OnSystemColorsChanged(EventArgs e) => base.OnSystemColorsChanged(e);
 
             public new void WndProc(ref Message m) => base.WndProc(ref m);
         }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Contributes to #4913

Note that analysis of #4913 is not complete, merging this PR before the issue is fully analysed is ok (this PR is self-contained) but should not close the issue until it is verified that all leaks have been fixed.

## Proposed changes

- Fix a GDI handle leak discovered in the investigation of #4913
- When a system colors change is detected, the ImageList is reconstructed without disposing the old ImageList. Previously this was not an issue because ImageLists were collected and released by GC, but due to a different issue (#3567) this regressed. This change makes the implementation more robust and less reliant on the GC. Even once #3567 is fixed for everyone, disposing the ImageList early instead of waiting for the GC is good practice.

## Customer Impact

- prevents a leak of GDI handles when using PropertyGrid

## Regression? 

- yes
  - while the regression itself is not in the PropertyGrid it can be easily worked around here and it is good practice to properly dispose disposable objects

## Risk

- If someone gets hold of the ImageList it may be disposed unexpectedly
  - I could not find any way to get hold of the ImageList besides private reflection. Subclassing does not seem to provide access either. Reviewers may want to pay special attention and double check this.

### Before

- GDI handles of the ImageList were leaked when the ImageList inside the PropertyGrid was reloaded
- debug assert was hit in debug builds of WinForms when the ImageList inside the PropertyGrid was reloaded

### After

- ImageList is properly disposed
- no debug assert is hit in debug builds

## Test methodology

- added a unit test that can trigger both the debug assert and checks for disposal of the ImageList
- unit test triggers if bugfix is not present


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4951)