### PR TITLE
Change to Show(this) so forms open on MainForm's monitor

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -59,91 +59,91 @@ namespace WinformsControlsTest
         {
             {
                 MainFormControlsTabOrder.ButtonsButton,
-                new InitInfo("Buttons", (obj, e) => new Buttons().Show())
+                new InitInfo("Buttons", (obj, e) => new Buttons().Show(this))
             },
             {
                 MainFormControlsTabOrder.CalendarButton,
-                new InitInfo("Calendar", (obj, e) => new Calendar().Show())
+                new InitInfo("Calendar", (obj, e) => new Calendar().Show(this))
             },
             {
                 MainFormControlsTabOrder.MultipleControlsButton,
-                new InitInfo("MultipleControls", (obj, e) => new MultipleControls().Show())
+                new InitInfo("MultipleControls", (obj, e) => new MultipleControls().Show(this))
             },
             {
                 MainFormControlsTabOrder.ComboBoxesButton,
-                new InitInfo("ComboBoxes", (obj, e) => new ComboBoxes().Show())
+                new InitInfo("ComboBoxes", (obj, e) => new ComboBoxes().Show(this))
             },
             {
                 MainFormControlsTabOrder.ComboBoxesWithScrollBarsButton,
-                new InitInfo("ComboBoxes with ScrollBars", (obj, e) => new ComboBoxesWithScrollBars().Show())
+                new InitInfo("ComboBoxes with ScrollBars", (obj, e) => new ComboBoxesWithScrollBars().Show(this))
             },
             {
                 MainFormControlsTabOrder.DateTimePickerButton,
-                new InitInfo("DateTimePicker", (obj, e) => new DateTimePicker().Show())
+                new InitInfo("DateTimePicker", (obj, e) => new DateTimePicker().Show(this))
             },
             {
                 MainFormControlsTabOrder.DialogsButton,
-                new InitInfo("Dialogs", (obj, e) => new Dialogs().ShowDialog())
+                new InitInfo("Dialogs", (obj, e) => new Dialogs().ShowDialog(this))
             },
             {
                 MainFormControlsTabOrder.DataGridViewButton,
-                new InitInfo("DataGridView", (obj, e) => new DataGridViewTest().Show())
+                new InitInfo("DataGridView", (obj, e) => new DataGridViewTest().Show(this))
             },
             {
                 MainFormControlsTabOrder.DataGridViewInVirtualModeButton,
-                new InitInfo("DataGridView in Virtual mode", (obj, e) => new DataGridViewInVirtualModeTest().Show())
+                new InitInfo("DataGridView in Virtual mode", (obj, e) => new DataGridViewInVirtualModeTest().Show(this))
             },
             {
                 MainFormControlsTabOrder.TreeViewButton,
-                new InitInfo("TreeView, ImageList", (obj, e) => new TreeViewTest().Show())
+                new InitInfo("TreeView, ImageList", (obj, e) => new TreeViewTest().Show(this))
             },
             {
                 MainFormControlsTabOrder.ContentAlignmentButton,
-                new InitInfo("ContentAlignment", (obj, e) => new DesignTimeAligned().Show())
+                new InitInfo("ContentAlignment", (obj, e) => new DesignTimeAligned().Show(this))
             },
             {
                 MainFormControlsTabOrder.MenusButton,
-                new InitInfo("Menus", (obj, e) => new MenuStripAndCheckedListBox().Show())
+                new InitInfo("Menus", (obj, e) => new MenuStripAndCheckedListBox().Show(this))
             },
             {
                 MainFormControlsTabOrder.PanelsButton,
-                new InitInfo("Panels", (obj, e) => new Panels().Show())
+                new InitInfo("Panels", (obj, e) => new Panels().Show(this))
             },
             {
                 MainFormControlsTabOrder.SplitterButton,
-                new InitInfo("Splitter", (obj, e) => new Splitter().Show())
+                new InitInfo("Splitter", (obj, e) => new Splitter().Show(this))
             },
             {
                 MainFormControlsTabOrder.MdiParentButton,
-                new InitInfo("MDI Parent", (obj, e) => new MdiParent().Show())
+                new InitInfo("MDI Parent", (obj, e) => new MdiParent().Show(this))
             },
             {
                 MainFormControlsTabOrder.PropertyGridButton,
-                new InitInfo("PropertyGrid", (obj, e) => new PropertyGrid(new UserControlWithObjectCollectionEditor()).Show())
+                new InitInfo("PropertyGrid", (obj, e) => new PropertyGrid(new UserControlWithObjectCollectionEditor()).Show(this))
             },
             {
                 MainFormControlsTabOrder.ListViewButton,
-                new InitInfo("ListView", (obj, e) => new ListViewTest().Show())
+                new InitInfo("ListView", (obj, e) => new ListViewTest().Show(this))
             },
             {
                 MainFormControlsTabOrder.FontNameEditorButton,
-                new InitInfo("FontNameEditor", (obj, e) => new PropertyGrid(new UserControlWithFontNameEditor()).Show())
+                new InitInfo("FontNameEditor", (obj, e) => new PropertyGrid(new UserControlWithFontNameEditor()).Show(this))
             },
             {
                 MainFormControlsTabOrder.CollectionEditorsButton,
-                new InitInfo("CollectionEditors", (obj, e) => new CollectionEditors().Show())
+                new InitInfo("CollectionEditors", (obj, e) => new CollectionEditors().Show(this))
             },
             {
                 MainFormControlsTabOrder.RichTextBoxesButton,
-                new InitInfo("RichTextBoxes", (obj, e) => new RichTextBoxes().Show())
+                new InitInfo("RichTextBoxes", (obj, e) => new RichTextBoxes().Show(this))
             },
             {
                 MainFormControlsTabOrder.PictureBoxesButton,
-                new InitInfo("PictureBoxes", (obj, e) => new PictureBoxes().Show())
+                new InitInfo("PictureBoxes", (obj, e) => new PictureBoxes().Show(this))
             },
             {
                 MainFormControlsTabOrder.FormBorderStylesButton,
-                new InitInfo("FormBorderStyles", (obj, e) => new FormBorderStyles().Show())
+                new InitInfo("FormBorderStyles", (obj, e) => new FormBorderStyles().Show(this))
             },
             {
                 MainFormControlsTabOrder.ToggleIconButton,
@@ -151,23 +151,23 @@ namespace WinformsControlsTest
             },
             {
                 MainFormControlsTabOrder.FileDialogButton,
-                new InitInfo("FileDialog", (obj, e) => new FileDialog().Show())
+                new InitInfo("FileDialog", (obj, e) => new FileDialog().Show(this))
             },
             {
                 MainFormControlsTabOrder.ErrorProviderButton,
-                new InitInfo("ErrorProvider", (obj, e) => new ErrorProviderTest().Show())
+                new InitInfo("ErrorProvider", (obj, e) => new ErrorProviderTest().Show(this))
             },
             {
                 MainFormControlsTabOrder.TaskDialogButton,
-                new InitInfo("Task Dialog", (obj, e) => new TaskDialogSamples().Show())
+                new InitInfo("Task Dialog", (obj, e) => new TaskDialogSamples().Show(this))
             },
             {
                 MainFormControlsTabOrder.MessageBoxButton,
-                new InitInfo("MessageBox", (obj, e) => new MessageBoxes().Show())
+                new InitInfo("MessageBox", (obj, e) => new MessageBoxes().Show(this))
             },
             {
                 MainFormControlsTabOrder.ToolStripsButton,
-                new InitInfo("ToolStrips", (obj, e) => new ToolStripTests().Show())
+                new InitInfo("ToolStrips", (obj, e) => new ToolStripTests().Show(this))
             }
         };
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- Change all calls in GetButtonsInitInfo from Show() to Show(this) so that MainForm will be the parent for all opened forms.  This way, when MainForm is moved from a monitor at 100% scaling to a monitor at 150% scaling, all forms will open on this new monitor and help surface any HDPI issues.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None except for improved testing.
 

## Regression? 

- No

## Risk

- None

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- 

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- 6.0.0-preview.7.21323.1


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5164)