### PR TITLE
Wrong `LabelEditEventArgs.Label` parameters when cancel editing in ListView (port to 5.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6277,7 +6277,7 @@ namespace System.Windows.Forms
                     {
                         listViewState[LISTVIEWSTATE_inLabelEdit] = false;
                         NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m.LParam;
-                        var text = new string(dispInfo->item.pszText);
+                        string text = dispInfo->item.pszText is null ? null : new string(dispInfo->item.pszText);
                         LabelEditEventArgs e = new LabelEditEventArgs(dispInfo->item.iItem, text);
                         OnAfterLabelEdit(e);
                         m.Result = (IntPtr)(e.CancelEdit ? 0 : 1);


### PR DESCRIPTION
Fixes #5180

## Proposed changes
- The issue is reproduced because if `dispInfo-> item.pszText` has `0x0000000000000000` value than the `new string (dispInfo-> item.pszText)` expression returns an empty string, although `dispInfo-> item.pszText is null` expression returns `true`.

- Added a condition, if `dispInfo-> item.pszText is null` expression is `true`, then return null, otherwise use `new string (dispInfo-> item.pszText)` code.

- Port from #5186 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

It will now be possible again to determine whether a label edit operation was cancelled by a user by correctly returning `null` in `LabelEditEventArgs` for `AfterLabelEdit` event.

**Before fix:**
![5180-before](https://user-images.githubusercontent.com/23376742/124142905-51a8d980-da93-11eb-892a-a5c6fc88aa27.gif)

**After fix:**
![5180-after](https://user-images.githubusercontent.com/23376742/124142935-57062400-da93-11eb-9ba5-45481c96773f.gif)

## Regression? 

- Yes (from .NET Core 3.1)

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 6.0.0-preview.6.21305.3

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5192)