### PR TITLE
Fix NullRefException for case when user closes Form with hidden PropertyGrid (port to 3.1)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -8462,34 +8462,15 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
 
-                if (_owningPropertyGridView.OwnerGrid.SortedByCategories)
+                return direction switch
                 {
-                    switch (direction)
-                    {
-                        case UnsafeNativeMethods.NavigateDirection.FirstChild:
-                            return GetFirstCategory();
-                        case UnsafeNativeMethods.NavigateDirection.LastChild:
-                            return GetLastCategory();
-                    }
-                }
-                else
-                {
-                    switch (direction)
-                    {
-                        case UnsafeNativeMethods.NavigateDirection.FirstChild:
-                            return GetChild(0);
-                        case UnsafeNativeMethods.NavigateDirection.LastChild:
-                            int childCount = GetChildCount();
-                            if (childCount > 0)
-                            {
-                                return GetChild(childCount - 1);
-                            }
+                    UnsafeNativeMethods.NavigateDirection.FirstChild => IsSortedByCategories() ? GetCategory(0) : GetChild(0),
+                    UnsafeNativeMethods.NavigateDirection.LastChild => IsSortedByCategories() ? GetLastCategory() : GetLastChild(),
+                    _ => base.FragmentNavigate(direction)
+                };
 
-                            return null;
-                    }
-                }
-
-                return base.FragmentNavigate(direction);
+                bool IsSortedByCategories() => _owningPropertyGridView.OwnerGrid is not null
+                                               && _owningPropertyGridView.OwnerGrid.SortedByCategories;
             }
 
             /// <summary>
@@ -8593,16 +8574,19 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return null;
             }
 
-            internal AccessibleObject GetFirstCategory()
-            {
-                return GetCategory(0);
-            }
-
             internal AccessibleObject GetLastCategory()
             {
                 GridEntryCollection topLevelGridEntries = _owningPropertyGridView.TopLevelGridEntries;
                 var topLevelGridEntriesCount = topLevelGridEntries.Count;
+
                 return GetCategory(topLevelGridEntries.Count - 1);
+            }
+
+            internal AccessibleObject GetLastChild()
+            {
+                int childCount = GetChildCount();
+
+                return childCount > 0 ? GetChild(childCount - 1) : null;
             }
 
             /// <summary>
@@ -8947,7 +8931,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return 0;
                     }
 
-                    if (!_owningPropertyGridView.OwnerGrid.SortedByCategories)
+                    if (_owningPropertyGridView.OwnerGrid is null || !_owningPropertyGridView.OwnerGrid.SortedByCategories)
                     {
                         return topLevelGridEntries.Count;
                     }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridViewAccessibleObjectTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Windows.Forms.PropertyGridInternal;
 using Xunit;
+using static System.Windows.Forms.PropertyGridInternal.PropertyGridView;
 
 namespace System.Windows.Forms.Tests.AccessibleObjects
 {
@@ -43,6 +45,20 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             var parentGridEntry = defaultGridEntry.ParentGridEntry; // Category which has item pattern.
             var accessibleObject = parentGridEntry.AccessibilityObject;
             Assert.True(accessibleObject.IsPatternSupported(pattern));
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UnsafeNativeMethods.NavigateDirection.Parent)]
+        [InlineData((int)UnsafeNativeMethods.NavigateDirection.NextSibling)]
+        [InlineData((int)UnsafeNativeMethods.NavigateDirection.PreviousSibling)]
+        [InlineData((int)UnsafeNativeMethods.NavigateDirection.FirstChild)]
+        [InlineData((int)UnsafeNativeMethods.NavigateDirection.LastChild)]
+        public void PropertyGridViewAccessibleObject_FragmentNavigate_DoesNotThrowExpection_WithoutOwnerGrid(int direction)
+        {
+            using PropertyGrid propertyGrid = new();
+            using PropertyGridView propertyGridView = new(null, null);
+            PropertyGridViewAccessibleObject accessibleObject = new(propertyGridView, propertyGrid);
+            Assert.Null(accessibleObject.FragmentNavigate((UnsafeNativeMethods.NavigateDirection)direction));
         }
     }
 }


### PR DESCRIPTION
Fixes #4861

## Proposed changes
This issue is reproducible because in some scenarios (e.g. disposing), `OwnerGrid` property can have `null` value. For properties `FragmentRoot` and `Name` we check a similar scenario, but the `FragmentNavigate` method and `RowCount` property don't have this check.

- Added missing check for null. 
- Added unit tests.

**Note:**
Ported from #5077

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
When closing a form with PropertyGrid, the exception is no longer throwed

## Regression? 

- Yes

## Risk
- Minimal 
## Test methodology <!-- How did you ensure quality? -->
- Unit tests 
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 3.1.9

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5107)