### PR TITLE
Enhance Invoke and BeginInvoke signatures

### DIFF
--- a/Winforms.sln
+++ b/Winforms.sln
@@ -155,6 +155,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DesignSurfaceExt", "src\Sys
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MauiImageListTests", "src\System.Windows.Forms\tests\IntegrationTests\MauiTests\ImageListTests\MauiImageListTests.csproj", "{0B4C8C7D-6157-46D4-AC1E-DF27F96C7AF6}"
 EndProject
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.VisualBasic.Forms.Tests", "src\Microsoft.VisualBasic.Forms\tests\UnitTests\Microsoft.VisualBasic.Forms.Tests.vbproj", "{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -871,6 +873,22 @@ Global
 		{0B4C8C7D-6157-46D4-AC1E-DF27F96C7AF6}.Release|x64.Build.0 = Release|Any CPU
 		{0B4C8C7D-6157-46D4-AC1E-DF27F96C7AF6}.Release|x86.ActiveCfg = Release|Any CPU
 		{0B4C8C7D-6157-46D4-AC1E-DF27F96C7AF6}.Release|x86.Build.0 = Release|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Debug|arm64.ActiveCfg = Debug|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Debug|arm64.Build.0 = Debug|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Debug|x64.Build.0 = Debug|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Debug|x86.Build.0 = Debug|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Release|arm64.ActiveCfg = Release|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Release|arm64.Build.0 = Release|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Release|x64.ActiveCfg = Release|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Release|x64.Build.0 = Release|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Release|x86.ActiveCfg = Release|Any CPU
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -928,6 +946,7 @@ Global
 		{93310A19-DDCA-4BCD-AEDE-5C5D788DAFB4} = {43E46506-7DF8-4E7A-A579-996CA43041EB}
 		{E96C74BA-9F74-4289-BF72-45CAD472D3D2} = {43E46506-7DF8-4E7A-A579-996CA43041EB}
 		{0B4C8C7D-6157-46D4-AC1E-DF27F96C7AF6} = {8F20A905-BD37-4D80-B8DF-FA45276FC23F}
+		{FC75CB54-D8D0-4B41-9A4D-9F862F34A02D} = {583F1292-AE8D-4511-B8D8-A81FE4642DDC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7B1B0433-F612-4E5A-BE7E-FCF5B9F6E136}

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/Microsoft.VisualBasic.Forms.Tests.vbproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualBasic.Forms.Tests</RootNamespace>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\System.Design\src\System.Design.Facade.csproj" />
+    <ProjectReference Include="..\..\..\System.Drawing\src\System.Drawing.Facade.csproj" />
+    <ProjectReference Include="..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
+    <ProjectReference Include="..\..\..\System.Windows.Forms.Primitives\tests\TestUtilities\System.Windows.Forms.Primitives.TestUtilities.csproj" />
+    <ProjectReference Include="..\..\..\System.Windows.Forms\tests\TestUtilities\System.Windows.Forms.TestUtilities.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.VisualBasic.Forms.vbproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- workaround for https://github.com/dotnet/sdk/issues/3254 -->
+    <Reference Include="$(BaseOutputPath)..\System.Drawing.Facade\$(Configuration)\$(TargetFramework)\System.Drawing.dll" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.vb
@@ -1,0 +1,107 @@
+﻿' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+' See the LICENSE file in the project root for more information.
+
+Imports System.Windows.Forms
+Imports Xunit
+
+Namespace Microsoft.VisualBasic.Forms.Tests
+    Partial Public Class ControlTests : Implements IClassFixture(Of ThreadExceptionFixture)
+
+        <WinFormsFact>
+        Public Sub Control_Invoke_Action_calls_correct_method()
+            Using _control As New Control
+                _control.CreateControl()
+
+                Dim invoker As Action = AddressOf FaultingMethod
+                Dim exception = Assert.Throws(Of DivideByZeroException)(Sub()
+                                                                            _control.Invoke(invoker)
+                                                                        End Sub)
+
+                '    Expecting something Like the following.
+                '    The first frame must be the this method, followed by MarshaledInvoke at previous location.
+                '
+                '    at Microsoft.VisualBasic.Forms.Tests.Microsoft.VisualBasic.Forms.Tests.ControlTests.FaultingMethod() in ...\winforms\src\Microsoft.VisualBasic.Forms\tests\UnitTests\ControlTests.vb:line 28
+                '       at System.Windows.Forms.Control.InvokeMarshaledCallbackDo(ThreadMethodEntry tme) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6511
+                '       at System.Windows.Forms.Control.InvokeMarshaledCallbackHelper(Object obj) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6487
+                '       at System.Windows.Forms.Control.InvokeMarshaledCallback(ThreadMethodEntry tme) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6459
+                '       at System.Windows.Forms.Control.InvokeMarshaledCallbacks() in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6563
+                '    --- End of stack trace from previous location ---
+                '       at System.Windows.Forms.Control.MarshaledInvoke(Control caller, Delegate method, Object[] args, Boolean synchronous) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6951
+                '       at System.Windows.Forms.Control.Invoke(Delegate method, Object[] args) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6413
+                '       at System.Windows.Forms.Control.Invoke(Delegate method) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6393
+                '       at Microsoft.VisualBasic.Forms.Tests.Microsoft.VisualBasic.Forms.Tests.ControlTests._Closure$__1-1._Lambda$__0() in ...\winforms\src\Microsoft.VisualBasic.Forms\tests\UnitTests\ControlTests.vb:line 18
+
+                Assert.Contains(NameOf(FaultingMethod), exception.StackTrace)
+                Assert.Contains(" System.Windows.Forms.Control.Invoke(Action method) ", exception.StackTrace)
+            End Using
+        End Sub
+
+        <WinFormsFact>
+        Public Sub Control_Invoke_Delegate_MethodInvoker_calls_correct_method()
+            Using _control As New Control
+                _control.CreateControl()
+
+                Dim invoker As New MethodInvoker(AddressOf FaultingMethod)
+                Dim exception = Assert.Throws(Of DivideByZeroException)(Sub()
+                                                                            _control.Invoke(invoker)
+                                                                        End Sub)
+
+                '    Expecting something Like the following.
+                '    The first frame must be the this method, followed by MarshaledInvoke at previous location.
+                '
+                '    at Microsoft.VisualBasic.Forms.Tests.Microsoft.VisualBasic.Forms.Tests.ControlTests.FaultingMethod() in ...\winforms\src\Microsoft.VisualBasic.Forms\tests\UnitTests\ControlTests.vb:line 28
+                '       at System.Windows.Forms.Control.InvokeMarshaledCallbackDo(ThreadMethodEntry tme) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6511
+                '       at System.Windows.Forms.Control.InvokeMarshaledCallbackHelper(Object obj) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6487
+                '       at System.Windows.Forms.Control.InvokeMarshaledCallback(ThreadMethodEntry tme) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6459
+                '       at System.Windows.Forms.Control.InvokeMarshaledCallbacks() in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6563
+                '    --- End of stack trace from previous location ---
+                '       at System.Windows.Forms.Control.MarshaledInvoke(Control caller, Delegate method, Object[] args, Boolean synchronous) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6951
+                '       at System.Windows.Forms.Control.Invoke(Delegate method, Object[] args) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6413
+                '       at System.Windows.Forms.Control.Invoke(Delegate method) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6393
+                '       at Microsoft.VisualBasic.Forms.Tests.Microsoft.VisualBasic.Forms.Tests.ControlTests._Closure$__1-1._Lambda$__0() in ...\winforms\src\Microsoft.VisualBasic.Forms\tests\UnitTests\ControlTests.vb:line 18
+
+                Assert.Contains(NameOf(FaultingMethod), exception.StackTrace)
+                Assert.Contains(" System.Windows.Forms.Control.Invoke(Delegate method) ", exception.StackTrace)
+            End Using
+        End Sub
+
+        <WinFormsFact>
+        Public Sub Control_Invoke_Func_calls_correct_method()
+            Using _control As New Control
+                _control.CreateControl()
+
+                Dim invoker As Func(Of Integer, Integer) = AddressOf FaultingFunc
+                Dim exception = Assert.Throws(Of DivideByZeroException)(Sub()
+                                                                            Dim result = _control.Invoke(Function() invoker(19))
+                                                                        End Sub)
+
+                '    Expecting something Like the following.
+                '    The first frame must be the this method, followed by MarshaledInvoke at previous location.
+                '
+                '    at Microsoft.VisualBasic.Forms.Tests.Microsoft.VisualBasic.Forms.Tests.ControlTests.FaultingFunc(Int32 a) in ...\winforms\src\Microsoft.VisualBasic.Forms\tests\UnitTests\ControlTests.vb:line 144
+                '       at Microsoft.VisualBasic.Forms.Tests.Microsoft.VisualBasic.Forms.Tests.ControlTests._Closure$__4-1._Lambda$__1() in ...\winforms\src\Microsoft.VisualBasic.Forms\tests\UnitTests\ControlTests.vb:line 112
+                '    --- End of stack trace from previous location ---
+                '       at System.Windows.Forms.Control.MarshaledInvoke(Control caller, Delegate method, Object[] args, Boolean synchronous) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6951
+                '       at System.Windows.Forms.Control.Invoke(Delegate method, Object[] args) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6413
+                '       at System.Windows.Forms.Control.Invoke[T](Func`1 method) in ...\winforms\src\System.Windows.Forms\src\System\Windows\Forms\Control.cs:line 6422
+                '       at Microsoft.VisualBasic.Forms.Tests.Microsoft.VisualBasic.Forms.Tests.ControlTests._Closure$__4-1._Lambda$__0() in ...\winforms\src\Microsoft.VisualBasic.Forms\tests\UnitTests\ControlTests.vb:line 111
+                '       at Xunit.Assert.RecordException(Action testCode) in C:\Dev\xunit\xunit\src\xunit.assert\Asserts\Record.cs:line 27
+
+                Assert.Contains(NameOf(FaultingFunc), exception.StackTrace)
+                Assert.Contains(" System.Windows.Forms.Control.Invoke[T](Func`1 method) ", exception.StackTrace)
+            End Using
+        End Sub
+
+        Shared Sub FaultingMethod()
+            Throw New DivideByZeroException()
+        End Sub
+
+        Shared Function FaultingFunc(a As Integer) As Integer
+            Return a \ 0
+        End Function
+
+    End Class
+
+End Namespace
+

--- a/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.vb
+++ b/src/Microsoft.VisualBasic.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.vb
@@ -14,9 +14,8 @@ Namespace Microsoft.VisualBasic.Forms.Tests
                 _control.CreateControl()
 
                 Dim invoker As Action = AddressOf FaultingMethod
-                Dim exception = Assert.Throws(Of DivideByZeroException)(Sub()
-                                                                            _control.Invoke(invoker)
-                                                                        End Sub)
+                Dim exception = Assert.Throws(Of DivideByZeroException)(
+                    Sub() _control.Invoke(invoker))
 
                 '    Expecting something Like the following.
                 '    The first frame must be the this method, followed by MarshaledInvoke at previous location.
@@ -43,9 +42,8 @@ Namespace Microsoft.VisualBasic.Forms.Tests
                 _control.CreateControl()
 
                 Dim invoker As New MethodInvoker(AddressOf FaultingMethod)
-                Dim exception = Assert.Throws(Of DivideByZeroException)(Sub()
-                                                                            _control.Invoke(invoker)
-                                                                        End Sub)
+                Dim exception = Assert.Throws(Of DivideByZeroException)(
+                    Sub() _control.Invoke(invoker))
 
                 '    Expecting something Like the following.
                 '    The first frame must be the this method, followed by MarshaledInvoke at previous location.
@@ -72,9 +70,10 @@ Namespace Microsoft.VisualBasic.Forms.Tests
                 _control.CreateControl()
 
                 Dim invoker As Func(Of Integer, Integer) = AddressOf FaultingFunc
-                Dim exception = Assert.Throws(Of DivideByZeroException)(Sub()
-                                                                            Dim result = _control.Invoke(Function() invoker(19))
-                                                                        End Sub)
+                Dim exception = Assert.Throws(Of DivideByZeroException)(
+                    Sub()
+                        Dim result = _control.Invoke(Function() invoker(19))
+                    End Sub)
 
                 '    Expecting something Like the following.
                 '    The first frame must be the this method, followed by MarshaledInvoke at previous location.

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,5 @@
 override System.Windows.Forms.ContainerControl.RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew) -> void
 *REMOVED*override System.Windows.Forms.PropertyGrid.RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew) -> void
+~System.Windows.Forms.Control.BeginInvoke(System.Action method) -> System.IAsyncResult
+~System.Windows.Forms.Control.Invoke(System.Action method) -> void
+~System.Windows.Forms.Control.Invoke<T>(System.Func<T> method) -> T


### PR DESCRIPTION


Closes #4608



## Proposed changes

Add overloads that takes `Action` and `Func<T>` as a parameter:

* `IAsyncResult BeginInvoke(Action method)`
* `void Invoke(Action method)`
* `T Invoke<T>(Func<T> method)`

<!-- We are in TELL-MODE the following section must be completed -->


## Test methodology <!-- How did you ensure quality? -->

- manual
- unit tests for both C# and VB


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5043)