### PR TITLE
 Fix NullRefException for case when user closes Form with hidden PropertyGrid (port to 5.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -6328,34 +6328,15 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
 
-                if (_owningPropertyGridView.OwnerGrid.SortedByCategories)
+                return direction switch
                 {
-                    switch (direction)
-                    {
-                        case UiaCore.NavigateDirection.FirstChild:
-                            return GetFirstCategory();
-                        case UiaCore.NavigateDirection.LastChild:
-                            return GetLastCategory();
-                    }
-                }
-                else
-                {
-                    switch (direction)
-                    {
-                        case UiaCore.NavigateDirection.FirstChild:
-                            return GetChild(0);
-                        case UiaCore.NavigateDirection.LastChild:
-                            int childCount = GetChildCount();
-                            if (childCount > 0)
-                            {
-                                return GetChild(childCount - 1);
-                            }
+                    UiaCore.NavigateDirection.FirstChild => IsSortedByCategories() ? GetCategory(0) : GetChild(0),
+                    UiaCore.NavigateDirection.LastChild => IsSortedByCategories() ? GetLastCategory() : GetLastChild(),
+                    _ => base.FragmentNavigate(direction)
+                };
 
-                            return null;
-                    }
-                }
-
-                return base.FragmentNavigate(direction);
+                bool IsSortedByCategories() => _owningPropertyGridView.OwnerGrid is not null
+                                               && _owningPropertyGridView.OwnerGrid.SortedByCategories;
             }
 
             /// <summary>
@@ -6459,16 +6440,19 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return null;
             }
 
-            internal AccessibleObject GetFirstCategory()
-            {
-                return GetCategory(0);
-            }
-
             internal AccessibleObject GetLastCategory()
             {
                 GridEntryCollection topLevelGridEntries = _owningPropertyGridView.TopLevelGridEntries;
                 var topLevelGridEntriesCount = topLevelGridEntries.Count;
+
                 return GetCategory(topLevelGridEntries.Count - 1);
+            }
+
+            internal AccessibleObject GetLastChild()
+            {
+                int childCount = GetChildCount();
+
+                return childCount > 0 ? GetChild(childCount - 1) : null;
             }
 
             /// <summary>
@@ -6814,7 +6798,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return 0;
                     }
 
-                    if (!_owningPropertyGridView.OwnerGrid.SortedByCategories)
+                    if (_owningPropertyGridView.OwnerGrid is null || !_owningPropertyGridView.OwnerGrid.SortedByCategories)
                     {
                         return topLevelGridEntries.Count;
                     }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
@@ -32,6 +32,20 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             Assert.Throws<ArgumentNullException>(() => new PropertyGridViewAccessibleObject(null, null));
         }
 
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.NavigateDirection.Parent)]
+        [InlineData((int)UiaCore.NavigateDirection.NextSibling)]
+        [InlineData((int)UiaCore.NavigateDirection.PreviousSibling)]
+        [InlineData((int)UiaCore.NavigateDirection.FirstChild)]
+        [InlineData((int)UiaCore.NavigateDirection.LastChild)]
+        public void PropertyGridViewAccessibleObject_FragmentNavigate_DoesNotThrowExpection_WithoutOwnerGrid(int direction)
+        {
+            using PropertyGrid propertyGrid = new();
+            using PropertyGridView propertyGridView = new(null, null);
+            PropertyGridViewAccessibleObject accessibleObject = new(propertyGridView, propertyGrid);
+            Assert.Null(accessibleObject.FragmentNavigate((UiaCore.NavigateDirection)direction));
+        }
+
         [WinFormsFact]
         public void PropertyGridViewAccessibleObject_GetFocused_ReturnsCorrectValue()
         {


### PR DESCRIPTION
Fixes #4861

## Proposed changes
This issue is reproducible because in some scenarios (e.g. disposing), `OwnerGrid` property can have `null` value. For properties `FragmentRoot` and `Name` we check a similar scenario, but the `FragmentNavigate` method and `RowCount` property don't have this check.

- Added missing check for null. 
- Added unit tests.

**Note:**
Ported from #5077

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
When closing a form with PropertyGrid, the exception is no longer throwed

## Regression? 

- Yes

## Risk
- Minimal 
## Test methodology <!-- How did you ensure quality? -->
- Unit tests 
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 5.0.7

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5103)