### PR TITLE
Scaling ToolStripItem text in PmV2 mode.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12186,7 +12186,9 @@ namespace System.Windows.Forms
             if (IsHandleCreated)
             {
                 _oldDeviceDpi = _deviceDpi;
-                _deviceDpi = (int)User32.GetDpiForWindow(this);
+
+                // In order to support tests, will be querying Dpi from the message instead of getting directly from the window handle.
+                _deviceDpi = PARAM.SignedLOWORD(m.WParam);
 
                 // Controls are by default font scaled.
                 // Dpi change requires font to be recalculated inorder to get controls scaled with right dpi.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12187,8 +12187,14 @@ namespace System.Windows.Forms
             {
                 _oldDeviceDpi = _deviceDpi;
 
-                // In order to support tests, will be querying Dpi from the message instead of getting directly from the window handle.
+                // In order to support tests, will be querying Dpi from the message first.
                 _deviceDpi = PARAM.SignedLOWORD(m.WParam);
+
+                // On certain OS versions, for non-test scenarios, WParam may be empty.
+                if (_deviceDpi == 0)
+                {
+                    _deviceDpi = (int)User32.GetDpiForWindow(this);
+                }
 
                 // Controls are by default font scaled.
                 // Dpi change requires font to be recalculated inorder to get controls scaled with right dpi.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4079,15 +4079,13 @@ namespace System.Windows.Forms
                         _toolStripGrip.ToolStrip_RescaleConstants(deviceDpiOld, deviceDpiNew);
                     }
 
-                    // ToolStripItems are components and have Font property. Components does not
-                    // receive DPICHANGED messages and ToolstripItems doesn't carry parent-child
-                    // relationship with owner to get scaled by parent/Container. For these reasons,
-                    // they need to be explicitly updated for the font when Dpi changes. If font was
-                    // not explicitly set, DefaultFont, that is scaled to current Dpi, will be applied.
+                    // ToolStripItems are components and have Font property. Components do not receive WM_DPICHANGED messages, nor they have
+                    // parent-child relationship with owners and, thus, do not get scaled by parent/Container. For these reasons, they need the font
+                    // to be explicitly updated when Dpi changes (only if the font was set explicitly).
                     var factor = (float)deviceDpiNew / deviceDpiOld;
                     foreach (ToolStripItem item in Items)
                     {
-                        if(item.TryGetExplicitlySetFont(out Font local))
+                        if (item.TryGetExplicitlySetFont(out Font local))
                         {
                             item.Font = local.WithSize(local.Size * factor);
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4079,6 +4079,20 @@ namespace System.Windows.Forms
                         _toolStripGrip.ToolStrip_RescaleConstants(deviceDpiOld, deviceDpiNew);
                     }
 
+                    // ToolStripItems are components and have Font property. Components does not
+                    // receive DPICHANGED messages and ToolstripItems doesn't carry parent-child
+                    // relationship with owner to get scaled by parent/Container. For these reasons,
+                    // they need to be explicitly updated for the font when Dpi changes. If font was
+                    // not explicitly set, DefaultFont, that is scaled to current Dpi, will be applied.
+                    var factor = (float)deviceDpiNew / deviceDpiOld;
+                    foreach (ToolStripItem item in Items)
+                    {
+                        if(item.TryGetExplicitlySetFont(out Font local))
+                        {
+                            item.Font = local.WithSize(local.Size * factor);
+                        }
+                    }
+
                     // We need to delegate this "event" to the Controls/Components, which are
                     // not directly affected by this, but need to consume.
                     _rescaleConstsCallbackDelegate?.Invoke(deviceDpiOld, deviceDpiNew);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -882,23 +882,22 @@ namespace System.Windows.Forms
         {
             get
             {
-                Font font = (Font)Properties.GetObject(s_fontProperty);
-                if (font is not null)
+                if (TryGetExplicitlySetFont(out Font font))
                 {
                     return font;
                 }
 
-                Font f = GetOwnerFont();
-                if (f is not null)
+                font = GetOwnerFont();
+                if (font is not null)
                 {
-                    return f;
+                    return font;
                 }
 
                 return DpiHelper.IsPerMonitorV2Awareness ? _defaultFont : ToolStripManager.DefaultFont;
             }
             set
             {
-                Font local = (Font)Properties.GetObject(s_fontProperty);
+                var local = (Font)Properties.GetObject(s_fontProperty);
                 if ((local != value))
                 {
                     Properties.SetObject(s_fontProperty, value);
@@ -2830,7 +2829,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected internal virtual void OnOwnerFontChanged(EventArgs e)
         {
-            if (Properties.GetObject(s_fontProperty) is null)
+            if (!TryGetExplicitlySetFont(out _))
             {
                 OnFontChanged(e);
             }
@@ -3207,11 +3206,7 @@ namespace System.Windows.Forms
         ///  Returns true if the font should be persisted in code gen.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        internal virtual bool ShouldSerializeFont()
-        {
-            object font = Properties.GetObject(s_fontProperty, out bool found);
-            return (found && font is not null);
-        }
+        internal virtual bool ShouldSerializeFont() => TryGetExplicitlySetFont(out _);
 
         /// <summary>
         ///  Determines if the <see cref='Padding'/> property needs to be persisted.
@@ -3542,5 +3537,15 @@ namespace System.Windows.Forms
         }
 
         internal virtual bool IsBeingTabbedTo() => ToolStrip.AreCommonNavigationalKeysDown();
+
+        /// <summary>
+        /// Query font from property bag.
+        /// </summary>
+        internal bool TryGetExplicitlySetFont(out Font local)
+        {
+            local = (Font)Properties.GetObject(s_fontProperty);
+
+            return local is not null;
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Methods.cs
@@ -12553,6 +12553,7 @@ namespace System.Windows.Forms.Tests
                 var m = new Message
                 {
                     Msg = (int)User32.WM.DPICHANGED_AFTERPARENT,
+                    WParam = PARAM.FromLowHigh(192, 192),
                     Result = (IntPtr)250
                 };
                 control.WndProc(ref m);
@@ -12584,6 +12585,7 @@ namespace System.Windows.Forms.Tests
             var m = new Message
             {
                 Msg = (int)User32.WM.DPICHANGED_AFTERPARENT,
+                WParam = PARAM.FromLowHigh(192, 192),
                 Result = (IntPtr)250
             };
             control.WndProc(ref m);
@@ -12611,6 +12613,7 @@ namespace System.Windows.Forms.Tests
                 var m = new Message
                 {
                     Msg = (int)User32.WM.DPICHANGED_BEFOREPARENT,
+                    WParam = PARAM.FromLowHigh(192, 192),
                     Result = (IntPtr)250
                 };
                 control.WndProc(ref m);
@@ -12642,6 +12645,7 @@ namespace System.Windows.Forms.Tests
             var m = new Message
             {
                 Msg = (int)User32.WM.DPICHANGED_BEFOREPARENT,
+                WParam = PARAM.FromLowHigh(192, 192),
                 Result = (IntPtr)250
             };
             control.WndProc(ref m);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/DpiMessageHelper.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/DpiMessageHelper.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+
+namespace System.Windows.Forms.Tests.Dpi
+{
+    internal static class DpiMessageHelper
+    {
+        public static IntPtr TriggerDpiMessage(User32.WM message, Control control, int newDpi)
+        {
+            double factor = newDpi / DpiHelper.LogicalDpi;
+            var wParam = PARAM.FromLowHigh(newDpi, newDpi);
+            RECT suggestedRect = new(0,
+                0,
+                (int)Math.Round(control.Width * factor),
+                (int)Math.Round(control.Height * factor));
+            return User32.SendMessageW(control, message, wParam, ref suggestedRect);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/DpiMessageHelper.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/DpiMessageHelper.cs
@@ -8,17 +8,17 @@ namespace System.Windows.Forms.Tests.Dpi
 {
     internal static class DpiMessageHelper
     {
-        public static IntPtr TriggerDpiMessage(User32.WM message, Control control, int newDpi)
+        public static void TriggerDpiMessage(User32.WM message, Control control, int newDpi)
         {
             double factor = newDpi / DpiHelper.LogicalDpi;
             IntPtr wParam = PARAM.FromLowHigh(newDpi, newDpi);
 
-            return message switch
+            _ = message switch
             {
                 User32.WM.DPICHANGED => SendWmDpiChangedMessage(),
                 User32.WM.DPICHANGED_BEFOREPARENT => User32.SendMessageW(control, message, wParam),
                 User32.WM.DPICHANGED_AFTERPARENT => User32.SendMessageW(control, message),
-                _ => IntPtr.Zero
+                _ => throw new NotImplementedException()
             };
 
             IntPtr SendWmDpiChangedMessage()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/FormTests.Dpi.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/FormTests.Dpi.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.Tests.Dpi
+{
+    public class FormDpiTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsTheory]
+        [InlineData(2 * DpiHelper.LogicalDpi)]
+        [InlineData(3.5 * DpiHelper.LogicalDpi)]
+        public void Form_DpiChanged_Bounds(int newDpi)
+        {
+            // Run tests only on Windows 10 versions that support thread dpi awareness.
+            if (!PlatformDetection.IsWindows10Version1803OrGreater)
+            {
+                return;
+            }
+
+            // Set thread awareness context to PermonitorV2(PMv2).
+            IntPtr originalAwarenessContext = User32.SetThreadDpiAwarenessContext(User32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_V2);
+
+            try
+            {
+                using var form = new Form();
+                form.AutoScaleMode = AutoScaleMode.Dpi;
+                form.Show();
+                Drawing.Rectangle initialBounds = form.Bounds;
+                float initialFontSize = form.Font.Size;
+                _ = DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED, form, newDpi);
+                var factor = newDpi / DpiHelper.LogicalDpi;
+
+                // Lab machines giving strange values that I could not explain. for ex: on local machine,
+                // I get 1050*1050 for factor 3.5. This is not same on lab machines ( ex, we get 1044). For now,
+                // just verifying they are scaled.
+                Assert.NotEqual(initialBounds.Width, form.Bounds.Width);
+                Assert.NotEqual(initialBounds.Height, form.Bounds.Height);
+                Assert.NotEqual(initialFontSize, form.Font.Size);
+                form.Close();
+            }
+            finally
+            {
+                // Reset back to original awareness context.
+                User32.SetThreadDpiAwarenessContext(originalAwarenessContext);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/FormTests.Dpi.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/FormTests.Dpi.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms.Tests.Dpi
                 form.Show();
                 Drawing.Rectangle initialBounds = form.Bounds;
                 float initialFontSize = form.Font.Size;
-                _ = DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED, form, newDpi);
+                DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED, form, newDpi);
                 var factor = newDpi / DpiHelper.LogicalDpi;
 
                 // Lab machines giving strange values that I could not explain. for ex: on local machine,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/ToolStripItemTests.Dpi.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/ToolStripItemTests.Dpi.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Forms.Tests.Dpi
 
                 form.Show();
 
-                _ = DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED_BEFOREPARENT, toolStrip, newDpi);
+                DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED_BEFOREPARENT, toolStrip, newDpi);
                 var factor = newDpi / DpiHelper.LogicalDpi;
 
                 Assert.Equal((float)initialFont.Size * factor, toolStrip.Font.Size);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/ToolStripItemTests.Dpi.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/ToolStripItemTests.Dpi.cs
@@ -33,7 +33,6 @@ namespace System.Windows.Forms.Tests.Dpi
                 var toolStrip = new ToolStrip();
                 var toolStripItemOpen = new ToolStripButton("Open");
 
-                toolStrip.BackColor = Color.FromArgb(((int)(((byte)(40)))), ((int)(((byte)(40)))), ((int)(((byte)(40)))));
                 toolStrip.GripStyle = ToolStripGripStyle.Hidden;
                 toolStrip.Items.Add(toolStripItemOpen);
                 toolStrip.Location = new Point(0, 0);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/ToolStripItemTests.Dpi.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/ToolStripItemTests.Dpi.cs
@@ -30,8 +30,8 @@ namespace System.Windows.Forms.Tests.Dpi
                 using var form = new Form();
                 form.AutoScaleMode = AutoScaleMode.Dpi;
                 form.ClientSize = new Size(clientWidth, 450);
-                var toolStrip = new ToolStrip();
-                var toolStripItemOpen = new ToolStripButton("Open");
+                using var toolStrip = new ToolStrip();
+                using var toolStripItemOpen = new ToolStripButton("Open");
 
                 toolStrip.GripStyle = ToolStripGripStyle.Hidden;
                 toolStrip.Items.Add(toolStripItemOpen);


### PR DESCRIPTION
Fixes #4872

ToolStripItems are components and have Font property. Components does not receive DPICHANGED messages and ToolstripItems doesn't carry parent-child relationship with owner to get scaled by parent/Container. For these reasons, they need to be explicitly updated for the font when Dpi changes. If font was not explicitly set, DefaultFont, that is scaled to current Dpi, will be applied.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5059)