### PR TITLE
Coherency fixes of runtime dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -39,10 +39,6 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>691c12bc9e4f8b7615e8108d57699485d5a67ea7</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.Cng" Version="6.0.0-preview.5.21226.1">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>3782e6e41cfaf76ec9ae4117722f835596026b1a</Sha>
-    </Dependency>
     <Dependency Name="System.Security.Permissions" Version="6.0.0-preview.5.21270.12">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>691c12bc9e4f8b7615e8108d57699485d5a67ea7</Sha>
@@ -98,10 +94,6 @@ Note: if the Uri is a new place, you will need to add a subscription from that p
     <Dependency Name="Microsoft.NETCore.ILDAsm" Version="6.0.0-preview.5.21270.12">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>691c12bc9e4f8b7615e8108d57699485d5a67ea7</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.Targets" Version="6.0.0-preview.5.21254.12">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>65020c946254c9a99497f4fdfa4136131f51f913</Sha>
     </Dependency>
     <Dependency Name="System.Diagnostics.PerformanceCounter" Version="6.0.0-preview.5.21270.12">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,7 +20,6 @@
     <SystemIOPackagingPackageVersion>6.0.0-preview.5.21270.12</SystemIOPackagingPackageVersion>
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>5.0.0-preview.7.20320.5</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreILDAsmPackageVersion>6.0.0-preview.5.21270.12</MicrosoftNETCoreILDAsmPackageVersion>
-    <MicrosoftNETCoreTargetsPackageVersion>6.0.0-preview.5.21254.12</MicrosoftNETCoreTargetsPackageVersion>
     <SystemDiagnosticsPerformanceCounterPackageVersion>6.0.0-preview.5.21270.12</SystemDiagnosticsPerformanceCounterPackageVersion>
     <SystemIOFileSystemAccessControlPackageVersion>6.0.0-preview.5.21270.12</SystemIOFileSystemAccessControlPackageVersion>
     <SystemIOPipesAccessControlPackageVersion>6.0.0-preview.5.21270.12</SystemIOPipesAccessControlPackageVersion>
@@ -39,7 +38,6 @@
     <SystemConfigurationConfigurationManagerPackageVersion>6.0.0-preview.5.21270.12</SystemConfigurationConfigurationManagerPackageVersion>
     <SystemDrawingCommonPackageVersion>6.0.0-preview.5.21270.12</SystemDrawingCommonPackageVersion>
     <SystemResourcesExtensionsPackageVersion>6.0.0-preview.5.21270.12</SystemResourcesExtensionsPackageVersion>
-    <SystemSecurityCryptographyCngPackageVersion>6.0.0-preview.5.21226.1</SystemSecurityCryptographyCngPackageVersion>
     <SystemSecurityPermissionsPackageVersion>6.0.0-preview.5.21270.12</SystemSecurityPermissionsPackageVersion>
     <SystemWindowsExtensionsPackageVersion>6.0.0-preview.5.21270.12</SystemWindowsExtensionsPackageVersion>
     <MicrosoftNETCoreILPackageVersion>3.0.0-preview5-27616-73</MicrosoftNETCoreILPackageVersion>


### PR DESCRIPTION
`Microsoft.NETCore.Targets` and `System.Security.Cryptography.Cng` got removed (see https://github.com/dotnet/runtime/pull/52261, https://github.com/dotnet/runtime/pull/51853) and cause incoherent builds.