### PR TITLE
Reworking ComboBox accessible object cast checks

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
@@ -41,9 +41,13 @@ namespace System.Windows.Forms
                             object before = _owner.SelectedItem;
                             DefWndProc(ref m);
                             object after = _owner.SelectedItem;
-                            if (before != after)
+
+                            // Call the focus event for the new selected item accessible object provided by ComboBoxAccessibleObject.
+                            // If the owning ComboBox has a custom accessible object,
+                            // it should override the logic and implement setting an item focus by itself.
+                            if (before != after && _owner.AccessibilityObject is ComboBoxAccessibleObject comboBoxAccessibleObject)
                             {
-                                (_owner.AccessibilityObject as ComboBoxAccessibleObject).SetComboBoxItemFocus();
+                                comboBoxAccessibleObject.SetComboBoxItemFocus();
                             }
                         }
                         else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
@@ -31,7 +31,10 @@ namespace System.Windows.Forms
                     throw new ArgumentException(nameof(owner));
                 }
 
-                _ownerComboBoxAccessibleObject = (ComboBoxAccessibleObject)_owner.AccessibilityObject;
+                if (_owner.AccessibilityObject is ComboBoxAccessibleObject accessibleObject)
+                {
+                    _ownerComboBoxAccessibleObject = accessibleObject;
+                }
             }
 
             internal List<Entry> InnerList
@@ -156,7 +159,7 @@ namespace System.Windows.Forms
                 {
                     if (!successful)
                     {
-                        _ownerComboBoxAccessibleObject.ItemAccessibleObjects.Remove(InnerList[index]);
+                        _ownerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
                         Remove(item);
                     }
                 }
@@ -245,7 +248,7 @@ namespace System.Windows.Forms
 
                 InnerList.Clear();
 
-                _ownerComboBoxAccessibleObject.ItemAccessibleObjects.Clear();
+                _ownerComboBoxAccessibleObject?.ItemAccessibleObjects.Clear();
 
                 _owner._selectedIndex = -1;
                 if (_owner.AutoCompleteSource == AutoCompleteSource.ListItems)
@@ -360,7 +363,7 @@ namespace System.Windows.Forms
                             }
                             else
                             {
-                                _ownerComboBoxAccessibleObject.ItemAccessibleObjects.Remove(InnerList[index]);
+                                _ownerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
                                 InnerList.RemoveAt(index);
                             }
                         }
@@ -385,7 +388,7 @@ namespace System.Windows.Forms
                     _owner.NativeRemoveAt(index);
                 }
 
-                _ownerComboBoxAccessibleObject.ItemAccessibleObjects.Remove(InnerList[index]);
+                _ownerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
                 InnerList.RemoveAt(index);
 
                 if (!_owner.IsHandleCreated && index < _owner._selectedIndex)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -1835,6 +1835,28 @@ namespace System.Windows.Forms.Tests
             Assert.False(comboBox.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ComboBox_CustomAccessibleObject_DoesntCrashControl_WhenAddingItems()
+        {
+            using CustomComboBox control = new();
+            control.Items.Add("item1");
+            control.Items.Add("item2");
+
+            Assert.False(control.IsHandleCreated);
+        }
+
+        private class CustomComboBox : ComboBox
+        {
+            protected override AccessibleObject CreateAccessibilityInstance()
+                => new CustomComboBoxAccessibleObject(this);
+        }
+
+        private class CustomComboBoxAccessibleObject : Control.ControlAccessibleObject
+        {
+            public CustomComboBoxAccessibleObject(ComboBox owner) : base(owner)
+            { }
+        }
+
         private class SubComboBox : ComboBox
         {
             public SubComboBox()


### PR DESCRIPTION
Fixes #5154
The previous implementation led to NRE, if a user set a custom accessible object for ComboBox via overriden CreateAccessibilityInstance




## Proposed changes

- Add an additional check of a ComboBox accessible object type 


## Customer Impact

- A user won't catch NRE when using a custom accessible object for a ComboBox

## Regression? 

- Yes

## Risk

- Minimal

### Before
- There is NRE when adding an item to a custom ComboBox
![image](https://user-images.githubusercontent.com/49272759/124177237-9dba4500-dab8-11eb-998e-9472e9cb279d.png)


### After

- There is no NRE


## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Manual testing
- CTI

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 6.0.0-preview.7.21319.2


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5188)