### PR TITLE
Enable nullability in some DataGridViewCell EventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1837,7 +1837,7 @@
 ~System.Windows.Forms.DataGridViewCellFormattingEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
 ~System.Windows.Forms.DataGridViewCellFormattingEventArgs.CellStyle.set -> void
 ~System.Windows.Forms.DataGridViewCellFormattingEventArgs.DataGridViewCellFormattingEventArgs(int columnIndex, int rowIndex, object value, System.Type desiredType, System.Windows.Forms.DataGridViewCellStyle cellStyle) -> void
-~System.Windows.Forms.DataGridViewCellMouseEventArgs.DataGridViewCellMouseEventArgs(int columnIndex, int rowIndex, int localX, int localY, System.Windows.Forms.MouseEventArgs e) -> void
+System.Windows.Forms.DataGridViewCellMouseEventArgs.DataGridViewCellMouseEventArgs(int columnIndex, int rowIndex, int localX, int localY, System.Windows.Forms.MouseEventArgs? e) -> void
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.AdvancedBorderStyle.get -> System.Windows.Forms.DataGridViewAdvancedBorderStyle
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.DataGridViewCellPaintingEventArgs(System.Windows.Forms.DataGridView dataGridView, System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, int columnIndex, System.Windows.Forms.DataGridViewElementStates cellState, object value, object formattedValue, string errorText, System.Windows.Forms.DataGridViewCellStyle cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void
@@ -1845,9 +1845,9 @@
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.FormattedValue.get -> object
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.Graphics.get -> System.Drawing.Graphics
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.Value.get -> object
-~System.Windows.Forms.DataGridViewCellParsingEventArgs.DataGridViewCellParsingEventArgs(int rowIndex, int columnIndex, object value, System.Type desiredType, System.Windows.Forms.DataGridViewCellStyle inheritedCellStyle) -> void
-~System.Windows.Forms.DataGridViewCellParsingEventArgs.InheritedCellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
-~System.Windows.Forms.DataGridViewCellParsingEventArgs.InheritedCellStyle.set -> void
+System.Windows.Forms.DataGridViewCellParsingEventArgs.DataGridViewCellParsingEventArgs(int rowIndex, int columnIndex, object? value, System.Type? desiredType, System.Windows.Forms.DataGridViewCellStyle? inheritedCellStyle) -> void
+System.Windows.Forms.DataGridViewCellParsingEventArgs.InheritedCellStyle.get -> System.Windows.Forms.DataGridViewCellStyle?
+System.Windows.Forms.DataGridViewCellParsingEventArgs.InheritedCellStyle.set -> void
 ~System.Windows.Forms.DataGridViewCellStateChangedEventArgs.Cell.get -> System.Windows.Forms.DataGridViewCell
 ~System.Windows.Forms.DataGridViewCellStateChangedEventArgs.DataGridViewCellStateChangedEventArgs(System.Windows.Forms.DataGridViewCell dataGridViewCell, System.Windows.Forms.DataGridViewElementStates stateChanged) -> void
 ~System.Windows.Forms.DataGridViewCellStyle.DataGridViewCellStyle(System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle) -> void
@@ -1867,8 +1867,8 @@
 ~System.Windows.Forms.DataGridViewCellToolTipTextNeededEventArgs.ToolTipText.get -> string
 ~System.Windows.Forms.DataGridViewCellToolTipTextNeededEventArgs.ToolTipText.set -> void
 ~System.Windows.Forms.DataGridViewCellValidatingEventArgs.FormattedValue.get -> object
-~System.Windows.Forms.DataGridViewCellValueEventArgs.Value.get -> object
-~System.Windows.Forms.DataGridViewCellValueEventArgs.Value.set -> void
+System.Windows.Forms.DataGridViewCellValueEventArgs.Value.get -> object?
+System.Windows.Forms.DataGridViewCellValueEventArgs.Value.set -> void
 ~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.get -> object
 ~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.set -> void
 ~System.Windows.Forms.DataGridViewCheckBoxCell.IndeterminateValue.get -> object

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellEventArgs.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewCellEventArgs : EventArgs
     {
-        internal DataGridViewCellEventArgs(DataGridViewCell dataGridViewCell) : this(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex)
+        internal DataGridViewCellEventArgs(DataGridViewCell dataGridViewCell)
+            : this(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex)
         {
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellMouseEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellMouseEventArgs.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewCellMouseEventArgs : MouseEventArgs
     {
-        public DataGridViewCellMouseEventArgs(int columnIndex,
+        public DataGridViewCellMouseEventArgs(
+            int columnIndex,
             int rowIndex,
             int localX,
             int localY,
-            MouseEventArgs e) : base(e?.Button ?? MouseButtons.None, e?.Clicks ?? 0, localX, localY, e?.Delta ?? 0)
+            MouseEventArgs? e)
+            : base(e?.Button ?? MouseButtons.None, e?.Clicks ?? 0, localX, localY, e?.Delta ?? 0)
         {
             if (columnIndex < -1)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellParsingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellParsingEventArgs.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewCellParsingEventArgs : ConvertEventArgs
     {
-        public DataGridViewCellParsingEventArgs(int rowIndex,
-                                         int columnIndex,
-                                         object value,
-                                         Type desiredType,
-                                         DataGridViewCellStyle inheritedCellStyle) : base(value, desiredType)
+        public DataGridViewCellParsingEventArgs(
+            int rowIndex,
+            int columnIndex,
+            object? value,
+            Type? desiredType,
+            DataGridViewCellStyle? inheritedCellStyle)
+            : base(value, desiredType)
         {
             RowIndex = rowIndex;
             ColumnIndex = columnIndex;
@@ -23,7 +23,7 @@ namespace System.Windows.Forms
 
         public int ColumnIndex { get; }
 
-        public DataGridViewCellStyle InheritedCellStyle { get; set; }
+        public DataGridViewCellStyle? InheritedCellStyle { get; set; }
 
         public bool ParsingApplied { get; set; }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellValueEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellValueEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 
 namespace System.Windows.Forms
@@ -36,9 +34,9 @@ namespace System.Windows.Forms
 
         public int RowIndex { get; private set; }
 
-        public object Value { get; set; }
+        public object? Value { get; set; }
 
-        internal void SetProperties(int columnIndex, int rowIndex, object value)
+        internal void SetProperties(int columnIndex, int rowIndex, object? value)
         {
             Debug.Assert(columnIndex >= -1);
             Debug.Assert(rowIndex >= -1);


### PR DESCRIPTION
## Proposed changes

- Enable nullability in some DataGridViewCell EventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4960)