### PR TITLE
Enable nullability in BindingCompleteEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1536,13 +1536,13 @@ static System.Windows.Forms.OwnerDrawPropertyBag.Copy(System.Windows.Forms.Owner
 ~System.Windows.Forms.Binding.NullValue.get -> object
 ~System.Windows.Forms.Binding.NullValue.set -> void
 ~System.Windows.Forms.Binding.PropertyName.get -> string
-~System.Windows.Forms.BindingCompleteEventArgs.Binding.get -> System.Windows.Forms.Binding
-~System.Windows.Forms.BindingCompleteEventArgs.BindingCompleteEventArgs(System.Windows.Forms.Binding binding, System.Windows.Forms.BindingCompleteState state, System.Windows.Forms.BindingCompleteContext context) -> void
-~System.Windows.Forms.BindingCompleteEventArgs.BindingCompleteEventArgs(System.Windows.Forms.Binding binding, System.Windows.Forms.BindingCompleteState state, System.Windows.Forms.BindingCompleteContext context, string errorText) -> void
-~System.Windows.Forms.BindingCompleteEventArgs.BindingCompleteEventArgs(System.Windows.Forms.Binding binding, System.Windows.Forms.BindingCompleteState state, System.Windows.Forms.BindingCompleteContext context, string errorText, System.Exception exception) -> void
-~System.Windows.Forms.BindingCompleteEventArgs.BindingCompleteEventArgs(System.Windows.Forms.Binding binding, System.Windows.Forms.BindingCompleteState state, System.Windows.Forms.BindingCompleteContext context, string errorText, System.Exception exception, bool cancel) -> void
-~System.Windows.Forms.BindingCompleteEventArgs.ErrorText.get -> string
-~System.Windows.Forms.BindingCompleteEventArgs.Exception.get -> System.Exception
+System.Windows.Forms.BindingCompleteEventArgs.Binding.get -> System.Windows.Forms.Binding?
+System.Windows.Forms.BindingCompleteEventArgs.BindingCompleteEventArgs(System.Windows.Forms.Binding? binding, System.Windows.Forms.BindingCompleteState state, System.Windows.Forms.BindingCompleteContext context) -> void
+System.Windows.Forms.BindingCompleteEventArgs.BindingCompleteEventArgs(System.Windows.Forms.Binding? binding, System.Windows.Forms.BindingCompleteState state, System.Windows.Forms.BindingCompleteContext context, string? errorText) -> void
+System.Windows.Forms.BindingCompleteEventArgs.BindingCompleteEventArgs(System.Windows.Forms.Binding? binding, System.Windows.Forms.BindingCompleteState state, System.Windows.Forms.BindingCompleteContext context, string? errorText, System.Exception? exception) -> void
+System.Windows.Forms.BindingCompleteEventArgs.BindingCompleteEventArgs(System.Windows.Forms.Binding? binding, System.Windows.Forms.BindingCompleteState state, System.Windows.Forms.BindingCompleteContext context, string? errorText, System.Exception? exception, bool cancel) -> void
+System.Windows.Forms.BindingCompleteEventArgs.ErrorText.get -> string!
+System.Windows.Forms.BindingCompleteEventArgs.Exception.get -> System.Exception?
 ~System.Windows.Forms.BindingContext.Add(object dataSource, System.Windows.Forms.BindingManagerBase listManager) -> void
 ~System.Windows.Forms.BindingContext.Contains(object dataSource) -> bool
 ~System.Windows.Forms.BindingContext.Contains(object dataSource, string dataMember) -> bool

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingCompleteEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingCompleteEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms
@@ -16,12 +14,14 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Constructor for BindingCompleteEventArgs.
         /// </summary>
-        public BindingCompleteEventArgs(Binding binding,
-                                        BindingCompleteState state,
-                                        BindingCompleteContext context,
-                                        string errorText,
-                                        Exception exception,
-                                        bool cancel) : base(cancel)
+        public BindingCompleteEventArgs(
+            Binding? binding,
+            BindingCompleteState state,
+            BindingCompleteContext context,
+            string? errorText,
+            Exception? exception,
+            bool cancel)
+            : base(cancel)
         {
             Binding = binding;
             BindingCompleteState = state;
@@ -33,34 +33,40 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Constructor for BindingCompleteEventArgs.
         /// </summary>
-        public BindingCompleteEventArgs(Binding binding,
-                                        BindingCompleteState state,
-                                        BindingCompleteContext context,
-                                        string errorText,
-                                        Exception exception) : this(binding, state, context, errorText, exception, true)
+        public BindingCompleteEventArgs(
+            Binding? binding,
+            BindingCompleteState state,
+            BindingCompleteContext context,
+            string? errorText,
+            Exception? exception)
+            : this(binding, state, context, errorText, exception, true)
         {
         }
 
         /// <summary>
         ///  Constructor for BindingCompleteEventArgs.
         /// </summary>
-        public BindingCompleteEventArgs(Binding binding,
-                                        BindingCompleteState state,
-                                        BindingCompleteContext context,
-                                        string errorText) : this(binding, state, context, errorText, null, true)
+        public BindingCompleteEventArgs(
+            Binding? binding,
+            BindingCompleteState state,
+            BindingCompleteContext context,
+            string? errorText)
+            : this(binding, state, context, errorText, null, true)
         {
         }
 
         /// <summary>
         ///  Constructor for BindingCompleteEventArgs.
         /// </summary>
-        public BindingCompleteEventArgs(Binding binding,
-                                        BindingCompleteState state,
-                                        BindingCompleteContext context) : this(binding, state, context, string.Empty, null, false)
+        public BindingCompleteEventArgs(
+            Binding? binding,
+            BindingCompleteState state,
+            BindingCompleteContext context)
+            : this(binding, state, context, string.Empty, null, false)
         {
         }
 
-        public Binding Binding { get; }
+        public Binding? Binding { get; }
 
         public BindingCompleteState BindingCompleteState { get; }
 
@@ -68,6 +74,6 @@ namespace System.Windows.Forms
 
         public string ErrorText { get; }
 
-        public Exception Exception { get; }
+        public Exception? Exception { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in BindingCompleteEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4994)