### PR TITLE
Removing unnecessary logs from a ComboBoxChildEditUiaProvider

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
@@ -51,7 +51,6 @@ namespace System.Windows.Forms
                 switch (direction)
                 {
                     case UiaCore.NavigateDirection.Parent:
-                        Debug.WriteLine("Edit parent " + _owner.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
                         return _owner.AccessibilityObject;
                     case UiaCore.NavigateDirection.PreviousSibling:
                         return _owner.DroppedDown


### PR DESCRIPTION
## Proposed changes
- Removing unnecessary logs from a ComboBoxChildEditUiaProvider

## Customer Impact
- No

## Regression? 
- No

## Risk
- Minimal

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.100-preview.3.21202.5

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4953)