### PR TITLE
Bring PropertyGrid members up to guidelines

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.SnappableControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.SnappableControl.cs
@@ -12,24 +12,21 @@ namespace System.Windows.Forms
     {
         internal abstract class SnappableControl : Control
         {
-            protected PropertyGrid ownerPropertyGrid;
-            internal bool userSized;
+            protected PropertyGrid OwnerPropertyGrid { get; }
+            internal bool UserSized { get; set; }
 
             public abstract int GetOptimalHeight(int width);
             public abstract int SnapHeightRequest(int request);
 
             public SnappableControl(PropertyGrid ownerPropertyGrid)
             {
-                this.ownerPropertyGrid = ownerPropertyGrid;
+                OwnerPropertyGrid = ownerPropertyGrid;
                 SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
             }
 
             public override Cursor Cursor
             {
-                get
-                {
-                    return Cursors.Default;
-                }
+                get => Cursors.Default;
                 set => base.Cursor = value;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -22,7 +22,7 @@ using static Interop;
 
 namespace System.Windows.Forms
 {
-    [Designer("System.Windows.Forms.Design.PropertyGridDesigner, " + AssemblyRef.SystemDesign)]
+    [Designer($"System.Windows.Forms.Design.PropertyGridDesigner, {AssemblyRef.SystemDesign}")]
     [SRDescription(nameof(SR.DescriptionPropertyGrid))]
     public partial class PropertyGrid : ContainerControl, IComPropertyBrowser, Ole32.IPropertyNotifySink
     {
@@ -3108,7 +3108,7 @@ namespace System.Windows.Forms
                     if (_doccomment.Visible)
                     {
                         dcOptHeight = _doccomment.GetOptimalHeight(Size.Width - s_cyDivider);
-                        if (_doccomment.userSized)
+                        if (_doccomment.UserSized)
                         {
                             dcRequestedHeight = _doccomment.Size.Height;
                         }
@@ -3125,7 +3125,7 @@ namespace System.Windows.Forms
                     if (_hotcommands.Visible)
                     {
                         hcOptHeight = _hotcommands.GetOptimalHeight(Size.Width - s_cyDivider);
-                        if (_hotcommands.userSized)
+                        if (_hotcommands.UserSized)
                         {
                             hcRequestedHeight = _hotcommands.Size.Height;
                         }
@@ -3168,9 +3168,9 @@ namespace System.Windows.Forms
                     // if we've modified the height to less than the optimal, clear the userSized item
                     if (height <= dcOptHeight && height < dcRequestedHeight)
                     {
-                        _doccomment.userSized = false;
+                        _doccomment.UserSized = false;
                     }
-                    else if (_dcSizeRatio != -1 || _doccomment.userSized)
+                    else if (_dcSizeRatio != -1 || _doccomment.UserSized)
                     {
                         _dcSizeRatio = (_doccomment.Height * 100) / Height;
                     }
@@ -3201,9 +3201,9 @@ namespace System.Windows.Forms
                     // if we've modified the height, clear the userSized item
                     if (height <= hcOptHeight && height < hcRequestedHeight)
                     {
-                        _hotcommands.userSized = false;
+                        _hotcommands.UserSized = false;
                     }
-                    else if (_hcSizeRatio != -1 || _hotcommands.userSized)
+                    else if (_hcSizeRatio != -1 || _hotcommands.UserSized)
                     {
                         _hcSizeRatio = (_hotcommands.Height * 100) / Height;
                     }
@@ -3282,7 +3282,7 @@ namespace System.Windows.Forms
                 Size size = _targetMove.Size;
                 size.Height = Math.Max(0, yNew);
                 _targetMove.Size = size;
-                _targetMove.userSized = true;
+                _targetMove.UserSized = true;
                 OnLayoutInternal(true);
                 // invalidate the divider area so we cleanup anything
                 // left by the xor

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ArrayElementGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ArrayElementGridEntry.cs
@@ -44,13 +44,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        public override Type PropertyType
-        {
-            get
-            {
-                return parentPE.PropertyType.GetElementType();
-            }
-        }
+        public override Type PropertyType => ParentGridEntry.PropertyType.GetElementType();
 
         public override object PropertyValue
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DetailsButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DetailsButton.cs
@@ -8,18 +8,18 @@ namespace System.Windows.Forms.PropertyGridInternal
 {
     internal partial class DetailsButton : Button
     {
-        private readonly GridErrorDlg parent;
+        private readonly GridErrorDlg _parent;
 
         public DetailsButton(GridErrorDlg form)
         {
-            parent = form;
+            _parent = form;
         }
 
         public bool Expanded
         {
             get
             {
-                return parent.DetailsButtonExpanded;
+                return _parent.DetailsButtonExpanded;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DocComment.cs
@@ -5,38 +5,37 @@
 #nullable disable
 
 using System.Drawing;
-using static Interop;
 
 namespace System.Windows.Forms.PropertyGridInternal
 {
     internal partial class DocComment : PropertyGrid.SnappableControl
     {
-        private readonly Label m_labelTitle;
-        private readonly Label m_labelDesc;
-        private string fullDesc;
+        private readonly Label _labelTitle;
+        private readonly Label _labelDesc;
+        private string _fullDesc;
 
-        protected int lineHeight;
-        private bool needUpdateUIWithFont = true;
+        private int _lineHeight;
+        private bool _needUpdateUIWithFont = true;
 
         protected const int CBORDER = 3;
         protected const int CXDEF = 0;
         protected const int CYDEF = 59;
         protected const int MIN_LINES = 2;
 
-        private int cydef = CYDEF;
-        private int cBorder = CBORDER;
+        private int _cydef = CYDEF;
+        private int _cBorder = CBORDER;
 
-        internal Rectangle rect = Rectangle.Empty;
+        private Rectangle _rect = Rectangle.Empty;
 
         internal DocComment(PropertyGrid owner) : base(owner)
         {
             SuspendLayout();
-            m_labelTitle = new Label
+            _labelTitle = new Label
             {
                 UseMnemonic = false,
                 Cursor = Cursors.Default
             };
-            m_labelDesc = new Label
+            _labelDesc = new Label
             {
                 AutoEllipsis = true,
                 Cursor = Cursors.Default
@@ -44,15 +43,15 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             UpdateTextRenderingEngine();
 
-            Controls.Add(m_labelTitle);
-            Controls.Add(m_labelDesc);
+            Controls.Add(_labelTitle);
+            Controls.Add(_labelDesc);
             if (DpiHelper.IsScalingRequirementMet)
             {
-                cBorder = LogicalToDeviceUnits(CBORDER);
-                cydef = LogicalToDeviceUnits(CYDEF);
+                _cBorder = LogicalToDeviceUnits(CBORDER);
+                _cydef = LogicalToDeviceUnits(CYDEF);
             }
 
-            Size = new Size(CXDEF, cydef);
+            Size = new Size(CXDEF, _cydef);
 
             Text = SR.PBRSDocCommentPaneTitle;
             SetStyle(ControlStyles.Selectable, false);
@@ -64,12 +63,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 UpdateUIWithFont();
-                return Height / lineHeight;
+                return Height / _lineHeight;
             }
             set
             {
                 UpdateUIWithFont();
-                Size = new Size(Width, 1 + value * lineHeight);
+                Size = new Size(Width, 1 + value * _lineHeight);
             }
         }
 
@@ -77,19 +76,19 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             UpdateUIWithFont();
             // compute optimal label height as one line only.
-            int height = m_labelTitle.Size.Height;
+            int height = _labelTitle.Size.Height;
 
             // do this to avoid getting parented to the Parking window.
             //
-            if (ownerPropertyGrid.IsHandleCreated && !IsHandleCreated)
+            if (OwnerPropertyGrid.IsHandleCreated && !IsHandleCreated)
             {
                 CreateControl();
             }
 
             // compute optimal text height
             var isScalingRequirementMet = DpiHelper.IsScalingRequirementMet;
-            Graphics g = m_labelDesc.CreateGraphicsInternal();
-            SizeF sizef = PropertyGrid.MeasureTextHelper.MeasureText(ownerPropertyGrid, g, m_labelTitle.Text, Font, width);
+            Graphics g = _labelDesc.CreateGraphicsInternal();
+            SizeF sizef = PropertyGrid.MeasureTextHelper.MeasureText(OwnerPropertyGrid, g, _labelTitle.Text, Font, width);
             Size sz = Size.Ceiling(sizef);
             g.Dispose();
             var padding = isScalingRequirementMet ? LogicalToDeviceUnits(2) : 2;
@@ -103,7 +102,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected override void OnFontChanged(EventArgs e)
         {
-            needUpdateUIWithFont = true;
+            _needUpdateUIWithFont = true;
             PerformLayout();
             base.OnFontChanged(e);
         }
@@ -112,34 +111,34 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             UpdateUIWithFont();
             SetChildLabelsBounds();
-            m_labelDesc.Text = fullDesc;
-            m_labelDesc.AccessibleName = fullDesc; // Don't crop the description for accessibility clients
+            _labelDesc.Text = _fullDesc;
+            _labelDesc.AccessibleName = _fullDesc; // Don't crop the description for accessibility clients
             base.OnLayout(e);
         }
 
         protected override void OnResize(EventArgs e)
         {
             Rectangle newRect = ClientRectangle;
-            if (!rect.IsEmpty && newRect.Width > rect.Width)
+            if (!_rect.IsEmpty && newRect.Width > _rect.Width)
             {
-                Rectangle rectInvalidate = new Rectangle(rect.Width - 1, 0, newRect.Width - rect.Width + 1, rect.Height);
+                Rectangle rectInvalidate = new Rectangle(_rect.Width - 1, 0, newRect.Width - _rect.Width + 1, _rect.Height);
                 Invalidate(rectInvalidate);
             }
 
             if (DpiHelper.IsScalingRequirementMet)
             {
-                var lineHeightOld = lineHeight;
-                lineHeight = (int)Font.Height + LogicalToDeviceUnits(2);
-                if (lineHeightOld != lineHeight)
+                var lineHeightOld = _lineHeight;
+                _lineHeight = (int)Font.Height + LogicalToDeviceUnits(2);
+                if (lineHeightOld != _lineHeight)
                 {
-                    m_labelTitle.Location = new Point(cBorder, cBorder);
-                    m_labelDesc.Location = new Point(cBorder, cBorder + lineHeight);
+                    _labelTitle.Location = new Point(_cBorder, _cBorder);
+                    _labelDesc.Location = new Point(_cBorder, _cBorder + _lineHeight);
                     // Labels were explicitly set bounds. resize of parent is not rescaling labels.
                     SetChildLabelsBounds();
                 }
             }
 
-            rect = newRect;
+            _rect = newRect;
             base.OnResize(e);
         }
 
@@ -152,19 +151,19 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             // if the client size is 0, setting this to a negative number
             // will force an extra layout.
-            size.Width = Math.Max(0, size.Width - 2 * cBorder);
-            size.Height = Math.Max(0, size.Height - 2 * cBorder);
+            size.Width = Math.Max(0, size.Width - 2 * _cBorder);
+            size.Height = Math.Max(0, size.Height - 2 * _cBorder);
 
-            m_labelTitle.SetBounds(m_labelTitle.Top,
-                                   m_labelTitle.Left,
+            _labelTitle.SetBounds(_labelTitle.Top,
+                                   _labelTitle.Left,
                                    size.Width,
-                                   Math.Min(lineHeight, size.Height),
+                                   Math.Min(_lineHeight, size.Height),
                                    BoundsSpecified.Size);
 
-            m_labelDesc.SetBounds(m_labelDesc.Top,
-                                  m_labelDesc.Left,
+            _labelDesc.SetBounds(_labelDesc.Top,
+                                  _labelDesc.Left,
                                   size.Width,
-                                  Math.Max(0, size.Height - lineHeight - (DpiHelper.IsScalingRequirementMet ? LogicalToDeviceUnits(1) : 1)),
+                                  Math.Max(0, size.Height - _lineHeight - (DpiHelper.IsScalingRequirementMet ? LogicalToDeviceUnits(1) : 1)),
                                   BoundsSpecified.Size);
         }
 
@@ -184,31 +183,31 @@ namespace System.Windows.Forms.PropertyGridInternal
             base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
             if (DpiHelper.IsScalingRequirementMet)
             {
-                cBorder = LogicalToDeviceUnits(CBORDER);
-                cydef = LogicalToDeviceUnits(CYDEF);
+                _cBorder = LogicalToDeviceUnits(CBORDER);
+                _cydef = LogicalToDeviceUnits(CYDEF);
             }
         }
 
         public virtual void SetComment(string title, string desc)
         {
-            if (m_labelDesc.Text != title)
+            if (_labelDesc.Text != title)
             {
-                m_labelTitle.Text = title;
+                _labelTitle.Text = title;
             }
 
-            if (desc != fullDesc)
+            if (desc != _fullDesc)
             {
-                fullDesc = desc;
-                m_labelDesc.Text = fullDesc;
-                m_labelDesc.AccessibleName = fullDesc; // Don't crop the description for accessibility clients
+                _fullDesc = desc;
+                _labelDesc.Text = _fullDesc;
+                _labelDesc.AccessibleName = _fullDesc; // Don't crop the description for accessibility clients
             }
         }
 
         public override int SnapHeightRequest(int cyNew)
         {
             UpdateUIWithFont();
-            int lines = Math.Max(MIN_LINES, cyNew / lineHeight);
-            return 1 + lines * lineHeight;
+            int lines = Math.Max(MIN_LINES, cyNew / _lineHeight);
+            return 1 + lines * _lineHeight;
         }
 
         /// <summary>
@@ -217,7 +216,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <returns>The accessibility object for this control.</returns>
         protected override AccessibleObject CreateAccessibilityInstance()
         {
-            return new DocCommentAccessibleObject(this, ownerPropertyGrid);
+            return new DocCommentAccessibleObject(this, OwnerPropertyGrid);
         }
 
         /// <summary>
@@ -228,29 +227,29 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal void UpdateTextRenderingEngine()
         {
-            m_labelTitle.UseCompatibleTextRendering = ownerPropertyGrid.UseCompatibleTextRendering;
-            m_labelDesc.UseCompatibleTextRendering = ownerPropertyGrid.UseCompatibleTextRendering;
+            _labelTitle.UseCompatibleTextRendering = OwnerPropertyGrid.UseCompatibleTextRendering;
+            _labelDesc.UseCompatibleTextRendering = OwnerPropertyGrid.UseCompatibleTextRendering;
         }
 
         private void UpdateUIWithFont()
         {
-            if (IsHandleCreated && needUpdateUIWithFont)
+            if (IsHandleCreated && _needUpdateUIWithFont)
             {
                 // Some fonts throw because Bold is not a valid option
                 // for them.  Fail gracefully.
                 try
                 {
-                    m_labelTitle.Font = new Font(Font, FontStyle.Bold);
+                    _labelTitle.Font = new Font(Font, FontStyle.Bold);
                 }
                 catch
                 {
                 }
 
-                lineHeight = (int)Font.Height + 2;
-                m_labelTitle.Location = new Point(cBorder, cBorder);
-                m_labelDesc.Location = new Point(cBorder, cBorder + lineHeight);
+                _lineHeight = (int)Font.Height + 2;
+                _labelTitle.Location = new Point(_cBorder, _cBorder);
+                _labelDesc.Location = new Point(_cBorder, _cBorder + _lineHeight);
 
-                needUpdateUIWithFont = false;
+                _needUpdateUIWithFont = false;
                 PerformLayout();
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.CacheItems.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.CacheItems.cs
@@ -10,17 +10,17 @@ namespace System.Windows.Forms.PropertyGridInternal
     {
         private class CacheItems
         {
-            public string? lastLabel;
-            public Font? lastLabelFont;
-            public int lastLabelWidth;
-            public bool lastShouldSerialize;
-            public object? lastValue;
-            public Font? lastValueFont;
-            public string? lastValueString;
-            public int lastValueTextWidth;
-            public bool useCompatTextRendering;
-            public bool useShouldSerialize;
-            public bool useValueString;
+            public string? LastLabel;
+            public Font? LastLabelFont;
+            public int LastLabelWidth;
+            public bool LastShouldSerialize;
+            public object? LastValue;
+            public Font? LastValueFont;
+            public string? LastValueString;
+            public int LastValueTextWidth;
+            public bool UseCompatTextRendering;
+            public bool UseShouldSerialize;
+            public bool UseValueString;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.DisplayNameSortComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.DisplayNameSortComparer.cs
@@ -16,8 +16,11 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             public int Compare(object left, object right)
             {
-                // review: (Microsoft) Is CurrentCulture correct here?  This was already reviewed as invariant...
-                return string.Compare(((PropertyDescriptor)left).DisplayName, ((PropertyDescriptor)right).DisplayName, true, CultureInfo.CurrentCulture);
+                return string.Compare(
+                    ((PropertyDescriptor)left).DisplayName,
+                    ((PropertyDescriptor)right).DisplayName,
+                    ignoreCase: true,
+                    CultureInfo.CurrentCulture);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.EventEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.EventEntry.cs
@@ -8,15 +8,15 @@ namespace System.Windows.Forms.PropertyGridInternal
     {
         private sealed class EventEntry
         {
-            internal Delegate _handler;
-            internal object _key;
-            internal EventEntry _next;
+            public Delegate Handler { get; set; }
+            public object Key { get; }
+            public EventEntry Next { get; set; }
 
             internal EventEntry(EventEntry next, object key, Delegate handler)
             {
-                this._next = next;
-                this._key = key;
-                this._handler = handler;
+                Next = next;
+                Key = key;
+                Handler = handler;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -119,7 +119,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     // Determine focus
                     //
-                    if (_owningGridEntry.Focus)
+                    if (_owningGridEntry.HasFocus)
                     {
                         state |= AccessibleStates.Focused;
                     }
@@ -293,7 +293,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// </summary>
             public override AccessibleObject? GetFocused()
             {
-                if (_owningGridEntry.Focus)
+                if (_owningGridEntry.HasFocus)
                 {
                     return this;
                 }
@@ -428,11 +428,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                         // button is one of the first children of PropertyGridView.
                         return UiaCore.UIA.TreeItemControlTypeId;
                     case UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId:
-                        return (Object)IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId);
+                        return IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId);
                     case UiaCore.UIA.AccessKeyPropertyId:
                         return string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
-                        return _owningGridEntry.hasFocus;
+                        return _owningGridEntry.HasFocus;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
                     case UiaCore.UIA.IsEnabledPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -1404,9 +1404,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected virtual void Dispose(bool disposing)
         {
-            // make sure we don't accidentally
-            // check flags in this state...
-            Flags |= FL_CHECKED;
+            // Make sure we don't accidentally check flags while disposing.
+            _flags |= FL_CHECKED;
 
             SetFlag(FLAG_DISPOSED, true);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -23,10 +23,12 @@ namespace System.Windows.Forms.PropertyGridInternal
     /// </summary>
     internal abstract partial class GridEntry : GridItem, ITypeDescriptorContext
     {
-        protected static readonly Point InvalidPoint = new Point(int.MinValue, int.MinValue);
-        private static readonly BooleanSwitch PbrsAssertPropsSwitch = new BooleanSwitch("PbrsAssertProps", "PropertyBrowser : Assert on broken properties");
+        protected static Point InvalidPoint { get; } = new(int.MinValue, int.MinValue);
 
-        internal static AttributeTypeSorter AttributeTypeSorter = new AttributeTypeSorter();
+        private static readonly BooleanSwitch s_pbrsAssertPropsSwitch
+            = new("PbrsAssertProps", "PropertyBrowser : Assert on broken properties");
+
+        internal static AttributeTypeSorter AttributeTypeSorter { get; } = new();
 
         // Type flags
         internal const int FLAG_TEXT_EDITABLE = 0x0001;
@@ -52,7 +54,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         internal const int FL_CATEGORIES = 0x00200000;
         internal const int FL_CHECKED = unchecked((int)0x80000000);
 
-        // rest are GridEntry constants.
+        // Rest are GridEntry constants.
 
         protected const int NOTIFY_RESET = 1;
         protected const int NOTIFY_CAN_RESET = 2;
@@ -62,12 +64,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected const int OUTLINE_ICON_PADDING = 5;
 
-        protected static IComparer DisplayNameComparer = new DisplayNameSortComparer();
+        protected static IComparer DisplayNameComparer { get; } = new DisplayNameSortComparer();
 
-        private static char passwordReplaceChar;
-        //Maximum number of characters we'll show in the property grid.  Too many characters leads
-        //to bad performance.
-        private const int maximumLengthOfPropertyString = 1000;
+        private static char s_passwordReplaceChar;
+
+        // Maximum number of characters we'll show in the property grid.  Too many characters leads
+        // to bad performance.
+        private const int MaximumLengthOfPropertyString = 1000;
 
         [Flags]
         internal enum PaintValueFlags
@@ -79,35 +82,34 @@ namespace System.Windows.Forms.PropertyGridInternal
             PaintInPlace = 0x8
         }
 
-        private CacheItems cacheItems;
+        private CacheItems _cacheItems;
 
-        // instance variables.
-        protected TypeConverter converter;
-        protected UITypeEditor editor;
-        internal GridEntry parentPE;
-        private GridEntryCollection childCollection;
-        internal int flags;
-        private int propertyDepth;
-        protected bool hasFocus;
-        private Rectangle outlineRect = Rectangle.Empty;
+        protected TypeConverter Converter { get; set; }
+        protected UITypeEditor Editor { get; set; }
+
+        private GridEntry _parentEntry;
+        private GridEntryCollection _childCollection;
+        private int _propertyDepth;
+        private bool _hasFocus;
+        private Rectangle _outlineRect = Rectangle.Empty;
+
+        internal int _flags;
         protected PropertySort PropertySort;
 
-        protected Point labelTipPoint = InvalidPoint;
-        protected Point valueTipPoint = InvalidPoint;
+        private Point _labelTipPoint = InvalidPoint;
+        private Point _valueTipPoint = InvalidPoint;
 
-        protected PropertyGrid ownerGrid;
+        private static readonly object s_valueClickEvent = new();
+        private static readonly object s_labelClickEvent = new();
+        private static readonly object s_outlineClickEvent = new();
+        private static readonly object s_valueDoubleClickEvent = new();
+        private static readonly object s_labelDoubleClickEvent = new();
+        private static readonly object s_outlineDoubleClickEvent = new();
+        private static readonly object s_recreateChildrenEvent = new();
 
-        private static readonly object EVENT_VALUE_CLICK = new object();
-        private static readonly object EVENT_LABEL_CLICK = new object();
-        private static readonly object EVENT_OUTLINE_CLICK = new object();
-        private static readonly object EVENT_VALUE_DBLCLICK = new object();
-        private static readonly object EVENT_LABEL_DBLCLICK = new object();
-        private static readonly object EVENT_OUTLINE_DBLCLICK = new object();
-        private static readonly object EVENT_RECREATE_CHILDREN = new object();
+        private GridEntryAccessibleObject _accessibleObject;
 
-        private GridEntryAccessibleObject accessibleObject;
-
-        private bool lastPaintWithExplorerStyle;
+        private bool _lastPaintWithExplorerStyle;
 
         private static Color InvertColor(Color color)
         {
@@ -116,24 +118,24 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected GridEntry(PropertyGrid owner, GridEntry peParent)
         {
-            parentPE = peParent;
-            ownerGrid = owner;
+            _parentEntry = peParent;
+            OwnerGrid = owner;
 
-            Debug.Assert(ownerGrid is not null, "GridEntry w/o PropertyGrid owner, text rendering will fail.");
+            Debug.Assert(OwnerGrid is not null, "GridEntry w/o PropertyGrid owner, text rendering will fail.");
 
             if (peParent is not null)
             {
-                propertyDepth = peParent.PropertyDepth + 1;
+                _propertyDepth = peParent.PropertyDepth + 1;
                 PropertySort = peParent.PropertySort;
 
                 if (peParent.ForceReadOnly)
                 {
-                    flags |= FLAG_FORCE_READONLY;
+                    Flags |= FLAG_FORCE_READONLY;
                 }
             }
             else
             {
-                propertyDepth = -1;
+                _propertyDepth = -1;
             }
         }
 
@@ -168,12 +170,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (accessibleObject is null)
+                if (_accessibleObject is null)
                 {
-                    accessibleObject = GetAccessibilityObject();
+                    _accessibleObject = GetAccessibilityObject();
                 }
 
-                return accessibleObject;
+                return _accessibleObject;
             }
         }
 
@@ -205,8 +207,8 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual AttributeCollection BrowsableAttributes
         {
-            get => parentPE?.BrowsableAttributes;
-            set => parentPE.BrowsableAttributes = value;
+            get => _parentEntry?.BrowsableAttributes;
+            set => _parentEntry.BrowsableAttributes = value;
         }
 
         /// <summary>
@@ -225,9 +227,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return (IComponent)owner;
                 }
 
-                if (parentPE is not null)
+                if (_parentEntry is not null)
                 {
-                    return parentPE.Component;
+                    return _parentEntry.Component;
                 }
 
                 return null;
@@ -238,7 +240,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return parentPE.ComponentChangeService;
+                return _parentEntry.ComponentChangeService;
             }
         }
 
@@ -271,25 +273,25 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (childCollection is null)
+                if (_childCollection is null)
                 {
-                    childCollection = new GridEntryCollection(this, null);
+                    _childCollection = new GridEntryCollection(this, null);
                 }
 
-                return childCollection;
+                return _childCollection;
             }
             set
             {
                 Debug.Assert(value is null || !Disposed, "Why are we putting new children in after we are disposed?");
-                if (childCollection != value)
+                if (_childCollection != value)
                 {
-                    if (childCollection is not null)
+                    if (_childCollection is not null)
                     {
-                        childCollection.Dispose();
-                        childCollection = null;
+                        _childCollection.Dispose();
+                        _childCollection = null;
                     }
 
-                    childCollection = value;
+                    _childCollection = value;
                 }
             }
         }
@@ -311,12 +313,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (childCollection is null && !Disposed)
+                if (_childCollection is null && !Disposed)
                 {
                     CreateChildren();
                 }
 
-                return childCollection;
+                return _childCollection;
             }
         }
 
@@ -324,18 +326,18 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (parentPE is not null)
+                if (_parentEntry is not null)
                 {
-                    return parentPE.CurrentTab;
+                    return _parentEntry.CurrentTab;
                 }
 
                 return null;
             }
             set
             {
-                if (parentPE is not null)
+                if (_parentEntry is not null)
                 {
-                    parentPE.CurrentTab = value;
+                    _parentEntry.CurrentTab = value;
                 }
             }
         }
@@ -357,18 +359,18 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (parentPE is not null)
+                if (_parentEntry is not null)
                 {
-                    return parentPE.DesignerHost;
+                    return _parentEntry.DesignerHost;
                 }
 
                 return null;
             }
             set
             {
-                if (parentPE is not null)
+                if (_parentEntry is not null)
                 {
-                    parentPE.DesignerHost = value;
+                    _parentEntry.DesignerHost = value;
                 }
             }
         }
@@ -385,7 +387,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (Flags & GridEntry.FLAG_ENUMERABLE) != 0;
+                return (Flags & FLAG_ENUMERABLE) != 0;
             }
         }
 
@@ -395,7 +397,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 bool fExpandable = GetFlagSet(FL_EXPANDABLE);
 
-                if (fExpandable && childCollection is not null && childCollection.Count > 0)
+                if (fExpandable && _childCollection is not null && _childCollection.Count > 0)
                 {
                     return true;
                 }
@@ -405,7 +407,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return false;
                 }
 
-                if (fExpandable && (cacheItems is null || cacheItems.lastValue is null) && PropertyValue is null)
+                if (fExpandable && (_cacheItems is null || _cacheItems.LastValue is null) && PropertyValue is null)
                 {
                     fExpandable = false;
                 }
@@ -430,7 +432,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (flags & FLAG_FORCE_READONLY) != 0;
+                return (Flags & FLAG_FORCE_READONLY) != 0;
             }
         }
 
@@ -439,7 +441,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 // short circuit if we don't have children
-                if (childCollection is null || childCollection.Count == 0)
+                if (_childCollection is null || _childCollection.Count == 0)
                 {
                     return false;
                 }
@@ -453,7 +455,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return;
                 }
 
-                if (childCollection is not null && childCollection.Count > 0)
+                if (_childCollection is not null && _childCollection.Count > 0)
                 {
                     SetFlag(FL_EXPAND, value);
                 }
@@ -490,12 +492,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if ((flags & FL_CHECKED) != 0)
+                if ((_flags & FL_CHECKED) != 0)
                 {
-                    return flags;
+                    return _flags;
                 }
 
-                flags |= FL_CHECKED;
+                _flags |= FL_CHECKED;
 
                 TypeConverter converter = TypeConverter;
                 UITypeEditor uiEditor = UITypeEditor;
@@ -509,46 +511,47 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (converter.GetStandardValuesSupported(this))
                 {
-                    flags |= GridEntry.FLAG_ENUMERABLE;
+                    _flags |= FLAG_ENUMERABLE;
                 }
 
                 if (!forceReadOnly && converter.CanConvertFrom(this, typeof(string)) &&
                     !converter.GetStandardValuesExclusive(this))
                 {
-                    flags |= GridEntry.FLAG_TEXT_EDITABLE;
+                    _flags |= FLAG_TEXT_EDITABLE;
                 }
 
-                bool isImmutableReadOnly = TypeDescriptor.GetAttributes(PropertyType)[typeof(ImmutableObjectAttribute)].Equals(ImmutableObjectAttribute.Yes);
+                bool isImmutableReadOnly = TypeDescriptor.GetAttributes(PropertyType)[typeof(ImmutableObjectAttribute)]
+                    .Equals(ImmutableObjectAttribute.Yes);
                 bool isImmutable = isImmutableReadOnly || converter.GetCreateInstanceSupported(this);
 
                 if (isImmutable)
                 {
-                    flags |= GridEntry.FLAG_IMMUTABLE;
+                    _flags |= FLAG_IMMUTABLE;
                 }
 
                 if (converter.GetPropertiesSupported(this))
                 {
-                    flags |= GridEntry.FL_EXPANDABLE;
+                    _flags |= FL_EXPANDABLE;
 
                     // If we're exapndable, but we don't support editing,
                     // make us read only editable so we don't paint grey.
                     //
-                    if (!forceReadOnly && (flags & GridEntry.FLAG_TEXT_EDITABLE) == 0 && !isImmutableReadOnly)
+                    if (!forceReadOnly && (Flags & FLAG_TEXT_EDITABLE) == 0 && !isImmutableReadOnly)
                     {
-                        flags |= GridEntry.FLAG_READONLY_EDITABLE;
+                        _flags |= FLAG_READONLY_EDITABLE;
                     }
                 }
 
                 if (Attributes.Contains(PasswordPropertyTextAttribute.Yes))
                 {
-                    flags |= GridEntry.FLAG_RENDER_PASSWORD;
+                    _flags |= FLAG_RENDER_PASSWORD;
                 }
 
                 if (uiEditor is not null)
                 {
                     if (uiEditor.GetPaintValueSupported(this))
                     {
-                        flags |= GridEntry.FLAG_CUSTOM_PAINT;
+                        _flags |= FLAG_CUSTOM_PAINT;
                     }
 
                     // We only allow drop-downs if the object is NOT being inherited
@@ -563,37 +566,34 @@ namespace System.Windows.Forms.PropertyGridInternal
                         switch (uiEditor.GetEditStyle(this))
                         {
                             case UITypeEditorEditStyle.Modal:
-                                flags |= GridEntry.FLAG_CUSTOM_EDITABLE;
+                                _flags |= FLAG_CUSTOM_EDITABLE;
                                 if (!isImmutable && !PropertyType.IsValueType)
                                 {
-                                    flags |= GridEntry.FLAG_READONLY_EDITABLE;
+                                    _flags |= FLAG_READONLY_EDITABLE;
                                 }
 
                                 break;
                             case UITypeEditorEditStyle.DropDown:
-                                flags |= GridEntry.FLAG_DROPDOWN_EDITABLE;
+                                _flags |= FLAG_DROPDOWN_EDITABLE;
                                 break;
                         }
                     }
                 }
 
-                return flags;
+                return _flags;
             }
             set
             {
-                flags = value;
+                _flags = value;
             }
         }
 
         /// <summary>
         ///  Checks if the entry is currently expanded
         /// </summary>
