### PR TITLE
Changing control types of DataGridView and its TextBox cell

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -240,6 +240,10 @@ namespace System.Windows.Forms
             {
                 switch (propertyID)
                 {
+                    case UiaCore.UIA.ControlTypePropertyId:
+                        return _ownerDataGridView.AccessibleRole == AccessibleRole.Default
+                               ? UiaCore.UIA.DataGridControlTypeId
+                               : base.GetPropertyValue(propertyID);
                     case UiaCore.UIA.NamePropertyId:
                         return Name;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObject.cs
@@ -19,7 +19,7 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.EditControlTypeId,
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.DataItemControlTypeId,
                     _ => base.GetPropertyValue(propertyID)
                 };
         }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DataGridViewAccessibleObjectTests.cs
@@ -141,12 +141,12 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         }
 
         [WinFormsFact]
-        public void DataGridViewAccessibleObject_ControlType_IsTable_IfAccessibleRoleIsDefault()
+        public void DataGridViewAccessibleObject_ControlType_IsDataGrid_IfAccessibleRoleIsDefault()
         {
             using DataGridView dataGridView = new DataGridView();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
-            UiaCore.UIA expected = UiaCore.UIA.TableControlTypeId;
+            UiaCore.UIA expected = UiaCore.UIA.DataGridControlTypeId;
             Assert.Equal(expected, actual);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxCell.DataGridViewTextBoxCellAccessibleObjectTests.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Tests
+{
+    public class DataGridViewTextBoxCell_DataGridViewTextBoxCellAccessibleObject : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void DataGridViewTextBoxCellAccessibleObject_ControlType_IsDataItem()
+        {
+            using var cell = new DataGridViewTextBoxCell();
+            AccessibleObject accessibleObject = cell.AccessibilityObject;
+
+            object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
+
+            Assert.Equal(UiaCore.UIA.DataItemControlTypeId, actual);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4031 

## Proposed changes

- Change DataGridView accessible object control type to "Data grid"
- Change DataGridView TextBox cell accessible object control type to "DataItem"

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user will see\hear the new values of control types 
- AccessibilityInsights won't throw errors about supporting TextPattern for a text cell if it is not in the editing mode

## Regression? 

- No

## Risk

- Minimal

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- AI throws the error, that a Text must support the Text pattern, because it has the "edit" control type. But a TextBox cell has an edit field that already supports the Text pattern. And it's impossible to implement the Text pattern for the cell, because it's just a container for its edit field.
![image](https://user-images.githubusercontent.com/49272759/120320061-69e9d500-c2ea-11eb-8c0e-dd5fa181648d.png)


### After

- The accessibility tree is changed. AI doesn't throw the error, because the cell is "data item" now, so it shouldn't support the Text pattern, but its child "edit" must support the Text pattern, if the cell in the editing mode.
![image](https://user-images.githubusercontent.com/49272759/120318241-4c1b7080-c2e8-11eb-9b43-6de193f4ad58.png)



## Test methodology <!-- How did you ensure quality? -->
- Manual testing
- CTI
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Inspect, Narrator, AI 

## Test environment(s) <!-- Remove any that don't apply -->
- .NET 6.0.0-preview.6.21276.13


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5025)