### PR TITLE
Enable nullability in DataGridViewColumn EventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1897,11 +1897,11 @@ static readonly System.Windows.Forms.PropertyGridInternal.PropertyGridCommands.R
 ~System.Windows.Forms.DataGridViewColumnCollection.IndexOf(System.Windows.Forms.DataGridViewColumn dataGridViewColumn) -> int
 ~System.Windows.Forms.DataGridViewColumnCollection.this[int index].get -> System.Windows.Forms.DataGridViewColumn
 ~System.Windows.Forms.DataGridViewColumnCollection.this[string columnName].get -> System.Windows.Forms.DataGridViewColumn
-~System.Windows.Forms.DataGridViewColumnDividerDoubleClickEventArgs.DataGridViewColumnDividerDoubleClickEventArgs(int columnIndex, System.Windows.Forms.HandledMouseEventArgs e) -> void
-~System.Windows.Forms.DataGridViewColumnEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn
-~System.Windows.Forms.DataGridViewColumnEventArgs.DataGridViewColumnEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn) -> void
-~System.Windows.Forms.DataGridViewColumnStateChangedEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn
-~System.Windows.Forms.DataGridViewColumnStateChangedEventArgs.DataGridViewColumnStateChangedEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn, System.Windows.Forms.DataGridViewElementStates stateChanged) -> void
+System.Windows.Forms.DataGridViewColumnDividerDoubleClickEventArgs.DataGridViewColumnDividerDoubleClickEventArgs(int columnIndex, System.Windows.Forms.HandledMouseEventArgs? e) -> void
+System.Windows.Forms.DataGridViewColumnEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn!
+System.Windows.Forms.DataGridViewColumnEventArgs.DataGridViewColumnEventArgs(System.Windows.Forms.DataGridViewColumn! dataGridViewColumn) -> void
+System.Windows.Forms.DataGridViewColumnStateChangedEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn!
+System.Windows.Forms.DataGridViewColumnStateChangedEventArgs.DataGridViewColumnStateChangedEventArgs(System.Windows.Forms.DataGridViewColumn! dataGridViewColumn, System.Windows.Forms.DataGridViewElementStates stateChanged) -> void
 ~System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.Add(object item) -> int
 ~System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.AddRange(params object[] items) -> void
 ~System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection.AddRange(System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection value) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnDividerDoubleClickEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnDividerDoubleClickEventArgs.cs
@@ -2,13 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewColumnDividerDoubleClickEventArgs : HandledMouseEventArgs
     {
-        public DataGridViewColumnDividerDoubleClickEventArgs(int columnIndex, HandledMouseEventArgs e) : base(e?.Button ?? MouseButtons.None, e?.Clicks ?? 0, e?.X ?? 0, e?.Y ?? 0, e?.Delta ?? 0, e?.Handled ?? false)
+        public DataGridViewColumnDividerDoubleClickEventArgs(int columnIndex, HandledMouseEventArgs? e)
+            : base(e?.Button ?? MouseButtons.None, e?.Clicks ?? 0, e?.X ?? 0, e?.Y ?? 0, e?.Delta ?? 0, e?.Handled ?? false)
         {
             if (columnIndex < -1)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnStateChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnStateChangedEventArgs.cs
@@ -2,14 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewColumnStateChangedEventArgs : EventArgs
     {
         public DataGridViewColumnStateChangedEventArgs(DataGridViewColumn dataGridViewColumn, DataGridViewElementStates stateChanged)
         {
+            if (dataGridViewColumn is null)
+            {
+                throw new ArgumentNullException(nameof(dataGridViewColumn));
+            }
+
             Column = dataGridViewColumn;
             StateChanged = stateChanged;
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewColumnStateChangedEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewColumnStateChangedEventArgsTests.cs
@@ -9,19 +9,19 @@ namespace System.Windows.Forms.Tests
     // NB: doesn't require thread affinity
     public class DataGridViewColumnStateChangedEventArgsTests : IClassFixture<ThreadExceptionFixture>
     {
-        public static IEnumerable<object[]> Ctor_DataGridViewColumn_DataGridViewElementStates_TestData()
+        [Fact]
+        public void Ctor_DataGridViewColumn_DataGridViewElementStates()
         {
-            yield return new object[] { null, (DataGridViewElementStates)7 };
-            yield return new object[] { new DataGridViewColumn(), DataGridViewElementStates.Displayed };
+            using var dataGridViewColumn = new DataGridViewColumn();
+            var e = new DataGridViewColumnStateChangedEventArgs(dataGridViewColumn, DataGridViewElementStates.Displayed);
+            Assert.Equal(dataGridViewColumn, e.Column);
+            Assert.Equal(DataGridViewElementStates.Displayed, e.StateChanged);
         }
 
-        [Theory]
-        [MemberData(nameof(Ctor_DataGridViewColumn_DataGridViewElementStates_TestData))]
-        public void Ctor_DataGridViewColumn_DataGridViewElementStates(DataGridViewColumn dataGridViewColumn, DataGridViewElementStates stateChanged)
+        [Fact]
+        public void DataGridViewColumnStateChangedEventArgs_Ctor_NullDataGridViewColumn_ThrowsArgumentNullException()
         {
-            var e = new DataGridViewColumnStateChangedEventArgs(dataGridViewColumn, stateChanged);
-            Assert.Equal(dataGridViewColumn, e.Column);
-            Assert.Equal(stateChanged, e.StateChanged);
+            Assert.Throws<ArgumentNullException>(() => new DataGridViewColumnStateChangedEventArgs(null, DataGridViewElementStates.Displayed));
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewColumn EventArgs.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/4995)