### PR TITLE
Fix ListViewGroup rendering (servicing)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -5602,11 +5602,26 @@ namespace System.Windows.Forms
             var lvgroup = new LVGROUPW
             {
                 cbSize = (uint)sizeof(LVGROUPW),
-                mask = LVGF.HEADER | LVGF.FOOTER | LVGF.ALIGN | LVGF.STATE | LVGF.SUBTITLE | LVGF.TASK | LVGF.TITLEIMAGE | additionalMask,
+                mask = LVGF.HEADER | LVGF.ALIGN | LVGF.STATE | LVGF.TITLEIMAGE | additionalMask,
                 cchHeader = header.Length,
                 iTitleImage = -1,
                 iGroupId = group.ID
             };
+
+            if (subtitle.Length != 0)
+            {
+                lvgroup.mask |= LVGF.SUBTITLE;
+            }
+
+            if (task.Length != 0)
+            {
+                lvgroup.mask |= LVGF.TASK;
+            }
+
+            if (footer.Length != 0)
+            {
+                lvgroup.mask |= LVGF.FOOTER;
+            }
 
             if (group.CollapsedState != ListViewGroupCollapsedState.Default)
             {
@@ -5640,25 +5655,36 @@ namespace System.Windows.Forms
             fixed (char* pHeader = header)
             fixed (char* pFooter = footer)
             {
-                lvgroup.cchFooter = footer.Length;
-                lvgroup.pszFooter = pFooter;
-                switch (group.FooterAlignment)
+                if (footer.Length != 0)
                 {
-                    case HorizontalAlignment.Left:
-                        lvgroup.uAlign |= LVGA.FOOTER_LEFT;
-                        break;
-                    case HorizontalAlignment.Right:
-                        lvgroup.uAlign |= LVGA.FOOTER_RIGHT;
-                        break;
-                    case HorizontalAlignment.Center:
-                        lvgroup.uAlign |= LVGA.FOOTER_CENTER;
-                        break;
+                    lvgroup.cchFooter = footer.Length;
+                    lvgroup.pszFooter = pFooter;
+                    switch (group.FooterAlignment)
+                    {
+                        case HorizontalAlignment.Left:
+                            lvgroup.uAlign |= LVGA.FOOTER_LEFT;
+                            break;
+                        case HorizontalAlignment.Right:
+                            lvgroup.uAlign |= LVGA.FOOTER_RIGHT;
+                            break;
+                        case HorizontalAlignment.Center:
+                            lvgroup.uAlign |= LVGA.FOOTER_CENTER;
+                            break;
+                    }
                 }
 
-                lvgroup.cchSubtitle = (uint)subtitle.Length;
-                lvgroup.pszSubtitle = pSubtitle;
-                lvgroup.cchTask = (uint)task.Length;
-                lvgroup.pszTask = pTask;
+                if (subtitle.Length != 0)
+                {
+                    lvgroup.cchSubtitle = (uint)subtitle.Length;
+                    lvgroup.pszSubtitle = pSubtitle;
+                }
+
+                if (task.Length != 0)
+                {
+                    lvgroup.cchTask = (uint)task.Length;
+                    lvgroup.pszTask = pTask;
+                }
+
                 lvgroup.pszHeader = pHeader;
                 return User32.SendMessageW(this, (User32.WM)msg, lParam, ref lvgroup);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -93,8 +93,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The text displayed in the group header.
         /// </summary>
-        [SRCategory(nameof(SR.CatAppearance))]
         [AllowNull]
+        [DefaultValue("")]
+        [SRCategory(nameof(SR.CatAppearance))]
         public string Header
         {
             get => _header ?? string.Empty;
@@ -138,8 +139,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The text displayed in the group footer.
         /// </summary>
-        [SRCategory(nameof(SR.CatAppearance))]
         [AllowNull]
+        [DefaultValue("")]
+        [SRCategory(nameof(SR.CatAppearance))]
         public string Footer
         {
             get => _footer ?? string.Empty;
@@ -223,8 +225,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The text displayed in the group subtitle.
         /// </summary>
-        [SRCategory(nameof(SR.CatAppearance))]
         [AllowNull]
+        [DefaultValue("")]
+        [SRCategory(nameof(SR.CatAppearance))]
         public string Subtitle
         {
             get => _subtitle ?? string.Empty;
@@ -243,8 +246,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The name of the task link displayed in the group header.
         /// </summary>
-        [SRCategory(nameof(SR.CatAppearance))]
         [AllowNull]
+        [DefaultValue("")]
+        [SRCategory(nameof(SR.CatAppearance))]
         public string TaskLink
         {
             get => _taskLink ?? string.Empty;


### PR DESCRIPTION
Fixes #5087




## Proposed changes

* Do not render empty ListViewGroup subtitles, tasks and footers.
* Do not serialize empty ListViewGroup subtitles, tasks and footers.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ListViewGroup will be rendered correctly

## Regression? 

- An incorrect implementation in .NET 5.0

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
![image](https://user-images.githubusercontent.com/4403806/121810086-bea22e00-cca2-11eb-8774-1c3af1f8ead9.png)
![image](https://user-images.githubusercontent.com/4403806/121810222-49832880-cca3-11eb-8bcc-9b2a817f4396.png)


### After

![image](https://user-images.githubusercontent.com/4403806/121857818-56eaf200-cd39-11eb-8dc6-8b8688f40025.png)
![image](https://user-images.githubusercontent.com/4403806/121838812-04e7a380-cd1c-11eb-9ad9-063419b08c49.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5094)