### PR TITLE
Changing ListView subitem control type to "Text"

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -120,13 +120,10 @@ namespace System.Windows.Forms
                 internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                     => propertyID switch
                     {
-                        // All subitems are "text".
-                        // Some of them can be editable, if ListView.LabelEdit is true.
-                        // In this case, an edit field appears when editing.
-                        // This field has own accessible object, that has the "edit" control type,
-                        // and it supports the Text pattern.
-                        // And its owning subitem accessible object has the "text" control type,
-                        // because it is just a container for the edit field.
+                        // All subitems are "text". Some of them can be editable, if ListView.LabelEdit is true.
+                        // In this case, an edit field appears when editing. This field has own accessible object, that
+                        // has the "edit" control type, and it supports the Text pattern. And its owning subitem accessible
+                        // object has the "text" control type, because it is just a container for the edit field.
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TextControlTypeId,
                         UiaCore.UIA.NamePropertyId => Name,
                         UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -120,11 +120,14 @@ namespace System.Windows.Forms
                 internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                     => propertyID switch
                     {
-                        // All subitems are "text" except the first.
-                        // It can be "edit" if ListView.LabelEdit is true.
-                        UiaCore.UIA.ControlTypePropertyId => _owningListView.LabelEdit && ParentInternal.GetChildIndex(this) == 0
-                                                             ? UiaCore.UIA.EditControlTypeId
-                                                             : UiaCore.UIA.TextControlTypeId,
+                        // All subitems are "text".
+                        // Some of them can be editable, if ListView.LabelEdit is true.
+                        // In this case, an edit field appears when editing.
+                        // This field has own accessible object, that has the "edit" control type,
+                        // and it supports the Text pattern.
+                        // And its owning subitem accessible object has the "text" control type,
+                        // because it is just a container for the edit field.
+                        UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TextControlTypeId,
                         UiaCore.UIA.NamePropertyId => Name,
                         UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
 #pragma warning disable CA1837 // Use 'Environment.ProcessId'

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -46,11 +46,11 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(true, 0, (int)UiaCore.UIA.EditControlTypeId)]
-        [InlineData(false, 0, (int)UiaCore.UIA.TextControlTypeId)]
-        [InlineData(true, 1, (int)UiaCore.UIA.TextControlTypeId)]
-        [InlineData(false, 1, (int)UiaCore.UIA.TextControlTypeId)]
-        public void ListViewSubItemAccessibleObject_GetPropertyValue_returns_correct_values(bool labelEdit, int childId, int expectedControlType)
+        [InlineData(true, 0)]
+        [InlineData(false, 0)]
+        [InlineData(true, 1)]
+        [InlineData(false, 1)]
+        public void ListViewSubItemAccessibleObject_GetPropertyValue_returns_correct_values(bool labelEdit, int childId)
         {
             using ListView list = new();
             ListViewItem listViewItem1 = new(new string[]
@@ -89,9 +89,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("WinForm", frameworkId);
 
             object controlType = accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
-            UiaCore.UIA expected = (UiaCore.UIA)expectedControlType;
 
-            Assert.Equal(expected, controlType);
+            Assert.Equal(UiaCore.UIA.TextControlTypeId, controlType);
             Assert.True(list.IsHandleCreated);
         }
 
@@ -717,7 +716,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.Tile, false)]
         public void ListViewSubItemAccessibleObject_ColumnProperty_ReturnMinusOne_ForNotTableView(View view, bool createControl)
         {
-            using ListView list = new() { View = view};
+            using ListView list = new() { View = view };
             ListViewItem listViewItem1 = new(new string[]
             {
                 "Test 1",


### PR DESCRIPTION
Fixes #4198 


## Proposed changes

- Change ListView subitem control type to "Text"
It's necessary to avoid Text pattern issues.
An "edit" element must support Text pattern,
but a ListView item is just a continer for an edit field, that already supports Text pattern.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user will see\hear a new control type for subitems


## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- A subitem control type is "edit". It must support Text patter, but it's impossible:
![image](https://user-images.githubusercontent.com/49272759/121320740-1b55bf80-c916-11eb-8e91-5f4d72cb94a6.png)

### After
- A subitem control type is "text". It mustn't support Text patter:
![image](https://user-images.githubusercontent.com/49272759/121320071-7f2bb880-c915-11eb-9411-ecc38514bd71.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Manual testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Narrator, Inspect and AI

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 6.0.0-preview.6.21276.13


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5063)