-        public bool Focus
+        public bool HasFocus
         {
-            get
-            {
-                return hasFocus;
-            }
+            get => _hasFocus;
             set
             {
                 if (Disposed)
@@ -601,16 +601,16 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return;
                 }
 
-                if (cacheItems is not null)
+                if (_cacheItems is not null)
                 {
-                    cacheItems.lastValueString = null;
-                    cacheItems.useValueString = false;
-                    cacheItems.useShouldSerialize = false;
+                    _cacheItems.LastValueString = null;
+                    _cacheItems.UseValueString = false;
+                    _cacheItems.UseShouldSerialize = false;
                 }
 
-                if (hasFocus != value)
+                if (_hasFocus != value)
                 {
-                    hasFocus = value;
+                    _hasFocus = value;
 
                     // Notify accessibility applications that keyboard focus has changed.
                     //
@@ -641,9 +641,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 string str = null;
-                if (parentPE is not null)
+                if (_parentEntry is not null)
                 {
-                    str = parentPE.FullLabel;
+                    str = _parentEntry.FullLabel;
                 }
 
                 if (str is not null)
@@ -670,7 +670,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     throw new ObjectDisposedException(SR.GridItemDisposed);
                 }
 
-                if (IsExpandable && childCollection is not null && childCollection.Count == 0)
+                if (IsExpandable && _childCollection is not null && _childCollection.Count == 0)
                 {
                     CreateChildren();
                 }
@@ -683,9 +683,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {        // ACCESSOR: virtual was missing from this get
-                if (parentPE is not null)
+                if (_parentEntry is not null)
                 {
-                    return parentPE.GridEntryHost;
+                    return _parentEntry.GridEntryHost;
                 }
 
                 return null;
@@ -725,9 +725,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 string keyWord = null;
 
-                if (parentPE is not null)
+                if (_parentEntry is not null)
                 {
-                    keyWord = parentPE.HelpKeyword;
+                    keyWord = _parentEntry.HelpKeyword;
                 }
 
                 if (keyWord is null)
@@ -752,31 +752,31 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 // prevent full flag population if possible.
-                if ((flags & FL_CHECKED) == 0)
+                if ((Flags & FL_CHECKED) == 0)
                 {
                     UITypeEditor typeEd = UITypeEditor;
                     if (typeEd is not null)
                     {
-                        if ((flags & GridEntry.FLAG_CUSTOM_PAINT) != 0 ||
-                            (flags & GridEntry.FL_NO_CUSTOM_PAINT) != 0)
+                        if ((Flags & FLAG_CUSTOM_PAINT) != 0 ||
+                            (Flags & FL_NO_CUSTOM_PAINT) != 0)
                         {
-                            return (flags & GridEntry.FLAG_CUSTOM_PAINT) != 0;
+                            return (Flags & FLAG_CUSTOM_PAINT) != 0;
                         }
 
                         if (typeEd.GetPaintValueSupported(this))
                         {
-                            flags |= GridEntry.FLAG_CUSTOM_PAINT;
+                            Flags |= FLAG_CUSTOM_PAINT;
                             return true;
                         }
                         else
                         {
-                            flags |= GridEntry.FL_NO_CUSTOM_PAINT;
+                            Flags |= FL_NO_CUSTOM_PAINT;
                             return false;
                         }
                     }
                 }
 
-                return (Flags & GridEntry.FLAG_CUSTOM_PAINT) != 0;
+                return (Flags & FLAG_CUSTOM_PAINT) != 0;
             }
         }
 
@@ -800,7 +800,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return IsValueEditable && (Flags & GridEntry.FLAG_TEXT_EDITABLE) != 0;
+                return IsValueEditable && (Flags & FLAG_TEXT_EDITABLE) != 0;
             }
         }
 
@@ -808,7 +808,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return !ForceReadOnly && 0 != (Flags & (GridEntry.FLAG_DROPDOWN_EDITABLE | GridEntry.FLAG_TEXT_EDITABLE | GridEntry.FLAG_CUSTOM_EDITABLE | GridEntry.FLAG_ENUMERABLE));
+                return !ForceReadOnly && 0 != (Flags & (FLAG_DROPDOWN_EDITABLE | FLAG_TEXT_EDITABLE | FLAG_CUSTOM_EDITABLE | FLAG_ENUMERABLE));
             }
         }
 
@@ -824,9 +824,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 object owner = GetValueOwner();
 
-                if (parentPE is not null && owner is null)
+                if (_parentEntry is not null && owner is null)
                 {
-                    return parentPE.Instance;
+                    return _parentEntry.Instance;
                 }
 
                 return owner;
@@ -860,13 +860,13 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 int borderWidth = GridEntryHost.GetOutlineIconSize() + OutlineIconPadding;
-                return ((propertyDepth + 1) * borderWidth) + 1;
+                return ((_propertyDepth + 1) * borderWidth) + 1;
             }
         }
 
         internal virtual Point GetLabelToolTipLocation(int mouseX, int mouseY)
         {
-            return labelTipPoint;
+            return _labelTipPoint;
         }
 
         internal virtual string LabelToolTipText
@@ -881,7 +881,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (Flags & GridEntry.FLAG_DROPDOWN_EDITABLE) != 0;
+                return (Flags & FLAG_DROPDOWN_EDITABLE) != 0;
             }
         }
 
@@ -889,17 +889,11 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (Flags & GridEntry.FLAG_CUSTOM_EDITABLE) != 0 && (IsValueEditable || (Flags & GridEntry.FLAG_READONLY_EDITABLE) != 0);
+                return (Flags & FLAG_CUSTOM_EDITABLE) != 0 && (IsValueEditable || (Flags & FLAG_READONLY_EDITABLE) != 0);
             }
         }
 
-        public PropertyGrid OwnerGrid
-        {
-            get
-            {
-                return ownerGrid;
-            }
-        }
+        public PropertyGrid OwnerGrid { get; }
 
         /// <summary>
         ///  Returns rect that the outline icon (+ or - or arrow) will be drawn into, relative
@@ -909,26 +903,26 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (!outlineRect.IsEmpty)
+                if (!_outlineRect.IsEmpty)
                 {
-                    return outlineRect;
+                    return _outlineRect;
                 }
 
                 PropertyGridView gridHost = GridEntryHost;
                 Debug.Assert(gridHost is not null, "No propEntryHost!");
                 int outlineSize = gridHost.GetOutlineIconSize();
                 int borderWidth = outlineSize + OutlineIconPadding;
-                int left = (propertyDepth * borderWidth) + (OutlineIconPadding) / 2;
+                int left = (_propertyDepth * borderWidth) + (OutlineIconPadding) / 2;
                 int top = (gridHost.GetGridEntryHeight() - outlineSize) / 2;
-                outlineRect = new Rectangle(left, top, outlineSize, outlineSize);
-                return outlineRect;
+                _outlineRect = new Rectangle(left, top, outlineSize, outlineSize);
+                return _outlineRect;
             }
             set
             {
                 // set property is required to reset cached value when dpi changed.
-                if (value != outlineRect)
+                if (value != _outlineRect)
                 {
-                    outlineRect = value;
+                    _outlineRect = value;
                 }
             }
         }
@@ -937,22 +931,22 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return parentPE;
+                return _parentEntry;
             }
             set
             {
                 Debug.Assert(value != this, "how can we be our own parent?");
-                parentPE = value;
+                _parentEntry = value;
                 if (value is not null)
                 {
-                    propertyDepth = value.PropertyDepth + 1;
+                    _propertyDepth = value.PropertyDepth + 1;
 
                     // Microsoft, why do we do this?
-                    if (childCollection is not null)
+                    if (_childCollection is not null)
                     {
-                        for (int i = 0; i < childCollection.Count; i++)
+                        for (int i = 0; i < _childCollection.Count; i++)
                         {
-                            childCollection.GetEntry(i).ParentGridEntry = this;
+                            _childCollection.GetEntry(i).ParentGridEntry = this;
                         }
                     }
                 }
@@ -998,7 +992,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return propertyDepth;
+                return _propertyDepth;
             }
         }
 
@@ -1063,9 +1057,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (cacheItems is not null)
+                if (_cacheItems is not null)
                 {
-                    return cacheItems.lastValue;
+                    return _cacheItems.LastValue;
                 }
 
                 return null;
@@ -1079,7 +1073,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (Flags & GridEntry.FLAG_RENDER_PASSWORD) != 0;
+                return (Flags & FLAG_RENDER_PASSWORD) != 0;
             }
         }
 
@@ -1087,7 +1081,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return ForceReadOnly || (0 != (Flags & GridEntry.FLAG_RENDER_READONLY) || (!IsValueEditable && (0 == (Flags & GridEntry.FLAG_READONLY_EDITABLE))));
+                return ForceReadOnly || (0 != (Flags & FLAG_RENDER_READONLY) || (!IsValueEditable && (0 == (Flags & FLAG_READONLY_EDITABLE))));
             }
         }
 
@@ -1098,20 +1092,20 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (converter is null)
+                if (Converter is null)
                 {
                     object value = PropertyValue;
                     if (value is null)
                     {
-                        converter = TypeDescriptor.GetConverter(PropertyType);
+                        Converter = TypeDescriptor.GetConverter(PropertyType);
                     }
                     else
                     {
-                        converter = TypeDescriptor.GetConverter(value);
+                        Converter = TypeDescriptor.GetConverter(value);
                     }
                 }
 
-                return converter;
+                return Converter;
             }
         }
 
@@ -1123,12 +1117,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (editor is null && PropertyType is not null)
+                if (Editor is null && PropertyType is not null)
                 {
-                    editor = (UITypeEditor)TypeDescriptor.GetEditor(PropertyType, typeof(UITypeEditor));
+                    Editor = (UITypeEditor)TypeDescriptor.GetEditor(PropertyType, typeof(UITypeEditor));
                 }
 
-                return editor;
+                return Editor;
             }
         }
 
@@ -1146,11 +1140,11 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return ShouldRenderPassword ? InvalidPoint : valueTipPoint;
+                return ShouldRenderPassword ? InvalidPoint : _valueTipPoint;
             }
             set
             {
-                valueTipPoint = value;
+                _valueTipPoint = value;
             }
         }
 
@@ -1180,7 +1174,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual void AddOnLabelClick(EventHandler h)
         {
-            AddEventHandler(EVENT_LABEL_CLICK, h);
+            AddEventHandler(s_labelClickEvent, h);
         }
 
         /// <summary>
@@ -1189,7 +1183,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual void AddOnLabelDoubleClick(EventHandler h)
         {
-            AddEventHandler(EVENT_LABEL_DBLCLICK, h);
+            AddEventHandler(s_labelDoubleClickEvent, h);
         }
 
         /// <summary>
@@ -1198,7 +1192,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual void AddOnValueClick(EventHandler h)
         {
-            AddEventHandler(EVENT_VALUE_CLICK, h);
+            AddEventHandler(s_valueClickEvent, h);
         }
 
         /// <summary>
@@ -1207,7 +1201,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual void AddOnValueDoubleClick(EventHandler h)
         {
-            AddEventHandler(EVENT_VALUE_DBLCLICK, h);
+            AddEventHandler(s_valueDoubleClickEvent, h);
         }
 
         /// <summary>
@@ -1216,7 +1210,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual void AddOnOutlineClick(EventHandler h)
         {
-            AddEventHandler(EVENT_OUTLINE_CLICK, h);
+            AddEventHandler(s_outlineClickEvent, h);
         }
 
         /// <summary>
@@ -1225,7 +1219,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual void AddOnOutlineDoubleClick(EventHandler h)
         {
-            AddEventHandler(EVENT_OUTLINE_DBLCLICK, h);
+            AddEventHandler(s_outlineDoubleClickEvent, h);
         }
 
         /// <summary>
@@ -1233,7 +1227,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual void AddOnRecreateChildren(GridEntryRecreateChildrenEventHandler h)
         {
-            AddEventHandler(EVENT_RECREATE_CHILDREN, h);
+            AddEventHandler(s_recreateChildrenEvent, h);
         }
 
         internal void ClearCachedValues()
