### PR TITLE
Fix NullRefException for case when user closes Form with hidden PropertyGrid

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridView.PropertyGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridView.PropertyGridViewAccessibleObjectTests.cs
@@ -32,6 +32,20 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             Assert.Throws<ArgumentNullException>(() => new PropertyGridViewAccessibleObject(null, null));
         }
 
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.NavigateDirection.Parent)]
+        [InlineData((int)UiaCore.NavigateDirection.NextSibling)]
+        [InlineData((int)UiaCore.NavigateDirection.PreviousSibling)]
+        [InlineData((int)UiaCore.NavigateDirection.FirstChild)]
+        [InlineData((int)UiaCore.NavigateDirection.LastChild)]
+        public void PropertyGridViewAccessibleObject_FragmentNavigate_DoesNotThrowExpection_WithoutOwnerGrid(int direction)
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            using PropertyGridView propertyGridView = new PropertyGridView(null, null);
+            AccessibleObject accessibleObject = new PropertyGridViewAccessibleObject(propertyGridView, propertyGrid);
+            Assert.Null(accessibleObject.FragmentNavigate((UiaCore.NavigateDirection)direction));
+        }
+
         [WinFormsFact]
         public void PropertyGridViewAccessibleObject_GetFocused_ReturnsCorrectValue()
         {


### PR DESCRIPTION
Fixes #4861

## Proposed changes
This issue is reproducible because in some scenarios (e.g. disposing), `OwnerGrid` property can have `null` value. For properties `FragmentRoot` and `Name` we check a similar scenario, but the `FragmentNavigate` method and `RowCount` property don't have this check.

- Added missing check for null. 
- Added unit tests.

**Note:**
I think there are possible scenarios where this bug might be reproducible in *.NET Core 5.0* and *.NET Core 6.0*. So I would suggest fixing this case in *.NET Core 3.1*, *.NET Core 5.0*, *.NET Core 6.0*

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
When closing a form with PropertyGrid, the exception is no longer throwed

## Regression? 

- Yes

## Risk
- Minimal 
## Test methodology <!-- How did you ensure quality? -->
- Unit tests 
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.0-preview.6.21310.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5077)