### PR TITLE
Fixing the issue with cancel editing in ListView, which led to the wrong "LabelEditEventArgs.Label" parameter

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6473,7 +6473,7 @@ namespace System.Windows.Forms
                     {
                         listViewState[LISTVIEWSTATE_inLabelEdit] = false;
                         NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m.LParam;
-                        var text = new string(dispInfo->item.pszText);
+                        string text = dispInfo->item.pszText is null ? null : new string(dispInfo->item.pszText);
                         LabelEditEventArgs e = new LabelEditEventArgs(dispInfo->item.iItem, text);
                         OnAfterLabelEdit(e);
                         m.Result = (IntPtr)(e.CancelEdit ? 0 : 1);


### PR DESCRIPTION
Fixes #5180

## Proposed changes
- The issue is reproduced because if `dispInfo-> item.pszText` has `0x0000000000000000` value than the `new string (dispInfo-> item.pszText)` expression returns an empty string, although `dispInfo-> item.pszText is null` expression returns `true`.

- Added a condition, if `dispInfo-> item.pszText is null` expression is `true`, then return null, otherwise use `new string (dispInfo-> item.pszText)` code.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![5180-before](https://user-images.githubusercontent.com/23376742/124142905-51a8d980-da93-11eb-892a-a5c6fc88aa27.gif)

**After fix:**
![5180-after](https://user-images.githubusercontent.com/23376742/124142935-57062400-da93-11eb-9ba5-45481c96773f.gif)

## Regression? 

- Yes (from .NET Core 3.1)

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 6.0.0-preview.6.21305.3


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5186)