@@ -1243,11 +1237,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal void ClearCachedValues(bool clearChildren)
         {
-            if (cacheItems is not null)
+            if (_cacheItems is not null)
             {
-                cacheItems.useValueString = false;
-                cacheItems.lastValue = null;
-                cacheItems.useShouldSerialize = false;
+                _cacheItems.UseValueString = false;
+                _cacheItems.LastValue = null;
+                _cacheItems.UseShouldSerialize = false;
             }
 
             if (clearChildren)
@@ -1321,19 +1315,19 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (!GetFlagSet(FL_EXPANDABLE))
             {
-                if (childCollection is not null)
+                if (_childCollection is not null)
                 {
-                    childCollection.Clear();
+                    _childCollection.Clear();
                 }
                 else
                 {
-                    childCollection = new GridEntryCollection(this, Array.Empty<GridEntry>());
+                    _childCollection = new GridEntryCollection(this, Array.Empty<GridEntry>());
                 }
 
                 return false;
             }
 
-            if (!diffOldChildren && childCollection is not null && childCollection.Count > 0)
+            if (!diffOldChildren && _childCollection is not null && _childCollection.Count > 0)
             {
                 return true;
             }
@@ -1344,14 +1338,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             bool fExpandable = (childProps is not null && childProps.Length > 0);
 
-            if (diffOldChildren && childCollection is not null && childCollection.Count > 0)
+            if (diffOldChildren && _childCollection is not null && _childCollection.Count > 0)
             {
                 bool same = true;
-                if (childProps.Length == childCollection.Count)
+                if (childProps.Length == _childCollection.Count)
                 {
                     for (int i = 0; i < childProps.Length; i++)
                     {
-                        if (!childProps[i].NonParentEquals(childCollection[i]))
+                        if (!childProps[i].NonParentEquals(_childCollection[i]))
                         {
                             same = false;
                             break;
@@ -1372,13 +1366,13 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (!fExpandable)
             {
                 SetFlag(FL_EXPANDABLE_FAILED, true);
-                if (childCollection is not null)
+                if (_childCollection is not null)
                 {
-                    childCollection.Clear();
+                    _childCollection.Clear();
                 }
                 else
                 {
-                    childCollection = new GridEntryCollection(this, Array.Empty<GridEntry>());
+                    _childCollection = new GridEntryCollection(this, Array.Empty<GridEntry>());
                 }
 
                 if (InternalExpanded)
@@ -1388,14 +1382,14 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else
             {
-                if (childCollection is not null)
+                if (_childCollection is not null)
                 {
-                    childCollection.Clear();
-                    childCollection.AddRange(childProps);
+                    _childCollection.Clear();
+                    _childCollection.AddRange(childProps);
                 }
                 else
                 {
-                    childCollection = new GridEntryCollection(this, childProps);
+                    _childCollection = new GridEntryCollection(this, childProps);
                 }
             }
 
@@ -1412,14 +1406,14 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             // make sure we don't accidentally
             // check flags in this state...
-            flags |= FL_CHECKED;
+            Flags |= FL_CHECKED;
 
             SetFlag(FLAG_DISPOSED, true);
 
-            cacheItems = null;
-            converter = null;
-            editor = null;
-            accessibleObject = null;
+            _cacheItems = null;
+            Converter = null;
+            Editor = null;
+            _accessibleObject = null;
 
             if (disposing)
             {
@@ -1432,10 +1426,10 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual void DisposeChildren()
         {
-            if (childCollection is not null)
+            if (_childCollection is not null)
             {
-                childCollection.Dispose();
-                childCollection = null;
+                _childCollection.Dispose();
+                _childCollection = null;
             }
         }
 
@@ -1529,9 +1523,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return property.GetValue(owner);
             }
 
-            if (parentPE is not null)
+            if (_parentEntry is not null)
             {
-                return parentPE.FindPropertyValue(propertyName, propertyType);
+                return _parentEntry.FindPropertyValue(propertyName, propertyType);
             }
 
             return null;
@@ -1563,41 +1557,41 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected int GetLabelTextWidth(string labelText, Graphics g, Font f)
         {
-            if (cacheItems is null)
+            if (_cacheItems is null)
             {
-                cacheItems = new CacheItems();
+                _cacheItems = new CacheItems();
             }
-            else if (cacheItems.useCompatTextRendering == ownerGrid.UseCompatibleTextRendering && cacheItems.lastLabel == labelText && f.Equals(cacheItems.lastLabelFont))
+            else if (_cacheItems.UseCompatTextRendering == OwnerGrid.UseCompatibleTextRendering && _cacheItems.LastLabel == labelText && f.Equals(_cacheItems.LastLabelFont))
             {
-                return cacheItems.lastLabelWidth;
+                return _cacheItems.LastLabelWidth;
             }
 
-            SizeF textSize = PropertyGrid.MeasureTextHelper.MeasureText(ownerGrid, g, labelText, f);
+            SizeF textSize = PropertyGrid.MeasureTextHelper.MeasureText(OwnerGrid, g, labelText, f);
 
-            cacheItems.lastLabelWidth = (int)textSize.Width;
-            cacheItems.lastLabel = labelText;
-            cacheItems.lastLabelFont = f;
-            cacheItems.useCompatTextRendering = ownerGrid.UseCompatibleTextRendering;
+            _cacheItems.LastLabelWidth = (int)textSize.Width;
+            _cacheItems.LastLabel = labelText;
+            _cacheItems.LastLabelFont = f;
+            _cacheItems.UseCompatTextRendering = OwnerGrid.UseCompatibleTextRendering;
 
-            return cacheItems.lastLabelWidth;
+            return _cacheItems.LastLabelWidth;
         }
 
         internal int GetValueTextWidth(string valueString, Graphics g, Font f)
         {
-            if (cacheItems is null)
+            if (_cacheItems is null)
             {
-                cacheItems = new CacheItems();
+                _cacheItems = new CacheItems();
             }
-            else if (cacheItems.lastValueTextWidth != -1 && cacheItems.lastValueString == valueString && f.Equals(cacheItems.lastValueFont))
+            else if (_cacheItems.LastValueTextWidth != -1 && _cacheItems.LastValueString == valueString && f.Equals(_cacheItems.LastValueFont))
             {
-                return cacheItems.lastValueTextWidth;
+                return _cacheItems.LastValueTextWidth;
             }
 
             // Value text is rendered using GDI directly (No TextRenderer) but measured/adjusted using GDI+ (since previous releases), so don't use MeasureTextHelper.
-            cacheItems.lastValueTextWidth = (int)g.MeasureString(valueString, f).Width;
-            cacheItems.lastValueString = valueString;
-            cacheItems.lastValueFont = f;
-            return cacheItems.lastValueTextWidth;
+            _cacheItems.LastValueTextWidth = (int)g.MeasureString(valueString, f).Width;
+            _cacheItems.LastValueString = valueString;
+            _cacheItems.LastValueFont = f;
+            return _cacheItems.LastValueTextWidth;
         }
 
         // To check if text contains multiple lines
@@ -1620,12 +1614,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual object GetValueOwner()
         {
-            if (parentPE is null)
+            if (_parentEntry is null)
             {
                 return PropertyValue;
             }
 
-            return parentPE.GetChildValueOwner(this);
+            return _parentEntry.GetChildValueOwner(this);
         }
 
         /// <summary>
@@ -1755,7 +1749,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         if (objType is null || !objType.IsArray)
                         {
-                            props = props.Sort(GridEntry.DisplayNameComparer);
+                            props = props.Sort(DisplayNameComparer);
                         }
 
                         PropertyDescriptor[] propertyDescriptors = new PropertyDescriptor[props.Count];
@@ -1780,7 +1774,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         for (int i = 0; i < entries.Length; i++)
                         {
-                            entries[i] = new ArrayElementGridEntry(ownerGrid, peParent, i);
+                            entries[i] = new ArrayElementGridEntry(OwnerGrid, peParent, i);
                         }
                     }
                     else
@@ -1812,7 +1806,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             }
                             catch (Exception w)
                             {
-                                if (PbrsAssertPropsSwitch.Enabled)
+                                if (s_pbrsAssertPropsSwitch.Enabled)
                                 {
                                     Debug.Fail("Bad property '" + peParent.PropertyLabel + "." + pd.Name + "': " + w.ToString());
                                 }
@@ -1822,16 +1816,16 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                             if (createInstanceSupported)
                             {
-                                newEntry = new ImmutablePropertyDescriptorGridEntry(ownerGrid, peParent, pd, hide);
+                                newEntry = new ImmutablePropertyDescriptorGridEntry(OwnerGrid, peParent, pd, hide);
                             }
                             else
                             {
-                                newEntry = new PropertyDescriptorGridEntry(ownerGrid, peParent, pd, hide);
+                                newEntry = new PropertyDescriptorGridEntry(OwnerGrid, peParent, pd, hide);
                             }
 
                             if (forceReadOnly)
                             {
-                                newEntry.flags |= FLAG_FORCE_READONLY;
+                                newEntry.Flags |= FLAG_FORCE_READONLY;
                             }
 
                             // check to see if we've come across the default item.
@@ -1851,7 +1845,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             catch (Exception e)
             {
 #if DEBUG
-                if (PbrsAssertPropsSwitch.Enabled)
+                if (s_pbrsAssertPropsSwitch.Enabled)
                 {
                     // Checked builds are not giving us enough information here.  So, output as much stuff as
                     // we can.
@@ -1861,7 +1855,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     b.Append(string.Format(CultureInfo.CurrentCulture, "Exception Text: \r\n{0}", e.ToString()));
                     b.Append(string.Format(CultureInfo.CurrentCulture, "Exception stack: \r\n{0}", e.StackTrace));
                     string path = string.Format(CultureInfo.CurrentCulture, "{0}\\PropertyGrid.log", Environment.GetEnvironmentVariable("SYSTEMDRIVE"));
-                    IO.FileStream s = new IO.FileStream(path, System.IO.FileMode.Append, System.IO.FileAccess.Write, System.IO.FileShare.None);
+                    IO.FileStream s = new IO.FileStream(path, IO.FileMode.Append, IO.FileAccess.Write, IO.FileShare.None);
                     IO.StreamWriter w = new IO.StreamWriter(s);
                     w.Write(b.ToString());
                     w.Close();
@@ -1984,9 +1978,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return (GridItem)this;
             }
 
-            if (parentPE is not null)
+            if (_parentEntry is not null)
             {
-                return parentPE.GetService(serviceType);
+                return _parentEntry.GetService(serviceType);
             }
 
             return null;
@@ -2031,7 +2025,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Color backColor = selected ? gridHost.GetSelectedItemWithFocusBackColor() : GetBackgroundColor();
 
             // if we don't have focus, paint with the line color
-            if (selected && !hasFocus)
+            if (selected && !_hasFocus)
             {
                 backColor = gridHost.GetLineColor();
             }
@@ -2048,7 +2042,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (paintFullLabel && (neededWidth >= (rect.Width - (stringX + 2))))
             {
                 // GDIPLUS_SPACE = extra needed to ensure text draws completely and isn't clipped.
-                int totalWidth = stringX + neededWidth + PropertyGridView.GDIPLUS_SPACE;
+                int totalWidth = stringX + neededWidth + PropertyGridView.GdiPlusSpace;
 
                 // blank out the space we're going to use
                 g.FillRectangle(backBrush, borderWidth - 1, rect.Y, totalWidth - borderWidth + 3, rect.Height);
@@ -2070,7 +2064,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             using var stripeBrush = gridHost.GetLineColor().GetCachedSolidBrushScope();
             g.FillRectangle(stripeBrush, rect.X, rect.Y, borderWidth, rect.Height);
 
-            if (selected && hasFocus)
+            if (selected && _hasFocus)
             {
                 using var focusBrush = gridHost.GetSelectedItemWithFocusBackColor().GetCachedSolidBrushScope();
                 g.FillRectangle(
@@ -2078,7 +2072,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     stringX, rect.Y, rect.Width - stringX - 1, rect.Height);
             }
 
-            int maxSpace = Math.Min(rect.Width - stringX - 1, labelWidth + PropertyGridView.GDIPLUS_SPACE);
+            int maxSpace = Math.Min(rect.Width - stringX - 1, labelWidth + PropertyGridView.GdiPlusSpace);
             Rectangle textRect = new Rectangle(stringX, rect.Y + 1, maxSpace, rect.Height - 1);
 
             if (!Rectangle.Intersect(textRect, clipRect).IsEmpty)
@@ -2088,17 +2082,17 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 // We need to Invert color only if in Highcontrast mode, targeting 4.7.1 and above, Gridcategory and
                 // not a developer override. This is required to achieve required contrast ratio.
-                var shouldInvertForHC = colorInversionNeededInHC && (fBold || (selected && !hasFocus));
+                var shouldInvertForHC = colorInversionNeededInHC && (fBold || (selected && !_hasFocus));
 
                 // Do actual drawing
                 // A brush is needed if using GDI+ only (UseCompatibleTextRendering); if using GDI, only the color is needed.
-                Color textColor = selected && hasFocus
+                Color textColor = selected && _hasFocus
                     ? gridHost.GetSelectedItemWithFocusForeColor()
                     : shouldInvertForHC
-                        ? InvertColor(ownerGrid.LineColor)
+                        ? InvertColor(OwnerGrid.LineColor)
                         : g.FindNearestColor(LabelTextColor);
 
-                if (ownerGrid.UseCompatibleTextRendering)
+                if (OwnerGrid.UseCompatibleTextRendering)
                 {
                     using var textBrush = textColor.GetCachedSolidBrushScope();
                     StringFormat stringFormat = new StringFormat(StringFormatFlags.NoWrap)
@@ -2117,11 +2111,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (maxSpace <= labelWidth)
                 {
-                    labelTipPoint = new Point(stringX + 2, rect.Y + 1);
+                    _labelTipPoint = new Point(stringX + 2, rect.Y + 1);
                 }
                 else
                 {
-                    labelTipPoint = InvalidPoint;
+                    _labelTipPoint = InvalidPoint;
                 }
             }
 
@@ -2145,10 +2139,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // size of Explorer Tree style glyph (triangle) is different from +/- glyph,
                 // so when we change the visual style (such as changing Windows theme),
                 // we need to recaculate outlineRect
-                if (!lastPaintWithExplorerStyle)
+                if (!_lastPaintWithExplorerStyle)
                 {
-                    outlineRect = Rectangle.Empty;
-                    lastPaintWithExplorerStyle = true;
+                    _outlineRect = Rectangle.Empty;
+                    _lastPaintWithExplorerStyle = true;
                 }
 
                 PaintOutlineWithExplorerTreeStyle(g, r, (GridEntryHost is not null) ? GridEntryHost.HandleInternal : IntPtr.Zero);
@@ -2160,10 +2154,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // size of Explorer Tree style glyph (triangle) is different from +/- glyph,
                 // so when we change the visual style (such as changing Windows theme),
                 // we need to recaculate outlineRect
-                if (lastPaintWithExplorerStyle)
+                if (_lastPaintWithExplorerStyle)
                 {
-                    outlineRect = Rectangle.Empty;
-                    lastPaintWithExplorerStyle = false;
+                    _outlineRect = Rectangle.Empty;
+                    _lastPaintWithExplorerStyle = false;
                 }
 
                 PaintOutlineWithClassicStyle(g, r);
@@ -2191,7 +2185,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // Invert color if it is not overriden by developer.
                 if (colorInversionNeededInHC)
                 {
-                    Color textColor = InvertColor(ownerGrid.LineColor);
+                    Color textColor = InvertColor(OwnerGrid.LineColor);
                     if (g is not null)
                     {
                         using var brush = textColor.GetCachedSolidBrushScope();
@@ -2227,7 +2221,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // inverting text color to back ground to get required contrast ratio
                 if (colorInversionNeededInHC)
                 {
-                    penColor = InvertColor(ownerGrid.LineColor);
+                    penColor = InvertColor(OwnerGrid.LineColor);
                 }
                 else
                 {
@@ -2278,26 +2272,26 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (paintFlags.HasFlag(PaintValueFlags.FetchValue))
             {
-                if (cacheItems is not null && cacheItems.useValueString)
+                if (_cacheItems is not null && _cacheItems.UseValueString)
                 {
-                    text = cacheItems.lastValueString;
-                    val = cacheItems.lastValue;
+                    text = _cacheItems.LastValueString;
+                    val = _cacheItems.LastValue;
                 }
                 else
                 {
                     val = PropertyValue;
                     text = GetPropertyTextValue(val);
 
-                    if (cacheItems is null)
+                    if (_cacheItems is null)
                     {
-                        cacheItems = new CacheItems();
+                        _cacheItems = new CacheItems();
                     }
 
-                    cacheItems.lastValueString = text;
-                    cacheItems.useValueString = true;
-                    cacheItems.lastValueTextWidth = -1;
-                    cacheItems.lastValueFont = null;
-                    cacheItems.lastValue = val;
+                    _cacheItems.LastValueString = text;
+                    _cacheItems.UseValueString = true;
+                    _cacheItems.LastValueTextWidth = -1;
+                    _cacheItems.LastValueFont = null;
+                    _cacheItems.LastValue = val;
                 }
             }
             else
@@ -2350,9 +2344,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            if (text.Length > maximumLengthOfPropertyString)
+            if (text.Length > MaximumLengthOfPropertyString)
             {
-                text = text.Substring(0, maximumLengthOfPropertyString);
+                text = text.Substring(0, MaximumLengthOfPropertyString);
             }
 
             int textWidth = GetValueTextWidth(text, g, GetFont(valueModified));
@@ -2402,13 +2396,13 @@ namespace System.Windows.Forms.PropertyGridInternal
             // For password mode, replace the string value with a bullet.
             if (ShouldRenderPassword)
             {
-                if (passwordReplaceChar == '\0')
+                if (s_passwordReplaceChar == '\0')
                 {
                     // Bullet is 2022, but edit box uses round circle 25CF
-                    passwordReplaceChar = '\u25CF';
+                    s_passwordReplaceChar = '\u25CF';
                 }
 
-                text = new string(passwordReplaceChar, text.Length);
+                text = new string(s_passwordReplaceChar, text.Length);
             }
 
             TextRenderer.DrawTextInternal(
@@ -2460,7 +2454,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         protected virtual void OnLabelClick(EventArgs e)
         {
-            RaiseEvent(EVENT_LABEL_CLICK, e);
+            RaiseEvent(s_labelClickEvent, e);
         }
 
         /// <summary>
@@ -2470,7 +2464,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         protected virtual void OnLabelDoubleClick(EventArgs e)
         {
-            RaiseEvent(EVENT_LABEL_DBLCLICK, e);
+            RaiseEvent(s_labelDoubleClickEvent, e);
         }
 
         /// <summary>
@@ -2550,7 +2544,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         protected virtual void OnOutlineClick(EventArgs e)
         {
-            RaiseEvent(EVENT_OUTLINE_CLICK, e);
+            RaiseEvent(s_outlineClickEvent, e);
         }
 
         /// <summary>
@@ -2560,7 +2554,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         protected virtual void OnOutlineDoubleClick(EventArgs e)
         {
-            RaiseEvent(EVENT_OUTLINE_DBLCLICK, e);
+            RaiseEvent(s_outlineDoubleClickEvent, e);
         }
 
         /// <summary>
@@ -2570,7 +2564,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         protected virtual void OnRecreateChildren(GridEntryRecreateChildrenEventArgs e)
         {
-            Delegate handler = GetEventHandler(EVENT_RECREATE_CHILDREN);
+            Delegate handler = GetEventHandler(s_recreateChildrenEvent);
             if (handler is not null)
             {
                 ((GridEntryRecreateChildrenEventHandler)handler)(this, e);
@@ -2584,7 +2578,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         protected virtual void OnValueClick(EventArgs e)
         {
-            RaiseEvent(EVENT_VALUE_CLICK, e);
+            RaiseEvent(s_valueClickEvent, e);
         }
 
         /// <summary>
@@ -2594,7 +2588,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         protected virtual void OnValueDoubleClick(EventArgs e)
         {
-            RaiseEvent(EVENT_VALUE_DBLCLICK, e);
+            RaiseEvent(s_valueDoubleClickEvent, e);
         }
 
         internal bool OnValueReturnKey()
@@ -2651,28 +2645,28 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         internal virtual bool ShouldSerializePropertyValue()
         {
-            if (cacheItems is not null)
+            if (_cacheItems is not null)
             {
-                if (cacheItems.useShouldSerialize)
+                if (_cacheItems.UseShouldSerialize)
                 {
-                    return cacheItems.lastShouldSerialize;
+                    return _cacheItems.LastShouldSerialize;
                 }
                 else
                 {
-                    cacheItems.lastShouldSerialize = NotifyValue(NOTIFY_SHOULD_PERSIST);
-                    cacheItems.useShouldSerialize = true;
+                    _cacheItems.LastShouldSerialize = NotifyValue(NOTIFY_SHOULD_PERSIST);
+                    _cacheItems.UseShouldSerialize = true;
                 }
             }
             else
             {
-                cacheItems = new CacheItems
+                _cacheItems = new CacheItems
                 {
-                    lastShouldSerialize = NotifyValue(NOTIFY_SHOULD_PERSIST),
-                    useShouldSerialize = true
+                    LastShouldSerialize = NotifyValue(NOTIFY_SHOULD_PERSIST),
+                    UseShouldSerialize = true
                 };
             }
 
-            return cacheItems.lastShouldSerialize;
+            return _cacheItems.LastShouldSerialize;
         }
 
         private PropertyDescriptor[] SortParenProperties(PropertyDescriptor[] props)
@@ -2730,13 +2724,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal virtual bool NotifyValue(int type)
         {
-            if (parentPE is null)
+            if (_parentEntry is null)
             {
                 return true;
             }
             else
             {
-                return parentPE.NotifyChildValue(this, type);
+                return _parentEntry.NotifyChildValue(this, type);
             }
         }
 
@@ -2782,11 +2776,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 CreateChildren(true);
             }
 
-            if (childCollection is not null)
+            if (_childCollection is not null)
             {
                 // check to see if the value has changed.
                 //
-                if (InternalExpanded && cacheItems is not null && cacheItems.lastValue is not null && cacheItems.lastValue != PropertyValue)
+                if (InternalExpanded && _cacheItems is not null && _cacheItems.LastValue is not null && _cacheItems.LastValue != PropertyValue)
                 {
                     ClearCachedValues();
                     RecreateChildren();
@@ -2795,7 +2789,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 else if (InternalExpanded)
                 {
                     // otherwise just do a refresh.
-                    IEnumerator childEnum = childCollection.GetEnumerator();
+                    IEnumerator childEnum = _childCollection.GetEnumerator();
                     while (childEnum.MoveNext())
                     {
                         object o = childEnum.Current;
@@ -2815,37 +2809,37 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public virtual void RemoveOnLabelClick(EventHandler h)
         {
-            RemoveEventHandler(EVENT_LABEL_CLICK, h);
+            RemoveEventHandler(s_labelClickEvent, h);
         }
 
         public virtual void RemoveOnLabelDoubleClick(EventHandler h)
         {
-            RemoveEventHandler(EVENT_LABEL_DBLCLICK, h);
+            RemoveEventHandler(s_labelDoubleClickEvent, h);
         }
 
         public virtual void RemoveOnValueClick(EventHandler h)
         {
-            RemoveEventHandler(EVENT_VALUE_CLICK, h);
+            RemoveEventHandler(s_valueClickEvent, h);
         }
 
         public virtual void RemoveOnValueDoubleClick(EventHandler h)
         {
-            RemoveEventHandler(EVENT_VALUE_DBLCLICK, h);
+            RemoveEventHandler(s_valueDoubleClickEvent, h);
         }
 
         public virtual void RemoveOnOutlineClick(EventHandler h)
         {
-            RemoveEventHandler(EVENT_OUTLINE_CLICK, h);
+            RemoveEventHandler(s_outlineClickEvent, h);
         }
 
         public virtual void RemoveOnOutlineDoubleClick(EventHandler h)
         {
-            RemoveEventHandler(EVENT_OUTLINE_DBLCLICK, h);
+            RemoveEventHandler(s_outlineDoubleClickEvent, h);
         }
 
         public virtual void RemoveOnRecreateChildren(GridEntryRecreateChildrenEventHandler h)
         {
-            RemoveEventHandler(EVENT_RECREATE_CHILDREN, h);
+            RemoveEventHandler(s_recreateChildrenEvent, h);
         }
 
         protected void ResetState()
@@ -2859,10 +2853,10 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual bool SetPropertyTextValue(string str)
         {
-            bool fChildrenPrior = (childCollection is not null && childCollection.Count > 0);
+            bool fChildrenPrior = (_childCollection is not null && _childCollection.Count > 0);
             PropertyValue = ConvertTextToValue(str);
             CreateChildren();
-            bool fChildrenAfter = (childCollection is not null && childCollection.Count > 0);
+            bool fChildrenAfter = (_childCollection is not null && _childCollection.Count > 0);
             return (fChildrenPrior != fChildrenAfter);
         }
 
@@ -2883,11 +2877,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return;
                 }
 
-                for (EventEntry e = eventList; e is not null; e = e._next)
+                for (EventEntry e = eventList; e is not null; e = e.Next)
                 {
-                    if (e._key == key)
+                    if (e.Key == key)
                     {
-                        e._handler = Delegate.Combine(e._handler, handler);
+                        e.Handler = Delegate.Combine(e.Handler, handler);
                         return;
                     }
                 }
@@ -2910,11 +2904,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             // Locking 'this' here is ok since this is an internal class.
             lock (this)
             {
-                for (EventEntry e = eventList; e is not null; e = e._next)
+                for (EventEntry e = eventList; e is not null; e = e.Next)
                 {
-                    if (e._key == key)
+                    if (e.Key == key)
                     {
-                        return e._handler;
+                        return e.Handler;
                     }
                 }
 
@@ -2932,20 +2926,20 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return;
                 }
 
-                for (EventEntry e = eventList, prev = null; e is not null; prev = e, e = e._next)
+                for (EventEntry e = eventList, prev = null; e is not null; prev = e, e = e.Next)
                 {
-                    if (e._key == key)
+                    if (e.Key == key)
                     {
-                        e._handler = Delegate.Remove(e._handler, handler);
-                        if (e._handler is null)
+                        e.Handler = Delegate.Remove(e.Handler, handler);
+                        if (e.Handler is null)
                         {
                             if (prev is null)
                             {
-                                eventList = e._next;
+                                eventList = e.Next;
                             }
                             else
                             {
-                                prev._next = e._next;
+                                prev.Next = e.Next;
                             }
                         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntryRecreateChildrenEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntryRecreateChildrenEventArgs.cs
@@ -6,8 +6,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 {
     internal class GridEntryRecreateChildrenEventArgs : EventArgs
     {
-        public readonly int NewChildCount;
-        public readonly int OldChildCount;
+        public int NewChildCount { get; }
+        public int OldChildCount { get; }
 
         public GridEntryRecreateChildrenEventArgs(int oldCount, int newCount)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
@@ -12,14 +12,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 {
     internal class GridToolTip : Control
     {
-        readonly Control[] controls;
-        string toolTipText;
-        bool dontShow;
-        private readonly int maximumToolTipLength = 1000;
+        private readonly Control[] _controls;
+        private string _toolTipText;
+        private bool _dontShow;
+        private const int MaximumToolTipLength = 1000;
 
         internal GridToolTip(Control[] controls)
         {
-            this.controls = controls;
+            _controls = controls;
             SetStyle(ControlStyles.UserPaint, false);
             Font = controls[0].Font;
 
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return toolTipText;
+                return _toolTipText;
             }
             set
             {
@@ -48,13 +48,13 @@ namespace System.Windows.Forms.PropertyGridInternal
                     Reset();
                 }
 
-                if (value is not null && value.Length > maximumToolTipLength)
+                if (value is not null && value.Length > MaximumToolTipLength)
                 {
                     //Let the user know the text was truncated by throwing on an ellipsis
-                    value = value.Substring(0, maximumToolTipLength) + "...";
+                    value = value.Substring(0, MaximumToolTipLength) + "...";
                 }
 
-                toolTipText = value;
+                _toolTipText = value;
 
                 if (IsHandleCreated)
                 {
@@ -67,15 +67,15 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     // Here's a workaround.  If we give the tooltip an empty string, it won't come back
                     // so we just force it hidden instead.
-                    dontShow = string.IsNullOrEmpty(value);
+                    _dontShow = string.IsNullOrEmpty(value);
 
-                    for (int i = 0; i < controls.Length; i++)
+                    for (int i = 0; i < _controls.Length; i++)
                     {
-                        ComCtl32.ToolInfoWrapper<Control> info = GetTOOLINFO(controls[i]);
+                        ComCtl32.ToolInfoWrapper<Control> info = GetTOOLINFO(_controls[i]);
                         info.SendMessage(this, (User32.WM)ComCtl32.TTM.UPDATETIPTEXTW);
                     }
 
-                    if (visible && !dontShow)
+                    if (visible && !_dontShow)
                     {
                         Visible = true;
                     }
@@ -109,7 +109,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         private ComCtl32.ToolInfoWrapper<Control> GetTOOLINFO(Control c)
-            => new ComCtl32.ToolInfoWrapper<Control>(c, ComCtl32.TTF.TRANSPARENT | ComCtl32.TTF.SUBCLASS, toolTipText);
+            => new ComCtl32.ToolInfoWrapper<Control>(c, ComCtl32.TTF.TRANSPARENT | ComCtl32.TTF.SUBCLASS, _toolTipText);
 
         private void OnControlCreateHandle(object sender, EventArgs e)
         {
@@ -127,11 +127,11 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            for (int i = 0; i < controls.Length; i++)
+            for (int i = 0; i < _controls.Length; i++)
             {
-                if (controls[i].IsHandleCreated)
+                if (_controls[i].IsHandleCreated)
                 {
-                    SetupToolTip(controls[i]);
+                    SetupToolTip(_controls[i]);
                 }
             }
         }
@@ -163,15 +163,15 @@ namespace System.Windows.Forms.PropertyGridInternal
             // what it was, so the tooltip thinks it's back in the regular state again
 
             string oldText = ToolTip;
-            toolTipText = string.Empty;
+            _toolTipText = string.Empty;
 
-            for (int i = 0; i < controls.Length; i++)
+            for (int i = 0; i < _controls.Length; i++)
             {
-                ComCtl32.ToolInfoWrapper<Control> info = GetTOOLINFO(controls[i]);
+                ComCtl32.ToolInfoWrapper<Control> info = GetTOOLINFO(_controls[i]);
                 info.SendMessage(this, (User32.WM)ComCtl32.TTM.UPDATETIPTEXTW);
             }
 
-            toolTipText = oldText;
+            _toolTipText = oldText;
             User32.SendMessageW(this, (User32.WM)ComCtl32.TTM.UPDATE);
         }
 
@@ -180,7 +180,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             switch ((User32.WM)msg.Msg)
             {
                 case User32.WM.SHOWWINDOW:
-                    if (unchecked((int)(long)msg.WParam) != 0 && dontShow)
+                    if (unchecked((int)(long)msg.WParam) != 0 && _dontShow)
                     {
                         msg.WParam = IntPtr.Zero;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
@@ -12,11 +12,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 {
     internal partial class HotCommands : PropertyGrid.SnappableControl
     {
-        private object component;
-        private DesignerVerb[] verbs;
-        private LinkLabel label;
-        private bool allowVisible = true;
-        private int optimalHeight = -1;
+        private object _component;
+        private DesignerVerb[] _verbs;
+        private LinkLabel _label;
+        private bool _allowVisible = true;
+        private int _optimalHeight = -1;
 
         internal HotCommands(PropertyGrid owner) : base(owner)
         {
@@ -27,13 +27,13 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return allowVisible;
+                return _allowVisible;
             }
             set
             {
-                if (allowVisible != value)
+                if (_allowVisible != value)
                 {
-                    allowVisible = value;
+                    _allowVisible = value;
                     if (value && WouldBeVisible)
                     {
                         Visible = true;
@@ -52,7 +52,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <returns>The accessibility object for this control.</returns>
         protected override AccessibleObject CreateAccessibilityInstance()
         {
-            return new HotCommandsAccessibleObject(this, ownerPropertyGrid);
+            return new HotCommandsAccessibleObject(this, OwnerPropertyGrid);
         }
 
         public override Rectangle DisplayRectangle
@@ -68,9 +68,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (label is null)
+                if (_label is null)
                 {
-                    label = new LinkLabel
+                    _label = new LinkLabel
                     {
                         Dock = DockStyle.Fill,
                         LinkBehavior = LinkBehavior.AlwaysUnderline,
@@ -78,11 +78,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                         // use default LinkLabel colors for regular, active, and visited
                         DisabledLinkColor = SystemColors.ControlDark
                     };
-                    label.LinkClicked += new LinkLabelLinkClickedEventHandler(LinkClicked);
-                    Controls.Add(label);
+                    _label.LinkClicked += new LinkLabelLinkClickedEventHandler(LinkClicked);
+                    Controls.Add(_label);
                 }
 
-                return label;
+                return _label;
             }
         }
 
@@ -90,25 +90,25 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (component is not null);
+                return (_component is not null);
             }
         }
 
         public override int GetOptimalHeight(int width)
         {
-            if (optimalHeight == -1)
+            if (_optimalHeight == -1)
             {
                 int lineHeight = (int)(1.5 * Font.Height);
                 int verbCount = 0;
-                if (verbs is not null)
+                if (_verbs is not null)
                 {
-                    verbCount = verbs.Length;
+                    verbCount = _verbs.Length;
                 }
 
-                optimalHeight = verbCount * lineHeight + 8;
+                _optimalHeight = verbCount * lineHeight + 8;
             }
 
-            return optimalHeight;
+            return _optimalHeight;
         }
 
         public override int SnapHeightRequest(int request)
@@ -154,7 +154,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected override void OnFontChanged(EventArgs e)
         {
             base.OnFontChanged(e);
-            optimalHeight = -1;
+            _optimalHeight = -1;
         }
 
         internal void SetColors(Color background, Color normalText, Color link, Color activeLink, Color visitedLink, Color disabledLink)
@@ -174,15 +174,15 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public virtual void SetVerbs(object component, DesignerVerb[] verbs)
         {
-            if (this.verbs is not null)
+            if (_verbs is not null)
             {
-                for (int i = 0; i < this.verbs.Length; i++)
+                for (int i = 0; i < _verbs.Length; i++)
                 {
-                    this.verbs[i].CommandChanged -= new EventHandler(OnCommandChanged);
+                    _verbs[i].CommandChanged -= new EventHandler(OnCommandChanged);
                 }
 
-                this.component = null;
-                this.verbs = null;
+                _component = null;
+                _verbs = null;
             }
 
             if (component is null || verbs is null || verbs.Length == 0)
@@ -193,15 +193,15 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else
             {
-                this.component = component;
-                this.verbs = verbs;
+                _component = component;
+                _verbs = verbs;
 
                 for (int i = 0; i < verbs.Length; i++)
                 {
                     verbs[i].CommandChanged += new EventHandler(OnCommandChanged);
                 }
 
-                if (allowVisible)
+                if (_allowVisible)
                 {
                     Visible = true;
                 }
@@ -209,20 +209,20 @@ namespace System.Windows.Forms.PropertyGridInternal
                 SetupLabel();
             }
 
-            optimalHeight = -1;
+            _optimalHeight = -1;
         }
 
         private void SetupLabel()
         {
             Label.Links.Clear();
             StringBuilder sb = new StringBuilder();
-            Point[] links = new Point[verbs.Length];
+            Point[] links = new Point[_verbs.Length];
             int charLoc = 0;
             bool firstVerb = true;
 
-            for (int i = 0; i < verbs.Length; i++)
+            for (int i = 0; i < _verbs.Length; i++)
             {
-                if (verbs[i].Visible && verbs[i].Supported)
+                if (_verbs[i].Visible && _verbs[i].Supported)
                 {
                     if (!firstVerb)
                     {
@@ -231,7 +231,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         charLoc += 2;
                     }
 
-                    string name = verbs[i].Text;
+                    string name = _verbs[i].Text;
 
                     links[i] = new Point(charLoc, name.Length);
                     sb.Append(name);
@@ -242,12 +242,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             Label.Text = sb.ToString();
 
-            for (int i = 0; i < verbs.Length; i++)
+            for (int i = 0; i < _verbs.Length; i++)
             {
-                if (verbs[i].Visible && verbs[i].Supported)
+                if (_verbs[i].Visible && _verbs[i].Supported)
                 {
-                    LinkLabel.Link link = Label.Links.Add(links[i].X, links[i].Y, verbs[i]);
-                    if (!verbs[i].Enabled)
+                    LinkLabel.Link link = Label.Links.Add(links[i].X, links[i].Y, _verbs[i]);
+                    if (!_verbs[i].Enabled)
                     {
                         link.Enabled = false;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
@@ -18,16 +18,9 @@ namespace System.Windows.Forms.PropertyGridInternal
     {
         private readonly PropertyDescriptor[] _descriptors;
 
-        private enum TriState
-        {
-            Unknown,
-            Yes,
-            No
-        }
-
-        private TriState _localizable = TriState.Unknown;
-        private TriState _readOnly = TriState.Unknown;
-        private TriState _canReset = TriState.Unknown;
+        private bool? _localizable;
+        private bool? _readOnly;
+        private bool? _canReset;
 
         private MultiMergeCollection _collection;
 
@@ -36,11 +29,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             _descriptors = descriptors;
         }
 
-        /// <summary>
-        ///  When overridden in a derived class, gets the type of the
-        ///  component this property
-        ///  is bound to.
-        /// </summary>
+        /// <inheritdoc />
         public override Type ComponentType
         {
             get
@@ -49,9 +38,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        /// <summary>
-        ///  Gets the type converter for this property.
-        /// </summary>
+        /// <inheritdoc />
         public override TypeConverter Converter
         {
             get
@@ -68,62 +55,51 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        /// <summary>
-        ///  Gets a value
-        ///  indicating whether this property should be localized, as
-        ///  specified in the <see cref='LocalizableAttribute'/>.
-        /// </summary>
+        /// <inheritdoc />
         public override bool IsLocalizable
         {
             get
             {
-                if (_localizable == TriState.Unknown)
+                if (!_localizable.HasValue)
                 {
-                    _localizable = TriState.Yes;
+                    _localizable = true;
                     foreach (PropertyDescriptor pd in _descriptors)
                     {
                         if (!pd.IsLocalizable)
                         {
-                            _localizable = TriState.No;
+                            _localizable = false;
                             break;
                         }
                     }
                 }
 
-                return (_localizable == TriState.Yes);
+                return _localizable.Value;
             }
         }
 
-        /// <summary>
-        ///  When overridden in
-        ///  a derived class, gets a value
-        ///  indicating whether this property is read-only.
-        /// </summary>
+        /// <inheritdoc />
         public override bool IsReadOnly
         {
             get
             {
-                if (_readOnly == TriState.Unknown)
+                if (!_readOnly.HasValue)
                 {
-                    _readOnly = TriState.No;
+                    _readOnly = false;
                     foreach (PropertyDescriptor pd in _descriptors)
                     {
                         if (pd.IsReadOnly)
                         {
-                            _readOnly = TriState.Yes;
+                            _readOnly = true;
                             break;
                         }
                     }
                 }
 
-                return (_readOnly == TriState.Yes);
+                return _readOnly.Value;
             }
         }
 
-        /// <summary>
-        ///  When overridden in a derived class,
-        ///  gets the type of the property.
-        /// </summary>
+        /// <inheritdoc />
         public override Type PropertyType
         {
             get
@@ -140,29 +116,25 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        /// <summary>
-        ///  When overridden in a derived class, indicates whether
-        ///  resetting the <paramref name="component"/> will change the value of the
-        ///  <paramref name="component"/>.
-        /// </summary>
+        /// <inheritdoc />
         public override bool CanResetValue(object component)
         {
             Debug.Assert(component is Array, "MergePropertyDescriptor::CanResetValue called with non-array value");
-            if (_canReset == TriState.Unknown)
+            if (!_canReset.HasValue)
             {
-                _canReset = TriState.Yes;
+                _canReset = true;
                 Array a = (Array)component;
                 for (int i = 0; i < _descriptors.Length; i++)
                 {
                     if (!_descriptors[i].CanResetValue(GetPropertyOwnerForComponent(a, i)))
                     {
-                        _canReset = TriState.No;
+                        _canReset = false;
                         break;
                     }
                 }
             }
 
-            return (_canReset == TriState.Yes);
+            return _canReset.Value;
         }
 
         /// <summary>
@@ -238,10 +210,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return value;
         }
 
-        /// <summary>
-        ///  Creates a collection of attributes using the
-        ///  array of attributes that you passed to the constructor.
-        /// </summary>
+        /// <inheritdoc />
         protected override AttributeCollection CreateAttributeCollection()
         {
             return new MergedAttributeCollection(this);
@@ -258,20 +227,13 @@ namespace System.Windows.Forms.PropertyGridInternal
             return propertyOwner;
         }
 
-        /// <summary>
-        ///  Gets an editor of the specified type.
-        /// </summary>
+        /// <inheritdoc />
         public override object GetEditor(Type editorBaseType)
         {
             return _descriptors[0].GetEditor(editorBaseType);
         }
 
-        /// <summary>
-        ///  When overridden in a derived class, gets the current
-        ///  value
-        ///  of the
-        ///  property on a component.
-        /// </summary>
+        /// <inheritdoc />
         public override object GetValue(object component)
         {
             Debug.Assert(component is Array, "MergePropertyDescriptor::GetValue called with non-array value");
@@ -343,12 +305,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return values;
         }
 
-        /// <summary>
-        ///  When overridden in a derived class, resets the
-        ///  value
-        ///  for this property
-        ///  of the component.
-        /// </summary>
+        /// <inheritdoc />
         public override void ResetValue(object component)
         {
             Debug.Assert(component is Array, "MergePropertyDescriptor::ResetValue called with non-array value");
@@ -396,10 +353,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        /// <summary>
-        ///  When overridden in a derived class, sets the value of
-        ///  the component to a different value.
-        /// </summary>
+        /// <inheritdoc />
         public override void SetValue(object component, object value)
         {
             Debug.Assert(component is Array, "MergePropertyDescriptor::SetValue called with non-array value");
@@ -418,11 +372,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        /// <summary>
-        ///  When overridden in a derived class, indicates whether the
-        ///  value of
-        ///  this property needs to be persisted.
-        /// </summary>
+        /// <inheritdoc />
         public override bool ShouldSerializeValue(object component)
         {
             Debug.Assert(component is Array, "MergePropertyDescriptor::ShouldSerializeValue called with non-array value");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
@@ -12,15 +12,15 @@ namespace System.Windows.Forms.PropertyGridInternal
 {
     internal class MultiPropertyDescriptorGridEntry : PropertyDescriptorGridEntry
     {
-        private readonly MergePropertyDescriptor mergedPd;
-        private readonly object[] objs;
+        private readonly MergePropertyDescriptor _mergedDescriptor;
+        private readonly object[] _objects;
 
         public MultiPropertyDescriptorGridEntry(PropertyGrid ownerGrid, GridEntry peParent, object[] objectArray, PropertyDescriptor[] propInfo, bool hide)
         : base(ownerGrid, peParent, hide)
         {
-            mergedPd = new MergePropertyDescriptor(propInfo);
-            objs = objectArray;
-            base.Initialize(mergedPd);
+            _mergedDescriptor = new MergePropertyDescriptor(propInfo);
+            _objects = objectArray;
+            Initialize(_mergedDescriptor);
         }
 
         public override IContainer Container
@@ -29,7 +29,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 IContainer c = null;
 
-                foreach (object o in objs)
+                foreach (object o in _objects)
                 {
                     if (!(o is IComponent comp))
                     {
@@ -76,7 +76,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 try
                 {
-                    foreach (object o in mergedPd.GetValues(objs))
+                    foreach (object o in _mergedDescriptor.GetValues(_objects))
                     {
                         if (o is null)
                         {
@@ -117,14 +117,14 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             try
             {
-                if (mergedPd.PropertyType.IsValueType || (Flags & GridEntry.FLAG_IMMUTABLE) != 0)
+                if (_mergedDescriptor.PropertyType.IsValueType || (Flags & GridEntry.FLAG_IMMUTABLE) != 0)
                 {
                     return base.CreateChildren(diffOldChildren);
                 }
 
                 ChildCollection.Clear();
 
-                MultiPropertyDescriptorGridEntry[] mergedProps = MultiSelectRootGridEntry.PropertyMerger.GetMergedProperties(mergedPd.GetValues(objs), this, PropertySort, CurrentTab);
+                MultiPropertyDescriptorGridEntry[] mergedProps = MultiSelectRootGridEntry.PropertyMerger.GetMergedProperties(_mergedDescriptor.GetValues(_objects), this, PropertySort, CurrentTab);
 
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose && mergedProps is null, "PropertyGridView: MergedProps returned null!");
 
@@ -149,18 +149,18 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public override object GetChildValueOwner(GridEntry childEntry)
         {
-            if (mergedPd.PropertyType.IsValueType || (Flags & GridEntry.FLAG_IMMUTABLE) != 0)
+            if (_mergedDescriptor.PropertyType.IsValueType || (Flags & GridEntry.FLAG_IMMUTABLE) != 0)
             {
                 return base.GetChildValueOwner(childEntry);
             }
 
-            return mergedPd.GetValues(objs);
+            return _mergedDescriptor.GetValues(_objects);
         }
 
         public override IComponent[] GetComponents()
         {
-            IComponent[] temp = new IComponent[objs.Length];
-            Array.Copy(objs, 0, temp, 0, objs.Length);
+            IComponent[] temp = new IComponent[_objects.Length];
+            Array.Copy(_objects, 0, temp, 0, _objects.Length);
             return temp;
         }
 
@@ -172,7 +172,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             bool allEqual = true;
             try
             {
-                if (value is null && mergedPd.GetValue(objs, out allEqual) is null)
+                if (value is null && _mergedDescriptor.GetValue(_objects, out allEqual) is null)
                 {
                     if (!allEqual)
                     {
@@ -313,7 +313,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                                 }
                             }
 
-                            mergedPd.ResetValue(obj);
+                            _mergedDescriptor.ResetValue(obj);
 
                             if (needChangeNotify)
                             {
@@ -395,12 +395,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (ComponentChangeService is not null)
             {
-                int cLength = objs.Length;
+                int cLength = _objects.Length;
                 for (int i = 0; i < cLength; i++)
                 {
                     try
                     {
-                        ComponentChangeService.OnComponentChanging(objs[i], mergedPd[i]);
+                        ComponentChangeService.OnComponentChanging(_objects[i], _mergedDescriptor[i]);
                     }
                     catch (CheckoutException co)
                     {
@@ -421,10 +421,10 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (ComponentChangeService is not null)
             {
-                int cLength = objs.Length;
+                int cLength = _objects.Length;
                 for (int i = 0; i < cLength; i++)
                 {
-                    ComponentChangeService.OnComponentChanged(objs[i], mergedPd[i], null, null);
+                    ComponentChangeService.OnComponentChanged(_objects[i], _mergedDescriptor[i], null, null);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     if (anyRO)
                     {
-                        flags |= FLAG_FORCE_READONLY;
+                        Flags |= FLAG_FORCE_READONLY;
                     }
 
                     forceReadOnlyChecked = true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -416,7 +416,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (Converter is null)
                 {
-                    Converter = _propertyInfo.Converter;
+                    Converter = _propertyInfo?.Converter;
                 }
 
                 return base.TypeConverter;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -9,9 +9,6 @@ using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Design;
-using System.Globalization;
-using System.Windows.Forms.Design;
-using static Interop;
 
 namespace System.Windows.Forms.PropertyGridInternal
 {
@@ -417,9 +414,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return _exceptionConverter;
                 }
 
-                if (converter is null)
+                if (Converter is null)
                 {
-                    converter = _propertyInfo.Converter;
+                    Converter = _propertyInfo.Converter;
                 }
 
                 return base.TypeConverter;
@@ -439,7 +436,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return _exceptionEditor;
                 }
 
-                editor = (UITypeEditor)_propertyInfo.GetEditor(typeof(UITypeEditor));
+                Editor = (UITypeEditor)_propertyInfo.GetEditor(typeof(UITypeEditor));
 
                 return base.UITypeEditor;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridCommands.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridCommands.cs
@@ -9,8 +9,7 @@ using System.ComponentModel.Design;
 namespace System.Windows.Forms.PropertyGridInternal
 {
     /// <summary>
-    ///  This class contains the set of menu commands our property browser
-    ///  uses.
+    ///  This class contains the set of menu commands our property browser uses.
     /// </summary>
     public class PropertyGridCommands
     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObject.cs
@@ -25,11 +25,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         case UiaCore.NavigateDirection.Parent:
                             return ExistsInAccessibleTree
-                                ? _owningDropDownHolder.gridView?.SelectedGridEntry?.AccessibilityObject
+                                ? _owningDropDownHolder._gridView?.SelectedGridEntry?.AccessibilityObject
                                 : null;
                         case UiaCore.NavigateDirection.NextSibling:
                             return ExistsInAccessibleTree
-                                ? _owningDropDownHolder.gridView?.EditAccessibleObject
+                                ? _owningDropDownHolder._gridView?.EditAccessibleObject
                                 : null;
                         case UiaCore.NavigateDirection.PreviousSibling:
                             return null;
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot =>
-                    _owningDropDownHolder.gridView?.OwnerGrid?.AccessibilityObject;
+                    _owningDropDownHolder._gridView?.OwnerGrid?.AccessibilityObject;
 
                 internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridPositionData.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridPositionData.cs
@@ -12,32 +12,32 @@ namespace System.Windows.Forms.PropertyGridInternal
     {
         internal class GridPositionData
         {
-            readonly ArrayList expandedState;
-            readonly GridEntryCollection selectedItemTree;
-            readonly int itemRow;
-            readonly int itemCount;
+            private readonly ArrayList _expandedState;
+            private readonly GridEntryCollection _selectedItemTree;
+            private readonly int _itemRow;
+            private readonly int _itemCount;
 
             public GridPositionData(PropertyGridView gridView)
             {
-                selectedItemTree = gridView.GetGridEntryHierarchy(gridView.selectedGridEntry);
-                expandedState = gridView.SaveHierarchyState(gridView.topLevelGridEntries);
-                itemRow = gridView.selectedRow;
-                itemCount = gridView.totalProps;
+                _selectedItemTree = gridView.GetGridEntryHierarchy(gridView._selectedGridEntry);
+                _expandedState = gridView.SaveHierarchyState(gridView._topLevelGridEntries);
+                _itemRow = gridView._selectedRow;
+                _itemCount = gridView.TotalProps;
             }
 
             public GridEntry Restore(PropertyGridView gridView)
             {
-                gridView.RestoreHierarchyState(expandedState);
-                GridEntry entry = gridView.FindEquivalentGridEntry(selectedItemTree);
+                gridView.RestoreHierarchyState(_expandedState);
+                GridEntry entry = gridView.FindEquivalentGridEntry(_selectedItemTree);
 
                 if (entry is not null)
                 {
                     gridView.SelectGridEntry(entry, true);
 
-                    int delta = gridView.selectedRow - itemRow;
+                    int delta = gridView._selectedRow - _itemRow;
                     if (delta != 0 && gridView.ScrollBar.Visible)
                     {
-                        if (itemRow < gridView.visibleRows)
+                        if (_itemRow < gridView._visibleRows)
                         {
                             delta += gridView.GetScrollOffset();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObject.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 public GridViewEditAccessibleObject(GridViewEdit owner) : base(owner)
                 {
-                    _owningPropertyGridView = owner.psheet;
+                    _owningPropertyGridView = owner.PropertyGridView;
                     _owningGridViewEdit = owner;
                     _textProvider = new TextBoxBaseUiaTextProvider(owner);
                     UseTextProviders(_textProvider, _textProvider);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.cs
@@ -15,13 +15,13 @@ namespace System.Windows.Forms.PropertyGridInternal
     {
         private partial class GridViewEdit : TextBox, IMouseHookClient
         {
-            internal bool fInSetText;
-            internal bool filter;
-            internal PropertyGridView psheet;
-            private bool dontFocusMe;
-            private int lastMove;
+            private bool _inSetText;
+            private bool _filter;
+            internal PropertyGridView PropertyGridView { get; }
+            private bool _dontFocus;
+            private int _lastMove;
 
-            private readonly MouseHook mouseHook;
+            private readonly MouseHook _mouseHook;
 
             // We do this because the Focus call above doesn't always stick, so
             // we make the Edit think that it doesn't have focus.  this prevents
@@ -31,17 +31,17 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 set
                 {
-                    dontFocusMe = value;
+                    _dontFocus = value;
                 }
             }
 
             public virtual bool Filter
             {
-                get { return filter; }
+                get { return _filter; }
 
                 set
                 {
-                    filter = value;
+                    _filter = value;
                 }
             }
 
@@ -55,7 +55,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 get
                 {
-                    if (dontFocusMe)
+                    if (_dontFocus)
                     {
                         return false;
                     }
@@ -69,9 +69,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 get => base.Text;
                 set
                 {
-                    fInSetText = true;
+                    _inSetText = true;
                     base.Text = value;
-                    fInSetText = false;
+                    _inSetText = false;
                 }
             }
 
@@ -79,7 +79,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 set
                 {
-                    mouseHook.DisableMouseHook = value;
+                    _mouseHook.DisableMouseHook = value;
                 }
             }
 
@@ -87,11 +87,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 get
                 {
-                    return mouseHook.HookMouseDown;
+                    return _mouseHook.HookMouseDown;
                 }
                 set
                 {
-                    mouseHook.HookMouseDown = value;
+                    _mouseHook.HookMouseDown = value;
                     if (value)
                     {
                         Focus();
@@ -101,8 +101,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public GridViewEdit(PropertyGridView psheet)
             {
-                this.psheet = psheet;
-                mouseHook = new MouseHook(this, this, psheet);
+                PropertyGridView = psheet;
+                _mouseHook = new MouseHook(this, this, psheet);
             }
 
             /// <summary>
@@ -119,7 +119,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             protected override void DestroyHandle()
             {
-                mouseHook.HookMouseDown = false;
+                _mouseHook.HookMouseDown = false;
                 base.DestroyHandle();
             }
 
@@ -127,7 +127,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (disposing)
                 {
-                    mouseHook.Dispose();
+                    _mouseHook.Dispose();
                 }
 
                 base.Dispose(disposing);
@@ -158,7 +158,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return false;
                 }
 
-                if (psheet.NeedsCommit)
+                if (PropertyGridView.NeedsCommit)
                 {
                     return false;
                 }
@@ -185,7 +185,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 base.OnGotFocus(e);
 
-                this.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
             }
 
             protected override void OnKeyDown(KeyEventArgs ke)
@@ -217,7 +217,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 // can we commit this value?
                 // eat the value if we failed to commit.
-                return !psheet._Commit();
+                return !PropertyGridView._Commit();
             }
 
             protected override void OnMouseEnter(EventArgs e)
@@ -227,10 +227,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (!Focused)
                 {
                     Graphics g = CreateGraphics();
-                    if (psheet.SelectedGridEntry is not null &&
-                        ClientRectangle.Width <= psheet.SelectedGridEntry.GetValueTextWidth(Text, g, Font))
+                    if (PropertyGridView.SelectedGridEntry is not null &&
+                        ClientRectangle.Width <= PropertyGridView.SelectedGridEntry.GetValueTextWidth(Text, g, Font))
                     {
-                        psheet.ToolTip.ToolTip = PasswordProtect ? "" : Text;
+                        PropertyGridView.ToolTip.ToolTip = PasswordProtect ? "" : Text;
                     }
 
                     g.Dispose();
@@ -296,12 +296,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                             // if this is just the delete key and we're on a non-text editable property that is resettable,
                             // reset it now.
                             //
-                            if (psheet.SelectedGridEntry is not null && !psheet.SelectedGridEntry.Enumerable && !psheet.SelectedGridEntry.IsTextEditable && psheet.SelectedGridEntry.CanResetPropertyValue())
+                            if (PropertyGridView.SelectedGridEntry is not null && !PropertyGridView.SelectedGridEntry.Enumerable && !PropertyGridView.SelectedGridEntry.IsTextEditable && PropertyGridView.SelectedGridEntry.CanResetPropertyValue())
                             {
-                                object oldValue = psheet.SelectedGridEntry.PropertyValue;
-                                psheet.SelectedGridEntry.ResetPropertyValue();
-                                psheet.UnfocusSelection();
-                                psheet.OwnerGrid.OnPropertyValueSet(psheet.SelectedGridEntry, oldValue);
+                                object oldValue = PropertyGridView.SelectedGridEntry.PropertyValue;
+                                PropertyGridView.SelectedGridEntry.ResetPropertyValue();
+                                PropertyGridView.UnfocusSelection();
+                                PropertyGridView.OwnerGrid.OnPropertyValueSet(PropertyGridView.SelectedGridEntry, oldValue);
                             }
                         }
 
@@ -324,18 +324,18 @@ namespace System.Windows.Forms.PropertyGridInternal
                     switch (keyData & Keys.KeyCode)
                     {
                         case Keys.Return:
-                            bool fwdReturn = !psheet.NeedsCommit;
-                            if (psheet.UnfocusSelection() && fwdReturn && psheet.SelectedGridEntry is not null)
+                            bool fwdReturn = !PropertyGridView.NeedsCommit;
+                            if (PropertyGridView.UnfocusSelection() && fwdReturn && PropertyGridView.SelectedGridEntry is not null)
                             {
-                                psheet.SelectedGridEntry.OnValueReturnKey();
+                                PropertyGridView.SelectedGridEntry.OnValueReturnKey();
                             }
 
                             return true;
                         case Keys.Escape:
-                            psheet.OnEscape(this);
+                            PropertyGridView.OnEscape(this);
                             return true;
                         case Keys.F4:
-                            psheet.F4Selection(true);
+                            PropertyGridView.F4Selection(true);
                             return true;
                     }
                 }
@@ -343,7 +343,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // for the tab key, we want to commit before we allow it to be processed.
                 if ((keyData & Keys.KeyCode) == Keys.Tab && ((keyData & (Keys.Control | Keys.Alt)) == 0))
                 {
-                    return !psheet._Commit();
+                    return !PropertyGridView._Commit();
                 }
 
                 return base.ProcessDialogKey(keyData);
@@ -356,7 +356,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // we're going invisible
                 if (value == false && HookMouseDown)
                 {
-                    mouseHook.HookMouseDown = false;
+                    _mouseHook.HookMouseDown = false;
                 }
 
                 base.SetVisibleCore(value);
@@ -366,7 +366,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // for responding to WM_GETDLGCODE
             internal bool WantsTab(bool forward)
             {
-                return psheet.WantsTab(forward);
+                return PropertyGridView.WantsTab(forward);
             }
 
             private unsafe bool WmNotify(ref Message m)
@@ -375,16 +375,16 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
 
-                    if (nmhdr->hwndFrom == psheet.ToolTip.Handle)
+                    if (nmhdr->hwndFrom == PropertyGridView.ToolTip.Handle)
                     {
                         switch ((ComCtl32.TTN)nmhdr->code)
                         {
                             case ComCtl32.TTN.SHOW:
-                                PropertyGridView.PositionTooltip(this, psheet.ToolTip, ClientRectangle);
+                                PropertyGridView.PositionTooltip(this, PropertyGridView.ToolTip, ClientRectangle);
                                 m.Result = (IntPtr)1;
                                 return true;
                             default:
-                                psheet.WndProc(ref m);
+                                PropertyGridView.WndProc(ref m);
                                 break;
                         }
                     }
@@ -395,9 +395,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             protected override void WndProc(ref Message m)
             {
-                if (filter)
+                if (_filter)
                 {
-                    if (psheet.FilterEditWndProc(ref m))
+                    if (PropertyGridView.FilterEditWndProc(ref m))
                     {
                         return;
                     }
@@ -408,25 +408,25 @@ namespace System.Windows.Forms.PropertyGridInternal
                     case User32.WM.STYLECHANGED:
                         if ((unchecked((int)(long)m.WParam) & (int)User32.GWL.EXSTYLE) != 0)
                         {
-                            psheet.Invalidate();
+                            PropertyGridView.Invalidate();
                         }
 
                         break;
                     case User32.WM.MOUSEMOVE:
-                        if (unchecked((int)(long)m.LParam) == lastMove)
+                        if (unchecked((int)(long)m.LParam) == _lastMove)
                         {
                             return;
                         }
 
-                        lastMove = unchecked((int)(long)m.LParam);
+                        _lastMove = unchecked((int)(long)m.LParam);
                         break;
                     case User32.WM.DESTROY:
-                        mouseHook.HookMouseDown = false;
+                        _mouseHook.HookMouseDown = false;
                         break;
                     case User32.WM.SHOWWINDOW:
                         if (IntPtr.Zero == m.WParam)
                         {
-                            mouseHook.HookMouseDown = false;
+                            _mouseHook.HookMouseDown = false;
                         }
 
                         break;
@@ -441,7 +441,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     case User32.WM.GETDLGCODE:
 
                         m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTARROWS | (int)User32.DLGC.WANTCHARS);
-                        if (psheet.NeedsCommit || WantsTab((ModifierKeys & Keys.Shift) == 0))
+                        if (PropertyGridView.NeedsCommit || WantsTab((ModifierKeys & Keys.Shift) == 0))
                         {
                             m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTALLKEYS | (int)User32.DLGC.WANTTAB);
                         }
@@ -462,7 +462,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public virtual bool InSetText()
             {
-                return fInSetText;
+                return _inSetText;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBox.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms.PropertyGridInternal
     {
         internal class GridViewListBox : ListBox
         {
-            internal bool fInSetSelectedIndex;
+            private bool _inSetSelectedIndex;
             private readonly PropertyGridView _owningPropertyGridView;
 
             public GridViewListBox(PropertyGridView gridView)
@@ -20,7 +20,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     throw new ArgumentNullException(nameof(gridView));
                 }
 
-                base.IntegralHeight = false;
+                IntegralHeight = false;
                 _owningPropertyGridView = gridView;
                 base.BackColor = gridView.BackColor;
             }
@@ -59,14 +59,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public virtual bool InSetSelectedIndex()
             {
-                return fInSetSelectedIndex;
+                return _inSetSelectedIndex;
             }
 
             protected override void OnSelectedIndexChanged(EventArgs e)
             {
-                fInSetSelectedIndex = true;
+                _inSetSelectedIndex = true;
                 base.OnSelectedIndexChanged(e);
-                fInSetSelectedIndex = false;
+                _inSetSelectedIndex = false;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.IMouseHookClient.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.IMouseHookClient.cs
@@ -8,8 +8,9 @@ namespace System.Windows.Forms.PropertyGridInternal
     {
         internal interface IMouseHookClient
         {
-            // return true if the click is handled, false
-            // to pass it on
+            /// <summary>
+            ///  Returns true if the click is handled, false to pass it on.
+            /// </summary>
             bool OnClickHooked();
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.MouseHook.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.MouseHook.cs
@@ -15,32 +15,32 @@ namespace System.Windows.Forms.PropertyGridInternal
     {
         internal class MouseHook
         {
-            private readonly PropertyGridView gridView;
-            private readonly Control control;
-            private readonly IMouseHookClient client;
+            private readonly PropertyGridView _gridView;
+            private readonly Control _control;
+            private readonly IMouseHookClient _client;
 
-            internal uint _thisProcessID;
+            private uint _thisProcessId;
             private GCHandle _mouseHookRoot;
             private IntPtr _mouseHookHandle = IntPtr.Zero;
-            private bool hookDisable;
+            private bool _hookDisable;
 
-            private bool processing;
+            private bool _processing;
 
             public MouseHook(Control control, IMouseHookClient client, PropertyGridView gridView)
             {
-                this.control = control;
-                this.gridView = gridView;
-                this.client = client;
+                _control = control;
+                _gridView = gridView;
+                _client = client;
 #if DEBUG
-                callingStack = Environment.StackTrace;
+                _callingStack = Environment.StackTrace;
 #endif
             }
 
 #if DEBUG
-            readonly string callingStack;
+            private readonly string _callingStack;
             ~MouseHook()
             {
-                Debug.Assert(_mouseHookHandle == IntPtr.Zero, "Finalizing an active mouse hook.  This will crash the process.  Calling stack: " + callingStack);
+                Debug.Assert(_mouseHookHandle == IntPtr.Zero, "Finalizing an active mouse hook.  This will crash the process.  Calling stack: " + _callingStack);
             }
 #endif
 
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 set
                 {
-                    hookDisable = value;
+                    _hookDisable = value;
                     if (value)
                     {
                         UnhookMouse();
@@ -65,7 +65,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 set
                 {
-                    if (value && !hookDisable)
+                    if (value && !_hookDisable)
                     {
                         HookMouse();
                     }
@@ -95,9 +95,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return;
                     }
 
-                    if (_thisProcessID == 0)
+                    if (_thisProcessId == 0)
                     {
-                        User32.GetWindowThreadProcessId(control, out _thisProcessID);
+                        User32.GetWindowThreadProcessId(_control, out _thisProcessId);
                     }
 
                     var hook = new User32.HOOKPROC(new MouseHookObject(this).Callback);
@@ -172,25 +172,25 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // If we put up the "invalid" message box, it appears this
                 // method is getting called re-entrantly when it shouldn't be.
                 // this prevents us from recursing.
-                if (processing)
+                if (_processing)
                 {
                     return false;
                 }
 
                 IntPtr hWndAtPoint = hWnd;
-                IntPtr handle = control.Handle;
+                IntPtr handle = _control.Handle;
                 Control ctrlAtPoint = FromHandle(hWndAtPoint);
 
                 // if it's us or one of our children, just process as normal
-                if (hWndAtPoint != handle && !control.Contains(ctrlAtPoint))
+                if (hWndAtPoint != handle && !_control.Contains(ctrlAtPoint))
                 {
-                    Debug.Assert(_thisProcessID != 0, "Didn't get our process id!");
+                    Debug.Assert(_thisProcessId != 0, "Didn't get our process id!");
 
                     // Make sure the window is in our process
                     User32.GetWindowThreadProcessId(hWndAtPoint, out uint pid);
 
                     // if this isn't our process, unhook the mouse.
-                    if (pid != _thisProcessID)
+                    if (pid != _thisProcessId)
                     {
                         HookMouseDown = false;
                         return false;
@@ -199,15 +199,15 @@ namespace System.Windows.Forms.PropertyGridInternal
                     bool needCommit = false;
 
                     // if this a sibling control (e.g. the drop down or buttons), just forward the message and skip the commit
-                    needCommit = ctrlAtPoint is null ? true : !gridView.IsSiblingControl(control, ctrlAtPoint);
+                    needCommit = ctrlAtPoint is null ? true : !_gridView.IsSiblingControl(_control, ctrlAtPoint);
 
                     try
                     {
-                        processing = true;
+                        _processing = true;
 
                         if (needCommit)
                         {
-                            if (client.OnClickHooked())
+                            if (_client.OnClickHooked())
                             {
                                 return true; // there was an error, so eat the mouse
                             }
@@ -215,7 +215,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                     finally
                     {
-                        processing = false;
+                        _processing = false;
                     }
 
                     // cancel our hook at this point

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.PropertyGridViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.PropertyGridViewAccessibleObject.cs
@@ -448,7 +448,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             public override AccessibleObject? GetFocused()
             {
                 GridEntry gridEntry = ((PropertyGridView)Owner).SelectedGridEntry;
-                if (gridEntry is not null && gridEntry.Focus)
+                if (gridEntry is not null && gridEntry.HasFocus)
                 {
                     return gridEntry.AccessibilityObject;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -24,36 +24,30 @@ namespace System.Windows.Forms.PropertyGridInternal
         IWindowsFormsEditorService,
         IServiceProvider
     {
-        protected static readonly Point InvalidPoint = new Point(int.MinValue, int.MinValue);
+        protected static Point InvalidPoint { get; } = new(int.MinValue, int.MinValue);
 
-        public const int RENDERMODE_LEFTDOT = 2;
-        public const int RENDERMODE_BOLD = 3;
-        public const int RENDERMODE_TRIANGLE = 4;
+        private static readonly TraceSwitch s_gridViewDebugPaint = new("GridViewDebugPaint", "PropertyGridView: Debug property painting");
 
-        public static int inheritRenderMode = RENDERMODE_BOLD;
-
-        public static TraceSwitch GridViewDebugPaint = new TraceSwitch("GridViewDebugPaint", "PropertyGridView: Debug property painting");
-        private const int LEFTDOT_SIZE = 4;
-        // constants
-        private const int EDIT_INDENT = 0;
-        private const int OUTLINE_INDENT = 10;
-        private const int OUTLINE_SIZE = 9;
-        private const int OUTLINE_SIZE_EXPLORER_TREE_STYLE = 16;
-        private int outlineSize = OUTLINE_SIZE;
-        private int outlineSizeExplorerTreeStyle = OUTLINE_SIZE_EXPLORER_TREE_STYLE;
-        private const int PAINT_WIDTH = 20;
-        private int paintWidth = PAINT_WIDTH;
-        private const int PAINT_INDENT = 26;
-        private int paintIndent = PAINT_INDENT;
-        private const int ROWLABEL = 1;
-        private const int ROWVALUE = 2;
-        private const int MAX_LISTBOX_HEIGHT = 200;
-        private int maxListBoxHeight = MAX_LISTBOX_HEIGHT;
+        // Constants
+        private const int EditIndent = 0;
+        private const int OutlineIndent = 10;
+        private const int OutlineSize = 9;
+        private const int OutlineSizeExplorerTreeStyle = 16;
+        private int _outlineSize = OutlineSize;
+        private int _outlineSizeExplorerTreeStyle = OutlineSizeExplorerTreeStyle;
+        private const int PaintWidth = 20;
+        private int _paintWidth = PaintWidth;
+        private const int PaintIndent = 26;
+        private int _paintIndent = PaintIndent;
+        private const int RowLabel = 1;
+        private const int RowValue = 2;
+        private const int MaxListBoxHeight = 200;
+        private int _maxListBoxHeight = MaxListBoxHeight;
 
         private const short ERROR_NONE = 0;
         private const short ERROR_THROWN = 1;
         private const short ERROR_MSGBOX_UP = 2;
-        internal const short GDIPLUS_SPACE = 2;
+        internal const short GdiPlusSpace = 2;
         internal const int MaxRecurseExpand = 10;
 
         private const int DOTDOTDOT_ICONWIDTH = 7;
@@ -61,48 +55,48 @@ namespace System.Windows.Forms.PropertyGridInternal
         private const int DOWNARROW_ICONWIDTH = 16;
         private const int DOWNARROW_ICONHEIGHT = 16;
 
-        private const int OFFSET_2PIXELS = 2;
-        private int offset_2Units = OFFSET_2PIXELS;
+        private const int Offset2Pixels = 2;
+        private int _offset2Units = Offset2Pixels;
 
-        protected static readonly Point InvalidPosition = new Point(int.MinValue, int.MinValue);
+        protected static Point InvalidPosition { get; } = new(int.MinValue, int.MinValue);
 
         // colors and fonts
         private Font _fontBold;
         private Color _grayTextColor;
 
         // for backwards compatibility of default colors
-        private bool grayTextColorModified; // true if someone has set the grayTextColor property
+        private bool _grayTextColorModified; // true if someone has set the grayTextColor property
 
         // property collections
-        private GridEntryCollection topLevelGridEntries;     // top level props
-        private GridEntryCollection allGridEntries;  // cache of viewable props
+        private GridEntryCollection _topLevelGridEntries;       // top level props
+        private GridEntryCollection _allGridEntries;            // cache of viewable props
 
         // row information
-        internal int totalProps = -1;        // # of viewable props
-        private int visibleRows = -1;         // # of visible rows
-        private int labelWidth = -1;
-        public double labelRatio = 2; // ratio of whole row to label width
+        public int TotalProps { get; private set; } = -1;       // # of viewable props
+        private int _visibleRows = -1;                          // # of visible rows
+        private int _labelWidth = -1;
+        public double _labelRatio = 2;                          // ratio of whole row to label width
 
-        private short requiredLabelPaintMargin = GDIPLUS_SPACE;
+        private short _requiredLabelPaintMargin = GdiPlusSpace;
 
         // current selected row and tooltip.
-        private int selectedRow = -1;
-        private GridEntry selectedGridEntry;
-        private int tipInfo = -1;
+        private int _selectedRow = -1;
+        private GridEntry _selectedGridEntry;
+        private int _tipInfo = -1;
 
         // editors & controls
-        private GridViewEdit edit;
-        private DropDownButton btnDropDown;
-        private DropDownButton btnDialog;
-        private GridViewListBox listBox;
-        private DropDownHolder dropDownHolder;
-        private Rectangle lastClientRect = Rectangle.Empty;
-        private Control currentEditor;
-        private ScrollBar scrollBar;
-        internal GridToolTip toolTip;
-        private GridErrorDlg errorDlg;
+        private GridViewEdit _edit;
+        private DropDownButton _buttonDropDown;
+        private DropDownButton _buttonDialog;
+        private GridViewListBox _listBox;
+        private DropDownHolder _dropDownHolder;
+        private Rectangle _lastClientRect = Rectangle.Empty;
+        private Control _currentEditor;
+        private ScrollBar _scrollBar;
+        internal GridToolTip _toolTip;
+        private GridErrorDlg _errorDialog;
 
-        // flags
+        // Flags
         private const short FlagNeedsRefresh = 0x0001;
         private const short FlagIsNewSelection = 0x0002;
         private const short FlagIsSplitterMove = 0x0004;
@@ -115,53 +109,53 @@ namespace System.Windows.Forms.PropertyGridInternal
         private const short FlagNoDefault = 0x0200;
         private const short FlagResizableDropDown = 0x0400;
 
-        private short flags = FlagNeedsRefresh | FlagIsNewSelection | FlagNeedUpdateUIBasedOnFont;
-        private short errorState = ERROR_NONE;
+        private short _flags = FlagNeedsRefresh | FlagIsNewSelection | FlagNeedUpdateUIBasedOnFont;
+        private short _errorState = ERROR_NONE;
 
-        private Point ptOurLocation = new Point(1, 1);
+        private Point _location = new(1, 1);
 
-        private string originalTextValue;     // original text, in case of ESC
-        private int cumulativeVerticalWheelDelta;
-        private long rowSelectTime;
-        private Point rowSelectPos = Point.Empty; // the position that we clicked on a row to test for double clicks
-        private Point lastMouseDown = InvalidPosition;
-        private int lastMouseMove;
-        private GridEntry lastClickedEntry;
+        private string _originalTextValue;          // original text, in case of ESC
+        private int _cumulativeVerticalWheelDelta;
+        private long _rowSelectTime;
+        private Point _rowSelectPos = Point.Empty;  // the position that we clicked on a row to test for double clicks
+        private Point _lastMouseDown = InvalidPosition;
+        private int _lastMouseMove;
+        private GridEntry _lastClickedEntry;
 
-        private IServiceProvider serviceProvider;
-        private IHelpService topHelpService;
-        private IHelpService helpService;
+        private IServiceProvider _serviceProvider;
+        private IHelpService _topHelpService;
+        private IHelpService _helpService;
 
-        private readonly EventHandler ehValueClick;
-        private readonly EventHandler ehLabelClick;
-        private readonly EventHandler ehOutlineClick;
-        private readonly EventHandler ehValueDblClick;
-        private readonly EventHandler ehLabelDblClick;
-        private readonly GridEntryRecreateChildrenEventHandler ehRecreateChildren;
+        private readonly EventHandler _valueClick;
+        private readonly EventHandler _labelClick;
+        private readonly EventHandler _outlineClick;
+        private readonly EventHandler _valueDoubleClick;
+        private readonly EventHandler _labelDoubleClick;
+        private readonly GridEntryRecreateChildrenEventHandler _recreateChildren;
 
-        private int cachedRowHeight = -1;
+        private int _cachedRowHeight = -1;
 
         public PropertyGridView(IServiceProvider serviceProvider, PropertyGrid propertyGrid)
-        : base()
+            : base()
         {
             if (DpiHelper.IsScalingRequired)
             {
-                paintWidth = DpiHelper.LogicalToDeviceUnitsX(PAINT_WIDTH);
-                paintIndent = DpiHelper.LogicalToDeviceUnitsX(PAINT_INDENT);
-                outlineSizeExplorerTreeStyle = DpiHelper.LogicalToDeviceUnitsX(OUTLINE_SIZE_EXPLORER_TREE_STYLE);
-                outlineSize = DpiHelper.LogicalToDeviceUnitsX(OUTLINE_SIZE);
-                maxListBoxHeight = DpiHelper.LogicalToDeviceUnitsY(MAX_LISTBOX_HEIGHT);
+                _paintWidth = DpiHelper.LogicalToDeviceUnitsX(PaintWidth);
+                _paintIndent = DpiHelper.LogicalToDeviceUnitsX(PaintIndent);
+                _outlineSizeExplorerTreeStyle = DpiHelper.LogicalToDeviceUnitsX(OutlineSizeExplorerTreeStyle);
+                _outlineSize = DpiHelper.LogicalToDeviceUnitsX(OutlineSize);
+                _maxListBoxHeight = DpiHelper.LogicalToDeviceUnitsY(MaxListBoxHeight);
             }
 
-            ehValueClick = new EventHandler(OnGridEntryValueClick);
-            ehLabelClick = new EventHandler(OnGridEntryLabelClick);
-            ehOutlineClick = new EventHandler(OnGridEntryOutlineClick);
-            ehValueDblClick = new EventHandler(OnGridEntryValueDoubleClick);
-            ehLabelDblClick = new EventHandler(OnGridEntryLabelDoubleClick);
-            ehRecreateChildren = new GridEntryRecreateChildrenEventHandler(OnRecreateChildren);
+            _valueClick = new EventHandler(OnGridEntryValueClick);
+            _labelClick = new EventHandler(OnGridEntryLabelClick);
+            _outlineClick = new EventHandler(OnGridEntryOutlineClick);
+            _valueDoubleClick = new EventHandler(OnGridEntryValueDoubleClick);
+            _labelDoubleClick = new EventHandler(OnGridEntryLabelDoubleClick);
+            _recreateChildren = new GridEntryRecreateChildrenEventHandler(OnRecreateChildren);
 
             OwnerGrid = propertyGrid;
-            this.serviceProvider = serviceProvider;
+            _serviceProvider = serviceProvider;
 
             SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
             SetStyle(ControlStyles.ResizeRedraw, false);
@@ -191,14 +185,14 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (selectedGridEntry is null)
+                if (_selectedGridEntry is null)
                 {
                     return false;
                 }
 
                 if (!Edit.Focused)
                 {
-                    string val = selectedGridEntry.GetPropertyTextValue();
+                    string val = _selectedGridEntry.GetPropertyTextValue();
 
                     return val is not null && val.Length > 0;
                 }
@@ -213,7 +207,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return CanCopy && selectedGridEntry is not null && selectedGridEntry.IsTextEditable;
+                return CanCopy && _selectedGridEntry is not null && _selectedGridEntry.IsTextEditable;
             }
         }
 
@@ -223,7 +217,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return selectedGridEntry is not null && selectedGridEntry.IsTextEditable; // return gridView.CanPaste;
+                return _selectedGridEntry is not null && _selectedGridEntry.IsTextEditable; // return gridView.CanPaste;
             }
         }
 
@@ -246,7 +240,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (btnDropDown is null)
+                if (_buttonDropDown is null)
                 {
 #if DEBUG
                     if (OwnerGrid.inGridViewCreate)
@@ -255,23 +249,23 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
 #endif
 
-                    btnDropDown = new DropDownButton
+                    _buttonDropDown = new DropDownButton
                     {
                         UseComboBoxTheme = true
                     };
                     Bitmap bitmap = CreateResizedBitmap("Arrow", DOWNARROW_ICONWIDTH, DOWNARROW_ICONHEIGHT);
-                    btnDropDown.Image = bitmap;
-                    btnDropDown.BackColor = SystemColors.Control;
-                    btnDropDown.ForeColor = SystemColors.ControlText;
-                    btnDropDown.Click += new EventHandler(OnBtnClick);
-                    btnDropDown.GotFocus += new EventHandler(OnDropDownButtonGotFocus);
-                    btnDropDown.LostFocus += new EventHandler(OnChildLostFocus);
-                    btnDropDown.TabIndex = 2;
-                    CommonEditorSetup(btnDropDown);
-                    btnDropDown.Size = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight) : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
+                    _buttonDropDown.Image = bitmap;
+                    _buttonDropDown.BackColor = SystemColors.Control;
+                    _buttonDropDown.ForeColor = SystemColors.ControlText;
+                    _buttonDropDown.Click += new EventHandler(OnBtnClick);
+                    _buttonDropDown.GotFocus += new EventHandler(OnDropDownButtonGotFocus);
+                    _buttonDropDown.LostFocus += new EventHandler(OnChildLostFocus);
+                    _buttonDropDown.TabIndex = 2;
+                    CommonEditorSetup(_buttonDropDown);
+                    _buttonDropDown.Size = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight) : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
                 }
 
-                return btnDropDown;
+                return _buttonDropDown;
             }
         }
 
@@ -279,7 +273,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (btnDialog is null)
+                if (_buttonDialog is null)
                 {
 #if DEBUG
                     if (OwnerGrid.inGridViewCreate)
@@ -287,22 +281,22 @@ namespace System.Windows.Forms.PropertyGridInternal
                         throw new Exception("PERF REGRESSION - Creating item in grid view create");
                     }
 #endif
-                    btnDialog = new DropDownButton
+                    _buttonDialog = new DropDownButton
                     {
                         BackColor = SystemColors.Control,
                         ForeColor = SystemColors.ControlText,
                         TabIndex = 3,
                         Image = CreateResizedBitmap("dotdotdot", DOTDOTDOT_ICONWIDTH, DOTDOTDOT_ICONHEIGHT)
                     };
-                    btnDialog.Click += new EventHandler(OnBtnClick);
-                    btnDialog.KeyDown += new KeyEventHandler(OnBtnKeyDown);
-                    btnDialog.GotFocus += new EventHandler(OnDropDownButtonGotFocus);
-                    btnDialog.LostFocus += new EventHandler(OnChildLostFocus);
-                    btnDialog.Size = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight) : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
-                    CommonEditorSetup(btnDialog);
+                    _buttonDialog.Click += new EventHandler(OnBtnClick);
+                    _buttonDialog.KeyDown += new KeyEventHandler(OnBtnKeyDown);
+                    _buttonDialog.GotFocus += new EventHandler(OnDropDownButtonGotFocus);
+                    _buttonDialog.LostFocus += new EventHandler(OnChildLostFocus);
+                    _buttonDialog.Size = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight) : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
+                    CommonEditorSetup(_buttonDialog);
                 }
 
-                return btnDialog;
+                return _buttonDialog;
             }
         }
 
@@ -330,7 +324,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (edit is null)
+                if (_edit is null)
                 {
 #if DEBUG
                     if (OwnerGrid.inGridViewCreate)
@@ -339,7 +333,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
 #endif
 
-                    edit = new GridViewEdit(this)
+                    _edit = new GridViewEdit(this)
                     {
                         BorderStyle = BorderStyle.None,
                         AutoSize = false,
@@ -348,18 +342,18 @@ namespace System.Windows.Forms.PropertyGridInternal
                         BackColor = BackColor,
                         ForeColor = ForeColor
                     };
-                    edit.KeyDown += new KeyEventHandler(OnEditKeyDown);
-                    edit.KeyPress += new KeyPressEventHandler(OnEditKeyPress);
-                    edit.GotFocus += new EventHandler(OnEditGotFocus);
-                    edit.LostFocus += new EventHandler(OnEditLostFocus);
-                    edit.MouseDown += new MouseEventHandler(OnEditMouseDown);
-                    edit.TextChanged += new EventHandler(OnEditChange);
+                    _edit.KeyDown += new KeyEventHandler(OnEditKeyDown);
+                    _edit.KeyPress += new KeyPressEventHandler(OnEditKeyPress);
+                    _edit.GotFocus += new EventHandler(OnEditGotFocus);
+                    _edit.LostFocus += new EventHandler(OnEditLostFocus);
+                    _edit.MouseDown += new MouseEventHandler(OnEditMouseDown);
+                    _edit.TextChanged += new EventHandler(OnEditChange);
                     //edit.ImeModeChanged += new EventHandler(this.OnEditImeModeChanged);
-                    edit.TabIndex = 1;
-                    CommonEditorSetup(edit);
+                    _edit.TabIndex = 1;
+                    CommonEditorSetup(_edit);
                 }
 
-                return edit;
+                return _edit;
             }
         }
 
@@ -378,7 +372,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (listBox is null)
+                if (_listBox is null)
                 {
 #if DEBUG
                     if (OwnerGrid.inGridViewCreate)
@@ -387,21 +381,21 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
 #endif
 
-                    listBox = new GridViewListBox(this)
+                    _listBox = new GridViewListBox(this)
                     {
                         DrawMode = DrawMode.OwnerDrawFixed
                     };
                     //listBox.Click += new EventHandler(this.OnListClick);
-                    listBox.MouseUp += new MouseEventHandler(OnListMouseUp);
-                    listBox.DrawItem += new DrawItemEventHandler(OnListDrawItem);
-                    listBox.SelectedIndexChanged += new EventHandler(OnListChange);
-                    listBox.KeyDown += new KeyEventHandler(OnListKeyDown);
-                    listBox.LostFocus += new EventHandler(OnChildLostFocus);
-                    listBox.Visible = true;
-                    listBox.ItemHeight = RowHeight;
+                    _listBox.MouseUp += new MouseEventHandler(OnListMouseUp);
+                    _listBox.DrawItem += new DrawItemEventHandler(OnListDrawItem);
+                    _listBox.SelectedIndexChanged += new EventHandler(OnListChange);
+                    _listBox.KeyDown += new KeyEventHandler(OnListKeyDown);
+                    _listBox.LostFocus += new EventHandler(OnChildLostFocus);
+                    _listBox.Visible = true;
+                    _listBox.ItemHeight = RowHeight;
                 }
 
-                return listBox;
+                return _listBox;
             }
         }
 
@@ -425,9 +419,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (edit is not null && edit.IsHandleCreated)
+                if (_edit is not null && _edit.IsHandleCreated)
                 {
-                    int exStyle = unchecked((int)((long)User32.GetWindowLong(edit, User32.GWL.EXSTYLE)));
+                    int exStyle = unchecked((int)((long)User32.GetWindowLong(_edit, User32.GWL.EXSTYLE)));
                     return (exStyle & (int)User32.WS_EX.RTLREADING) != 0;
                 }
                 else
@@ -437,13 +431,13 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        internal DropDownHolder DropDownControlHolder => dropDownHolder;
+        internal DropDownHolder DropDownControlHolder => _dropDownHolder;
 
         internal bool DropDownVisible
         {
             get
             {
-                return dropDownHolder is not null && dropDownHolder.Visible;
+                return _dropDownHolder is not null && _dropDownHolder.Visible;
             }
         }
 
@@ -451,7 +445,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (ContainsFocus || (dropDownHolder is not null && dropDownHolder.ContainsFocus));
+                return (ContainsFocus || (_dropDownHolder is not null && _dropDownHolder.ContainsFocus));
             }
         }
 
@@ -460,7 +454,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 // if changed from the default, then the set value is returned
-                if (grayTextColorModified)
+                if (_grayTextColorModified)
                 {
                     return _grayTextColor;
                 }
@@ -491,7 +485,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             set
             {
                 _grayTextColor = value;
-                grayTextColorModified = true;
+                _grayTextColorModified = true;
             }
         }
 
@@ -503,12 +497,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (errorDlg is null)
+                if (_errorDialog is null)
                 {
-                    errorDlg = new GridErrorDlg(OwnerGrid);
+                    _errorDialog = new GridErrorDlg(OwnerGrid);
                 }
 
-                return errorDlg;
+                return _errorDialog;
             }
         }
 
@@ -516,7 +510,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return topLevelGridEntries is not null && topLevelGridEntries.Count > 0;
+                return _topLevelGridEntries is not null && _topLevelGridEntries.Count > 0;
             }
         }
 
@@ -529,12 +523,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                     UpdateUIBasedOnFont(true);
                 }
 
-                if (labelWidth == -1)
+                if (_labelWidth == -1)
                 {
                     SetConstants();
                 }
 
-                return labelWidth;
+                return _labelWidth;
             }
         }
 
@@ -542,7 +536,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             set
             {
-                requiredLabelPaintMargin = (short)Math.Max(Math.Max(value, requiredLabelPaintMargin), GDIPLUS_SPACE);
+                _requiredLabelPaintMargin = (short)Math.Max(Math.Max(value, _requiredLabelPaintMargin), GdiPlusSpace);
             }
         }
 
@@ -552,15 +546,15 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 string text;
 
-                if (edit is null || !Edit.Visible)
+                if (_edit is null || !Edit.Visible)
                 {
                     return false;
                 }
 
                 text = Edit.Text;
 
-                if (((text is null || text.Length == 0) && (originalTextValue is null || originalTextValue.Length == 0)) ||
-                    (text is not null && originalTextValue is not null && text.Equals(originalTextValue)))
+                if (((text is null || text.Length == 0) && (_originalTextValue is null || _originalTextValue.Length == 0)) ||
+                    (text is not null && _originalTextValue is not null && text.Equals(_originalTextValue)))
                 {
                     return false;
                 }
@@ -575,12 +569,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (cachedRowHeight == -1)
+                if (_cachedRowHeight == -1)
                 {
-                    cachedRowHeight = (int)Font.Height + 2;
+                    _cachedRowHeight = (int)Font.Height + 2;
                 }
 
-                return cachedRowHeight;
+                return _cachedRowHeight;
             }
         }
 
@@ -595,7 +589,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 // get the rect for the currently selected prop name, find the middle
-                Rectangle rect = GetRectangle(selectedRow, ROWLABEL);
+                Rectangle rect = GetRectangle(_selectedRow, RowLabel);
                 Point pt = PointToScreen(new Point(rect.X, rect.Y));
                 return new Point(pt.X + (rect.Width / 2), pt.Y + (rect.Height / 2));
             }
@@ -605,7 +599,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (scrollBar is null)
+                if (_scrollBar is null)
                 {
 #if DEBUG
                     if (OwnerGrid.inGridViewCreate)
@@ -613,12 +607,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                         throw new Exception("PERF REGRESSION - Creating item in grid view create");
                     }
 #endif
-                    scrollBar = new VScrollBar();
-                    scrollBar.Scroll += new ScrollEventHandler(OnScroll);
-                    Controls.Add(scrollBar);
+                    _scrollBar = new VScrollBar();
+                    _scrollBar.Scroll += new ScrollEventHandler(OnScroll);
+                    Controls.Add(_scrollBar);
                 }
 
-                return scrollBar;
+                return _scrollBar;
             }
         }
 
@@ -626,13 +620,13 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return selectedGridEntry;
+                return _selectedGridEntry;
             }
             set
             {
-                if (allGridEntries is not null)
+                if (_allGridEntries is not null)
                 {
-                    foreach (GridEntry e in allGridEntries)
+                    foreach (GridEntry e in _allGridEntries)
                     {
                         if (e == value)
                         {
@@ -662,22 +656,22 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return serviceProvider;
+                return _serviceProvider;
             }
             set
             {
-                if (value != serviceProvider)
+                if (value != _serviceProvider)
                 {
-                    serviceProvider = value;
+                    _serviceProvider = value;
 
-                    topHelpService = null;
+                    _topHelpService = null;
 
-                    if (helpService is not null && helpService is IDisposable)
+                    if (_helpService is not null && _helpService is IDisposable)
                     {
-                        ((IDisposable)helpService).Dispose();
+                        ((IDisposable)_helpService).Dispose();
                     }
 
-                    helpService = null;
+                    _helpService = null;
                 }
             }
         }
@@ -692,15 +686,15 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (tipInfo & unchecked((int)0xFFFF0000)) >> 16;
+                return (_tipInfo & unchecked((int)0xFFFF0000)) >> 16;
             }
             set
             {
                 // clear the column
-                tipInfo &= 0xFFFF;
+                _tipInfo &= 0xFFFF;
 
                 // set the row
-                tipInfo |= ((value & 0xFFFF) << 16);
+                _tipInfo |= ((value & 0xFFFF) << 16);
             }
         }
 
@@ -708,15 +702,15 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return tipInfo & 0xFFFF;
+                return _tipInfo & 0xFFFF;
             }
             set
             {
                 // clear the row
-                tipInfo &= unchecked((int)0xFFFF0000);
+                _tipInfo &= unchecked((int)0xFFFF0000);
 
                 // set the row
-                tipInfo |= (value & 0xFFFF);
+                _tipInfo |= (value & 0xFFFF);
             }
         }
 
@@ -724,7 +718,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (toolTip is null)
+                if (_toolTip is null)
                 {
 #if DEBUG
                     if (OwnerGrid.inGridViewCreate)
@@ -732,14 +726,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                         throw new Exception("PERF REGRESSION - Creating item in grid view create");
                     }
 #endif
-                    toolTip = new GridToolTip(new Control[] { this, Edit })
+                    _toolTip = new GridToolTip(new Control[] { this, Edit })
                     {
                         ToolTip = string.Empty,
                         Font = Font
                     };
                 }
 
-                return toolTip;
+                return _toolTip;
             }
         }
 
@@ -750,7 +744,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return topLevelGridEntries;
+                return _topLevelGridEntries;
             }
         }
 
@@ -767,7 +761,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return Rectangle.Empty;
             }
 
-            Rectangle rect = GetRectangle(row, ROWVALUE | ROWLABEL);
+            Rectangle rect = GetRectangle(row, RowValue | RowLabel);
 
             // Translate rect to screen coordinates
             var pt = new Point(rect.X, rect.Y);
@@ -835,20 +829,20 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (ipeArray[i] is not null)
                 {
                     GridEntry ge = ipeArray.GetEntry(i);
-                    ge.AddOnValueClick(ehValueClick);
-                    ge.AddOnLabelClick(ehLabelClick);
-                    ge.AddOnOutlineClick(ehOutlineClick);
-                    ge.AddOnOutlineDoubleClick(ehOutlineClick);
-                    ge.AddOnValueDoubleClick(ehValueDblClick);
-                    ge.AddOnLabelDoubleClick(ehLabelDblClick);
-                    ge.AddOnRecreateChildren(ehRecreateChildren);
+                    ge.AddOnValueClick(_valueClick);
+                    ge.AddOnLabelClick(_labelClick);
+                    ge.AddOnOutlineClick(_outlineClick);
+                    ge.AddOnOutlineDoubleClick(_outlineClick);
+                    ge.AddOnValueDoubleClick(_valueDoubleClick);
+                    ge.AddOnLabelDoubleClick(_labelDoubleClick);
+                    ge.AddOnRecreateChildren(_recreateChildren);
                 }
             }
         }
 
         protected virtual void AdjustOrigin(Graphics g, Point newOrigin, ref Rectangle r)
         {
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Adjusting paint origin to (" + newOrigin.X.ToString(CultureInfo.InvariantCulture) + "," + newOrigin.Y.ToString(CultureInfo.InvariantCulture) + ")");
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Adjusting paint origin to (" + newOrigin.X.ToString(CultureInfo.InvariantCulture) + "," + newOrigin.Y.ToString(CultureInfo.InvariantCulture) + ")");
 
             g.ResetTransform();
             g.TranslateTransform(newOrigin.X, newOrigin.Y);
@@ -863,9 +857,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 SetFlag(FlagIsSplitterMove, false);
                 Capture = false;
 
-                if (selectedRow != -1)
+                if (_selectedRow != -1)
                 {
-                    SelectRow(selectedRow);
+                    SelectRow(_selectedRow);
                 }
             }
         }
@@ -893,13 +887,13 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (ipeArray[i] is not null)
                 {
                     GridEntry ge = ipeArray.GetEntry(i);
-                    ge.RemoveOnValueClick(ehValueClick);
-                    ge.RemoveOnLabelClick(ehLabelClick);
-                    ge.RemoveOnOutlineClick(ehOutlineClick);
-                    ge.RemoveOnOutlineDoubleClick(ehOutlineClick);
-                    ge.RemoveOnValueDoubleClick(ehValueDblClick);
-                    ge.RemoveOnLabelDoubleClick(ehLabelDblClick);
-                    ge.RemoveOnRecreateChildren(ehRecreateChildren);
+                    ge.RemoveOnValueClick(_valueClick);
+                    ge.RemoveOnLabelClick(_labelClick);
+                    ge.RemoveOnOutlineClick(_outlineClick);
+                    ge.RemoveOnOutlineDoubleClick(_outlineClick);
+                    ge.RemoveOnValueDoubleClick(_valueDoubleClick);
+                    ge.RemoveOnLabelDoubleClick(_labelDoubleClick);
+                    ge.RemoveOnRecreateChildren(_recreateChildren);
                 }
             }
         }
@@ -914,12 +908,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             CommonEditorHide();
-            topLevelGridEntries = null;
-            ClearGridEntryEvents(allGridEntries, 0, -1);
-            allGridEntries = null;
-            selectedRow = -1;
+            _topLevelGridEntries = null;
+            ClearGridEntryEvents(_allGridEntries, 0, -1);
+            _allGridEntries = null;
+            _selectedRow = -1;
             // Don't clear selectedGridEntry because then we can't save where we were on a Refresh()
-            tipInfo = -1;
+            _tipInfo = -1;
         }
 
         /// <summary>
@@ -945,9 +939,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             try
             {
                 SetFlag(FlagDropDownClosing, true);
-                if (dropDownHolder is not null && dropDownHolder.Visible)
+                if (_dropDownHolder is not null && _dropDownHolder.Visible)
                 {
-                    if (dropDownHolder.Component == DropDownListBox && GetFlag(FlagDropDownCommit))
+                    if (_dropDownHolder.Component == DropDownListBox && GetFlag(FlagDropDownCommit))
                     {
                         OnListClick(null, null);
                     }
@@ -956,8 +950,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     // disable the ddh so it wont' steal the focus back
                     //
-                    dropDownHolder.SetComponent(null, false);
-                    dropDownHolder.Visible = false;
+                    _dropDownHolder.SetComponent(null, false);
+                    _dropDownHolder.Visible = false;
 
                     // when we disable the dropdown holder, focus will be lost,
                     // so put it onto one of our children first.
@@ -980,15 +974,15 @@ namespace System.Windows.Forms.PropertyGridInternal
                             Focus();
                         }
 
-                        if (selectedRow != -1)
+                        if (_selectedRow != -1)
                         {
-                            SelectRow(selectedRow);
+                            SelectRow(_selectedRow);
                         }
                     }
 
-                    if (selectedRow != -1)
+                    if (_selectedRow != -1)
                     {
-                        var gridEntry = GetGridEntryFromRow(selectedRow);
+                        var gridEntry = GetGridEntryFromRow(_selectedRow);
                         if (gridEntry is not null)
                         {
                             gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
@@ -1062,7 +1056,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 DropDownButton.Visible = false;
-                currentEditor = null;
+                _currentEditor = null;
             }
             finally
             {
@@ -1080,7 +1074,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected virtual void CommonEditorUse(Control ctl, Rectangle rectTarget)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:CommonEditorUse");
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Showing common editors");
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Showing common editors");
 
             Debug.Assert(ctl is not null, "Null control passed to CommonEditorUse");
 
@@ -1118,7 +1112,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 ctl.Visible = false;
             }
 
-            currentEditor = ctl;
+            _currentEditor = ctl;
         }
 
         private /*protected virtual*/ int CountPropsFromOutline(GridEntryCollection rgipes)
@@ -1191,43 +1185,43 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (disposing)
             {
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Dispose");
-                if (scrollBar is not null)
+                if (_scrollBar is not null)
                 {
-                    scrollBar.Dispose();
+                    _scrollBar.Dispose();
                 }
 
-                if (listBox is not null)
+                if (_listBox is not null)
                 {
-                    listBox.Dispose();
+                    _listBox.Dispose();
                 }
 
-                if (dropDownHolder is not null)
+                if (_dropDownHolder is not null)
                 {
-                    dropDownHolder.Dispose();
+                    _dropDownHolder.Dispose();
                 }
 
-                scrollBar = null;
-                listBox = null;
-                dropDownHolder = null;
+                _scrollBar = null;
+                _listBox = null;
+                _dropDownHolder = null;
 
                 OwnerGrid = null;
-                topLevelGridEntries = null;
-                allGridEntries = null;
-                serviceProvider = null;
+                _topLevelGridEntries = null;
+                _allGridEntries = null;
+                _serviceProvider = null;
 
-                topHelpService = null;
+                _topHelpService = null;
 
-                if (helpService is not null && helpService is IDisposable)
+                if (_helpService is not null && _helpService is IDisposable)
                 {
-                    ((IDisposable)helpService).Dispose();
+                    ((IDisposable)_helpService).Dispose();
                 }
 
-                helpService = null;
+                _helpService = null;
 
-                if (edit is not null)
+                if (_edit is not null)
                 {
-                    edit.Dispose();
-                    edit = null;
+                    _edit.Dispose();
+                    _edit = null;
                 }
 
                 if (_fontBold is not null)
@@ -1236,22 +1230,22 @@ namespace System.Windows.Forms.PropertyGridInternal
                     _fontBold = null;
                 }
 
-                if (btnDropDown is not null)
+                if (_buttonDropDown is not null)
                 {
-                    btnDropDown.Dispose();
-                    btnDropDown = null;
+                    _buttonDropDown.Dispose();
+                    _buttonDropDown = null;
                 }
 
-                if (btnDialog is not null)
+                if (_buttonDialog is not null)
                 {
-                    btnDialog.Dispose();
-                    btnDialog = null;
+                    _buttonDialog.Dispose();
+                    _buttonDialog = null;
                 }
 
-                if (toolTip is not null)
+                if (_toolTip is not null)
                 {
-                    toolTip.Dispose();
-                    toolTip = null;
+                    _toolTip.Dispose();
+                    _toolTip = null;
                 }
             }
 
@@ -1266,9 +1260,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     Edit.Copy();
                 }
-                else if (selectedGridEntry is not null)
+                else if (_selectedGridEntry is not null)
                 {
-                    Clipboard.SetDataObject(selectedGridEntry.GetPropertyTextValue());
+                    Clipboard.SetDataObject(_selectedGridEntry.GetPropertyTextValue());
                 }
             }
         }
@@ -1350,7 +1344,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             SizeF sizeF = PropertyGrid.MeasureTextHelper.MeasureText(OwnerGrid, g, gridEntry.PropertyLabel, Font);
             Size size = Size.Ceiling(sizeF);
-            return ptOurLocation.X + GetIPELabelIndent(gridEntry) + size.Width;
+            return _location.X + GetIPELabelIndent(gridEntry) + size.Width;
         }
 
         private bool IsIPELabelLong(Graphics g, GridEntry gridEntry)
@@ -1361,7 +1355,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             int length = GetIPELabelLength(g, gridEntry);
-            return (length > ptOurLocation.X + InternalLabelWidth);
+            return (length > _location.X + InternalLabelWidth);
         }
 
         protected virtual void DrawLabel(Graphics g, int row, Rectangle rect, bool selected, bool fLongLabelRequest, ref Rectangle clipRect)
@@ -1373,7 +1367,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Drawing label for property " + gridEntry.PropertyLabel);
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing label for property " + gridEntry.PropertyLabel);
 
             Point newOrigin = new Point(rect.X, rect.Y);
             Rectangle cr = Rectangle.Intersect(rect, clipRect);
@@ -1421,9 +1415,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Drawing value for property " + gridEntry.PropertyLabel);
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing value for property " + gridEntry.PropertyLabel);
 
-            Rectangle r = GetRectangle(row, ROWVALUE);
+            Rectangle r = GetRectangle(row, RowValue);
             Point newOrigin = new Point(r.X, r.Y);
             Rectangle cr = Rectangle.Intersect(clipRect, r);
 
@@ -1460,14 +1454,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void F4Selection(bool popupModalDialog)
         {
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is null)
             {
                 return;
             }
 
             // if we are in an errorState, just put the focus back on the Edit
-            if (errorState != ERROR_NONE && Edit.Visible)
+            if (_errorState != ERROR_NONE && Edit.Visible)
             {
                 Edit.Focus();
                 return;
@@ -1475,13 +1469,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (DropDownButton.Visible)
             {
-                PopupDialog(selectedRow);
+                PopupDialog(_selectedRow);
             }
             else if (DialogButton.Visible)
             {
                 if (popupModalDialog)
                 {
-                    PopupDialog(selectedRow);
+                    PopupDialog(_selectedRow);
                 }
                 else
                 {
@@ -1506,9 +1500,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Property " + gridEntry.PropertyLabel + " double clicked");
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Property " + gridEntry.PropertyLabel + " double clicked");
 
-            if (!toggleExpand || type == ROWVALUE)
+            if (!toggleExpand || type == RowValue)
             {
                 try
                 {
@@ -1529,7 +1523,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             SelectGridEntry(gridEntry, true);
 
-            if (type == ROWLABEL && toggleExpand && gridEntry.Expandable)
+            if (type == RowLabel && toggleExpand && gridEntry.Expandable)
             {
                 SetExpand(gridEntry, !gridEntry.InternalExpanded);
                 return;
@@ -1553,7 +1547,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
 
                     CommitValue(values[index]);
-                    SelectRow(selectedRow);
+                    SelectRow(_selectedRow);
                     Refresh();
                     return;
                 }
@@ -1615,7 +1609,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private bool GetFlag(short flag)
         {
-            return (flags & flag) != 0;
+            return (_flags & flag) != 0;
         }
 
         public virtual Color GetLineColor()
@@ -1652,11 +1646,11 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (IsExplorerTreeSupported)
             {
-                return outlineSizeExplorerTreeStyle;
+                return _outlineSizeExplorerTreeStyle;
             }
             else
             {
-                return outlineSize;
+                return _outlineSize;
             }
         }
 
@@ -1668,23 +1662,23 @@ namespace System.Windows.Forms.PropertyGridInternal
         // for qa automation
         internal int GetPropertyLocation(string propName, bool getXY, bool rowValue)
         {
-            if (allGridEntries is not null && allGridEntries.Count > 0)
+            if (_allGridEntries is not null && _allGridEntries.Count > 0)
             {
-                for (int i = 0; i < allGridEntries.Count; i++)
+                for (int i = 0; i < _allGridEntries.Count; i++)
                 {
-                    if (0 == string.Compare(propName, allGridEntries.GetEntry(i).PropertyLabel, true, CultureInfo.InvariantCulture))
+                    if (0 == string.Compare(propName, _allGridEntries.GetEntry(i).PropertyLabel, true, CultureInfo.InvariantCulture))
                     {
                         if (getXY)
                         {
-                            int row = GetRowFromGridEntry(allGridEntries.GetEntry(i));
+                            int row = GetRowFromGridEntry(_allGridEntries.GetEntry(i));
 
-                            if (row < 0 || row >= visibleRows)
+                            if (row < 0 || row >= _visibleRows)
                             {
                                 return -1;
                             }
                             else
                             {
-                                Rectangle r = GetRectangle(row, rowValue ? ROWVALUE : ROWLABEL);
+                                Rectangle r = GetRectangle(row, rowValue ? RowValue : RowLabel);
                                 return PARAM.ToInt(r.X, r.Y);
                             }
                         }
@@ -1708,7 +1702,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (ServiceProvider is not null)
             {
-                return serviceProvider.GetService(classService);
+                return _serviceProvider.GetService(classService);
             }
 
             return null;
@@ -1726,22 +1720,22 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public virtual int GetValuePaintIndent()
         {
-            return paintIndent;
+            return _paintIndent;
         }
 
         public virtual int GetValuePaintWidth()
         {
-            return paintWidth;
+            return _paintWidth;
         }
 
         public virtual int GetValueStringIndent()
         {
-            return EDIT_INDENT;
+            return EditIndent;
         }
 
         public virtual int GetValueWidth()
         {
-            return (int)(InternalLabelWidth * (labelRatio - 1));
+            return (int)(InternalLabelWidth * (_labelRatio - 1));
         }
 
         /// <summary>
@@ -1755,16 +1749,16 @@ namespace System.Windows.Forms.PropertyGridInternal
         public void /* cpr IWindowsFormsEditorService. */ DropDownControl(Control ctl)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:DropDownControl");
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "DropDownControl(ctl = " + ctl.GetType().Name + ")");
-            if (dropDownHolder is null)
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "DropDownControl(ctl = " + ctl.GetType().Name + ")");
+            if (_dropDownHolder is null)
             {
-                dropDownHolder = new DropDownHolder(this);
+                _dropDownHolder = new DropDownHolder(this);
             }
 
-            dropDownHolder.Visible = false;
-            dropDownHolder.SetComponent(ctl, GetFlag(FlagResizableDropDown));
-            Rectangle rect = GetRectangle(selectedRow, ROWVALUE);
-            Size size = dropDownHolder.Size;
+            _dropDownHolder.Visible = false;
+            _dropDownHolder.SetComponent(ctl, GetFlag(FlagResizableDropDown));
+            Rectangle rect = GetRectangle(_selectedRow, RowValue);
+            Size size = _dropDownHolder.Size;
             Point loc = PointToScreen(new Point(0, 0));
             Rectangle rectScreen = Screen.FromControl(Edit).WorkingArea;
             size.Width = Math.Max(rect.Width + 1, size.Width);
@@ -1778,26 +1772,26 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (rectScreen.Y + rectScreen.Height < (size.Height + loc.Y + Edit.Height))
             {
                 loc.Y -= size.Height;
-                dropDownHolder.ResizeUp = true;
+                _dropDownHolder.ResizeUp = true;
             }
             else
             {
                 loc.Y += rect.Height + 1;
-                dropDownHolder.ResizeUp = false;
+                _dropDownHolder.ResizeUp = false;
             }
 
             // control is a top=level window. standard way of setparent on the control is prohibited for top-level controls.
             // It is unknown why this control was created as a top-level control. Windows does not recommend this way of setting parent.
             // We are not touching this for this relase. We may revisit it in next release.
-            User32.SetWindowLong(dropDownHolder, User32.GWL.HWNDPARENT, new HandleRef(this, Handle));
-            dropDownHolder.SetBounds(loc.X, loc.Y, size.Width, size.Height);
-            User32.ShowWindow(dropDownHolder, User32.SW.SHOWNA);
+            User32.SetWindowLong(_dropDownHolder, User32.GWL.HWNDPARENT, new HandleRef(this, Handle));
+            _dropDownHolder.SetBounds(loc.X, loc.Y, size.Width, size.Height);
+            User32.ShowWindow(_dropDownHolder, User32.SW.SHOWNA);
             Edit.Filter = true;
-            dropDownHolder.Visible = true;
-            dropDownHolder.FocusComponent();
+            _dropDownHolder.Visible = true;
+            _dropDownHolder.FocusComponent();
             SelectEdit(false);
 
-            var gridEntry = GetGridEntryFromRow(selectedRow);
+            var gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is not null)
             {
                 gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
@@ -1810,17 +1804,17 @@ namespace System.Windows.Forms.PropertyGridInternal
             try
             {
                 DropDownButton.IgnoreMouse = true;
-                dropDownHolder.DoModalLoop();
+                _dropDownHolder.DoModalLoop();
             }
             finally
             {
                 DropDownButton.IgnoreMouse = false;
             }
 
-            if (selectedRow != -1)
+            if (_selectedRow != -1)
             {
                 Focus();
-                SelectRow(selectedRow);
+                SelectRow(_selectedRow);
             }
         }
 
@@ -1832,9 +1826,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         public virtual void DropDownUpdate()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "DropDownHolder:DropDownUpdate");
-            if (dropDownHolder is not null && dropDownHolder.GetUsed())
+            if (_dropDownHolder is not null && _dropDownHolder.GetUsed())
             {
-                int row = selectedRow;
+                int row = _selectedRow;
                 GridEntry gridEntry = GetGridEntryFromRow(row);
                 Edit.Text = gridEntry.GetPropertyTextValue();
             }
@@ -1849,9 +1843,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         private bool FilterEditWndProc(ref Message m)
         {
             // if it's the TAB key, we keep it since we'll give them focus with it.
-            if (dropDownHolder is not null && dropDownHolder.Visible && m.Msg == (int)User32.WM.KEYDOWN && (int)m.WParam != (int)Keys.Tab)
+            if (_dropDownHolder is not null && _dropDownHolder.Visible && m.Msg == (int)User32.WM.KEYDOWN && (int)m.WParam != (int)Keys.Tab)
             {
-                Control ctl = dropDownHolder.Component;
+                Control ctl = _dropDownHolder.Component;
                 if (ctl is not null)
                 {
                     m.Result = User32.SendMessageW(ctl, (User32.WM)m.Msg, m.WParam, m.LParam);
@@ -1864,7 +1858,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private bool FilterReadOnlyEditKeyPress(char keyChar)
         {
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry.Enumerable && gridEntry.IsValueEditable)
             {
                 int index = GetCurrentValueIndex(gridEntry);
@@ -1909,14 +1903,14 @@ namespace System.Windows.Forms.PropertyGridInternal
             // for the tree.
             //
 
-            if (selectedGridEntry is not null)
+            if (_selectedGridEntry is not null)
             {
                 switch (charPressed)
                 {
                     case '+':
                     case '-':
                     case '*':
-                        return !selectedGridEntry.Expandable;
+                        return !_selectedGridEntry.Expandable;
                     case unchecked((char)(int)(long)Keys.Tab):
                         return false;
                 }
@@ -1927,7 +1921,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public void FilterKeyPress(char keyChar)
         {
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is null)
             {
                 return;
@@ -2013,18 +2007,18 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             Size size = GetOurSize();
 
-            if (x < 0 || x > size.Width + ptOurLocation.X)
+            if (x < 0 || x > size.Width + _location.X)
             {
                 return InvalidPosition;
             }
 
-            Point pt = new Point(ROWLABEL, 0);
-            if (x > InternalLabelWidth + ptOurLocation.X)
+            Point pt = new Point(RowLabel, 0);
+            if (x > InternalLabelWidth + _location.X)
             {
-                pt.X = ROWVALUE;
+                pt.X = RowValue;
             }
 
-            pt.Y = (y - ptOurLocation.Y) / (1 + RowHeight);
+            pt.Y = (y - _location.Y) / (1 + RowHeight);
             return pt;
         }
 
@@ -2044,29 +2038,29 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private GridEntryCollection GetAllGridEntries(bool fUpdateCache)
         {
-            if (visibleRows == -1 || totalProps == -1 || !HasEntries)
+            if (_visibleRows == -1 || TotalProps == -1 || !HasEntries)
             {
                 return null;
             }
 
-            if (allGridEntries is not null && !fUpdateCache)
+            if (_allGridEntries is not null && !fUpdateCache)
             {
-                return allGridEntries;
+                return _allGridEntries;
             }
 
-            GridEntry[] rgipes = new GridEntry[totalProps];
+            GridEntry[] rgipes = new GridEntry[TotalProps];
             try
             {
-                GetGridEntriesFromOutline(topLevelGridEntries, 0, 0, rgipes);
+                GetGridEntriesFromOutline(_topLevelGridEntries, 0, 0, rgipes);
             }
             catch (Exception ex)
             {
                 Debug.Fail(ex.ToString());
             }
 
-            allGridEntries = new GridEntryCollection(null, rgipes);
-            AddGridEntryEvents(allGridEntries, 0, -1);
-            return allGridEntries;
+            _allGridEntries = new GridEntryCollection(null, rgipes);
+            AddGridEntryEvents(_allGridEntries, 0, -1);
+            return _allGridEntries;
         }
 
         private int GetCurrentValueIndex(GridEntry gridEntry)
@@ -2131,30 +2125,30 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public virtual int GetDefaultOutlineIndent()
         {
-            return OUTLINE_INDENT;
+            return OutlineIndent;
         }
 
         private IHelpService GetHelpService()
         {
-            if (helpService is null && ServiceProvider is not null)
+            if (_helpService is null && ServiceProvider is not null)
             {
-                topHelpService = (IHelpService)ServiceProvider.GetService(typeof(IHelpService));
-                if (topHelpService is not null)
+                _topHelpService = (IHelpService)ServiceProvider.GetService(typeof(IHelpService));
+                if (_topHelpService is not null)
                 {
-                    IHelpService localHelpService = topHelpService.CreateLocalContext(HelpContextType.ToolWindowSelection);
+                    IHelpService localHelpService = _topHelpService.CreateLocalContext(HelpContextType.ToolWindowSelection);
                     if (localHelpService is not null)
                     {
-                        helpService = localHelpService;
+                        _helpService = localHelpService;
                     }
                 }
             }
 
-            return helpService;
+            return _helpService;
         }
 
         public virtual int GetScrollOffset()
         {
-            if (scrollBar is null)
+            if (_scrollBar is null)
             {
                 return 0;
             }
@@ -2280,10 +2274,10 @@ namespace System.Windows.Forms.PropertyGridInternal
             Rectangle rect = new Rectangle(0, 0, 0, 0);
             Size size = GetOurSize();
 
-            rect.X = ptOurLocation.X;
+            rect.X = _location.X;
 
-            bool fLabel = ((flRow & ROWLABEL) != 0);
-            bool fValue = ((flRow & ROWVALUE) != 0);
+            bool fLabel = ((flRow & RowLabel) != 0);
+            bool fValue = ((flRow & RowValue) != 0);
 
             if (fLabel && fValue)
             {
@@ -2297,11 +2291,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else if (fValue)
             {
-                rect.X = ptOurLocation.X + InternalLabelWidth;
+                rect.X = _location.X + InternalLabelWidth;
                 rect.Width = size.Width - InternalLabelWidth;
             }
 
-            rect.Y = (row) * (RowHeight + 1) + 1 + ptOurLocation.Y;
+            rect.Y = (row) * (RowHeight + 1) + 1 + _location.Y;
             rect.Height = RowHeight;
 
             return rect;
@@ -2346,7 +2340,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected virtual bool GetScrollbarHidden()
         {
-            if (scrollBar is null)
+            if (_scrollBar is null)
             {
                 return true;
             }
@@ -2361,7 +2355,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         public virtual string GetTestingInfo(int entry)
         {
-            GridEntry gridEntry = (entry < 0) ? GetGridEntryFromRow(selectedRow) : GetGridEntryFromOffset(entry);
+            GridEntry gridEntry = (entry < 0) ? GetGridEntryFromRow(_selectedRow) : GetGridEntryFromOffset(entry);
 
             if (gridEntry is null)
             {
@@ -2383,7 +2377,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Rectangle rect = ClientRectangle;
             Size sizeWindow = new Size(rect.Width, rect.Height);
 
-            if (scrollBar is not null)
+            if (_scrollBar is not null)
             {
                 Rectangle boundsScroll = ScrollBar.Bounds;
                 boundsScroll.X = sizeWindow.Width - boundsScroll.Width - 1;
@@ -2403,25 +2397,25 @@ namespace System.Windows.Forms.PropertyGridInternal
             int row = GetRowFromGridEntry(ge);
             if (row != -1)
             {
-                InvalidateRows(row, row, ROWVALUE);
+                InvalidateRows(row, row, RowValue);
             }
         }
 
         private void InvalidateRow(int row)
         {
-            InvalidateRows(row, row, ROWVALUE | ROWLABEL);
+            InvalidateRows(row, row, RowValue | RowLabel);
         }
 
         private void InvalidateRows(int startRow, int endRow)
         {
-            InvalidateRows(startRow, endRow, ROWVALUE | ROWLABEL);
+            InvalidateRows(startRow, endRow, RowValue | RowLabel);
         }
 
         private void InvalidateRows(int startRow, int endRow, int type)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:InvalidateRows");
 
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Invalidating rows " + startRow.ToString(CultureInfo.InvariantCulture) + " through " + endRow.ToString(CultureInfo.InvariantCulture));
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Invalidating rows " + startRow.ToString(CultureInfo.InvariantCulture) + " through " + endRow.ToString(CultureInfo.InvariantCulture));
             Rectangle rect;
 
             // invalidate from the start row down
@@ -2500,7 +2494,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (newValue == ScrollBar.Value ||
                 newValue < 0 ||
                 newValue > ScrollBar.Maximum ||
-                (newValue + (ScrollBar.LargeChange - 1) >= totalProps))
+                (newValue + (ScrollBar.LargeChange - 1) >= TotalProps))
             {
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView: move not needed, returning");
                 return false;
@@ -2530,19 +2524,19 @@ namespace System.Windows.Forms.PropertyGridInternal
         private void MoveSplitterTo(int xpos)
         {
             int widthPS = GetOurSize().Width;
-            int startPS = ptOurLocation.X;
+            int startPS = _location.X;
             int pos = Math.Max(Math.Min(xpos, widthPS - 10), GetOutlineIconSize() * 2);
 
             int oldLabelWidth = InternalLabelWidth;
 
-            labelRatio = ((double)widthPS / (double)(pos - startPS));
+            _labelRatio = ((double)widthPS / (double)(pos - startPS));
 
             SetConstants();
 
-            if (selectedRow != -1)
+            if (_selectedRow != -1)
             {
                 // do this to move any editor we have
-                SelectRow(selectedRow);
+                SelectRow(_selectedRow);
             }
 
             Rectangle r = ClientRectangle;
@@ -2550,14 +2544,14 @@ namespace System.Windows.Forms.PropertyGridInternal
             // if we're moving to the left, just invalidate the values
             if (oldLabelWidth > InternalLabelWidth)
             {
-                int left = InternalLabelWidth - requiredLabelPaintMargin;
+                int left = InternalLabelWidth - _requiredLabelPaintMargin;
                 Invalidate(new Rectangle(left, 0, Size.Width - left, Size.Height));
             }
             else
             {
                 // to the right, just invalidate from where the splitter was
                 // to the right
-                r.X = oldLabelWidth - requiredLabelPaintMargin;
+                r.X = oldLabelWidth - _requiredLabelPaintMargin;
                 r.Width -= r.X;
                 Invalidate(r);
             }
@@ -2581,7 +2575,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 Commit();
                 SetFlag(FlagBtnLaunchedEditor, true);
-                PopupDialog(selectedRow);
+                PopupDialog(_selectedRow);
             }
             finally
             {
@@ -2623,31 +2617,31 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            if (selectedGridEntry is not null && GetRowFromGridEntry(selectedGridEntry) != -1)
+            if (_selectedGridEntry is not null && GetRowFromGridEntry(_selectedGridEntry) != -1)
             {
-                selectedGridEntry.Focus = true;
-                SelectGridEntry(selectedGridEntry, false);
+                _selectedGridEntry.HasFocus = true;
+                SelectGridEntry(_selectedGridEntry, false);
             }
             else
             {
                 SelectRow(0);
             }
 
-            if (selectedGridEntry is not null && selectedGridEntry.GetValueOwner() is not null)
+            if (_selectedGridEntry is not null && _selectedGridEntry.GetValueOwner() is not null)
             {
-                UpdateHelpAttributes(null, selectedGridEntry);
+                UpdateHelpAttributes(null, _selectedGridEntry);
             }
 
             // For empty GridView, draw a focus-indicator rectangle, just inside GridView borders
-            if (totalProps <= 0)
+            if (TotalProps <= 0)
             {
-                int doubleOffset = 2 * offset_2Units;
+                int doubleOffset = 2 * _offset2Units;
 
                 if ((Size.Width > doubleOffset) && (Size.Height > doubleOffset))
                 {
                     using (Graphics g = CreateGraphicsInternal())
                     {
-                        ControlPaint.DrawFocusRectangle(g, new Rectangle(offset_2Units, offset_2Units, Size.Width - doubleOffset, Size.Height - doubleOffset));
+                        ControlPaint.DrawFocusRectangle(g, new Rectangle(_offset2Units, _offset2Units, Size.Width - doubleOffset, Size.Height - doubleOffset));
                     }
                 }
             }
@@ -2664,10 +2658,10 @@ namespace System.Windows.Forms.PropertyGridInternal
             SystemEvents.UserPreferenceChanged -= new UserPreferenceChangedEventHandler(OnSysColorChange);
             // We can leak this if we aren't disposed.
             //
-            if (toolTip is not null && !RecreatingHandle)
+            if (_toolTip is not null && !RecreatingHandle)
             {
-                toolTip.Dispose();
-                toolTip = null;
+                _toolTip.Dispose();
+                _toolTip = null;
             }
 
             base.OnHandleDestroyed(e);
@@ -2678,7 +2672,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnListChange");
             if (!DropDownListBox.InSetSelectedIndex())
             {
-                GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+                GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
                 Edit.Text = gridEntry.GetPropertyTextValue(DropDownListBox.SelectedItem);
                 Edit.Focus();
                 SelectEdit(false);
@@ -2695,13 +2689,13 @@ namespace System.Windows.Forms.PropertyGridInternal
         private void OnListClick(object sender, EventArgs e)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnListClick");
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
 
             if (DropDownListBox.Items.Count == 0)
             {
                 CommonEditorHide();
                 SetCommitError(ERROR_NONE);
-                SelectRow(selectedRow);
+                SelectRow(_selectedRow);
                 return;
             }
             else
@@ -2714,7 +2708,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (value is not null && !CommitText((string)value))
                 {
                     SetCommitError(ERROR_NONE);
-                    SelectRow(selectedRow);
+                    SelectRow(_selectedRow);
                 }
             }
         }
@@ -2723,14 +2717,14 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             int index = die.Index;
 
-            if (index < 0 || selectedGridEntry is null)
+            if (index < 0 || _selectedGridEntry is null)
             {
                 return;
             }
 
             string text = (string)DropDownListBox.Items[die.Index];
 
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Drawing list item, value='" + text + "'");
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing list item, value='" + text + "'");
             die.DrawBackground();
             die.DrawFocusRectangle();
 
@@ -2738,7 +2732,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             drawBounds.Y += 1;
             drawBounds.X -= 1;
 
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
 
             try
             {
@@ -2764,9 +2758,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (ke.KeyCode == Keys.Return)
             {
                 OnListClick(null, null);
-                if (selectedGridEntry is not null)
+                if (_selectedGridEntry is not null)
                 {
-                    selectedGridEntry.OnValueReturnKey();
+                    _selectedGridEntry.OnValueReturnKey();
                 }
             }
 
@@ -2776,7 +2770,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected override void OnLostFocus(EventArgs e)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnLostFocus");
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "PropertyGridView lost focus");
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "PropertyGridView lost focus");
 
             if (e is not null)
             {
@@ -2789,22 +2783,22 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is not null)
             {
-                Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "removing gridEntry focus");
-                gridEntry.Focus = false;
+                Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "removing gridEntry focus");
+                gridEntry.HasFocus = false;
                 CommonEditorHide();
-                InvalidateRow(selectedRow);
+                InvalidateRow(_selectedRow);
             }
 
             base.OnLostFocus(e);
 
             // For empty GridView, clear the focus indicator that was painted in OnGotFocus()
-            if (totalProps <= 0)
+            if (TotalProps <= 0)
             {
                 Rectangle clearRect = new Rectangle(1, 1, Size.Width - 2, Size.Height - 2);
-                Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, $"Filling empty gridview rect={clearRect}");
+                Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"Filling empty gridview rect={clearRect}");
 
                 Color color = BackColor;
                 if (color.HasTransparency())
@@ -2832,7 +2826,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (!Edit.InSetText())
             {
-                GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+                GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
                 if (gridEntry is not null && (gridEntry.Flags & GridEntry.FLAG_IMMEDIATELY_EDITABLE) != 0)
                 {
                     Commit();
@@ -2850,7 +2844,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            switch (errorState)
+            switch (_errorState)
             {
                 case ERROR_MSGBOX_UP:
                     return;
@@ -2870,11 +2864,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                     break;
             }
 
-            if (selectedGridEntry is not null && GetRowFromGridEntry(selectedGridEntry) != -1)
+            if (_selectedGridEntry is not null && GetRowFromGridEntry(_selectedGridEntry) != -1)
             {
-                Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "adding gridEntry focus");
-                selectedGridEntry.Focus = true;
-                InvalidateRow(selectedRow);
+                Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "adding gridEntry focus");
+                _selectedGridEntry.HasFocus = true;
+                InvalidateRow(_selectedRow);
                 (Edit.AccessibilityObject as ControlAccessibleObject).NotifyClients(AccessibleEvents.Focus);
 
                 Edit.AccessibilityObject.SetFocus();
@@ -2944,7 +2938,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             bool fAlt = ke.Alt;
             if (!fAlt && (ke.KeyCode == Keys.Up || ke.KeyCode == Keys.Down))
             {
-                GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+                GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
                 if (!gridEntry.Enumerable || !gridEntry.IsValueEditable)
                 {
                     return;
@@ -2971,7 +2965,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         private void OnEditKeyPress(object sender, KeyPressEventArgs ke)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnEditKeyPress");
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is null)
             {
                 return;
@@ -2988,20 +2982,20 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnEditLostFocus");
 
             // believe it or not, this can actually happen.
-            if (Edit.Focused || (errorState == ERROR_MSGBOX_UP) || (errorState == ERROR_THROWN) || GetInPropertySet())
+            if (Edit.Focused || (_errorState == ERROR_MSGBOX_UP) || (_errorState == ERROR_THROWN) || GetInPropertySet())
             {
                 return;
             }
 
             // check to see if the focus is on the drop down or one of it's children
             // if so, return;
-            if (dropDownHolder is not null && dropDownHolder.Visible)
+            if (_dropDownHolder is not null && _dropDownHolder.Visible)
             {
                 bool found = false;
                 for (IntPtr hwnd = User32.GetForegroundWindow();
                     hwnd != IntPtr.Zero; hwnd = User32.GetParent(hwnd))
                 {
-                    if (hwnd == dropDownHolder.Handle)
+                    if (hwnd == _dropDownHolder.Handle)
                     {
                         found = true;
                     }
@@ -3035,16 +3029,16 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (!FocusInside)
             {
-                SelectGridEntry(selectedGridEntry, false);
+                SelectGridEntry(_selectedGridEntry, false);
             }
 
             if (me.Clicks % 2 == 0)
             {
-                DoubleClickRow(selectedRow, false, ROWVALUE);
+                DoubleClickRow(_selectedRow, false, RowValue);
                 Edit.SelectAll();
             }
 
-            if (rowSelectTime == 0)
+            if (_rowSelectTime == 0)
             {
                 return;
             }
@@ -3053,23 +3047,23 @@ namespace System.Windows.Forms.PropertyGridInternal
             // this allows the edits to be selected with two clicks instead of 3 (select row, double click).
             //
             long timeStamp = DateTime.Now.Ticks;
-            int delta = (int)((timeStamp - rowSelectTime) / 10000); // make it milleseconds
+            int delta = (int)((timeStamp - _rowSelectTime) / 10000); // make it milleseconds
 
             if (delta < SystemInformation.DoubleClickTime)
             {
                 Point screenPoint = Edit.PointToScreen(new Point(me.X, me.Y));
 
-                if (Math.Abs(screenPoint.X - rowSelectPos.X) < SystemInformation.DoubleClickSize.Width &&
-                    Math.Abs(screenPoint.Y - rowSelectPos.Y) < SystemInformation.DoubleClickSize.Height)
+                if (Math.Abs(screenPoint.X - _rowSelectPos.X) < SystemInformation.DoubleClickSize.Width &&
+                    Math.Abs(screenPoint.Y - _rowSelectPos.Y) < SystemInformation.DoubleClickSize.Height)
                 {
-                    DoubleClickRow(selectedRow, false, ROWVALUE);
+                    DoubleClickRow(_selectedRow, false, RowValue);
                     User32.SendMessageW(Edit, User32.WM.LBUTTONUP, IntPtr.Zero, PARAM.FromLowHigh(me.X, me.Y));
                     Edit.SelectAll();
                 }
 
-                rowSelectPos = Point.Empty;
+                _rowSelectPos = Point.Empty;
 
-                rowSelectTime = 0;
+                _rowSelectTime = 0;
             }
         }
 
@@ -3106,9 +3100,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (sender == Edit && Edit.Focused)
             {
                 // if we aren't in an error state, just quit
-                if (errorState == ERROR_NONE)
+                if (_errorState == ERROR_NONE)
                 {
-                    Edit.Text = originalTextValue;
+                    Edit.Text = _originalTextValue;
                     Focus();
                     return true;
                 }
@@ -3116,20 +3110,20 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (NeedsCommit)
                 {
                     bool success = false;
-                    Edit.Text = originalTextValue;
+                    Edit.Text = _originalTextValue;
                     bool needReset = true;
 
-                    if (selectedGridEntry is not null)
+                    if (_selectedGridEntry is not null)
                     {
-                        string curTextValue = selectedGridEntry.GetPropertyTextValue();
-                        needReset = originalTextValue != curTextValue && !(string.IsNullOrEmpty(originalTextValue) && string.IsNullOrEmpty(curTextValue));
+                        string curTextValue = _selectedGridEntry.GetPropertyTextValue();
+                        needReset = _originalTextValue != curTextValue && !(string.IsNullOrEmpty(_originalTextValue) && string.IsNullOrEmpty(curTextValue));
                     }
 
                     if (needReset)
                     {
                         try
                         {
-                            success = CommitText(originalTextValue);
+                            success = CommitText(_originalTextValue);
                         }
                         catch
                         {
@@ -3169,7 +3163,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void OnKeyDown(object sender, KeyEventArgs ke)
         {
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is null)
             {
                 return;
@@ -3204,7 +3198,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            if (keyCode == Keys.Up && fAlt && DropDownButton.Visible && (dropDownHolder is not null) && dropDownHolder.Visible)
+            if (keyCode == Keys.Up && fAlt && DropDownButton.Visible && (_dropDownHolder is not null) && _dropDownHolder.Visible)
             {
                 UnfocusSelection();
                 return;
@@ -3221,7 +3215,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     case Keys.Up:
                     case Keys.Down:
-                        int pos = (keyCode == Keys.Up ? selectedRow - 1 : selectedRow + 1);
+                        int pos = (keyCode == Keys.Up ? _selectedRow - 1 : _selectedRow + 1);
                         SelectGridEntry(GetGridEntryFromRow(pos), true);
                         SetFlag(FlagNoDefault, false);
                         return;
@@ -3240,7 +3234,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         else
                         {
                             // Handle non-expand/collapse case of left & right as up & down
-                            SelectGridEntry(GetGridEntryFromRow(selectedRow - 1), true);
+                            SelectGridEntry(GetGridEntryFromRow(_selectedRow - 1), true);
                         }
 
                         return;
@@ -3267,7 +3261,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         else
                         {
                             // Handle non-expand/collapse case of left & right as up & down
-                            SelectGridEntry(GetGridEntryFromRow(selectedRow + 1), true);
+                            SelectGridEntry(GetGridEntryFromRow(_selectedRow + 1), true);
                         }
 
                         return;
@@ -3323,16 +3317,16 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         bool next = (keyCode == Keys.Next);
                         //int rowGoal = next ? visibleRows - 1 : 0;
-                        int offset = next ? visibleRows - 1 : 1 - visibleRows;
+                        int offset = next ? _visibleRows - 1 : 1 - _visibleRows;
 
-                        int row = selectedRow;
+                        int row = _selectedRow;
 
                         if (fControl && !fShift)
                         {
                             return;
                         }
 
-                        if (selectedRow != -1)
+                        if (_selectedRow != -1)
                         { // actual paging.
                             int start = GetScrollOffset();
                             SetScrollOffset(start + offset);
@@ -3342,7 +3336,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                                 // we didn't make a full page
                                 if (next)
                                 {
-                                    row = visibleRows - 1;
+                                    row = _visibleRows - 1;
                                 }
                                 else
                                 {
@@ -3454,11 +3448,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                }
             */
 
-            if (selectedGridEntry is not null && selectedGridEntry.Enumerable &&
-                dropDownHolder is not null && dropDownHolder.Visible &&
+            if (_selectedGridEntry is not null && _selectedGridEntry.Enumerable &&
+                _dropDownHolder is not null && _dropDownHolder.Visible &&
                 (keyCode == Keys.Up || keyCode == Keys.Down))
             {
-                ProcessEnumUpAndDown(selectedGridEntry, keyCode, false);
+                ProcessEnumUpAndDown(_selectedGridEntry, keyCode, false);
             }
 
             ke.Handled = false;
@@ -3482,7 +3476,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected override void OnMouseDown(MouseEventArgs me)
         {
             // check for a splitter
-            if (me.Button == MouseButtons.Left && SplitterInside(me.X, me.Y) && totalProps != 0)
+            if (me.Button == MouseButtons.Left && SplitterInside(me.X, me.Y) && TotalProps != 0)
             {
                 if (!Commit())
                 {
@@ -3497,7 +3491,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 UnfocusSelection();
                 SetFlag(FlagIsSplitterMove, true);
-                tipInfo = -1;
+                _tipInfo = -1;
                 Capture = true;
                 return;
             }
@@ -3517,9 +3511,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (gridEntry is not null)
             {
                 // get the origin of this pe
-                Rectangle r = GetRectangle(pos.Y, ROWLABEL);
+                Rectangle r = GetRectangle(pos.Y, RowLabel);
 
-                lastMouseDown = new Point(me.X, me.Y);
+                _lastMouseDown = new Point(me.X, me.Y);
 
                 // offset the mouse points
                 // notify the prop entry
@@ -3532,8 +3526,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                     SelectGridEntry(gridEntry, false);
                 }
 
-                lastMouseDown = InvalidPosition;
-                gridEntry.Focus = true;
+                _lastMouseDown = InvalidPosition;
+                gridEntry.HasFocus = true;
                 SetFlag(FlagNoDefault, false);
             }
         }
@@ -3563,7 +3557,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             else
             {
                 pt = FindPosition(me.X, me.Y);
-                if (pt == InvalidPosition || (pt.X != ROWLABEL && pt.X != ROWVALUE))
+                if (pt == InvalidPosition || (pt.X != RowLabel && pt.X != RowValue))
                 {
                     rowMoveCur = -1;
                     ToolTip.ToolTip = string.Empty;
@@ -3571,7 +3565,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 else
                 {
                     rowMoveCur = pt.Y;
-                    onLabel = pt.X == ROWLABEL;
+                    onLabel = pt.X == RowLabel;
                 }
             }
 
@@ -3589,7 +3583,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 GridEntry gridItem = GetGridEntryFromRow(rowMoveCur);
                 string tip = string.Empty;
-                tipInfo = -1;
+                _tipInfo = -1;
 
                 if (gridItem is not null)
                 {
@@ -3618,7 +3612,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (User32.IsChild(foregroundWindow, new HandleRef(this, Handle)).IsTrue())
                 {
                     // Don't show the tips if a dropdown is showing
-                    if ((dropDownHolder is null || dropDownHolder.Component is null) || rowMoveCur == selectedRow)
+                    if ((_dropDownHolder is null || _dropDownHolder.Component is null) || rowMoveCur == _selectedRow)
                     {
                         ToolTip.ToolTip = tip;
                     }
@@ -3629,7 +3623,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            if (totalProps != 0 && (SplitterInside(me.X, me.Y) || GetFlag(FlagIsSplitterMove)))
+            if (TotalProps != 0 && (SplitterInside(me.X, me.Y) || GetFlag(FlagIsSplitterMove)))
             {
                 Cursor = Cursors.VSplit;
             }
@@ -3671,20 +3665,20 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return; // Do not scroll when the user system setting is 0 lines per notch
             }
 
-            Debug.Assert(cumulativeVerticalWheelDelta > -NativeMethods.WHEEL_DELTA, "cumulativeVerticalWheelDelta is too small");
-            Debug.Assert(cumulativeVerticalWheelDelta < NativeMethods.WHEEL_DELTA, "cumulativeVerticalWheelDelta is too big");
+            Debug.Assert(_cumulativeVerticalWheelDelta > -NativeMethods.WHEEL_DELTA, "cumulativeVerticalWheelDelta is too small");
+            Debug.Assert(_cumulativeVerticalWheelDelta < NativeMethods.WHEEL_DELTA, "cumulativeVerticalWheelDelta is too big");
 
             // Should this only work if the Edit has focus?  anyway
             // we use the mouse wheel to change the values in the dropdown if it's
             // an enumerable value.
             //
-            if (selectedGridEntry is not null && selectedGridEntry.Enumerable && Edit.Focused && selectedGridEntry.IsValueEditable)
+            if (_selectedGridEntry is not null && _selectedGridEntry.Enumerable && Edit.Focused && _selectedGridEntry.IsValueEditable)
             {
-                int index = GetCurrentValueIndex(selectedGridEntry);
+                int index = GetCurrentValueIndex(_selectedGridEntry);
                 if (index != -1)
                 {
                     int delta = me.Delta > 0 ? -1 : 1;
-                    object[] values = selectedGridEntry.GetPropertyValueList();
+                    object[] values = _selectedGridEntry.GetPropertyValueList();
 
                     if (delta > 0 && index >= (values.Length - 1))
                     {
@@ -3700,15 +3694,15 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
 
                     CommitValue(values[index]);
-                    SelectGridEntry(selectedGridEntry, true);
+                    SelectGridEntry(_selectedGridEntry, true);
                     Edit.Focus();
                     return;
                 }
             }
 
             int initialOffset = GetScrollOffset();
-            cumulativeVerticalWheelDelta += me.Delta;
-            float partialNotches = (float)cumulativeVerticalWheelDelta / (float)NativeMethods.WHEEL_DELTA;
+            _cumulativeVerticalWheelDelta += me.Delta;
+            float partialNotches = (float)_cumulativeVerticalWheelDelta / (float)NativeMethods.WHEEL_DELTA;
             int fullNotches = (int)partialNotches;
 
             if (wheelScrollLines == -1)
@@ -3717,23 +3711,23 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (fullNotches != 0)
                 {
                     int originalOffset = initialOffset;
-                    int large = fullNotches * scrollBar.LargeChange;
+                    int large = fullNotches * _scrollBar.LargeChange;
                     int newOffset = Math.Max(0, initialOffset - large);
-                    newOffset = Math.Min(newOffset, totalProps - visibleRows + 1);
+                    newOffset = Math.Min(newOffset, TotalProps - _visibleRows + 1);
 
-                    initialOffset -= fullNotches * scrollBar.LargeChange;
-                    if (Math.Abs(initialOffset - originalOffset) >= Math.Abs(fullNotches * scrollBar.LargeChange))
+                    initialOffset -= fullNotches * _scrollBar.LargeChange;
+                    if (Math.Abs(initialOffset - originalOffset) >= Math.Abs(fullNotches * _scrollBar.LargeChange))
                     {
-                        cumulativeVerticalWheelDelta -= fullNotches * NativeMethods.WHEEL_DELTA;
+                        _cumulativeVerticalWheelDelta -= fullNotches * NativeMethods.WHEEL_DELTA;
                     }
                     else
                     {
-                        cumulativeVerticalWheelDelta = 0;
+                        _cumulativeVerticalWheelDelta = 0;
                     }
 
                     if (!ScrollRows(newOffset))
                     {
-                        cumulativeVerticalWheelDelta = 0;
+                        _cumulativeVerticalWheelDelta = 0;
                         return;
                     }
                 }
@@ -3752,40 +3746,40 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
 
                     int newOffset = Math.Max(0, initialOffset - scrollBands);
-                    newOffset = Math.Min(newOffset, totalProps - visibleRows + 1);
+                    newOffset = Math.Min(newOffset, TotalProps - _visibleRows + 1);
 
                     if (scrollBands > 0)
                     {
-                        if (scrollBar.Value <= scrollBar.Minimum)
+                        if (_scrollBar.Value <= _scrollBar.Minimum)
                         {
-                            cumulativeVerticalWheelDelta = 0;
+                            _cumulativeVerticalWheelDelta = 0;
                         }
                         else
                         {
-                            cumulativeVerticalWheelDelta -= (int)((float)scrollBands * ((float)NativeMethods.WHEEL_DELTA / (float)wheelScrollLines));
+                            _cumulativeVerticalWheelDelta -= (int)((float)scrollBands * ((float)NativeMethods.WHEEL_DELTA / (float)wheelScrollLines));
                         }
                     }
                     else
                     {
-                        if (scrollBar.Value > (scrollBar.Maximum - visibleRows + 1))
+                        if (_scrollBar.Value > (_scrollBar.Maximum - _visibleRows + 1))
                         {
-                            cumulativeVerticalWheelDelta = 0;
+                            _cumulativeVerticalWheelDelta = 0;
                         }
                         else
                         {
-                            cumulativeVerticalWheelDelta -= (int)((float)scrollBands * ((float)NativeMethods.WHEEL_DELTA / (float)wheelScrollLines));
+                            _cumulativeVerticalWheelDelta -= (int)((float)scrollBands * ((float)NativeMethods.WHEEL_DELTA / (float)wheelScrollLines));
                         }
                     }
 
                     if (!ScrollRows(newOffset))
                     {
-                        cumulativeVerticalWheelDelta = 0;
+                        _cumulativeVerticalWheelDelta = 0;
                         return;
                     }
                 }
                 else
                 {
-                    cumulativeVerticalWheelDelta = 0;
+                    _cumulativeVerticalWheelDelta = 0;
                 }
             }
         }
@@ -3802,12 +3796,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected override void OnPaint(PaintEventArgs pe)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnPaint");
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "On paint called.  Rect=" + pe.ClipRectangle.ToString());
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "On paint called.  Rect=" + pe.ClipRectangle.ToString());
             Graphics g = pe.Graphics;
 
             int yPos = 0;
             int startRow = 0;
-            int endRow = visibleRows - 1;
+            int endRow = _visibleRows - 1;
 
             Rectangle clipRect = pe.ClipRectangle;
 
@@ -3832,7 +3826,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     endRow = posEnd.Y;
                 }
 
-                int cPropsVisible = Math.Min(totalProps - GetScrollOffset(), 1 + visibleRows);
+                int cPropsVisible = Math.Min(TotalProps - GetScrollOffset(), 1 + _visibleRows);
 
 #if DEBUG
                 GridEntry debugIPEStart = GetGridEntryFromRow(startRow);
@@ -3853,7 +3847,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 SetFlag(FlagNeedsRefresh, false);
 
                 Size size = GetOurSize();
-                Point loc = ptOurLocation;
+                Point loc = _location;
 
                 if (GetGridEntryFromRow(cPropsVisible - 1) is null)
                 {
@@ -3861,17 +3855,17 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 // if we actually have some properties, then start drawing the grid
-                if (totalProps > 0)
+                if (TotalProps > 0)
                 {
                     // draw splitter
                     cPropsVisible = Math.Min(cPropsVisible, endRow + 1);
 
-                    Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Drawing splitter");
+                    Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing splitter");
                     using var splitterPen = OwnerGrid.LineColor.GetCachedPenScope(GetSplitterWidth());
-                    g.DrawLine(splitterPen, labelWidth, loc.Y, labelWidth, (cPropsVisible) * (RowHeight + 1) + loc.Y);
+                    g.DrawLine(splitterPen, _labelWidth, loc.Y, _labelWidth, (cPropsVisible) * (RowHeight + 1) + loc.Y);
 
                     // draw lines.
-                    Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Drawing lines");
+                    Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing lines");
                     using var linePen = g.FindNearestColor(OwnerGrid.LineColor).GetCachedPenScope();
 
                     int cHeightCurRow = 0;
@@ -3894,17 +3888,17 @@ namespace System.Windows.Forms.PropertyGridInternal
                             DrawValueEntry(g, i, ref clipRect);
 
                             // draw the label
-                            Rectangle rect = GetRectangle(i, ROWLABEL);
+                            Rectangle rect = GetRectangle(i, RowLabel);
                             yPos = rect.Y + rect.Height;
-                            DrawLabel(g, i, rect, (i == selectedRow), false, ref clipRect);
-                            if (i == selectedRow)
+                            DrawLabel(g, i, rect, (i == _selectedRow), false, ref clipRect);
+                            if (i == _selectedRow)
                             {
                                 Edit.Invalidate();
                             }
                         }
                         catch
                         {
-                            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose,
+                            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose,
                                 $"Exception thrown during painting property {GetGridEntryFromRow(i).PropertyLabel}");
                         }
                     }
@@ -3919,7 +3913,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     yPos++;
                     Rectangle clearRect = new Rectangle(1, yPos, Size.Width - 2, Size.Height - yPos - 1);
-                    Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, $"Filling remaining area rect={clearRect}");
+                    Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"Filling remaining area rect={clearRect}");
 
                     using var backBrush = BackColor.GetCachedSolidBrushScope();
                     g.FillRectangle(backBrush, clearRect);
@@ -3944,13 +3938,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             // if we've changed since the click (probably because we moved a row into view), bail
             //
-            if (gridEntry != lastClickedEntry)
+            if (gridEntry != _lastClickedEntry)
             {
                 return;
             }
 
             int row = GetRowFromGridEntry(gridEntry);
-            DoubleClickRow(row, gridEntry.Expandable, ROWLABEL);
+            DoubleClickRow(row, gridEntry.Expandable, RowLabel);
         }
 
         private void OnGridEntryValueDoubleClick(object s, EventArgs e)
@@ -3958,19 +3952,19 @@ namespace System.Windows.Forms.PropertyGridInternal
             GridEntry gridEntry = (GridEntry)s;
             // if we've changed since the click (probably because we moved a row into view), bail
             //
-            if (gridEntry != lastClickedEntry)
+            if (gridEntry != _lastClickedEntry)
             {
                 return;
             }
 
             int row = GetRowFromGridEntry(gridEntry);
-            DoubleClickRow(row, gridEntry.Expandable, ROWVALUE);
+            DoubleClickRow(row, gridEntry.Expandable, RowValue);
         }
 
         private void OnGridEntryLabelClick(object s, EventArgs e)
         {
-            lastClickedEntry = (GridEntry)s;
-            SelectGridEntry(lastClickedEntry, true);
+            _lastClickedEntry = (GridEntry)s;
+            SelectGridEntry(_lastClickedEntry, true);
         }
 
         private void OnGridEntryOutlineClick(object s, EventArgs e)
@@ -3999,18 +3993,18 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void OnGridEntryValueClick(object s, EventArgs e)
         {
-            lastClickedEntry = (GridEntry)s;
-            bool setSelectTime = s != selectedGridEntry;
-            SelectGridEntry(lastClickedEntry, true);
+            _lastClickedEntry = (GridEntry)s;
+            bool setSelectTime = s != _selectedGridEntry;
+            SelectGridEntry(_lastClickedEntry, true);
             Edit.Focus();
 
-            if (lastMouseDown != InvalidPosition)
+            if (_lastMouseDown != InvalidPosition)
             {
                 // clear the row select time so we don't interpret this as a double click.
                 //
-                rowSelectTime = 0;
+                _rowSelectTime = 0;
 
-                Point editPoint = PointToScreen(lastMouseDown);
+                Point editPoint = PointToScreen(_lastMouseDown);
                 editPoint = Edit.PointToClient(editPoint);
                 User32.SendMessageW(Edit, User32.WM.LBUTTONDOWN, IntPtr.Zero, PARAM.FromLowHigh(editPoint.X, editPoint.Y));
                 User32.SendMessageW(Edit, User32.WM.LBUTTONUP, IntPtr.Zero, PARAM.FromLowHigh(editPoint.X, editPoint.Y));
@@ -4018,19 +4012,19 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (setSelectTime)
             {
-                rowSelectTime = DateTime.Now.Ticks;
-                rowSelectPos = PointToScreen(lastMouseDown);
+                _rowSelectTime = DateTime.Now.Ticks;
+                _rowSelectPos = PointToScreen(_lastMouseDown);
             }
             else
             {
-                rowSelectTime = 0;
-                rowSelectPos = Point.Empty;
+                _rowSelectTime = 0;
+                _rowSelectPos = Point.Empty;
             }
         }
 
         protected override void OnFontChanged(EventArgs e)
         {
-            cachedRowHeight = -1;
+            _cachedRowHeight = -1;
 
             if (Disposing || ParentInternal is null || ParentInternal.Disposing)
             {
@@ -4044,9 +4038,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             UpdateUIBasedOnFont(true);
             base.OnFontChanged(e);
 
-            if (selectedGridEntry is not null)
+            if (_selectedGridEntry is not null)
             {
-                SelectGridEntry(selectedGridEntry, true);
+                SelectGridEntry(_selectedGridEntry, true);
             }
         }
 
@@ -4060,12 +4054,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (Visible && ParentInternal is not null)
             {
                 SetConstants();
-                if (selectedGridEntry is not null)
+                if (_selectedGridEntry is not null)
                 {
-                    SelectGridEntry(selectedGridEntry, true);
+                    SelectGridEntry(_selectedGridEntry, true);
                 }
 
-                if (toolTip is not null)
+                if (_toolTip is not null)
                 {
                     ToolTip.Font = Font;
                 }
@@ -4081,8 +4075,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (parent.Expanded)
             {
-                GridEntry[] entries = new GridEntry[allGridEntries.Count];
-                allGridEntries.CopyTo(entries, 0);
+                GridEntry[] entries = new GridEntry[_allGridEntries.Count];
+                _allGridEntries.CopyTo(entries, 0);
 
                 // find the index of the gridEntry that fired the event in our main list.
                 int parentIndex = -1;
@@ -4098,7 +4092,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Debug.Assert(parentIndex != -1, "parent GridEntry not found in allGridEntries");
 
                 // clear our existing handlers
-                ClearGridEntryEvents(allGridEntries, parentIndex + 1, e.OldChildCount);
+                ClearGridEntryEvents(_allGridEntries, parentIndex + 1, e.OldChildCount);
 
                 // resize the array if it's changed
                 if (e.OldChildCount != e.NewChildCount)
@@ -4128,14 +4122,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 // reset the array, rehook the handlers.
-                allGridEntries.Clear();
-                allGridEntries.AddRange(entries);
-                AddGridEntryEvents(allGridEntries, parentIndex + 1, childCount);
+                _allGridEntries.Clear();
+                _allGridEntries.AddRange(entries);
+                AddGridEntryEvents(_allGridEntries, parentIndex + 1, childCount);
             }
 
             if (e.OldChildCount != e.NewChildCount)
             {
-                totalProps = CountPropsFromOutline(topLevelGridEntries);
+                TotalProps = CountPropsFromOutline(_topLevelGridEntries);
                 SetConstants();
             }
 
@@ -4147,23 +4141,23 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnResize");
 
             Rectangle newRect = ClientRectangle;
-            int yDelta = lastClientRect == Rectangle.Empty ? 0 : newRect.Height - lastClientRect.Height;
-            bool lastRow = (selectedRow + 1) == visibleRows;
+            int yDelta = _lastClientRect == Rectangle.Empty ? 0 : newRect.Height - _lastClientRect.Height;
+            bool lastRow = (_selectedRow + 1) == _visibleRows;
 
             // if we are hiding or showing the scroll bar, update the selected row
             // or if we are changing widths
             //
             bool sbVisible = ScrollBar.Visible;
 
-            if (!lastClientRect.IsEmpty && newRect.Width > lastClientRect.Width)
+            if (!_lastClientRect.IsEmpty && newRect.Width > _lastClientRect.Width)
             {
-                Rectangle rectInvalidate = new Rectangle(lastClientRect.Width - 1, 0, newRect.Width - lastClientRect.Width + 1, lastClientRect.Height);
+                Rectangle rectInvalidate = new Rectangle(_lastClientRect.Width - 1, 0, newRect.Width - _lastClientRect.Width + 1, _lastClientRect.Height);
                 Invalidate(rectInvalidate);
             }
 
-            if (!lastClientRect.IsEmpty && yDelta > 0)
+            if (!_lastClientRect.IsEmpty && yDelta > 0)
             {
-                Rectangle rectInvalidate = new Rectangle(0, lastClientRect.Height - 1, lastClientRect.Width, newRect.Height - lastClientRect.Height + 1);
+                Rectangle rectInvalidate = new Rectangle(0, _lastClientRect.Height - 1, _lastClientRect.Width, newRect.Height - _lastClientRect.Height + 1);
                 Invalidate(rectInvalidate);
             }
 
@@ -4183,9 +4177,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             LayoutWindow(false);
 
-            bool selectionVisible = (selectedGridEntry is not null && selectedRow >= 0 && selectedRow <= visibleRows);
-            SelectGridEntry(selectedGridEntry, selectionVisible);
-            lastClientRect = newRect;
+            bool selectionVisible = (_selectedGridEntry is not null && _selectedRow >= 0 && _selectedRow <= _visibleRows);
+            SelectGridEntry(_selectedGridEntry, selectionVisible);
+            _lastClientRect = newRect;
         }
 
         private void OnScroll(object sender, ScrollEventArgs se)
@@ -4200,8 +4194,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             int oldRow = -1;
-            GridEntry oldGridEntry = selectedGridEntry;
-            if (selectedGridEntry is not null)
+            GridEntry oldGridEntry = _selectedGridEntry;
+            if (_selectedGridEntry is not null)
             {
                 oldRow = GetRowFromGridEntry(oldGridEntry);
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "OnScroll: SelectedGridEntry=" + oldGridEntry.PropertyLabel);
@@ -4211,8 +4205,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (oldGridEntry is not null)
             {
                 // we need to zero out the selected row so we don't try to commit again...since selectedRow is now bogus.
-                selectedRow = -1;
-                SelectGridEntry(oldGridEntry, (ScrollBar.Value == totalProps ? true : false));
+                _selectedRow = -1;
+                SelectGridEntry(oldGridEntry, (ScrollBar.Value == TotalProps ? true : false));
                 int newRow = GetRowFromGridEntry(oldGridEntry);
                 if (oldRow != newRow)
                 {
@@ -4239,7 +4233,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             GridEntry gridEntry = GetGridEntryFromRow(row);
             if (gridEntry is not null)
             {
-                if (dropDownHolder is not null && dropDownHolder.GetUsed())
+                if (_dropDownHolder is not null && _dropDownHolder.GetUsed())
                 {
                     CloseDropDown();
                     return;
@@ -4298,8 +4292,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
 
                     SetFlag(FlagDropDownCommit, false);
-                    DropDownListBox.Height = Math.Max(tm.tmHeight + 2, Math.Min(maxListBoxHeight, DropDownListBox.PreferredHeight));
-                    DropDownListBox.Width = Math.Max(maxWidth, GetRectangle(row, ROWVALUE).Width);
+                    DropDownListBox.Height = Math.Max(tm.tmHeight + 2, Math.Min(_maxListBoxHeight, DropDownListBox.PreferredHeight));
+                    DropDownListBox.Width = Math.Max(maxWidth, GetRectangle(row, RowValue).Width);
                     try
                     {
                         bool resizable = DropDownListBox.Items.Count > (DropDownListBox.Height / DropDownListBox.ItemHeight);
@@ -4450,7 +4444,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                                 }
                                 else
                                 {
-                                    SelectGridEntry(GetGridEntryFromRow(selectedRow), false);
+                                    SelectGridEntry(GetGridEntryFromRow(_selectedRow), false);
                                     return true;
                                 }
                             }
@@ -4478,9 +4472,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                             OnBtnClick((DialogButton.Focused ? DialogButton : DropDownButton), EventArgs.Empty);
                             return true;
                         }
-                        else if (selectedGridEntry is not null && selectedGridEntry.Expandable)
+                        else if (_selectedGridEntry is not null && _selectedGridEntry.Expandable)
                         {
-                            SetExpand(selectedGridEntry, !selectedGridEntry.InternalExpanded);
+                            SetExpand(_selectedGridEntry, !_selectedGridEntry.InternalExpanded);
                             return true;
                         }
 
@@ -4494,12 +4488,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected virtual void RecalculateProps()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:RecalculateProps");
-            int props = CountPropsFromOutline(topLevelGridEntries);
-            if (totalProps != props)
+            int props = CountPropsFromOutline(_topLevelGridEntries);
+            if (TotalProps != props)
             {
-                totalProps = props;
-                ClearGridEntryEvents(allGridEntries, 0, -1);
-                allGridEntries = null;
+                TotalProps = props;
+                ClearGridEntryEvents(_allGridEntries, 0, -1);
+                _allGridEntries = null;
             }
         }
 
@@ -4523,7 +4517,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (fInit)
             {
-                GridEntry ipeSelect = selectedGridEntry;
+                GridEntry ipeSelect = _selectedGridEntry;
                 Refresh();
                 SelectGridEntry(ipeSelect, false);
                 Invalidate();
@@ -4536,10 +4530,10 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             //resetting gridoutline rect to recalculate before repaint when viewsort property changed. This is necessary especially when user
             // changes sort and move to a secondary monitor with different DPI and change view sort back to original.
-            if (topLevelGridEntries is not null && DpiHelper.IsScalingRequirementMet)
+            if (_topLevelGridEntries is not null && DpiHelper.IsScalingRequirementMet)
             {
                 var outlineRectIconSize = GetOutlineIconSize();
-                foreach (GridEntry gridentry in topLevelGridEntries)
+                foreach (GridEntry gridentry in _topLevelGridEntries)
                 {
                     if (gridentry.OutlineRect.Height != outlineRectIconSize || gridentry.OutlineRect.Width != outlineRectIconSize)
                     {
@@ -4562,7 +4556,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         private void Refresh(bool fullRefresh, int rowStart, int rowEnd)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Refresh");
-            Debug.WriteLineIf(GridViewDebugPaint.TraceVerbose, "Refresh called for rows " + rowStart.ToString(CultureInfo.InvariantCulture) + " through " + rowEnd.ToString(CultureInfo.InvariantCulture));
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Refresh called for rows " + rowStart.ToString(CultureInfo.InvariantCulture) + " through " + rowEnd.ToString(CultureInfo.InvariantCulture));
             SetFlag(FlagNeedsRefresh, true);
             GridEntry gridEntry = null;
 
@@ -4587,8 +4581,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                     OnEscape(this);
                 }
 
-                int oldLength = totalProps;
-                object oldObject = topLevelGridEntries is null || topLevelGridEntries.Count == 0 ? null : ((GridEntry)topLevelGridEntries[0]).GetValueOwner();
+                int oldLength = TotalProps;
+                object oldObject = _topLevelGridEntries is null || _topLevelGridEntries.Count == 0 ? null : ((GridEntry)_topLevelGridEntries[0]).GetValueOwner();
 
                 // walk up to the main IPE and refresh it.
                 if (fullRefresh)
@@ -4602,16 +4596,16 @@ namespace System.Windows.Forms.PropertyGridInternal
                     CommonEditorHide(true);
                 }
 
-                UpdateHelpAttributes(selectedGridEntry, null);
-                selectedGridEntry = null;
+                UpdateHelpAttributes(_selectedGridEntry, null);
+                _selectedGridEntry = null;
                 SetFlag(FlagIsNewSelection, true);
-                topLevelGridEntries = OwnerGrid.GetPropEntries();
+                _topLevelGridEntries = OwnerGrid.GetPropEntries();
 
-                ClearGridEntryEvents(allGridEntries, 0, -1);
-                allGridEntries = null;
+                ClearGridEntryEvents(_allGridEntries, 0, -1);
+                _allGridEntries = null;
                 RecalculateProps();
 
-                int newLength = totalProps;
+                int newLength = TotalProps;
                 if (newLength > 0)
                 {
                     if (newLength < oldLength)
@@ -4629,21 +4623,21 @@ namespace System.Windows.Forms.PropertyGridInternal
                         // Upon restoring the grid entry position, we don't
                         // want to page it in
                         //
-                        object newObject = topLevelGridEntries is null || topLevelGridEntries.Count == 0 ? null : ((GridEntry)topLevelGridEntries[0]).GetValueOwner();
+                        object newObject = _topLevelGridEntries is null || _topLevelGridEntries.Count == 0 ? null : ((GridEntry)_topLevelGridEntries[0]).GetValueOwner();
                         pageInGridEntry = (gridEntry is null) || oldLength != newLength || newObject != oldObject;
                     }
 
                     if (gridEntry is null)
                     {
                         gridEntry = OwnerGrid.GetDefaultGridEntry();
-                        SetFlag(FlagNoDefault, gridEntry is null && totalProps > 0);
+                        SetFlag(FlagNoDefault, gridEntry is null && TotalProps > 0);
                     }
 
                     InvalidateRows(rowStart, rowEnd);
                     if (gridEntry is null)
                     {
-                        selectedRow = 0;
-                        selectedGridEntry = GetGridEntryFromRow(selectedRow);
+                        _selectedRow = 0;
+                        _selectedGridEntry = GetGridEntryFromRow(_selectedRow);
                     }
                 }
                 else if (oldLength == 0)
@@ -4657,15 +4651,15 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 // Release the old positionData which contains reference to previous selected objects.
                 positionData = null;
-                lastClickedEntry = null;
+                _lastClickedEntry = null;
             }
 
             if (!HasEntries)
             {
-                CommonEditorHide(selectedRow != -1);
+                CommonEditorHide(_selectedRow != -1);
                 OwnerGrid.SetStatusBox(null, null);
                 SetScrollOffset(0);
-                selectedRow = -1;
+                _selectedRow = -1;
                 Invalidate();
                 return;
             }
@@ -4685,14 +4679,14 @@ namespace System.Windows.Forms.PropertyGridInternal
         public virtual void Reset()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Reset");
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is null)
             {
                 return;
             }
 
             gridEntry.ResetPropertyValue();
-            SelectRow(selectedRow);
+            SelectRow(_selectedRow);
         }
 
         protected virtual void ResetOrigin(Graphics g)
@@ -4751,7 +4745,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         // Scroll to the new offset
         private bool ScrollRows(int newOffset)
         {
-            GridEntry ipeCur = selectedGridEntry;
+            GridEntry ipeCur = _selectedGridEntry;
 
             if (!IsScrollValueValid(newOffset) || !Commit())
             {
@@ -4771,7 +4765,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (ipeCur is not null)
             {
                 int curRow = GetRowFromGridEntry(ipeCur);
-                if (curRow >= 0 && curRow < visibleRows - 1)
+                if (curRow >= 0 && curRow < _visibleRows - 1)
                 {
                     Edit.Visible = showEdit;
                     DialogButton.Visible = showBtnEdit;
@@ -4794,7 +4788,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void SelectEdit(bool caretAtEnd)
         {
-            if (edit is not null)
+            if (_edit is not null)
             {
                 Edit.SelectAll();
             }
@@ -4835,7 +4829,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // Page-in the selected GridEntry
                 //
 
-                selectedRow = -1; // clear the selected row since it's no longer a valid number
+                _selectedRow = -1; // clear the selected row since it's no longer a valid number
 
                 int cOffset = GetScrollOffset();
                 if (row < 0)
@@ -4869,7 +4863,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (FocusInside)
                 {
                     // If we're in an error state, we want to bail out of this.
-                    if (errorState != ERROR_NONE || (row != selectedRow && !Commit()))
+                    if (_errorState != ERROR_NONE || (row != _selectedRow && !Commit()))
                     {
                         return;
                     }
@@ -4884,30 +4878,30 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             // Update our reset command.
             //
-            if (row != selectedRow)
+            if (row != _selectedRow)
             {
                 UpdateResetCommand(gridEntry);
             }
 
-            if (GetFlag(FlagIsNewSelection) && GetGridEntryFromRow(selectedRow) is null)
+            if (GetFlag(FlagIsNewSelection) && GetGridEntryFromRow(_selectedRow) is null)
             {
                 CommonEditorHide();
             }
 
-            UpdateHelpAttributes(selectedGridEntry, gridEntry);
+            UpdateHelpAttributes(_selectedGridEntry, gridEntry);
 
             // tell the old selection it's not focused any more
-            if (selectedGridEntry is not null)
+            if (_selectedGridEntry is not null)
             {
-                selectedGridEntry.Focus = false;
+                _selectedGridEntry.HasFocus = false;
             }
 
             // selection not visible.
-            if (row < 0 || row >= visibleRows)
+            if (row < 0 || row >= _visibleRows)
             {
                 CommonEditorHide();
-                selectedRow = row;
-                selectedGridEntry = gridEntry;
+                _selectedRow = row;
+                _selectedGridEntry = gridEntry;
                 Refresh();
                 return;
             }
@@ -4919,8 +4913,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             bool newRow = false;
-            int oldSel = selectedRow;
-            if (selectedRow != row || !gridEntry.Equals(selectedGridEntry))
+            int oldSel = _selectedRow;
+            if (_selectedRow != row || !gridEntry.Equals(_selectedGridEntry))
             {
                 CommonEditorHide();
                 newRow = true;
@@ -4931,7 +4925,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 CloseDropDown();
             }
 
-            Rectangle rect = GetRectangle(row, ROWVALUE);
+            Rectangle rect = GetRectangle(row, RowValue);
             string s = gridEntry.GetPropertyTextValue();
 
             // what components are we using?
@@ -4961,50 +4955,32 @@ namespace System.Windows.Forms.PropertyGridInternal
             // if we're painting the value, size the rect between the button and the painted value
             if (fPaint)
             {
-                rect.X += paintIndent + 1;
-                rect.Width -= paintIndent + 1;
+                rect.X += _paintIndent + 1;
+                rect.Width -= _paintIndent + 1;
             }
             else
             {
-                rect.X += EDIT_INDENT + 1; // +1 to compensate for where GDI+ draws it's string relative to the rect.
-                rect.Width -= EDIT_INDENT + 1;
+                rect.X += EditIndent + 1; // +1 to compensate for where GDI+ draws it's string relative to the rect.
+                rect.Width -= EditIndent + 1;
             }
 
             if ((GetFlag(FlagIsNewSelection) || !Edit.Focused) && (s is not null && !s.Equals(Edit.Text)))
             {
                 Edit.Text = s;
-                originalTextValue = s;
+                _originalTextValue = s;
                 Edit.SelectionStart = 0;
                 Edit.SelectionLength = 0;
             }
 
             Edit.AccessibleName = gridEntry.Label;
 
-            switch (inheritRenderMode)
+            if (gridEntry.ShouldSerializePropertyValue())
             {
-                case RENDERMODE_BOLD:
-                    if (gridEntry.ShouldSerializePropertyValue())
-                    {
-                        Edit.Font = GetBoldFont();
-                    }
-                    else
-                    {
-                        Edit.Font = Font;
-                    }
-
-                    break;
-                case RENDERMODE_LEFTDOT:
-                    if (gridEntry.ShouldSerializePropertyValue())
-                    {
-                        rect.X += (LEFTDOT_SIZE * 2);
-                        rect.Width -= (LEFTDOT_SIZE * 2);
-                    }
-
-                    // nothing
-                    break;
-                case RENDERMODE_TRIANGLE:
-                    // nothing
-                    break;
+                Edit.Font = GetBoldFont();
+            }
+            else
+            {
+                Edit.Font = Font;
             }
 
             if (GetFlag(FlagIsSplitterMove) || !gridEntry.HasValue || !FocusInside)
@@ -5024,15 +5000,15 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Edit.UseSystemPasswordChar = gridEntry.ShouldRenderPassword;
             }
 
-            GridEntry oldSelectedGridEntry = selectedGridEntry;
-            selectedRow = row;
-            selectedGridEntry = gridEntry;
+            GridEntry oldSelectedGridEntry = _selectedGridEntry;
+            _selectedRow = row;
+            _selectedGridEntry = gridEntry;
             OwnerGrid.SetStatusBox(gridEntry.PropertyLabel, gridEntry.PropertyDescription);
 
             // tell the new focused item that it now has focus
-            if (selectedGridEntry is not null)
+            if (_selectedGridEntry is not null)
             {
-                selectedGridEntry.Focus = FocusInside;
+                _selectedGridEntry.HasFocus = FocusInside;
             }
 
             if (!GetFlag(FlagIsNewSelection))
@@ -5052,9 +5028,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             try
             {
-                if (selectedGridEntry != oldSelectedGridEntry)
+                if (_selectedGridEntry != oldSelectedGridEntry)
                 {
-                    OwnerGrid.OnSelectedGridItemChanged(oldSelectedGridEntry, selectedGridEntry);
+                    OwnerGrid.OnSelectedGridItemChanged(oldSelectedGridEntry, _selectedGridEntry);
                 }
             }
             catch
@@ -5067,40 +5043,40 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:SetConstants");
             Size size = GetOurSize();
 
-            visibleRows = (int)Math.Ceiling(((double)size.Height) / (1 + RowHeight));
+            _visibleRows = (int)Math.Ceiling(((double)size.Height) / (1 + RowHeight));
 
             size = GetOurSize();
 
             if (size.Width >= 0)
             {
-                labelRatio = Math.Max(Math.Min(labelRatio, 9), 1.1);
-                labelWidth = ptOurLocation.X + (int)((double)size.Width / labelRatio);
+                _labelRatio = Math.Max(Math.Min(_labelRatio, 9), 1.1);
+                _labelWidth = _location.X + (int)((double)size.Width / _labelRatio);
             }
 
-            int oldWidth = labelWidth;
+            int oldWidth = _labelWidth;
 
             bool adjustWidth = SetScrollbarLength();
             GridEntryCollection rgipesAll = GetAllGridEntries();
             if (rgipesAll is not null)
             {
                 int scroll = GetScrollOffset();
-                if ((scroll + visibleRows) >= rgipesAll.Count)
+                if ((scroll + _visibleRows) >= rgipesAll.Count)
                 {
-                    visibleRows = rgipesAll.Count - scroll;
+                    _visibleRows = rgipesAll.Count - scroll;
                 }
             }
 
             if (adjustWidth && size.Width >= 0)
             {
-                labelRatio = ((double)GetOurSize().Width / (double)(oldWidth - ptOurLocation.X));
+                _labelRatio = ((double)GetOurSize().Width / (double)(oldWidth - _location.X));
                 //labelWidth = loc.X + (int) ((double)size.Width / labelRatio);
             }
 
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tsize       :" + size.ToString());
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tlocation   :" + ptOurLocation.ToString());
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tvisibleRows:" + (visibleRows).ToString(CultureInfo.InvariantCulture));
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tlabelWidth :" + (labelWidth).ToString(CultureInfo.InvariantCulture));
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tlabelRatio :" + (labelRatio).ToString(CultureInfo.InvariantCulture));
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tlocation   :" + _location.ToString());
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tvisibleRows:" + (_visibleRows).ToString(CultureInfo.InvariantCulture));
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tlabelWidth :" + (_labelWidth).ToString(CultureInfo.InvariantCulture));
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tlabelRatio :" + (_labelRatio).ToString(CultureInfo.InvariantCulture));
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\trowHeight  :" + (RowHeight).ToString(CultureInfo.InvariantCulture));
 #if DEBUG
             if (rgipesAll is null)
@@ -5141,7 +5117,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Debug.WriteLine("PropertyGridView:SetCommitError(error=" + err + ", capture=" + capture.ToString() + ")");
             }
 #endif
-            errorState = error;
+            _errorState = error;
             if (error != ERROR_NONE)
             {
                 CancelSplitterMove();
@@ -5155,31 +5131,31 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (gridEntry is not null && gridEntry.Expandable)
             {
                 int row = GetRowFromGridEntry(gridEntry);
-                int countFromEnd = visibleRows - row;
-                int curRow = selectedRow;
+                int countFromEnd = _visibleRows - row;
+                int curRow = _selectedRow;
 
                 // if the currently selected row is below us, we need to commit now
                 // or the offsets will be wrong
-                if (selectedRow != -1 && row < selectedRow && Edit.Visible)
+                if (_selectedRow != -1 && row < _selectedRow && Edit.Visible)
                 {
                     // this will cause the commit
                     Focus();
                 }
 
                 int offset = GetScrollOffset();
-                int items = totalProps;
+                int items = TotalProps;
 
                 gridEntry.InternalExpanded = value;
 
                 var oldExpandedState = value ? UiaCore.ExpandCollapseState.Collapsed : UiaCore.ExpandCollapseState.Expanded;
                 var newExpandedState = value ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
-                selectedGridEntry?.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
+                _selectedGridEntry?.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
                     UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
                     oldExpandedState,
                     newExpandedState);
 
                 RecalculateProps();
-                GridEntry ipeSelect = selectedGridEntry;
+                GridEntry ipeSelect = _selectedGridEntry;
                 if (!value)
                 {
                     for (GridEntry ipeCur = ipeSelect; ipeCur is not null; ipeCur = ipeCur.ParentGridEntry)
@@ -5195,12 +5171,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 SetConstants();
 
-                int newItems = totalProps - items;
+                int newItems = TotalProps - items;
 
-                if (value && newItems > 0 && newItems < visibleRows && (row + (newItems)) >= visibleRows && newItems < curRow)
+                if (value && newItems > 0 && newItems < _visibleRows && (row + (newItems)) >= _visibleRows && newItems < curRow)
                 {
                     // scroll to show the newly opened items.
-                    SetScrollOffset((totalProps - items) + offset);
+                    SetScrollOffset((TotalProps - items) + offset);
                 }
 
                 Invalidate();
@@ -5218,24 +5194,24 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (value)
             {
-                flags = (short)((ushort)flags | (ushort)flag);
+                _flags = (short)((ushort)_flags | (ushort)flag);
             }
             else
             {
-                flags &= (short)~flag;
+                _flags &= (short)~flag;
             }
         }
 
         public virtual void SetScrollOffset(int cOffset)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:SetScrollOffset(" + cOffset.ToString(CultureInfo.InvariantCulture) + ")");
-            int posNew = Math.Max(0, Math.Min(totalProps - visibleRows + 1, cOffset));
+            int posNew = Math.Max(0, Math.Min(TotalProps - _visibleRows + 1, cOffset));
             int posOld = ScrollBar.Value;
-            if (posNew != posOld && IsScrollValueValid(posNew) && visibleRows > 0)
+            if (posNew != posOld && IsScrollValueValid(posNew) && _visibleRows > 0)
             {
                 ScrollBar.Value = posNew;
                 Invalidate();
-                selectedRow = GetRowFromGridEntry(selectedGridEntry);
+                _selectedRow = GetRowFromGridEntry(_selectedGridEntry);
             }
         }
 
@@ -5249,7 +5225,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Commit()");
 
-            if (errorState == ERROR_MSGBOX_UP)
+            if (_errorState == ERROR_MSGBOX_UP)
             {
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Commit() returning false because an error has been thrown or we are in a property set");
                 return false;
@@ -5267,7 +5243,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return false;
             }
 
-            GridEntry ipeCur = GetGridEntryFromRow(selectedRow);
+            GridEntry ipeCur = GetGridEntryFromRow(_selectedRow);
             if (ipeCur is null)
             {
                 return true;
@@ -5296,11 +5272,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private bool CommitValue(object value)
         {
-            GridEntry ipeCur = selectedGridEntry;
+            GridEntry ipeCur = _selectedGridEntry;
 
-            if (selectedGridEntry is null && selectedRow != -1)
+            if (_selectedGridEntry is null && _selectedRow != -1)
             {
-                ipeCur = GetGridEntryFromRow(selectedRow);
+                ipeCur = GetGridEntryFromRow(_selectedRow);
             }
 
             if (ipeCur is null)
@@ -5380,7 +5356,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Edit.SelectionLength = 0;
             }
 
-            originalTextValue = text;
+            _originalTextValue = text;
 
             // Update our reset command.
             //
@@ -5388,24 +5364,24 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (ipeCur.ChildCount != propCount)
             {
-                ClearGridEntryEvents(allGridEntries, 0, -1);
-                allGridEntries = null;
+                ClearGridEntryEvents(_allGridEntries, 0, -1);
+                _allGridEntries = null;
                 SelectGridEntry(ipeCur, true);
             }
 
             // in case this guy got disposed...
             if (ipeCur.Disposed)
             {
-                bool editfocused = (edit is not null && edit.Focused);
+                bool editfocused = (_edit is not null && _edit.Focused);
 
                 // reselect the row to find the replacement.
                 //
                 SelectGridEntry(ipeCur, true);
-                ipeCur = selectedGridEntry;
+                ipeCur = _selectedGridEntry;
 
-                if (editfocused && edit is not null)
+                if (editfocused && _edit is not null)
                 {
-                    edit.Focus();
+                    _edit.Focus();
                 }
             }
 
@@ -5420,11 +5396,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             object value = null;
 
-            GridEntry ipeCur = selectedGridEntry;
+            GridEntry ipeCur = _selectedGridEntry;
 
-            if (selectedGridEntry is null && selectedRow != -1)
+            if (_selectedGridEntry is null && _selectedRow != -1)
             {
-                ipeCur = GetGridEntryFromRow(selectedRow);
+                ipeCur = GetGridEntryFromRow(_selectedRow);
             }
 
             if (ipeCur is null)
@@ -5451,13 +5427,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal void ReverseFocus()
         {
-            if (selectedGridEntry is null)
+            if (_selectedGridEntry is null)
             {
                 Focus();
             }
             else
             {
-                SelectGridEntry(selectedGridEntry, true);
+                SelectGridEntry(_selectedGridEntry, true);
 
                 if (DialogButton.Visible)
                 {
@@ -5479,38 +5455,38 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:SetScrollBarLength");
             bool sbChange = false;
-            if (totalProps != -1)
+            if (TotalProps != -1)
             {
-                if (totalProps < visibleRows)
+                if (TotalProps < _visibleRows)
                 {
                     SetScrollOffset(0);
                 }
-                else if (GetScrollOffset() > totalProps)
+                else if (GetScrollOffset() > TotalProps)
                 {
-                    SetScrollOffset((totalProps + 1) - visibleRows);
+                    SetScrollOffset((TotalProps + 1) - _visibleRows);
                 }
 
                 bool fHidden = !ScrollBar.Visible;
-                if (visibleRows > 0)
+                if (_visibleRows > 0)
                 {
-                    ScrollBar.LargeChange = visibleRows - 1;
+                    ScrollBar.LargeChange = _visibleRows - 1;
                 }
 
-                ScrollBar.Maximum = Math.Max(0, totalProps - 1);
-                if (fHidden != (totalProps < visibleRows))
+                ScrollBar.Maximum = Math.Max(0, TotalProps - 1);
+                if (fHidden != (TotalProps < _visibleRows))
                 {
                     sbChange = true;
                     ScrollBar.Visible = fHidden;
                     Size size = GetOurSize();
-                    if (labelWidth != -1 && size.Width > 0)
+                    if (_labelWidth != -1 && size.Width > 0)
                     {
-                        if (labelWidth > ptOurLocation.X + size.Width)
+                        if (_labelWidth > _location.X + size.Width)
                         {
-                            labelWidth = ptOurLocation.X + (int)((double)size.Width / labelRatio);
+                            _labelWidth = _location.X + (int)((double)size.Width / _labelRatio);
                         }
                         else
                         {
-                            labelRatio = ((double)GetOurSize().Width / (double)(labelWidth - ptOurLocation.X));
+                            _labelRatio = ((double)GetOurSize().Width / (double)(_labelWidth - _location.X));
                         }
                     }
 
@@ -5648,7 +5624,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (hooked)
             {
-                SelectGridEntry(selectedGridEntry, true);
+                SelectGridEntry(_selectedGridEntry, true);
             }
 
             SetCommitError(ERROR_THROWN, hooked);
@@ -5732,7 +5708,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (hooked)
             {
-                SelectGridEntry(selectedGridEntry, true);
+                SelectGridEntry(_selectedGridEntry, true);
             }
 
             SetCommitError(ERROR_THROWN, hooked);
@@ -5750,7 +5726,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void TabSelection()
         {
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is null)
             {
                 return;
@@ -5761,14 +5737,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Edit.Focus();
                 SelectEdit(false);
             }
-            else if (dropDownHolder is not null && dropDownHolder.Visible)
+            else if (_dropDownHolder is not null && _dropDownHolder.Visible)
             {
-                dropDownHolder.FocusComponent();
+                _dropDownHolder.FocusComponent();
                 return;
             }
-            else if (currentEditor is not null)
+            else if (_currentEditor is not null)
             {
-                currentEditor.Focus();
+                _currentEditor.Focus();
             }
 
             return;
@@ -5776,7 +5752,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal void RemoveSelectedEntryHelpAttributes()
         {
-            UpdateHelpAttributes(selectedGridEntry, null);
+            UpdateHelpAttributes(_selectedGridEntry, null);
         }
 
         private void UpdateHelpAttributes(GridEntry oldEntry, GridEntry newEntry)
@@ -5828,35 +5804,35 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 try
                 {
-                    if (listBox is not null)
+                    if (_listBox is not null)
                     {
                         DropDownListBox.ItemHeight = RowHeight + 2;
                     }
 
-                    if (btnDropDown is not null)
+                    if (_buttonDropDown is not null)
                     {
                         var isScalingRequirementMet = DpiHelper.IsScalingRequirementMet;
                         if (isScalingRequirementMet)
                         {
-                            btnDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight);
+                            _buttonDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight);
                         }
                         else
                         {
-                            btnDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
+                            _buttonDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
                         }
 
-                        if (btnDialog is not null)
+                        if (_buttonDialog is not null)
                         {
                             DialogButton.Size = DropDownButton.Size;
                             if (isScalingRequirementMet)
                             {
-                                btnDialog.Image = CreateResizedBitmap("dotdotdot", DOTDOTDOT_ICONWIDTH, DOTDOTDOT_ICONHEIGHT);
+                                _buttonDialog.Image = CreateResizedBitmap("dotdotdot", DOTDOTDOT_ICONWIDTH, DOTDOTDOT_ICONHEIGHT);
                             }
                         }
 
                         if (isScalingRequirementMet)
                         {
-                            btnDropDown.Image = CreateResizedBitmap("Arrow", DOWNARROW_ICONWIDTH, DOWNARROW_ICONHEIGHT);
+                            _buttonDropDown.Image = CreateResizedBitmap("Arrow", DOWNARROW_ICONWIDTH, DOWNARROW_ICONHEIGHT);
                         }
                     }
 
@@ -5875,7 +5851,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         private bool UnfocusSelection()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:UnfocusSelection()");
-            GridEntry gridEntry = GetGridEntryFromRow(selectedRow);
+            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is null)
             {
                 return true;
@@ -5893,7 +5869,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void UpdateResetCommand(GridEntry gridEntry)
         {
-            if (totalProps > 0)
+            if (TotalProps > 0)
             {
                 IMenuCommandService mcs = (IMenuCommandService)GetService(typeof(IMenuCommandService));
                 if (mcs is not null)
@@ -5982,11 +5958,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                             Point tipPt = Point.Empty;
 
                             // and if we need a tooltip, move the tooltip control to that point.
-                            if (mouseLoc.X == ROWLABEL)
+                            if (mouseLoc.X == RowLabel)
                             {
                                 tipPt = curEntry.GetLabelToolTipLocation(mouseLoc.X - itemRect.X, mouseLoc.Y - itemRect.Y);
                             }
-                            else if (mouseLoc.X == ROWVALUE)
+                            else if (mouseLoc.X == RowValue)
                             {
                                 tipPt = curEntry.ValueToolTipLocation;
                             }
@@ -6025,7 +6001,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // our state...
                 //
                 case (int)User32.WM.SETFOCUS:
-                    if (!GetInPropertySet() && Edit.Visible && (errorState != ERROR_NONE || !Commit()))
+                    if (!GetInPropertySet() && Edit.Visible && (_errorState != ERROR_NONE || !Commit()))
                     {
                         base.WndProc(ref m);
                         Edit.Focus();
@@ -6049,14 +6025,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     int flags = (int)(User32.DLGC.WANTCHARS | User32.DLGC.WANTARROWS);
 
-                    if (selectedGridEntry is not null)
+                    if (_selectedGridEntry is not null)
                     {
                         if ((ModifierKeys & Keys.Shift) == 0)
                         {
                             // if we're going backwards, we don't want the tab.
                             // otherwise, we only want it if we have an edit...
                             //
-                            if (edit.Visible)
+                            if (_edit.Visible)
                             {
                                 flags |= (int)User32.DLGC.WANTTAB;
                             }
@@ -6069,12 +6045,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                 case (int)User32.WM.MOUSEMOVE:
 
                     // check if it's the same position, of so eat the message
-                    if (unchecked((int)(long)m.LParam) == lastMouseMove)
+                    if (unchecked((int)(long)m.LParam) == _lastMouseMove)
                     {
                         return;
                     }
 
-                    lastMouseMove = unchecked((int)(long)m.LParam);
+                    _lastMouseMove = unchecked((int)(long)m.LParam);
                     break;
 
                 case (int)User32.WM.NOTIFY:
@@ -6085,10 +6061,10 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     break;
                 case AutomationMessages.PGM_GETSELECTEDROW:
-                    m.Result = (IntPtr)GetRowFromGridEntry(selectedGridEntry);
+                    m.Result = (IntPtr)GetRowFromGridEntry(_selectedGridEntry);
                     return;
                 case AutomationMessages.PGM_GETVISIBLEROWCOUNT:
-                    m.Result = (IntPtr)Math.Min(visibleRows, totalProps);
+                    m.Result = (IntPtr)Math.Min(_visibleRows, TotalProps);
                     return;
             }
 
@@ -6113,16 +6089,16 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (DpiHelper.IsScalingRequirementMet)
             {
-                cachedRowHeight = -1;
-                paintWidth = LogicalToDeviceUnits(PAINT_WIDTH);
-                paintIndent = LogicalToDeviceUnits(PAINT_INDENT);
-                outlineSizeExplorerTreeStyle = LogicalToDeviceUnits(OUTLINE_SIZE_EXPLORER_TREE_STYLE);
-                outlineSize = LogicalToDeviceUnits(OUTLINE_SIZE);
-                maxListBoxHeight = LogicalToDeviceUnits(MAX_LISTBOX_HEIGHT);
-                offset_2Units = LogicalToDeviceUnits(OFFSET_2PIXELS);
-                if (topLevelGridEntries is not null)
+                _cachedRowHeight = -1;
+                _paintWidth = LogicalToDeviceUnits(PaintWidth);
+                _paintIndent = LogicalToDeviceUnits(PaintIndent);
+                _outlineSizeExplorerTreeStyle = LogicalToDeviceUnits(OutlineSizeExplorerTreeStyle);
+                _outlineSize = LogicalToDeviceUnits(OutlineSize);
+                _maxListBoxHeight = LogicalToDeviceUnits(MaxListBoxHeight);
+                _offset2Units = LogicalToDeviceUnits(Offset2Pixels);
+                if (_topLevelGridEntries is not null)
                 {
-                    foreach (GridEntry t in topLevelGridEntries)
+                    foreach (GridEntry t in _topLevelGridEntries)
                     {
                         ResetOutline(t);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
@@ -169,7 +169,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     ReadOnlyAttribute readOnlyAttr = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(objValue)[typeof(ReadOnlyAttribute)];
                     if ((readOnlyAttr is not null && !readOnlyAttr.IsDefaultAttribute()) || TypeDescriptor.GetAttributes(objValue).Contains(InheritanceAttribute.InheritedReadOnly))
                     {
-                        flags |= FLAG_FORCE_READONLY;
+                        Flags |= FLAG_FORCE_READONLY;
                     }
 
                     forceReadOnlyChecked = true;
@@ -257,7 +257,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 object old = objValue;
                 objValue = value;
                 objValueClassName = TypeDescriptor.GetClassName(objValue);
-                ownerGrid.ReplaceSelectedObject(old, value);
+                OwnerGrid.ReplaceSelectedObject(old, value);
             }
         }
 
@@ -385,7 +385,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                                 bin.CopyTo(rgpes, 0);
                                 try
                                 {
-                                    propList.Add(new CategoryGridEntry(ownerGrid, this, category, rgpes));
+                                    propList.Add(new CategoryGridEntry(OwnerGrid, this, category, rgpes));
                                 }
                                 catch
                                 {

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridView.PropertyGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridView.PropertyGridViewAccessibleObjectTests.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             using ComboBox comboBox = new ComboBox();
             propertyGrid.SelectedObject = comboBox;
             GridEntry entry = (GridEntry)((GridEntry)propertyGrid.GetPropEntries()[0]).Children[2];
-            entry.Focus = true;
+            entry.HasFocus = true;
             entry.Select();
             Assert.Equal(entry, propertyGrid.SelectedGridItem);
 
@@ -54,7 +54,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             using ComboBox comboBox = new ComboBox();
             propertyGrid.SelectedObject = comboBox;
             GridEntry entry = (GridEntry)((GridEntry)propertyGrid.GetPropEntries()[0]).Children[2];
-            entry.Focus = true;
+            entry.HasFocus = true;
             entry.Select();
             Assert.Equal(entry, propertyGrid.SelectedGridItem);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
@@ -17,11 +17,11 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             using TestPropertyGridView testPropertyGridView = new(null, propertyGrid);
 
             TestPropertyDescriptorGridEntry gridEntry = new(propertyGrid, null, false);
-            testPropertyGridView.TestAccessor().Dynamic.selectedGridEntry = gridEntry;
+            testPropertyGridView.TestAccessor().Dynamic._selectedGridEntry = gridEntry;
 
             TestDropDownHolder dropDownHolder = new(testPropertyGridView);
             dropDownHolder.SetState(0x00000002, true); // Control class States.Visible flag
-            testPropertyGridView.TestAccessor().Dynamic.dropDownHolder = dropDownHolder;
+            testPropertyGridView.TestAccessor().Dynamic._dropDownHolder = dropDownHolder;
             gridEntry.TestAccessor().Dynamic._parentEntry = new TestGridEntry(propertyGrid, null, testPropertyGridView);
 
             UiaCore.IRawElementProviderFragment firstChild = gridEntry.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObjectTests.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
 
             PropertyDescriptor property = TypeDescriptor.GetProperties(typeof(PropertyGrid))[0];
             PropertyDescriptorGridEntry gridEntry = new PropertyDescriptorGridEntry(propertyGrid, null, property, false);
-            propertyGridView.TestAccessor().Dynamic.selectedGridEntry = gridEntry;
+            propertyGridView.TestAccessor().Dynamic._selectedGridEntry = gridEntry;
 
             ownerControl.Visible = true;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObjectTests.cs
@@ -28,7 +28,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             PropertyGridView propertyGridView = propertyGrid.TestAccessor().GridView;
             int firstPropertyIndex = 1; // Index 0 corresponds to the category grid entry.
             PropertyDescriptorGridEntry gridEntry = (PropertyDescriptorGridEntry)propertyGridView.AccessibilityGetGridEntries()[firstPropertyIndex];
-            PropertyDescriptorGridEntry selectedGridEntry = propertyGridView.TestAccessor().Dynamic.selectedGridEntry;
+            PropertyDescriptorGridEntry selectedGridEntry = propertyGridView.TestAccessor().Dynamic._selectedGridEntry;
 
             Assert.Equal(gridEntry.PropertyName, selectedGridEntry.PropertyName);
 
@@ -52,7 +52,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             int firstPropertyIndex = 2; // Index of Text property which has a RichEdit control as an editor.
             PropertyDescriptorGridEntry gridEntry = (PropertyDescriptorGridEntry)propertyGridView.AccessibilityGetGridEntries()[firstPropertyIndex];
 
-            propertyGridView.TestAccessor().Dynamic.selectedGridEntry = gridEntry;
+            propertyGridView.TestAccessor().Dynamic._selectedGridEntry = gridEntry;
 
             UiaCore.IRawElementProviderFragment editFieldAccessibleObject = gridEntry.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
             Assert.Equal("GridViewEditAccessibleObject", editFieldAccessibleObject.GetType().Name);
@@ -60,7 +60,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             // The case with drop down holder:
             using TestDropDownHolder dropDownHolder = new TestDropDownHolder(propertyGridView);
             dropDownHolder.CreateControl();
-            propertyGridView.TestAccessor().Dynamic.dropDownHolder = dropDownHolder;
+            propertyGridView.TestAccessor().Dynamic._dropDownHolder = dropDownHolder;
 
             dropDownHolder.SetState(0x00000002, true); // Control class States.Visible flag
 


### PR DESCRIPTION
A time boxed pass to fix more PropertyGrid member naming and accessiblity.

- Fix locking in CategoryGridEntry
- Remove TriState in MergePropertyDescriptor


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5058)