### PR TITLE
Enable nullability in DpiChangedEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -434,7 +434,7 @@
 ~override System.Windows.Forms.DomainUpDown.OnChanged(object source, System.EventArgs e) -> void
 ~override System.Windows.Forms.DomainUpDown.OnTextBoxKeyPress(object source, System.Windows.Forms.KeyPressEventArgs e) -> void
 ~override System.Windows.Forms.DomainUpDown.ToString() -> string
-~override System.Windows.Forms.DpiChangedEventArgs.ToString() -> string
+override System.Windows.Forms.DpiChangedEventArgs.ToString() -> string!
 ~override System.Windows.Forms.ErrorProvider.Site.set -> void
 ~override System.Windows.Forms.FileDialog.ToString() -> string
 ~override System.Windows.Forms.FlowLayoutPanel.LayoutEngine.get -> System.Windows.Forms.Layout.LayoutEngine

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DpiChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DpiChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DpiChangedEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4961)