### PR TITLE
Add global usings and plumb through the WPF

### DIFF
--- a/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
+++ b/pkg/Microsoft.Private.Winforms/Microsoft.Private.Winforms.csproj
@@ -58,35 +58,42 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
+  
+  <ItemGroup>
+    <None Include="sdk\dotnet-wpf\*">
+      <Pack>True</Pack>
+      <PackagePath>sdk\dotnet-wpf</PackagePath>
+    </None>
+  </ItemGroup>
 
   <!-- Any projects referenced here will have their outputs automatically put into the package -->
   <!-- If you add a new csproj, and you want the outputs in the package, you must add it here -->
   <ItemGroup>
-    <!-- Facade for System.Drawing include -->
+    <!-- Facade for System.Drawing -->
     <ProjectReference Include="..\..\src\System.Drawing\src\System.Drawing.Facade.csproj" />
 
-    <!-- Facade for System.Design include -->
+    <!-- Facade for System.Design -->
     <ProjectReference Include="..\..\src\System.Design\src\System.Design.Facade.csproj" />
 
-    <!-- Facade for System.Drawing.Design include -->
+    <!-- Facade for System.Drawing.Design -->
     <ProjectReference Include="..\..\src\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
 
-    <!-- Reference and Source System.Windows.Forms includes -->
+    <!-- Reference and Source System.Windows.Forms -->
     <ProjectReference Include="..\..\src\System.Windows.Forms\src\System.Windows.Forms.csproj" />
 
-    <!-- Reference and Source System.Windows.Forms.Primitives includes -->
+    <!-- Reference and Source System.Windows.Forms.Primitives -->
     <ProjectReference Include="..\..\src\System.Windows.Forms.Primitives\src\System.Windows.Forms.Primitives.csproj" />
 
-    <!-- Reference and Source System.Windows.Forms.Design includes -->
+    <!-- Reference and Source System.Windows.Forms.Design -->
     <ProjectReference Include="..\..\src\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />
 
-    <!-- Facade for System.Windows.Forms.Design.Editors includes -->
+    <!-- Facade for System.Windows.Forms.Design.Editors -->
     <ProjectReference Include="..\..\src\System.Windows.Forms.Design.Editors\src\System.Windows.Forms.Design.Editors.Facade3x.csproj" />
     
-    <!-- Facade for Microsoft.VisualBasic include -->
+    <!-- Facade for Microsoft.VisualBasic -->
     <ProjectReference Include="..\..\src\Microsoft.VisualBasic\src\Microsoft.VisualBasic.Facade.csproj" />
 
-    <!-- Reference and Source Microsoft.VisualBasic.Forms includes -->
+    <!-- Reference and Source Microsoft.VisualBasic.Forms -->
     <ProjectReference Include="..\..\src\Microsoft.VisualBasic.Forms\src\Microsoft.VisualBasic.Forms.vbproj" />
 
     <ProjectReference Include="..\..\src\Accessibility\src\Accessibility.ilproj" />

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-wpf/System.Windows.Forms.GlobalUsings.props
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-wpf/System.Windows.Forms.GlobalUsings.props
@@ -1,0 +1,27 @@
+<!--
+    This props file comes from dotnet/winforms. It gets ingested by dotnet/wpf and processed by
+    packaging/Microsoft.NET.Sdk.WindowsDesktop project.
+    
+    It is referenced via Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.props.
+   -->
+
+<Project>
+  <!--
+    ============================================================
+                                     GenerateImplicitNamespaceImports
+    Generates implicit namespace imports source to intermediate directory for C# projects
+    ============================================================
+    -->
+  <ItemGroup Condition="'$(DisableImplicitNamespaceImports_WindowsForms)' != 'true'
+                        and '$(TargetFrameworkIdentifier)' == '.NETCoreApp'
+                        and $([MSBuild]::VersionGreaterThanOrEquals($(_TargetFrameworkVersionWithoutV), '6.0'))
+                        and '$(UseWindowsForms)' == 'true'">
+    <Import Include="System" />
+    <Import Include="System.Collections.Generic" />
+    <Import Include="System.IO" />
+    <Import Include="System.Linq" />
+    <Import Include="System.Drawing" />
+    <Import Include="System.Windows.Forms" />
+  </ItemGroup>
+
+</Project>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-wpf/System.Windows.Forms.GlobalUsings.targets
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-wpf/System.Windows.Forms.GlobalUsings.targets
@@ -1,0 +1,21 @@
+<!--
+    This props file comes from dotnet/winforms. It gets ingested by dotnet/wpf and processed by
+    packaging/Microsoft.NET.Sdk.WindowsDesktop project.
+    
+    It is referenced via Microsoft.NET.Sdk.WindowsDesktop/targets/Microsoft.NET.Sdk.WindowsDesktop.targets.
+   -->
+
+<Project>
+  <!--
+    ============================================================
+                                     GenerateImplicitNamespaceImports
+    Generates implicit namespace imports source to intermediate directory for C# projects
+    ============================================================
+    -->
+  <PropertyGroup>
+    <DisableImplicitNamespaceImports_WindowsForms
+        Condition="'$(DisableImplicitNamespaceImports_WindowsForms)' == ''
+                   and '$(DisableImplicitNamespaceImports)' != 'true'">false</DisableImplicitNamespaceImports_WindowsForms>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Resolves #5074 
Relates to https://github.com/dotnet/sdk/pull/18459

Global usings can be disabled in the following way:
* `DisableImplicitNamespaceImports` disables \*ALL\* global usings
* `DisableImplicitNamespaceImports_WindowsForms` disables Windows Forms specific global usings

It is possible to add additional usings via:
```xml
  <ItemGroup>
    <Import Add="MyCompany.Super.CoolStuff" />
  </ItemGroup>
```

It is possible to remove selected usings 
```xml
  <ItemGroup>
    <Import Remove="System.Drawing" />
  </ItemGroup>
```

## Screenshots <!-- Remove this section if PR does not change UI -->

Referenced through the Microsoft.NET.Sdk.WindowsDesktop.props this leads to the following:
![image](https://user-images.githubusercontent.com/4403806/125027242-47a55d00-e0c9-11eb-8001-04c8fdfd8054.png)



## Test methodology <!-- How did you ensure quality? -->

- Manually locally modifying the installed SDK
- Building winforms -> wpf -> windowsdesktop


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5183)