### PR TITLE
Reworking `Flags` to `_flags` in GridEntry

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -132,7 +132,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (peParent.ForceReadOnly)
                 {
-                    Flags |= FLAG_FORCE_READONLY;
+                    _flags |= FLAG_FORCE_READONLY;
                 }
             }
             else
@@ -434,7 +434,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (Flags & FLAG_FORCE_READONLY) != 0;
+                return (_flags & FLAG_FORCE_READONLY) != 0;
             }
         }
 
@@ -538,7 +538,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     // If we're expandable, but we don't support editing,
                     // make us read only editable so we don't paint grey.
                     //
-                    if (!forceReadOnly && (Flags & FLAG_TEXT_EDITABLE) == 0 && !isImmutableReadOnly)
+                    if (!forceReadOnly && (_flags & FLAG_TEXT_EDITABLE) == 0 && !isImmutableReadOnly)
                     {
                         _flags |= FLAG_READONLY_EDITABLE;
                     }
@@ -754,25 +754,25 @@ namespace System.Windows.Forms.PropertyGridInternal
             get
             {
                 // prevent full flag population if possible.
-                if ((Flags & FL_CHECKED) == 0)
+                if ((_flags & FL_CHECKED) == 0)
                 {
                     UITypeEditor typeEd = UITypeEditor;
                     if (typeEd is not null)
                     {
-                        if ((Flags & FLAG_CUSTOM_PAINT) != 0 ||
-                            (Flags & FL_NO_CUSTOM_PAINT) != 0)
+                        if ((_flags & FLAG_CUSTOM_PAINT) != 0 ||
+                            (_flags & FL_NO_CUSTOM_PAINT) != 0)
                         {
-                            return (Flags & FLAG_CUSTOM_PAINT) != 0;
+                            return (_flags & FLAG_CUSTOM_PAINT) != 0;
                         }
 
                         if (typeEd.GetPaintValueSupported(this))
                         {
-                            Flags |= FLAG_CUSTOM_PAINT;
+                            _flags |= FLAG_CUSTOM_PAINT;
                             return true;
                         }
                         else
                         {
-                            Flags |= FL_NO_CUSTOM_PAINT;
+                            _flags |= FL_NO_CUSTOM_PAINT;
                             return false;
                         }
                     }
@@ -1826,7 +1826,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                             if (forceReadOnly)
                             {
-                                newEntry.Flags |= FLAG_FORCE_READONLY;
+                                newEntry._flags |= FLAG_FORCE_READONLY;
                             }
 
                             // check to see if we've come across the default item.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     if (anyRO)
                     {
-                        Flags |= FLAG_FORCE_READONLY;
+                        _flags |= FLAG_FORCE_READONLY;
                     }
 
                     forceReadOnlyChecked = true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
@@ -169,7 +169,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     ReadOnlyAttribute readOnlyAttr = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(objValue)[typeof(ReadOnlyAttribute)];
                     if ((readOnlyAttr is not null && !readOnlyAttr.IsDefaultAttribute()) || TypeDescriptor.GetAttributes(objValue).Contains(InheritanceAttribute.InheritedReadOnly))
                     {
-                        Flags |= FLAG_FORCE_READONLY;
+                        _flags |= FLAG_FORCE_READONLY;
                     }
 
                     forceReadOnlyChecked = true;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -3788,6 +3788,22 @@ namespace System.Windows.Forms.Tests
 #endif
         }
 
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void PropertyGrid_SetEnableFalse_DoesntBreakEntries_AndFlagsReturnCorrectValue(bool enable)
+        {
+            using PropertyGrid propertyGrid = new();
+            using Button button = new();
+            propertyGrid.SelectedObject = button;
+            propertyGrid.Enabled = enable;
+            var entry = (GridEntry)propertyGrid.SelectedGridItem;
+
+            Assert.True(entry.Flags != 0);
+            Assert.False(propertyGrid.IsHandleCreated);
+            Assert.False(button.IsHandleCreated);
+        }
+
         private class SubToolStripRenderer : ToolStripRenderer
         {
         }


### PR DESCRIPTION
Fixes #5143

The fix returns the previous logic that was broken in c5e6890.
The main reason of the regression is that `Flags`'s getter calls `TypeConverter`,
that tries to get non-initialized `_propertyInfo` field.

## Proposed changes

- Change several `Flags` to `_flags` 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
- A user doesn't catch NRE anymore

## Regression? 

- Yes, from c5e6890.

## Risk

- MInimal

<!-- end TELL-MODE -->



### Before
- There is NRE when setting `PropertyGrid.Enabled`:
![image](https://user-images.githubusercontent.com/49272759/123954283-e38be600-d9b0-11eb-869c-e6cb9617e03e.png)

<!-- TODO -->

### After
- There is no exception, when setting `PropertyGrid.Enabled`
<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests
- CTI

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 6.0.0-preview.7.21319.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5176)