### PR TITLE
Preserve font styles when rescale default font

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FontExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FontExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+
+namespace System.Windows.Forms
+{
+    internal static class FontExtensions
+    {
+        /// <summary>
+        /// Creates a copy of the <paramref name="templateFont"/> with the new em-size in the units of the template font.
+        /// </summary>
+        /// <param name="templateFont">The font instance to clone.</param>
+        /// <param name="emSize">The em-size of the new font in the units specified by the unit parameter.</param>
+        /// <returns>A new <see cref="Font"/> object with the new size, or <see langword="null"/> if <paramref name="templateFont"/>
+        /// is <see langword="null"/>.</returns>
+        [return: NotNullIfNotNull("templateFont")]
+        public static Font? WithSize(this Font? templateFont, float emSize)
+        {
+            if (templateFont is null)
+                return null;
+
+            return new Font(templateFont.FontFamily,
+                            emSize,
+                            templateFont.Style,
+                            templateFont.Unit,
+                            templateFont.GdiCharSet,
+                            templateFont.GdiVerticalFont);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
@@ -16,6 +16,14 @@ namespace System.Windows.Forms
     /// </summary>
     internal static partial class DpiHelper
     {
+        // The default(100) and max(225) text scale factor is value what Settings display text scale
+        // applies and also clamps the text scale factor value between 100 and 225 value.
+        // See https://docs.microsoft.com/windows/uwp/design/input/text-scaling.
+        internal const short MinTextScaleValue = 100;
+        internal const short MaxTextScaleValue = 225;
+        internal const float MinTextScaleFactorValue = 1.00f;
+        internal const float MaxTextScaleFactorValue = 2.25f;
+
         internal const double LogicalDpi = 96.0;
         private static InterpolationMode s_interpolationMode;
 
@@ -180,11 +188,6 @@ namespace System.Windows.Forms
         /// <seealso href="https://docs.microsoft.com/windows/uwp/design/input/text-scaling">Windows Text scaling</seealso>
         public static float GetTextScaleFactor()
         {
-            // The default(100) and max(225) text scale factor is value what Settings display text scale
-            // applies and also clamps the text scale factor value between 100 and 225 value.
-            const short MinTextScaleValue = 100;
-            const short MaxTextScaleValue = 225;
-
             short textScaleValue = MinTextScaleValue;
             try
             {
@@ -208,7 +211,7 @@ namespace System.Windows.Forms
                 return (float)textScaleValue / MinTextScaleValue;
             }
 
-            return 1.0f;
+            return MinTextScaleFactorValue;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -1237,8 +1237,8 @@ namespace System.Windows.Forms
             }
 
             // Restore the text scale if it isn't the default value in the valid text scale factor value
-            textScaleFactor = Math.Min(2.25f, textScaleFactor);
-            if (textScaleFactor > 1.0f)
+            textScaleFactor = Math.Min(DpiHelper.MaxTextScaleFactorValue, textScaleFactor);
+            if (textScaleFactor > DpiHelper.MinTextScaleFactorValue)
             {
                 s_defaultFontScaled = s_defaultFont.WithSize(s_defaultFont.Size * textScaleFactor);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -1240,7 +1240,7 @@ namespace System.Windows.Forms
             textScaleFactor = Math.Min(2.25f, textScaleFactor);
             if (textScaleFactor > 1.0f)
             {
-                s_defaultFontScaled = new Font(s_defaultFont.FontFamily, s_defaultFont.Size * textScaleFactor, s_defaultFont.Style, s_defaultFont.Unit);
+                s_defaultFontScaled = s_defaultFont.WithSize(s_defaultFont.Size * textScaleFactor);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -1222,14 +1222,13 @@ namespace System.Windows.Forms
         /// <summary>
         /// Scale the default font (if it is set) as per the Settings display text scale settings.
         /// </summary>
-        internal static void ScaleDefaultFont()
+        /// <param name="textScaleFactor">The scaling factor in the range [1.0, 2.25].</param>
+        internal static void ScaleDefaultFont(float textScaleFactor)
         {
             if (s_defaultFont is null || !OsVersion.IsWindows10_1507OrGreater)
             {
                 return;
             }
-
-            float textScaleValue = DpiHelper.GetTextScaleFactor();
 
             if (s_defaultFontScaled is not null)
             {
@@ -1238,9 +1237,10 @@ namespace System.Windows.Forms
             }
 
             // Restore the text scale if it isn't the default value in the valid text scale factor value
-            if (textScaleValue > 1.0f)
+            textScaleFactor = Math.Min(2.25f, textScaleFactor);
+            if (textScaleFactor > 1.0f)
             {
-                s_defaultFontScaled = new Font(s_defaultFont.FontFamily, s_defaultFont.Size * textScaleValue);
+                s_defaultFontScaled = new Font(s_defaultFont.FontFamily, s_defaultFont.Size * textScaleFactor, s_defaultFont.Style, s_defaultFont.Unit);
             }
         }
 
@@ -1303,7 +1303,7 @@ namespace System.Windows.Forms
             else
             {
                 s_defaultFont = font;
-                ScaleDefaultFont();
+                ScaleDefaultFont(DpiHelper.GetTextScaleFactor());
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12143,12 +12143,13 @@ namespace System.Windows.Forms
                 // Dpi change requires font to be recalculated inorder to get controls scaled with right dpi.
                 if (_oldDeviceDpi != _deviceDpi)
                 {
-                    // Checking if font was inherited from parent. Font inherited from parent will receive OnParentFontChanged() events to scale those controls.
-                    Font local = (Font)Properties.GetObject(s_fontProperty);
-                    if (local is not null)
+                    // Checking if font was inherited from parent. Font inherited from parent will receive OnParentFontChanged()
+                    // events to scale those controls.
+                    Font currentFont = (Font)Properties.GetObject(s_fontProperty);
+                    if (currentFont is not null)
                     {
-                        var factor = (float)_deviceDpi / _oldDeviceDpi;
-                        Font = new Font(local.FontFamily, local.Size * factor, local.Style, local.Unit, local.GdiCharSet, local.GdiVerticalFont);
+                        float factor = (float)_deviceDpi / _oldDeviceDpi;
+                        Font = currentFont.WithSize(currentFont.Size * factor);
                     }
 
                     RescaleConstantsForDpi(_oldDeviceDpi, _deviceDpi);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -11614,7 +11614,7 @@ namespace System.Windows.Forms
             if (pref.Category == UserPreferenceCategory.Color)
             {
                 s_defaultFont = null;
-                Application.ScaleDefaultFont();
+                Application.ScaleDefaultFont(DpiHelper.GetTextScaleFactor());
                 OnSystemColorsChanged(EventArgs.Empty);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -755,12 +755,11 @@ namespace System.Windows.Forms
                             continue;
 
                         // Checking if font was inherited from parent.
-                        Font local = childItem.Font;
-                        if (!local.Equals(childItem.OwnerItem?.Font))
+                        Font currentFont = childItem.Font;
+                        if (!currentFont.Equals(childItem.OwnerItem?.Font))
                         {
-                            var factor = (float)newDpi / oldDpi;
-                            childItem.Font = new Font(local.FontFamily, local.Size * factor, local.Style,
-                                                    local.Unit, local.GdiCharSet, local.GdiVerticalFont);
+                            float factor = (float)newDpi / oldDpi;
+                            childItem.Font = currentFont.WithSize(currentFont.Size * factor);
                         }
 
                         childItem.DeviceDpi = newDpi;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -225,7 +225,7 @@ namespace System.Windows.Forms.Tests
 
                 AreFontEqual(scaled, Application.DefaultFont);
 
-                Application.ScaleDefaultFont(/* default scaling factor */1.0f);
+                Application.ScaleDefaultFont(DpiHelper.MinTextScaleFactorValue);
 
                 // The font is not scaled at 100% (factor=1.0)
                 Assert.Null(applicationTestAccessor.s_defaultFontScaled);
@@ -303,7 +303,7 @@ namespace System.Windows.Forms.Tests
                 Application.ScaleDefaultFont(4.0f);
 
                 Assert.NotNull(applicationTestAccessor.s_defaultFontScaled);
-                Assert.Equal(12f * 2.25f, applicationTestAccessor.s_defaultFontScaled.SizeInPoints);
+                Assert.Equal(12f * DpiHelper.MaxTextScaleFactorValue, applicationTestAccessor.s_defaultFontScaled.SizeInPoints);
             }
             finally
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationTests.cs
@@ -209,12 +209,136 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        private static void AreFontEqual(Font expected, Font actual)
+        [WinFormsFact]
+        public void Application_ScaleDefaultFont_Disposes_ScaleDefaultFont_IfExists()
         {
-            Assert.Equal(expected.Name, actual.Name);
-            Assert.Equal(expected.SizeInPoints, actual.SizeInPoints);
-            Assert.Equal(expected.GdiCharSet, actual.GdiCharSet);
-            Assert.Equal(expected.Style, actual.Style);
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+            Assert.Null(applicationTestAccessor.s_defaultFont);
+            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+
+            Font font = new Font(new FontFamily("Arial"), 12f);
+            Font scaled = new Font(new FontFamily("Arial"), 16f);
+            try
+            {
+                applicationTestAccessor.s_defaultFont = font;
+                applicationTestAccessor.s_defaultFontScaled = scaled;
+
+                AreFontEqual(scaled, Application.DefaultFont);
+
+                Application.ScaleDefaultFont(/* default scaling factor */1.0f);
+
+                // The font is not scaled at 100% (factor=1.0)
+                Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+            }
+            finally
+            {
+                applicationTestAccessor.s_defaultFont = null;
+                font.Dispose();
+                scaled.Dispose();
+            }
+        }
+
+        [WinFormsFact]
+        public void Application_ScaleDefaultFont_Should_Not_Rescale_IfTextScaleFactorLessThan1()
+        {
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+            Assert.Null(applicationTestAccessor.s_defaultFont);
+            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+
+            Font font = new Font(new FontFamily("Arial"), 12f);
+            try
+            {
+                applicationTestAccessor.s_defaultFont = font;
+
+                Application.ScaleDefaultFont(0f);
+
+                // The font is not scaled at 100% (factor=1.0)
+                Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+            }
+            finally
+            {
+                applicationTestAccessor.s_defaultFont = null;
+                font.Dispose();
+            }
+        }
+
+        [WinFormsFact]
+        public void Application_ScaleDefaultFont_Should_Rescale_IfTextScaleFactorGreaterThan1()
+        {
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+            Assert.Null(applicationTestAccessor.s_defaultFont);
+            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+
+            Font font = new Font(new FontFamily("Arial"), 12f);
+            try
+            {
+                applicationTestAccessor.s_defaultFont = font;
+
+                Application.ScaleDefaultFont(2.0f);
+
+                Assert.NotNull(applicationTestAccessor.s_defaultFontScaled);
+                Assert.Equal(12f * 2, applicationTestAccessor.s_defaultFontScaled.SizeInPoints);
+            }
+            finally
+            {
+                applicationTestAccessor.s_defaultFont = null;
+                applicationTestAccessor.s_defaultFontScaled.Dispose();
+                applicationTestAccessor.s_defaultFontScaled = null;
+                font.Dispose();
+            }
+        }
+
+        [WinFormsFact]
+        public void Application_ScaleDefaultFont_Should_Cap_Rescale_ToTextScaleFactor225()
+        {
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+            Assert.Null(applicationTestAccessor.s_defaultFont);
+            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+
+            Font font = new Font(new FontFamily("Arial"), 12f);
+            try
+            {
+                applicationTestAccessor.s_defaultFont = font;
+
+                Application.ScaleDefaultFont(4.0f);
+
+                Assert.NotNull(applicationTestAccessor.s_defaultFontScaled);
+                Assert.Equal(12f * 2.25f, applicationTestAccessor.s_defaultFontScaled.SizeInPoints);
+            }
+            finally
+            {
+                applicationTestAccessor.s_defaultFont = null;
+                applicationTestAccessor.s_defaultFontScaled.Dispose();
+                applicationTestAccessor.s_defaultFontScaled = null;
+                font.Dispose();
+            }
+        }
+
+        [WinFormsFact]
+        public void Application_ScaleDefaultFont_Should_Rescale_FontCorrectly()
+        {
+            var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
+            Assert.Null(applicationTestAccessor.s_defaultFont);
+            Assert.Null(applicationTestAccessor.s_defaultFontScaled);
+
+            Font font = new Font(new FontFamily("Arial"), 12f, FontStyle.Italic | FontStyle.Underline, GraphicsUnit.Pixel);
+            Font scaled = new Font(new FontFamily("Arial"), 18f, FontStyle.Italic | FontStyle.Underline, GraphicsUnit.Pixel);
+            try
+            {
+                applicationTestAccessor.s_defaultFont = font;
+
+                Application.ScaleDefaultFont(1.5f);
+
+                Assert.NotNull(applicationTestAccessor.s_defaultFontScaled);
+                AreFontEqual(scaled, applicationTestAccessor.s_defaultFontScaled);
+            }
+            finally
+            {
+                applicationTestAccessor.s_defaultFont = null;
+                applicationTestAccessor.s_defaultFontScaled = null;
+                font.Dispose();
+                scaled.Dispose();
+            }
         }
 
         [WinFormsFact]
@@ -234,7 +358,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void Application_SetDefaultFont_MustCloseSystemFont()
+        public void Application_SetDefaultFont_MustCloneSystemFont()
         {
             var applicationTestAccessor = typeof(Application).TestAccessor().Dynamic;
             Assert.Null(applicationTestAccessor.s_defaultFont);
@@ -272,6 +396,14 @@ namespace System.Windows.Forms.Tests
         public void Application_SetHighDpiMode_SetInvalidValue_ThrowsInvalidEnumArgumentException(HighDpiMode value)
         {
             Assert.Throws<InvalidEnumArgumentException>("highDpiMode", () => Application.SetHighDpiMode(value));
+        }
+
+        private static void AreFontEqual(Font expected, Font actual)
+        {
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.SizeInPoints, actual.SizeInPoints);
+            Assert.Equal(expected.GdiCharSet, actual.GdiCharSet);
+            Assert.Equal(expected.Style, actual.Style);
         }
 
         private class CustomLCIDCultureInfo : CultureInfo


### PR DESCRIPTION
Fixes #4978



## Proposed changes

- Preserve font styles when rescale default font



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

See https://github.com/dotnet/winforms/issues/4978

### After

![fontstyle1](https://user-images.githubusercontent.com/4403806/120415587-27ce9b00-c39f-11eb-82b1-fdd2474616de.gif)


## Test methodology <!-- How did you ensure quality? -->

- manual
- unit tests

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5030)