### PR TITLE
Clean messages for PropertyGrid classes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -95,9 +95,9 @@ csharp_indent_switch_labels = true
 csharp_indent_labels = one_less_than_current
 
 # only use var when it's obvious what the variable type is
-csharp_style_var_for_built_in_types = false:none
+csharp_style_var_for_built_in_types = false:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_elsewhere = false:silent
 
 
 # Code style defaults

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -74,37 +74,13 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            public override string Help
-            {
-                get
-                {
-                    return _owningGridEntry.PropertyDescription;
-                }
-            }
+            public override string Help => _owningGridEntry.PropertyDescription;
 
-            public override string? Name
-            {
-                get
-                {
-                    return _owningGridEntry?.PropertyLabel;
-                }
-            }
+            public override string? Name => _owningGridEntry?.PropertyLabel;
 
-            public override AccessibleObject? Parent
-            {
-                get
-                {
-                    return _owningGridEntry?.GridEntryHost?.AccessibilityObject;
-                }
-            }
+            public override AccessibleObject? Parent => _owningGridEntry?.GridEntryHost?.AccessibilityObject;
 
-            public override AccessibleRole Role
-            {
-                get
-                {
-                    return AccessibleRole.Cell;
-                }
-            }
+            public override AccessibleRole Role => AccessibleRole.Cell;
 
             public override AccessibleStates State
             {
@@ -118,23 +94,20 @@ namespace System.Windows.Forms.PropertyGridInternal
                     AccessibleStates state = AccessibleStates.Selectable | AccessibleStates.Focusable;
 
                     // Determine focus
-                    //
                     if (_owningGridEntry.HasFocus)
                     {
                         state |= AccessibleStates.Focused;
                     }
 
                     // Determine selected
-                    //
                     Debug.Assert(Parent is not null, "GridEntry AO does not have a parent AO");
-                    PropertyGridView.PropertyGridViewAccessibleObject parent = (PropertyGridView.PropertyGridViewAccessibleObject)Parent;
+                    var parent = (PropertyGridView.PropertyGridViewAccessibleObject)Parent;
                     if (parent.GetSelected() == this)
                     {
                         state |= AccessibleStates.Selected;
                     }
 
                     // Determine expanded/collapsed state
-                    //
                     if (_owningGridEntry.Expandable)
                     {
                         if (_owningGridEntry.Expanded)
@@ -148,14 +121,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
 
                     // Determine readonly/editable state
-                    //
                     if (_owningGridEntry.ShouldRenderReadOnly)
                     {
                         state |= AccessibleStates.ReadOnly;
                     }
 
                     // Determine password state
-                    //
                     if (_owningGridEntry.ShouldRenderPassword)
                     {
                         state |= AccessibleStates.Protected;
@@ -342,23 +313,20 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return;
                 }
 
-                // make sure we're on the right thread.
-                //
+                // Make sure we're on the right thread.
                 if (PropertyGridView.InvokeRequired)
                 {
                     PropertyGridView.Invoke(new SelectDelegate(Select), new object[] { flags });
                     return;
                 }
 
-                // Focus the PropertyGridView window
-                //
+                // Focus the PropertyGridView window.
                 if ((flags & AccessibleSelection.TakeFocus) == AccessibleSelection.TakeFocus)
                 {
                     bool focused = PropertyGridView.Focus();
                 }
 
-                // Select the grid entry
-                //
+                // Select the grid entry.
                 if ((flags & AccessibleSelection.TakeSelection) == AccessibleSelection.TakeSelection)
                 {
                     PropertyGridView.AccessibilitySelect(_owningGridEntry);
@@ -416,46 +384,30 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
             {
-                switch (propertyID)
+                return propertyID switch
                 {
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
-                    case UiaCore.UIA.ControlTypePropertyId:
+                    UiaCore.UIA.NamePropertyId => Name,
 
-                        // The accessible hierarchy is changed so we cannot use Button type
-                        // for the grid items to not break automation logic that searches for the first
-                        // button in the PropertyGridView to show dialog/drop-down. In Level < 3 action
-                        // button is one of the first children of PropertyGridView.
-                        return UiaCore.UIA.TreeItemControlTypeId;
-                    case UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId);
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return string.Empty;
-                    case UiaCore.UIA.HasKeyboardFocusPropertyId:
-                        return _owningGridEntry.HasFocus;
-                    case UiaCore.UIA.IsKeyboardFocusablePropertyId:
-                        return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
-                    case UiaCore.UIA.IsEnabledPropertyId:
-                        return true;
-                    case UiaCore.UIA.AutomationIdPropertyId:
-                        return GetHashCode().ToString();
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
-                    case UiaCore.UIA.IsOffscreenPropertyId:
-                        return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
-                    case UiaCore.UIA.IsGridItemPatternAvailablePropertyId:
-                    case UiaCore.UIA.IsTableItemPatternAvailablePropertyId:
-                        return true;
-                    case UiaCore.UIA.LegacyIAccessibleRolePropertyId:
-                        return Role;
-                    case UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId:
-                        return DefaultAction;
+                    // The accessible hierarchy is changed so we cannot use Button type
+                    // for the grid items to not break automation logic that searches for the first
+                    // button in the PropertyGridView to show dialog/drop-down. In Level < 3 action
+                    // button is one of the first children of PropertyGridView.
 
-                    default:
-                        return base.GetPropertyValue(propertyID);
-                }
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TreeItemControlTypeId,
+                    UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId),
+                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId => _owningGridEntry.HasFocus,
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                    UiaCore.UIA.IsEnabledPropertyId => true,
+                    UiaCore.UIA.AutomationIdPropertyId => GetHashCode().ToString(),
+                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
+                    UiaCore.UIA.IsPasswordPropertyId => false,
+                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
+                    UiaCore.UIA.IsGridItemPatternAvailablePropertyId or UiaCore.UIA.IsTableItemPatternAvailablePropertyId => true,
+                    UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
+                    UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId => DefaultAction,
+                    _ => base.GetPropertyValue(propertyID),
+                };
             }
 
             internal override bool IsIAccessibleExSupported()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HotCommands.cs
@@ -167,7 +167,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Label.DisabledLinkColor = disabledLink;
         }
 
-        public void Select(bool forward)
+        public void FocusLabel()
         {
             Label.Focus();
         }
@@ -215,8 +215,8 @@ namespace System.Windows.Forms.PropertyGridInternal
         private void SetupLabel()
         {
             Label.Links.Clear();
-            StringBuilder sb = new StringBuilder();
-            Point[] links = new Point[_verbs.Length];
+            StringBuilder sb = new();
+            var links = new Point[_verbs.Length];
             int charLoc = 0;
             bool firstVerb = true;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ImmutablePropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ImmutablePropertyDescriptorGridEntry.cs
@@ -35,14 +35,13 @@ namespace System.Windows.Forms.PropertyGridInternal
             set
             {
                 // Create a new instance of the value and set it into the parent grid entry.
-                //
                 object owner = GetValueOwner();
                 GridEntry parentEntry = InstanceParentGridEntry;
                 TypeConverter parentConverter = parentEntry.TypeConverter;
 
                 PropertyDescriptorCollection props = parentConverter.GetProperties(parentEntry, owner);
                 IDictionary values = new Hashtable(props.Count);
-                object newObject = null;
+                object newObject;
 
                 for (int i = 0; i < props.Count; i++)
                 {
@@ -64,9 +63,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     if (string.IsNullOrEmpty(e.Message))
                     {
-                        throw new TargetInvocationException(string.Format(SR.ExceptionCreatingObject,
-                                                            InstanceParentGridEntry.PropertyType.FullName,
-                                                            e.ToString()), e);
+                        throw new TargetInvocationException(
+                            string.Format(SR.ExceptionCreatingObject, InstanceParentGridEntry.PropertyType.FullName, e.ToString()),
+                            e);
                     }
                     else
                     {
@@ -81,18 +80,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        internal override bool NotifyValueGivenParent(object obj, int type)
-        {
-            return ParentGridEntry.NotifyValue(type);
-        }
+        internal override bool NotifyValueGivenParent(object obj, int type) => ParentGridEntry.NotifyValue(type);
 
-        public override bool ShouldRenderReadOnly
-        {
-            get
-            {
-                return InstanceParentGridEntry.ShouldRenderReadOnly;
-            }
-        }
+        public override bool ShouldRenderReadOnly => InstanceParentGridEntry.ShouldRenderReadOnly;
 
         private GridEntry InstanceParentGridEntry
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.MergedAttributeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.MergedAttributeCollection.cs
@@ -23,13 +23,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 _owner = owner;
             }
 
-            public override Attribute this[Type attributeType]
-            {
-                get
-                {
-                    return GetCommonAttribute(attributeType);
-                }
-            }
+            public override Attribute this[Type attributeType] => GetCommonAttribute(attributeType);
 
             private Attribute GetCommonAttribute(Type attributeType)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.cs
@@ -30,30 +30,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <inheritdoc />
-        public override Type ComponentType
-        {
-            get
-            {
-                return _descriptors[0].ComponentType;
-            }
-        }
+        public override Type ComponentType => _descriptors[0].ComponentType;
 
         /// <inheritdoc />
-        public override TypeConverter Converter
-        {
-            get
-            {
-                return _descriptors[0].Converter;
-            }
-        }
+        public override TypeConverter Converter => _descriptors[0].Converter;
 
-        public override string DisplayName
-        {
-            get
-            {
-                return _descriptors[0].DisplayName;
-            }
-        }
+        public override string DisplayName => _descriptors[0].DisplayName;
 
         /// <inheritdoc />
         public override bool IsLocalizable
@@ -100,21 +82,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <inheritdoc />
-        public override Type PropertyType
-        {
-            get
-            {
-                return _descriptors[0].PropertyType;
-            }
-        }
+        public override Type PropertyType => _descriptors[0].PropertyType;
 
-        public PropertyDescriptor this[int index]
-        {
-            get
-            {
-                return _descriptors[index];
-            }
-        }
+        public PropertyDescriptor this[int index] => _descriptors[index];
 
         /// <inheritdoc />
         public override bool CanResetValue(object component)
@@ -123,7 +93,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (!_canReset.HasValue)
             {
                 _canReset = true;
-                Array a = (Array)component;
+                var a = (Array)component;
                 for (int i = 0; i < _descriptors.Length; i++)
                 {
                     if (!_descriptors[i].CanResetValue(GetPropertyOwnerForComponent(a, i)))
@@ -144,7 +114,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         private object CopyValue(object value)
         {
-            // null is always OK
+            // Null is always OK.
             if (value is null)
             {
                 return value;
@@ -152,7 +122,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             Type type = value.GetType();
 
-            // value types are always copies
+            // Value types are always copies.
             if (type.IsValueType)
             {
                 return value;
@@ -160,7 +130,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             object clonedValue = null;
 
-            // ICloneable is the next easiest thing
+            // ICloneable is the next easiest thing.
             if (value is ICloneable clone)
             {
                 clonedValue = clone.Clone();
@@ -172,9 +142,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                 TypeConverter converter = TypeDescriptor.GetConverter(value);
                 if (converter.CanConvertTo(typeof(InstanceDescriptor)))
                 {
-                    // Instance descriptors provide full fidelity unless
-                    // they are marked as incomplete.
-                    InstanceDescriptor desc = (InstanceDescriptor)converter.ConvertTo(null, CultureInfo.InvariantCulture, value, typeof(InstanceDescriptor));
+                    // Instance descriptors provide full fidelity unless they are marked as incomplete.
+                    var desc = (InstanceDescriptor)converter.ConvertTo(null, CultureInfo.InvariantCulture, value, typeof(InstanceDescriptor));
                     if (desc is not null && desc.IsComplete)
                     {
                         clonedValue = desc.Invoke();
@@ -192,8 +161,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             // How about serialization?
             if (clonedValue is null && type.IsSerializable)
             {
-                BinaryFormatter f = new BinaryFormatter();
-                MemoryStream ms = new MemoryStream();
+                BinaryFormatter f = new();
+                MemoryStream ms = new();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
                 f.Serialize(ms, value);
                 ms.Position = 0;
@@ -211,33 +180,27 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <inheritdoc />
-        protected override AttributeCollection CreateAttributeCollection()
-        {
-            return new MergedAttributeCollection(this);
-        }
+        protected override AttributeCollection CreateAttributeCollection() => new MergedAttributeCollection(this);
 
         private object GetPropertyOwnerForComponent(Array a, int i)
         {
             object propertyOwner = a.GetValue(i);
-            if (propertyOwner is ICustomTypeDescriptor)
+            if (propertyOwner is ICustomTypeDescriptor descriptor)
             {
-                propertyOwner = ((ICustomTypeDescriptor)propertyOwner).GetPropertyOwner(_descriptors[i]);
+                propertyOwner = descriptor.GetPropertyOwner(_descriptors[i]);
             }
 
             return propertyOwner;
         }
 
         /// <inheritdoc />
-        public override object GetEditor(Type editorBaseType)
-        {
-            return _descriptors[0].GetEditor(editorBaseType);
-        }
+        public override object GetEditor(Type editorBaseType) => _descriptors[0].GetEditor(editorBaseType);
 
         /// <inheritdoc />
         public override object GetValue(object component)
         {
             Debug.Assert(component is Array, "MergePropertyDescriptor::GetValue called with non-array value");
-            return GetValue((Array)component, out bool temp);
+            return GetValue((Array)component, out bool _);
         }
 
         public object GetValue(Array components, out bool allEqual)
@@ -245,11 +208,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             allEqual = true;
             object obj = _descriptors[0].GetValue(GetPropertyOwnerForComponent(components, 0));
 
-            if (obj is ICollection)
+            if (obj is ICollection collection)
             {
                 if (_collection is null)
                 {
-                    _collection = new MultiMergeCollection((ICollection)obj);
+                    _collection = new MultiMergeCollection(collection);
                 }
                 else if (_collection.Locked)
                 {
@@ -257,7 +220,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 else
                 {
-                    _collection.SetItems((ICollection)obj);
+                    _collection.SetItems(collection);
                 }
             }
 
@@ -309,10 +272,10 @@ namespace System.Windows.Forms.PropertyGridInternal
         public override void ResetValue(object component)
         {
             Debug.Assert(component is Array, "MergePropertyDescriptor::ResetValue called with non-array value");
-            Array a = (Array)component;
+            var array = (Array)component;
             for (int i = 0; i < _descriptors.Length; i++)
             {
-                _descriptors[i].ResetValue(GetPropertyOwnerForComponent(a, i));
+                _descriptors[i].ResetValue(GetPropertyOwnerForComponent(array, i));
             }
         }
 
@@ -325,14 +288,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                     _collection.Locked = true;
                 }
 
-                // now we have to copy the value into each property.
+                // Now we have to copy the value into each property.
                 object[] values = new object[listValue.Count];
 
                 listValue.CopyTo(values, 0);
 
                 for (int i = 0; i < _descriptors.Length; i++)
                 {
-                    if (!(_descriptors[i].GetValue(GetPropertyOwnerForComponent(a, i)) is IList propList))
+                    if (_descriptors[i].GetValue(GetPropertyOwnerForComponent(a, i)) is not IList propList)
                     {
                         continue;
                     }
@@ -357,17 +320,17 @@ namespace System.Windows.Forms.PropertyGridInternal
         public override void SetValue(object component, object value)
         {
             Debug.Assert(component is Array, "MergePropertyDescriptor::SetValue called with non-array value");
-            Array a = (Array)component;
-            if (value is IList && typeof(IList).IsAssignableFrom(PropertyType))
+            var array = (Array)component;
+            if (value is IList list && typeof(IList).IsAssignableFrom(PropertyType))
             {
-                SetCollectionValues(a, (IList)value);
+                SetCollectionValues(array, list);
             }
             else
             {
                 for (int i = 0; i < _descriptors.Length; i++)
                 {
                     object clonedValue = CopyValue(value);
-                    _descriptors[i].SetValue(GetPropertyOwnerForComponent(a, i), clonedValue);
+                    _descriptors[i].SetValue(GetPropertyOwnerForComponent(array, i), clonedValue);
                 }
             }
         }
@@ -376,10 +339,10 @@ namespace System.Windows.Forms.PropertyGridInternal
         public override bool ShouldSerializeValue(object component)
         {
             Debug.Assert(component is Array, "MergePropertyDescriptor::ShouldSerializeValue called with non-array value");
-            Array a = (Array)component;
+            var array = (Array)component;
             for (int i = 0; i < _descriptors.Length; i++)
             {
-                if (!_descriptors[i].ShouldSerializeValue(GetPropertyOwnerForComponent(a, i)))
+                if (!_descriptors[i].ShouldSerializeValue(GetPropertyOwnerForComponent(array, i)))
                 {
                     return false;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.PDComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.PDComparer.cs
@@ -14,8 +14,8 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             public int Compare(object? obj1, object? obj2)
             {
-                PropertyDescriptor? a1 = obj1 as PropertyDescriptor;
-                PropertyDescriptor? a2 = obj2 as PropertyDescriptor;
+                var a1 = obj1 as PropertyDescriptor;
+                var a2 = obj2 as PropertyDescriptor;
 
                 if (a1 is null && a2 is null)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.PropertyMerger.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.PropertyMerger.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         ArrayList props = GetCommonProperties(rgobjs, true, tab, parentEntry);
 
-                        MultiPropertyDescriptorGridEntry[] entries = new MultiPropertyDescriptorGridEntry[props.Count];
+                        var entries = new MultiPropertyDescriptorGridEntry[props.Count];
                         for (int i = 0; i < entries.Length; i++)
                         {
                             entries[i] = new MultiPropertyDescriptorGridEntry(parentEntry.OwnerGrid, parentEntry, rgobjs, (PropertyDescriptor[])props[i], false);
@@ -45,7 +45,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         // this'll work for just one as well
                         ArrayList firstProps = GetCommonProperties(new object[] { rgobjs[0] }, false, tab, parentEntry);
 
-                        PropertyDescriptor[] firstPds = new PropertyDescriptor[firstProps.Count];
+                        var firstPds = new PropertyDescriptor[firstProps.Count];
                         for (int i = 0; i < firstProps.Count; i++)
                         {
                             firstPds[i] = ((PropertyDescriptor[])firstProps[i])[0];
@@ -53,7 +53,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         props = UnsortedMerge(firstPds, props);
 
-                        MultiPropertyDescriptorGridEntry[] entries = new MultiPropertyDescriptorGridEntry[props.Count];
+                        var entries = new MultiPropertyDescriptorGridEntry[props.Count];
 
                         for (int i = 0; i < entries.Length; i++)
                         {
@@ -70,14 +70,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return result;
             }
 
-            // this returns an array list of the PropertyDescriptor arrays, one for each
-            // component
-            //
+            /// <summary>
+            ///  Returns an array list of the PropertyDescriptor arrays, one for each component.
+            /// </summary>
             private static ArrayList GetCommonProperties(object[] objs, bool presort, PropertyTab tab, GridEntry parentEntry)
             {
-                PropertyDescriptorCollection[] propCollections = new PropertyDescriptorCollection[objs.Length];
+                var propCollections = new PropertyDescriptorCollection[objs.Length];
+                var attrs = new Attribute[parentEntry.BrowsableAttributes.Count];
 
-                Attribute[] attrs = new Attribute[parentEntry.BrowsableAttributes.Count];
                 parentEntry.BrowsableAttributes.CopyTo(attrs, 0);
 
                 for (int i = 0; i < objs.Length; i++)
@@ -91,12 +91,13 @@ namespace System.Windows.Forms.PropertyGridInternal
                     propCollections[i] = pdc;
                 }
 
-                ArrayList mergedList = new ArrayList();
-                PropertyDescriptor[] matchArray = new PropertyDescriptor[objs.Length];
+                ArrayList mergedList = new();
+                var matchArray = new PropertyDescriptor[objs.Length];
 
                 //
                 // Merge the property descriptors
                 //
+
                 int[] posArray = new int[propCollections.Length];
                 for (int i = 0; i < propCollections[0].Count; i++)
                 {
@@ -112,8 +113,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             break;
                         }
 
-                        // check to see if we're on a match
-                        //
+                        // Check to see if we're on a match.
                         PropertyDescriptor jProp = propCollections[j][posArray[j]];
                         if (pivotDesc.Equals(jProp))
                         {
@@ -134,11 +134,10 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         match = false;
 
-                        // if we aren't on a match, check all the items until we're past
-                        // where the matching item would be
+                        // If we aren't on a match, check all the items until we're past where the matching item would be.
                         while (s_propertyComparer.Compare(jProp, pivotDesc) <= 0)
                         {
-                            // got a match!
+                            // Got a match!
                             if (pivotDesc.Equals(jProp))
                             {
                                 if (!jProp.Attributes[typeof(MergablePropertyAttribute)].IsDefaultAttribute())
@@ -156,7 +155,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                                 break;
                             }
 
-                            // try again
+                            // Try again.
                             jPos++;
                             if (jPos < propCollections[j].Count)
                             {
@@ -168,7 +167,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             }
                         }
 
-                        // if we got here, there is no match, quit for this guy
+                        // If we got here, there is no match, quit for this one.
                         if (!match)
                         {
                             posArray[j] = jPos;
@@ -176,7 +175,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                     }
 
-                    // do we have a match?
+                    // Do we have a match?
                     if (match)
                     {
                         matchArray[0] = pivotDesc;
@@ -192,7 +191,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 MultiPropertyDescriptorGridEntry[] newEntries = null;
                 int newPos = 0;
 
-                // first scan the list and move any parenthesized properties to the front.
+                // First scan the list and move any parenthesized properties to the front.
                 for (int i = 0; i < entries.Length; i++)
                 {
                     if (entries[i].ParensAroundName)
@@ -207,7 +206,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
 
-                // second pass, copy any that didn't have the parens.
+                // Second pass, copy any that didn't have the parens.
                 if (newPos > 0)
                 {
                     for (int i = 0; i < entries.Length; i++)
@@ -225,31 +224,32 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             /// <summary>
-            ///  merges an unsorted array of grid entries with a sorted array of grid entries that
+            ///  Merges an unsorted array of grid entries with a sorted array of grid entries that
             ///  have already been merged.  The resulting array is the intersection of entries between the two,
             ///  but in the order of baseEntries.
             /// </summary>
             private static ArrayList UnsortedMerge(PropertyDescriptor[] baseEntries, ArrayList sortedMergedEntries)
             {
-                ArrayList mergedEntries = new ArrayList();
-                PropertyDescriptor[] mergeArray = new PropertyDescriptor[((PropertyDescriptor[])sortedMergedEntries[0]).Length + 1];
+                ArrayList mergedEntries = new();
+                var mergeArray = new PropertyDescriptor[((PropertyDescriptor[])sortedMergedEntries[0]).Length + 1];
 
                 for (int i = 0; i < baseEntries.Length; i++)
                 {
                     PropertyDescriptor basePd = baseEntries[i];
 
-                    // first, do a binary search for a matching item
+                    // First, do a binary search for a matching item.
                     PropertyDescriptor[] mergedEntryList = null;
-                    string entryName = basePd.Name + " " + basePd.PropertyType.FullName;
+                    string entryName = $"{basePd.Name} {basePd.PropertyType.FullName}";
 
                     int len = sortedMergedEntries.Count;
-                    // perform a binary search
+
+                    // Perform a binary search.
                     int offset = len / 2;
                     int start = 0;
 
                     while (len > 0)
                     {
-                        PropertyDescriptor[] pdList = (PropertyDescriptor[])sortedMergedEntries[start + offset];
+                        var pdList = (PropertyDescriptor[])sortedMergedEntries[start + offset];
                         PropertyDescriptor pd = pdList[0];
                         string sortString = pd.Name + " " + pd.PropertyType.FullName;
                         int result = string.Compare(entryName, sortString, false, CultureInfo.InvariantCulture);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         private static readonly PDComparer s_propertyComparer = new();
 
         internal MultiSelectRootGridEntry(PropertyGridView view, object obj, IServiceProvider baseProvider, IDesignerHost host, PropertyTab tab, PropertySort sortType)
-        : base(view, obj, baseProvider, host, tab, sortType)
+            : base(view, obj, baseProvider, host, tab, sortType)
         {
         }
 
@@ -24,12 +24,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (!forceReadOnlyChecked)
+                if (!_forceReadOnlyChecked)
                 {
                     bool anyRO = false;
-                    foreach (object obj in (Array)objValue)
+                    foreach (object obj in (Array)_objValue)
                     {
-                        ReadOnlyAttribute readOnlyAttr = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(obj)[typeof(ReadOnlyAttribute)];
+                        var readOnlyAttr = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(obj)[typeof(ReadOnlyAttribute)];
                         if ((readOnlyAttr is not null && !readOnlyAttr.IsDefaultAttribute()) || TypeDescriptor.GetAttributes(obj).Contains(InheritanceAttribute.InheritedReadOnly))
                         {
                             anyRO = true;
@@ -42,7 +42,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         _flags |= FLAG_FORCE_READONLY;
                     }
 
-                    forceReadOnlyChecked = true;
+                    _forceReadOnlyChecked = true;
                 }
 
                 return base.ForceReadOnly;
@@ -58,7 +58,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             try
             {
-                object[] rgobjs = (object[])objValue;
+                object[] rgobjs = (object[])_objValue;
 
                 ChildCollection.Clear();
 
@@ -74,7 +74,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 bool fExpandable = Children.Count > 0;
                 if (!fExpandable)
                 {
-                    SetFlag(GridEntry.FL_EXPANDABLE_FAILED, true);
+                    SetFlag(FL_EXPANDABLE_FAILED, true);
                 }
 
                 CategorizePropEntries();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertiesTab.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertiesTab.cs
@@ -11,23 +11,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 {
     public class PropertiesTab : PropertyTab
     {
-        public override string TabName
-        {
-            get
-            {
-                return SR.PBRSToolTipProperties;
-            }
-        }
+        public override string TabName => SR.PBRSToolTipProperties;
 
-        public override string HelpKeyword
-        {
-            get
-            {
-                return "vs.properties"; // do not localize.
-            }
-        }
+        public override string HelpKeyword => "vs.properties"; // do not localize.
 
+#pragma warning disable CA1725 // Parameter names should match base declaration - publicly shipped API
         public override PropertyDescriptor GetDefaultProperty(object obj)
+#pragma warning restore CA1725
         {
             PropertyDescriptor def = base.GetDefaultProperty(obj);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
@@ -68,13 +68,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                     case UiaCore.NavigateDirection.NextSibling:
                         var propertyGridViewAccessibleObject = (PropertyGridView.PropertyGridViewAccessibleObject)Parent;
                         var propertyGridView = propertyGridViewAccessibleObject.Owner as PropertyGridView;
-                        bool currentGridEntryFound = false;
-                        return propertyGridViewAccessibleObject.GetNextGridEntry(_owningPropertyDescriptorGridEntry, propertyGridView.TopLevelGridEntries, out currentGridEntryFound);
+                        return propertyGridViewAccessibleObject.GetNextGridEntry(_owningPropertyDescriptorGridEntry, propertyGridView.TopLevelGridEntries, out _);
                     case UiaCore.NavigateDirection.PreviousSibling:
                         propertyGridViewAccessibleObject = (PropertyGridView.PropertyGridViewAccessibleObject)Parent;
                         propertyGridView = propertyGridViewAccessibleObject.Owner as PropertyGridView;
-                        currentGridEntryFound = false;
-                        return propertyGridViewAccessibleObject.GetPreviousGridEntry(_owningPropertyDescriptorGridEntry, propertyGridView.TopLevelGridEntries, out currentGridEntryFound);
+                        return propertyGridViewAccessibleObject.GetPreviousGridEntry(_owningPropertyDescriptorGridEntry, propertyGridView.TopLevelGridEntries, out _);
                     case UiaCore.NavigateDirection.FirstChild:
                         return GetFirstChild();
                     case UiaCore.NavigateDirection.LastChild:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -50,32 +50,25 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         internal PropertyDescriptorGridEntry(PropertyGrid ownerGrid, GridEntry peParent, PropertyDescriptor propInfo, bool hide)
-        : base(ownerGrid, peParent)
+            : base(ownerGrid, peParent)
         {
             _activeXHide = hide;
             Initialize(propInfo);
         }
 
         /// <summary>
-        ///  specify that this grid entry should be allowed to be merged for.
-        ///  multi-select.
+        ///  Specify that this grid entry should be allowed to be merged for multi-select.
         /// </summary>
         public override bool AllowMerge
         {
             get
             {
-                MergablePropertyAttribute mpa = (MergablePropertyAttribute)_propertyInfo.Attributes[typeof(MergablePropertyAttribute)];
+                var mpa = (MergablePropertyAttribute)_propertyInfo.Attributes[typeof(MergablePropertyAttribute)];
                 return mpa is null || mpa.IsDefaultAttribute();
             }
         }
 
-        internal override AttributeCollection Attributes
-        {
-            get
-            {
-                return _propertyInfo.Attributes;
-            }
-        }
+        internal override AttributeCollection Attributes => _propertyInfo.Attributes;
 
         /// <summary>
         ///  Retrieves the keyword that the VS help dynamic help window will
@@ -93,7 +86,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return null; //null exception protection.
                     }
 
-                    HelpKeywordAttribute helpAttribute = (HelpKeywordAttribute)_propertyInfo.Attributes[typeof(HelpKeywordAttribute)];
+                    var helpAttribute = (HelpKeywordAttribute)_propertyInfo.Attributes[typeof(HelpKeywordAttribute)];
 
                     if (helpAttribute is not null && !helpAttribute.IsDefaultAttribute())
                     {
@@ -109,18 +102,17 @@ namespace System.Windows.Forms.PropertyGridInternal
                         {
                             ge = ge.ParentGridEntry;
 
-                            // for value classes, the equality will never work, so
-                            // just try the type equality
+                            // For value classes, the equality will never work, so just try the type equality
                             if (ge.PropertyValue == owner || (owner.GetType().IsValueType && owner.GetType() == ge.PropertyValue.GetType()))
                             {
-                                _helpKeyword = ge.PropertyName + "." + _helpKeyword;
+                                _helpKeyword = $"{ge.PropertyName}.{_helpKeyword}";
                                 break;
                             }
                         }
                     }
                     else
                     {
-                        string typeName = string.Empty;
+                        string typeName;
 
                         Type componentType = _propertyInfo.ComponentType;
 
@@ -130,11 +122,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         else
                         {
-                            // make sure this property is declared on a class that
-                            // is related to the component we're looking at.
-                            // if it's not, it could be a shadow property so we need
-                            // to try to find the real property.
-                            //
+                            // Make sure this property is declared on a class that is related to the component we're
+                            // looking at. If it's not, it could be a shadow property so we need to try to find the
+                            // real property.
+
                             Type ownerType = owner.GetType();
                             if (!componentType.IsPublic || !componentType.IsAssignableFrom(ownerType))
                             {
@@ -155,18 +146,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                             }
                             else
                             {
-                                //
-
-                                //if (helpAttribute is not null && !helpAttribute.IsDefaultAttribute()) {
-                                //    typeName = helpAttribute.HelpKeyword;
-                                //}
-                                //else {
                                 typeName = componentType.FullName;
-                                //}
                             }
                         }
 
-                        _helpKeyword = typeName + "." + _propertyInfo.Name;
+                        _helpKeyword = $"{typeName}.{_propertyInfo.Name}";
                     }
                 }
 
@@ -174,47 +158,17 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        internal override string LabelToolTipText
-        {
-            get
-            {
-                return (_toolTipText ?? base.LabelToolTipText);
-            }
-        }
+        internal override string LabelToolTipText => _toolTipText ?? base.LabelToolTipText;
 
-        internal override string HelpKeywordInternal
-        {
-            get
-            {
-                return PropertyLabel;
-            }
-        }
+        internal override string HelpKeywordInternal => PropertyLabel;
 
-        internal override bool Enumerable
-        {
-            get => base.Enumerable && !IsPropertyReadOnly;
-        }
+        internal override bool Enumerable => base.Enumerable && !IsPropertyReadOnly;
 
-        internal virtual bool IsPropertyReadOnly
-        {
-            get
-            {
-                return _propertyInfo.IsReadOnly;
-            }
-        }
+        internal virtual bool IsPropertyReadOnly => _propertyInfo.IsReadOnly;
 
-        public override bool IsValueEditable
-        {
-            get
-            {
-                return _exceptionConverter is null && !IsPropertyReadOnly && base.IsValueEditable;
-            }
-        }
+        public override bool IsValueEditable => _exceptionConverter is null && !IsPropertyReadOnly && base.IsValueEditable;
 
-        public override bool NeedsDropDownButton
-        {
-            get => base.NeedsDropDownButton && !IsPropertyReadOnly;
-        }
+        public override bool NeedsDropDownButton => base.NeedsDropDownButton && !IsPropertyReadOnly;
 
         internal bool ParensAroundName
         {
@@ -232,7 +186,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
 
-                return (_parensAroundName == ParensAroundNameYes);
+                return _parensAroundName == ParensAroundNameYes;
             }
         }
 
@@ -253,21 +207,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <summary>
         ///  Retrieves the PropertyDescriptor that is surfacing the given object/
         /// </summary>
-        public override PropertyDescriptor PropertyDescriptor
-        {
-            get
-            {
-                return _propertyInfo;
-            }
-        }
+        public override PropertyDescriptor PropertyDescriptor => _propertyInfo;
 
-        public override string PropertyDescription
-        {
-            get
-            {
-                return _propertyInfo.Description;
-            }
-        }
+        public override string PropertyDescription => _propertyInfo.Description;
 
         public override string PropertyLabel
         {
@@ -276,7 +218,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 string label = _propertyInfo.DisplayName;
                 if (ParensAroundName)
                 {
-                    label = "(" + label + ")";
+                    label = $"({label})";
                 }
 
                 return label;
@@ -286,30 +228,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <summary>
         ///  Returns non-localized name of this property.
         /// </summary>
-        public override string PropertyName
-        {
-            get
-            {
-                if (_propertyInfo is not null)
-                {
-                    return _propertyInfo.Name;
-                }
+        public override string PropertyName => _propertyInfo?.Name;
 
-                return null;
-            }
-        }
-
-        public override Type PropertyType
-        {
-            get
-            {
-                return _propertyInfo.PropertyType;
-            }
-        }
+        public override Type PropertyType => _propertyInfo.PropertyType;
 
         /// <summary>
-        ///  Gets or sets the value for the property that is represented
-        ///  by this GridEntry.
+        ///  Gets or sets the value for the property that is represented by this GridEntry.
         /// </summary>
         public override object PropertyValue
         {
@@ -321,7 +245,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     if (_exceptionConverter is not null)
                     {
-                        // undo the exception converter
+                        // Undo the exception converter.
                         SetFlagsAndExceptionInfo(0, null, null);
                     }
 
@@ -331,7 +255,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     if (_exceptionConverter is null)
                     {
-                        // clear the flags
+                        // Clear the flags.
                         SetFlagsAndExceptionInfo(0, new ExceptionConverter(), new ExceptionEditor());
                     }
 
@@ -374,9 +298,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return true;
                 }
 
-                // if read only editable is set, make sure it's valid
-                //
-                if (_propertyInfo.IsReadOnly && !_readOnlyVerified && GetFlagSet(GridEntry.FLAG_READONLY_EDITABLE))
+                // If read only editable is set, make sure it's valid.
+                if (_propertyInfo.IsReadOnly && !_readOnlyVerified && GetFlagSet(FLAG_READONLY_EDITABLE))
                 {
                     Type propType = PropertyType;
 
@@ -424,8 +347,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <summary>
-        ///  Returns the type editor for this entry.  This may return null if there
-        ///  is no type editor.
+        ///  Returns the type editor for this entry.  This may return null if there is no type editor.
         /// </summary>
         internal override UITypeEditor UITypeEditor
         {
@@ -451,8 +373,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (!IsValueEditable)
             {
-                RefreshPropertiesAttribute refreshAttr = (RefreshPropertiesAttribute)_propertyInfo.Attributes[typeof(RefreshPropertiesAttribute)];
-                if ((refreshAttr is not null && !refreshAttr.RefreshProperties.Equals(RefreshProperties.None)))
+                var refreshAttr = (RefreshPropertiesAttribute)_propertyInfo.Attributes[typeof(RefreshPropertiesAttribute)];
+                if (refreshAttr is not null && !refreshAttr.RefreshProperties.Equals(RefreshProperties.None))
                 {
                     GridEntryHost.Refresh(refreshAttr is not null && refreshAttr.Equals(RefreshPropertiesAttribute.All));
                 }
@@ -484,9 +406,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return null;
             }
 
-            if (target is ICustomTypeDescriptor)
+            if (target is ICustomTypeDescriptor descriptor)
             {
-                target = ((ICustomTypeDescriptor)target).GetPropertyOwner(_propertyInfo);
+                target = descriptor.GetPropertyOwner(_propertyInfo);
             }
 
             try
@@ -503,7 +425,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             _propertyInfo = propInfo;
 
-            _isSerializeContentsProp = (_propertyInfo.SerializationVisibility == DesignerSerializationVisibility.Content);
+            _isSerializeContentsProp = _propertyInfo.SerializationVisibility == DesignerSerializationVisibility.Content;
 
             Debug.Assert(propInfo is not null, "Can't create propEntry because of null prop info");
 
@@ -522,8 +444,8 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             // now see if we need to notify the parent(s) up the chain
             while (ge is not null &&
-                   ge is PropertyDescriptorGridEntry &&
-                   ((PropertyDescriptorGridEntry)ge)._propertyInfo.Attributes.Contains(NotifyParentPropertyAttribute.Yes))
+                   ge is PropertyDescriptorGridEntry entry &&
+                   entry._propertyInfo.Attributes.Contains(NotifyParentPropertyAttribute.Yes))
             {
                 // find the next parent property with a different value owner
                 object owner = ge.GetValueOwner();
@@ -552,8 +474,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     if (changeService is not null)
                     {
-                        changeService.OnComponentChanging(owner, ((PropertyDescriptorGridEntry)ge)._propertyInfo);
-                        changeService.OnComponentChanged(owner, ((PropertyDescriptorGridEntry)ge)._propertyInfo, null, null);
+                        changeService.OnComponentChanging(owner, entry._propertyInfo);
+                        changeService.OnComponentChanged(owner, entry._propertyInfo, null, null);
                     }
 
                     ge.ClearCachedValues(false); //clear the value so it paints correctly next time.
@@ -568,9 +490,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal override bool NotifyValueGivenParent(object obj, int type)
         {
-            if (obj is ICustomTypeDescriptor)
+            if (obj is ICustomTypeDescriptor descriptor)
             {
-                obj = ((ICustomTypeDescriptor)obj).GetPropertyOwner(_propertyInfo);
+                obj = descriptor.GetPropertyOwner(_propertyInfo);
             }
 
             switch (type)
@@ -597,7 +519,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         if (_exceptionConverter is null)
                         {
-                            // clear the flags
+                            // Clear the flags.
                             Flags = 0;
                             _exceptionConverter = new ExceptionConverter();
                             _exceptionEditor = new ExceptionEditor();
@@ -615,7 +537,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         if (_exceptionConverter is null)
                         {
-                            // clear the flags
+                            // Clear the flags.
                             Flags = 0;
                             _exceptionConverter = new ExceptionConverter();
                             _exceptionEditor = new ExceptionEditor();
@@ -633,8 +555,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     if (_eventBindings is not null)
                     {
-                        EventDescriptor descriptor = _eventBindings.GetEvent(_propertyInfo);
-                        if (descriptor is not null)
+                        EventDescriptor eventDescriptor = _eventBindings.GetEvent(_propertyInfo);
+                        if (eventDescriptor is not null)
                         {
                             return ViewEvent(obj, null, null, true);
                         }
@@ -649,6 +571,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         public override void OnComponentChanged()
         {
             base.OnComponentChanged();
+
             // If we got this it means someone called ITypeDescriptorContext.OnComponentChanged.
             // so we need to echo that change up the inheritance change in case the owner object isn't a sited component.
             NotifyParentChange(this);
@@ -704,7 +627,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 for (int i = 0; i < _pvUIItems.Length; i++)
                 {
-                    _uiItemRects[i] = new Rectangle(rect.Right - ((s_scaledImageSizeX + 1) * (i + 1)), (rect.Height - s_scaledImageSizeY) / 2, s_scaledImageSizeX, s_scaledImageSizeY);
+                    _uiItemRects[i] = new Rectangle(
+                        rect.Right - ((s_scaledImageSizeX + 1) * (i + 1)),
+                        (rect.Height - s_scaledImageSizeY) / 2,
+                        s_scaledImageSizeX,
+                        s_scaledImageSizeY);
                     g.DrawImage(_pvUIItems[i].Image, _uiItemRects[i]);
                 }
 
@@ -730,16 +657,15 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (host is not null)
                 {
-                    string text = (undoText ?? string.Format(SR.PropertyGridSetValue, _propertyInfo.Name));
+                    string text = undoText ?? string.Format(SR.PropertyGridSetValue, _propertyInfo.Name);
                     trans = host.CreateTransaction(text);
                 }
 
-                // Usually IComponent things are sited and this notification will be
-                // fired automatically by the PropertyDescriptor.  However, for non-IComponent sub objects
-                // or sub objects that are non-sited sub components, we need to manually fire
-                // the notification.
-                //
-                bool needChangeNotify = !(obj is IComponent) || ((IComponent)obj).Site is null;
+                // Usually IComponent things are sited and this notification will be fired automatically by
+                // the PropertyDescriptor.  However, for non-IComponent sub objects or sub objects that are
+                // non-sited sub components, we need to manually fire the notification.
+
+                bool needChangeNotify = obj is not IComponent component || component.Site is null;
 
                 if (needChangeNotify)
                 {
@@ -768,7 +694,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     childCount = ChildCount;
                 }
 
-                RefreshPropertiesAttribute refreshAttr = (RefreshPropertiesAttribute)_propertyInfo.Attributes[typeof(RefreshPropertiesAttribute)];
+                var refreshAttr = (RefreshPropertiesAttribute)_propertyInfo.Attributes[typeof(RefreshPropertiesAttribute)];
                 bool needsRefresh = wasExpanded || (refreshAttr is not null && !refreshAttr.RefreshProperties.Equals(RefreshProperties.None));
 
                 if (needsRefresh)
@@ -777,12 +703,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 // Determine if this is an event being created, and if so, navigate to the event code
-                //
 
                 EventDescriptor eventDesc = null;
 
                 // This is possibly an event.  Check it out.
-                //
                 if (obj is not null && objVal is string)
                 {
                     if (_eventBindings is null)
@@ -797,17 +721,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     // For a merged set of properties, the event binding service won't
                     // find an event.  So, we ask type descriptor directly.
-                    //
                     if (eventDesc is null)
                     {
-                        // If we have a merged property descriptor, pull out one of
-                        // the elements.
-                        //
+                        // If we have a merged property descriptor, pull out one of the elements.
                         object eventObj = obj;
 
                         if (_propertyInfo is MergePropertyDescriptor && obj is Array)
                         {
-                            Array objArray = obj as Array;
+                            var objArray = obj as Array;
                             if (objArray.Length > 0)
                             {
                                 eventObj = objArray.GetValue(0);
@@ -830,14 +751,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                         ViewEvent(obj, (string)objVal, eventDesc, false);
                     }
                     else
-                    { // Not an event
-                        SetPropertyValueCore(obj, objVal, true);
+                    {
+                        // Not an event
+                        SetPropertyValueCore(obj, objVal);
                     }
 
                     setSuccessful = true;
 
                     // Now notify the change service that the change was successful.
-                    //
                     if (needChangeNotify && ComponentChangeService is not null)
                     {
                         ComponentChangeService.OnComponentChanged(obj, _propertyInfo, null, objVal);
@@ -847,10 +768,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 finally
                 {
-                    // see if we need to refresh the property browser
-                    // 1) if this property has the refreshpropertiesattribute, or
-                    // 2) it's got expanded sub properties
+                    // See if we need to refresh the property browser
                     //
+                    //   1) if this property has the refreshpropertiesattribute, or
+                    //   2) it's got expanded sub properties
+
                     if (needsRefresh && GridEntryHost is not null)
                     {
                         RecreateChildren(childCount);
@@ -897,7 +819,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return obj;
         }
 
-        protected void SetPropertyValueCore(object obj, object value, bool doUndo)
+        protected void SetPropertyValueCore(object obj, object value)
         {
             if (_propertyInfo is null)
             {
@@ -905,7 +827,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             // Store the current cursor and set it to the HourGlass.
-            //
             Cursor oldCursor = Cursor.Current;
             try
             {
@@ -913,14 +834,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 object target = obj;
 
-                if (target is ICustomTypeDescriptor)
+                if (target is ICustomTypeDescriptor descriptor)
                 {
-                    target = ((ICustomTypeDescriptor)target).GetPropertyOwner(_propertyInfo);
+                    target = descriptor.GetPropertyOwner(_propertyInfo);
                 }
 
-                // check the type of the object we are modifying.  If it's a value type or an array,
+                // Check the type of the object we are modifying.  If it's a value type or an array,
                 // we need to modify the object and push the value back up to the parent.
-                //
+
                 bool treatAsValueType = false;
 
                 if (ParentGridEntry is not null)
@@ -933,13 +854,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     _propertyInfo.SetValue(target, value);
 
-                    // Microsoft, okay, since the value that we modified may not
-                    // be stored by the parent property, we need to push this
-                    // value back into the parent.  An example here is Size or
-                    // Location, which return Point objects that are unconnected
-                    // to the object they relate to.  So we modify the Point object and
+                    // Since the value that we modified may not be stored by the parent property, we need to push this
+                    // value back into the parent.  An example here is Size or Location, which return Point objects
+                    // that are unconnected to the object they relate to.  So we modify the Point object and
                     // push it back into the object we got it from.
-                    //
+
                     if (treatAsValueType)
                     {
                         GridEntry parent = ParentGridEntry;
@@ -953,7 +872,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             finally
             {
                 // Flip back to the old cursor.
-                //
                 Cursor.Current = oldCursor;
             }
         }
@@ -981,12 +899,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return true;
             }
 
-            IComponent component = obj as IComponent;
+            var component = obj as IComponent;
 
             if (component is null && _propertyInfo is MergePropertyDescriptor)
             {
                 // It's possible that multiple objects are selected, and we're trying to create an event for each of them
-                //
                 if (obj is Array objArray && objArray.Length > 0)
                 {
                     component = objArray.GetValue(0) as IComponent;
@@ -1031,7 +948,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (host is not null)
                 {
                     string compName = component.Site is not null ? component.Site.Name : component.GetType().Name;
-                    trans = DesignerHost.CreateTransaction(string.Format(SR.WindowsFormsSetEvent, compName + "." + PropertyName));
+                    trans = DesignerHost.CreateTransaction(string.Format(SR.WindowsFormsSetEvent, $"{compName}.{PropertyName}"));
                 }
 
                 if (_eventBindings is null)
@@ -1050,9 +967,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (newHandler is not null)
                 {
-                    // now walk through all the matching methods to see if this one exists.
-                    // if it doesn't we'll wanna show code.
-                    //
+                    // Now walk through all the matching methods to see if this one exists.
+                    // If it doesn't we'll wanna show code.
                     if (_eventBindings is not null)
                     {
                         bool methodExists = false;
@@ -1083,11 +999,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             trans = null;
                         }
 
-                        if (GridEntryHost is not null && GridEntryHost is PropertyGridView)
-                        {
-                            PropertyGridView pgv = GridEntryHost as PropertyGridView;
-                            pgv.ShowInvalidMessage(newHandler, obj, ex);
-                        }
+                        GridEntryHost?.ShowInvalidMessage(newHandler, ex);
 
                         return false;
                     }
@@ -1098,7 +1010,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     s_targetBindingService = _eventBindings;
                     s_targetComponent = component;
                     s_targetEventdesc = eventdesc;
-                    Application.Idle += new EventHandler(PropertyDescriptorGridEntry.ShowCodeIdle);
+                    Application.Idle += ShowCodeIdle;
                 }
             }
             catch

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridCommands.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridCommands.cs
@@ -13,21 +13,23 @@ namespace System.Windows.Forms.PropertyGridInternal
     /// </summary>
     public class PropertyGridCommands
     {
+#pragma warning disable IDE1006 // Naming Styles - Shipped public API
         /// <summary>
         ///  This guid corresponds to the menu grouping windows forms will use for its menus.  This is
         ///  defined in the windows forms menu CTC file, but we need it here so we can define what
         ///  context menus to use.
         /// </summary>
-        protected static readonly Guid wfcMenuGroup = new Guid("{a72bd644-1979-4cbc-a620-ea4112198a66}");
+        protected static readonly Guid wfcMenuGroup = new("{a72bd644-1979-4cbc-a620-ea4112198a66}");
 
         /// <summary>
         ///  This guid corresponds to the windows forms command set.
         /// </summary>
-        protected static readonly Guid wfcMenuCommand = new Guid("{5a51cf82-7619-4a5d-b054-47f438425aa7}");
+        protected static readonly Guid wfcMenuCommand = new("{5a51cf82-7619-4a5d-b054-47f438425aa7}");
 
-        public static readonly CommandID Reset = new CommandID(wfcMenuCommand, 0x3000);
-        public static readonly CommandID Description = new CommandID(wfcMenuCommand, 0x3001);
-        public static readonly CommandID Hide = new CommandID(wfcMenuCommand, 0x3002);
-        public static readonly CommandID Commands = new CommandID(wfcMenuCommand, 0x3010);
+        public static readonly CommandID Reset = new(wfcMenuCommand, 0x3000);
+        public static readonly CommandID Description = new(wfcMenuCommand, 0x3001);
+        public static readonly CommandID Hide = new(wfcMenuCommand, 0x3002);
+        public static readonly CommandID Commands = new(wfcMenuCommand, 0x3010);
+#pragma warning restore IDE1006 // Naming Styles
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -135,6 +135,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private int _cachedRowHeight = -1;
 
+        private GridPositionData _positionData;
+
         public PropertyGridView(IServiceProvider serviceProvider, PropertyGrid propertyGrid)
             : base()
         {
@@ -243,7 +245,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (_buttonDropDown is null)
                 {
 #if DEBUG
-                    if (OwnerGrid.inGridViewCreate)
+                    if (OwnerGrid._inGridViewCreate)
                     {
                         throw new Exception("PERF REGRESSION - Creating item in grid view create");
                     }
@@ -276,7 +278,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (_buttonDialog is null)
                 {
 #if DEBUG
-                    if (OwnerGrid.inGridViewCreate)
+                    if (OwnerGrid._inGridViewCreate)
                     {
                         throw new Exception("PERF REGRESSION - Creating item in grid view create");
                     }
@@ -302,12 +304,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private static Bitmap GetBitmapFromIcon(string iconName, int iconsWidth, int iconsHeight)
         {
-            Size desiredSize = new Size(iconsWidth, iconsHeight);
-            Icon icon = new Icon(new Icon(typeof(PropertyGrid), iconName), desiredSize);
-            Bitmap b = icon.ToBitmap();
+            Size desiredSize = new(iconsWidth, iconsHeight);
+            Icon icon = new(new Icon(typeof(PropertyGrid), iconName), desiredSize);
+            var b = icon.ToBitmap();
             icon.Dispose();
 
-            if ((b.Size.Width != iconsWidth || b.Size.Height != iconsHeight))
+            if (b.Size.Width != iconsWidth || b.Size.Height != iconsHeight)
             {
                 Bitmap scaledBitmap = DpiHelper.CreateResizedBitmap(b, desiredSize);
                 if (scaledBitmap is not null)
@@ -327,7 +329,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (_edit is null)
                 {
 #if DEBUG
-                    if (OwnerGrid.inGridViewCreate)
+                    if (OwnerGrid._inGridViewCreate)
                     {
                         throw new Exception("PERF REGRESSION - Creating item in grid view create");
                     }
@@ -375,7 +377,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (_listBox is null)
                 {
 #if DEBUG
-                    if (OwnerGrid.inGridViewCreate)
+                    if (OwnerGrid._inGridViewCreate)
                     {
                         throw new Exception("PERF REGRESSION - Creating item in grid view create");
                     }
@@ -421,7 +423,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (_edit is not null && _edit.IsHandleCreated)
                 {
-                    int exStyle = unchecked((int)((long)User32.GetWindowLong(_edit, User32.GWL.EXSTYLE)));
+                    int exStyle = unchecked((int)(long)User32.GetWindowLong(_edit, User32.GWL.EXSTYLE));
                     return (exStyle & (int)User32.WS_EX.RTLREADING) != 0;
                 }
                 else
@@ -445,7 +447,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                return (ContainsFocus || (_dropDownHolder is not null && _dropDownHolder.ContainsFocus));
+                return ContainsFocus || (_dropDownHolder is not null && _dropDownHolder.ContainsFocus);
             }
         }
 
@@ -571,7 +573,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (_cachedRowHeight == -1)
                 {
-                    _cachedRowHeight = (int)Font.Height + 2;
+                    _cachedRowHeight = Font.Height + 2;
                 }
 
                 return _cachedRowHeight;
@@ -602,7 +604,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (_scrollBar is null)
                 {
 #if DEBUG
-                    if (OwnerGrid.inGridViewCreate)
+                    if (OwnerGrid._inGridViewCreate)
                     {
                         throw new Exception("PERF REGRESSION - Creating item in grid view create");
                     }
@@ -666,9 +668,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     _topHelpService = null;
 
-                    if (_helpService is not null && _helpService is IDisposable)
+                    if (_helpService is not null && _helpService is IDisposable disposable)
                     {
-                        ((IDisposable)_helpService).Dispose();
+                        disposable.Dispose();
                     }
 
                     _helpService = null;
@@ -694,7 +696,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 _tipInfo &= 0xFFFF;
 
                 // set the row
-                _tipInfo |= ((value & 0xFFFF) << 16);
+                _tipInfo |= (value & 0xFFFF) << 16;
             }
         }
 
@@ -710,7 +712,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 _tipInfo &= unchecked((int)0xFFFF0000);
 
                 // set the row
-                _tipInfo |= (value & 0xFFFF);
+                _tipInfo |= value & 0xFFFF;
             }
         }
 
@@ -721,7 +723,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (_toolTip is null)
                 {
 #if DEBUG
-                    if (OwnerGrid.inGridViewCreate)
+                    if (OwnerGrid._inGridViewCreate)
                     {
                         throw new Exception("PERF REGRESSION - Creating item in grid view create");
                     }
@@ -929,7 +931,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:CloseDropDown");
 
-            // the activation code in the DropDownHolder can cause this to recurse...
+            // The activation code in the DropDownHolder can cause this to recurse.
 
             if (GetFlag(FlagDropDownClosing))
             {
@@ -948,12 +950,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     Edit.Filter = false;
 
-                    // disable the ddh so it won't steal the focus back
-                    //
+                    // Disable the ddh so it won't steal the focus back
                     _dropDownHolder.SetComponent(null, false);
                     _dropDownHolder.Visible = false;
 
-                    // when we disable the dropdown holder, focus will be lost,
+                    // When we disable the dropdown holder focus will be lost,
                     // so put it onto one of our children first.
                     if (resetFocus)
                     {
@@ -982,7 +983,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     if (_selectedRow != -1)
                     {
-                        var gridEntry = GetGridEntryFromRow(_selectedRow);
+                        GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
                         if (gridEntry is not null)
                         {
                             gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
@@ -1080,7 +1081,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             Rectangle rectCur = ctl.Bounds;
 
-            // the client rect minus the border line
+            // The client rect minus the border line.
             Rectangle clientRect = ClientRectangle;
 
             clientRect.Inflate(-1, -1);
@@ -1088,15 +1089,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             try
             {
                 rectTarget = Rectangle.Intersect(clientRect, rectTarget);
-                //if (ctl is Button)
-                //   Debug.WriteStackTrace();
 
                 if (!rectTarget.IsEmpty)
                 {
                     if (!rectTarget.Equals(rectCur))
                     {
-                        ctl.SetBounds(rectTarget.X, rectTarget.Y,
-                                      rectTarget.Width, rectTarget.Height);
+                        ctl.SetBounds(rectTarget.X, rectTarget.Y, rectTarget.Width, rectTarget.Height);
                     }
 
                     ctl.Visible = true;
@@ -1115,7 +1113,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             _currentEditor = ctl;
         }
 
-        private /*protected virtual*/ int CountPropsFromOutline(GridEntryCollection rgipes)
+        private int CountPropsFromOutline(GridEntryCollection rgipes)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:CountPropsFromOutLine");
             if (rgipes is null)
@@ -1146,12 +1144,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private Bitmap CreateResizedBitmap(string icon, int width, int height)
         {
-            Bitmap bitmap = null;
-            var scaledIconWidth = width;
-            var scaledIconHeight = height;
+            Bitmap bitmap;
+            int scaledIconWidth = width;
+            int scaledIconHeight = height;
             try
             {
-                //scale for per-monitor DPI.
+                // Scale for per-monitor DPI.
                 if (DpiHelper.IsPerMonitorV2Awareness)
                 {
                     scaledIconWidth = LogicalToDeviceUnits(width);
@@ -1159,7 +1157,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 else if (DpiHelper.IsScalingRequired)
                 {
-                    // only primary monitor scaling.
+                    // Only primary monitor scaling.
                     scaledIconWidth = DpiHelper.LogicalToDeviceUnitsX(width);
                     scaledIconHeight = DpiHelper.LogicalToDeviceUnitsY(height);
                 }
@@ -1185,20 +1183,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (disposing)
             {
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Dispose");
-                if (_scrollBar is not null)
-                {
-                    _scrollBar.Dispose();
-                }
-
-                if (_listBox is not null)
-                {
-                    _listBox.Dispose();
-                }
-
-                if (_dropDownHolder is not null)
-                {
-                    _dropDownHolder.Dispose();
-                }
+                _scrollBar?.Dispose();
+                _listBox?.Dispose();
+                _dropDownHolder?.Dispose();
 
                 _scrollBar = null;
                 _listBox = null;
@@ -1211,42 +1198,27 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 _topHelpService = null;
 
-                if (_helpService is not null && _helpService is IDisposable)
+                if (_helpService is not null && _helpService is IDisposable disposable)
                 {
-                    ((IDisposable)_helpService).Dispose();
+                    disposable.Dispose();
                 }
 
                 _helpService = null;
 
-                if (_edit is not null)
-                {
-                    _edit.Dispose();
-                    _edit = null;
-                }
+                _edit?.Dispose();
+                _edit = null;
 
-                if (_fontBold is not null)
-                {
-                    _fontBold.Dispose();
-                    _fontBold = null;
-                }
+                _fontBold?.Dispose();
+                _fontBold = null;
 
-                if (_buttonDropDown is not null)
-                {
-                    _buttonDropDown.Dispose();
-                    _buttonDropDown = null;
-                }
+                _buttonDropDown?.Dispose();
+                _buttonDropDown = null;
 
-                if (_buttonDialog is not null)
-                {
-                    _buttonDialog.Dispose();
-                    _buttonDialog = null;
-                }
+                _buttonDialog?.Dispose();
+                _buttonDialog = null;
 
-                if (_toolTip is not null)
-                {
-                    _toolTip.Dispose();
-                    _toolTip = null;
-                }
+                _toolTip?.Dispose();
+                _toolTip = null;
             }
 
             base.Dispose(disposing);
@@ -1312,38 +1284,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        internal void DumpPropsToConsole(GridEntry entry, string prefix)
-        {
-            Type propType = entry.PropertyType;
-
-            if (entry.PropertyValue is not null)
-            {
-                propType = entry.PropertyValue.GetType();
-            }
-
-            System.Console.WriteLine(prefix + entry.PropertyLabel + ", value type=" + (propType is null ? "(null)" : propType.FullName) + ", value=" + (entry.PropertyValue is null ? "(null)" : entry.PropertyValue.ToString()) +
-                                     ", flags=" + entry.Flags.ToString(CultureInfo.InvariantCulture) +
-                                     ", TypeConverter=" + (entry.TypeConverter is null ? "(null)" : entry.TypeConverter.GetType().FullName) + ", UITypeEditor=" + ((entry.UITypeEditor is null ? "(null)" : entry.UITypeEditor.GetType().FullName)));
-            GridEntryCollection children = entry.Children;
-
-            if (children is not null)
-            {
-                foreach (GridEntry g in children)
-                {
-                    DumpPropsToConsole(g, prefix + "\t");
-                }
-            }
-        }
-
-        private int GetIPELabelIndent(GridEntry gridEntry)
-        {
-            return gridEntry.PropertyLabelIndent + 1;
-        }
+        private int GetIPELabelIndent(GridEntry gridEntry) => gridEntry.PropertyLabelIndent + 1;
 
         private int GetIPELabelLength(Graphics g, GridEntry gridEntry)
         {
             SizeF sizeF = PropertyGrid.MeasureTextHelper.MeasureText(OwnerGrid, g, gridEntry.PropertyLabel, Font);
-            Size size = Size.Ceiling(sizeF);
+            var size = Size.Ceiling(sizeF);
             return _location.X + GetIPELabelIndent(gridEntry) + size.Width;
         }
 
@@ -1355,7 +1301,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             int length = GetIPELabelLength(g, gridEntry);
-            return (length > _location.X + InternalLabelWidth);
+            return length > _location.X + InternalLabelWidth;
         }
 
         protected virtual void DrawLabel(Graphics g, int row, Rectangle rect, bool selected, bool fLongLabelRequest, ref Rectangle clipRect)
@@ -1367,10 +1313,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing label for property " + gridEntry.PropertyLabel);
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"Drawing label for property {gridEntry.PropertyLabel}");
 
-            Point newOrigin = new Point(rect.X, rect.Y);
-            Rectangle cr = Rectangle.Intersect(rect, clipRect);
+            var newOrigin = new Point(rect.X, rect.Y);
+            var cr = Rectangle.Intersect(rect, clipRect);
 
             if (cr.IsEmpty)
             {
@@ -1415,11 +1361,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing value for property " + gridEntry.PropertyLabel);
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"Drawing value for property {gridEntry.PropertyLabel}");
 
             Rectangle r = GetRectangle(row, RowValue);
-            Point newOrigin = new Point(r.X, r.Y);
-            Rectangle cr = Rectangle.Intersect(clipRect, r);
+            var newOrigin = new Point(r.X, r.Y);
+            var cr = Rectangle.Intersect(clipRect, r);
 
             if (cr.IsEmpty)
             {
@@ -1460,7 +1406,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            // if we are in an errorState, just put the focus back on the Edit
+            // If we are in an errorState, just put the focus back on the Edit.
             if (_errorState != ERROR_NONE && Edit.Visible)
             {
                 Edit.Focus();
@@ -1485,7 +1431,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             else if (Edit.Visible)
             {
                 Edit.Focus();
-                SelectEdit(false);
+                SelectEdit();
             }
 
             return;
@@ -1500,7 +1446,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Property " + gridEntry.PropertyLabel + " double clicked");
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"Property {gridEntry.PropertyLabel} double clicked");
 
             if (!toggleExpand || type == RowValue)
             {
@@ -1516,7 +1462,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 catch (Exception ex)
                 {
                     SetCommitError(ERROR_THROWN);
-                    ShowInvalidMessage(gridEntry.PropertyLabel, null, ex);
+                    ShowInvalidMessage(gridEntry.PropertyLabel, ex);
                     return;
                 }
             }
@@ -1556,15 +1502,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (Edit.Visible)
             {
                 Edit.Focus();
-                SelectEdit(false);
+                SelectEdit();
                 return;
             }
         }
 
-        public Font GetBaseFont()
-        {
-            return Font;
-        }
+        public Font GetBaseFont() => Font;
 
         public Font GetBoldFont()
         {
@@ -1584,9 +1527,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <returns>The found grid element.</returns>
         internal GridEntry GetElementFromPoint(int x, int y)
         {
-            Point point = new Point(x, y);
+            var point = new Point(x, y);
             GridEntryCollection allGridEntries = GetAllGridEntries();
-            GridEntry[] targetEntries = new GridEntry[allGridEntries.Count];
+            var targetEntries = new GridEntry[allGridEntries.Count];
             try
             {
                 GetGridEntriesFromOutline(allGridEntries, 0, allGridEntries.Count - 1, targetEntries);
@@ -1607,59 +1550,24 @@ namespace System.Windows.Forms.PropertyGridInternal
             return null;
         }
 
-        private bool GetFlag(short flag)
-        {
-            return (_flags & flag) != 0;
-        }
+        private bool GetFlag(short flag) => (_flags & flag) != 0;
 
-        public virtual Color GetLineColor()
-        {
-            return OwnerGrid.LineColor;
-        }
+        public virtual Color GetLineColor() => OwnerGrid.LineColor;
 
-        public virtual Color GetSelectedItemWithFocusForeColor()
-        {
-            return OwnerGrid.SelectedItemWithFocusForeColor;
-        }
+        public virtual Color GetSelectedItemWithFocusForeColor() => OwnerGrid.SelectedItemWithFocusForeColor;
 
-        public virtual Color GetSelectedItemWithFocusBackColor()
-        {
-            return OwnerGrid.SelectedItemWithFocusBackColor;
-        }
+        public virtual Color GetSelectedItemWithFocusBackColor() => OwnerGrid.SelectedItemWithFocusBackColor;
 
-        public virtual IntPtr GetHostHandle()
-        {
-            return Handle;
-        }
+        public virtual IntPtr GetHostHandle() => Handle;
 
-        public virtual int GetLabelWidth()
-        {
-            return InternalLabelWidth;
-        }
+        public virtual int GetLabelWidth() => InternalLabelWidth;
 
-        internal bool IsExplorerTreeSupported
-        {
-            get => OwnerGrid.CanShowVisualStyleGlyphs && VisualStyleRenderer.IsSupported;
-        }
+        internal bool IsExplorerTreeSupported => OwnerGrid.CanShowVisualStyleGlyphs && VisualStyleRenderer.IsSupported;
 
-        public virtual int GetOutlineIconSize()
-        {
-            if (IsExplorerTreeSupported)
-            {
-                return _outlineSizeExplorerTreeStyle;
-            }
-            else
-            {
-                return _outlineSize;
-            }
-        }
+        public virtual int GetOutlineIconSize() => IsExplorerTreeSupported ? _outlineSizeExplorerTreeStyle : _outlineSize;
 
-        public virtual int GetGridEntryHeight()
-        {
-            return RowHeight;
-        }
+        public virtual int GetGridEntryHeight() => RowHeight;
 
-        // for qa automation
         internal int GetPropertyLocation(string propName, bool getXY, bool rowValue)
         {
             if (_allGridEntries is not null && _allGridEntries.Count > 0)
@@ -1708,35 +1616,17 @@ namespace System.Windows.Forms.PropertyGridInternal
             return null;
         }
 
-        public virtual int GetSplitterWidth()
-        {
-            return 1;
-        }
+        public virtual int GetSplitterWidth() => 1;
 
-        public virtual int GetTotalWidth()
-        {
-            return GetLabelWidth() + GetSplitterWidth() + GetValueWidth();
-        }
+        public virtual int GetTotalWidth() => GetLabelWidth() + GetSplitterWidth() + GetValueWidth();
 
-        public virtual int GetValuePaintIndent()
-        {
-            return _paintIndent;
-        }
+        public virtual int GetValuePaintIndent() => _paintIndent;
 
-        public virtual int GetValuePaintWidth()
-        {
-            return _paintWidth;
-        }
+        public virtual int GetValuePaintWidth() => _paintWidth;
 
-        public virtual int GetValueStringIndent()
-        {
-            return EditIndent;
-        }
+        public virtual int GetValueStringIndent() => EditIndent;
 
-        public virtual int GetValueWidth()
-        {
-            return (int)(InternalLabelWidth * (_labelRatio - 1));
-        }
+        public virtual int GetValueWidth() => (int)(InternalLabelWidth * (_labelRatio - 1));
 
         /// <summary>
         ///  Displays the provided control in a drop down.  When possible, the
@@ -1746,7 +1636,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         ///  nicely.  If the user performs an action that would cause the drop down
         ///  to prematurely disappear the control will be hidden.
         /// </summary>
-        public void /* cpr IWindowsFormsEditorService. */ DropDownControl(Control ctl)
+        public void DropDownControl(Control ctl)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:DropDownControl");
             Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "DropDownControl(ctl = " + ctl.GetType().Name + ")");
@@ -1763,9 +1653,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             Rectangle rectScreen = Screen.FromControl(Edit).WorkingArea;
             size.Width = Math.Max(rect.Width + 1, size.Width);
 
-            // Not needed... CYMAXDDLHEIGHT used to be 200, but why limit it???
-            //size.Height = Math.Min(size.Height,CYMAXDDLHEIGHT);
-
             loc.X = Math.Min(rectScreen.X + rectScreen.Width - size.Width,
                              Math.Max(rectScreen.X, loc.X + rect.X + rect.Width - size.Width));
             loc.Y += rect.Y;
@@ -1780,16 +1667,17 @@ namespace System.Windows.Forms.PropertyGridInternal
                 _dropDownHolder.ResizeUp = false;
             }
 
-            // control is a top=level window. standard way of setparent on the control is prohibited for top-level controls.
+            // Control is a top level window. Standard way of set parent on the control is prohibited for top-level controls.
             // It is unknown why this control was created as a top-level control. Windows does not recommend this way of setting parent.
             // We are not touching this for this release. We may revisit it in next release.
+
             User32.SetWindowLong(_dropDownHolder, User32.GWL.HWNDPARENT, new HandleRef(this, Handle));
             _dropDownHolder.SetBounds(loc.X, loc.Y, size.Width, size.Height);
             User32.ShowWindow(_dropDownHolder, User32.SW.SHOWNA);
             Edit.Filter = true;
             _dropDownHolder.Visible = true;
             _dropDownHolder.FocusComponent();
-            SelectEdit(false);
+            SelectEdit();
 
             var gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is not null)
@@ -1842,7 +1730,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private bool FilterEditWndProc(ref Message m)
         {
-            // if it's the TAB key, we keep it since we'll give them focus with it.
+            // If it's the TAB key, we keep it since we'll give them focus with it.
             if (_dropDownHolder is not null && _dropDownHolder.Visible && m.Msg == (int)User32.WM.KEYDOWN && (int)m.WParam != (int)Keys.Tab)
             {
                 Control ctl = _dropDownHolder.Component;
@@ -1864,7 +1752,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 int index = GetCurrentValueIndex(gridEntry);
 
                 object[] values = gridEntry.GetPropertyValueList();
-                string letter = new string(new char[] { keyChar });
+                string letter = new(new char[] { keyChar });
                 for (int i = 0; i < values.Length; i++)
                 {
                     object valueCur = values[(i + index + 1) % values.Length];
@@ -1874,7 +1762,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         CommitValue(valueCur);
                         if (Edit.Focused)
                         {
-                            SelectEdit(false);
+                            SelectEdit();
                         }
 
                         return true;
@@ -1893,15 +1781,13 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             Keys modifiers = ModifierKeys;
-            if ((int)(modifiers & ~Keys.Shift) != 0)
+            if ((modifiers & ~Keys.Shift) != 0)
             {
                 return false;
             }
 
-            // try to activate the Edit.
-            // we don't activate for +,-, or * on expandable items because they have special meaning
-            // for the tree.
-            //
+            // Try to activate the Edit.
+            // We don't activate for +, -, or * on expandable items because they have special meaning for the tree.
 
             if (_selectedGridEntry is not null)
             {
@@ -1932,7 +1818,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Edit.FilterKeyPress(keyChar);
         }
 
-        private /*protected virtual*/ GridEntry FindEquivalentGridEntry(GridEntryCollection ipeHier)
+        private GridEntry FindEquivalentGridEntry(GridEntryCollection ipeHier)
         {
             if (ipeHier is null || ipeHier.Count == 0)
             {
@@ -1957,14 +1843,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                     continue;
                 }
 
-                // if we've got one above, and it's expandable,
-                // expand it
+                // If we've got one above, and it's expandable, expand it.
                 if (targetEntry is not null)
                 {
-                    // how many do we have?
-                    int items = rgipes.Count;
-
-                    // expand and get the new count
+                    // Expand and get the new count.
                     if (!targetEntry.InternalExpanded)
                     {
                         SetExpand(targetEntry, true);
@@ -1977,7 +1859,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 int start = row;
                 targetEntry = null;
 
-                // now, we will only go as many as were expanded...
+                // Now, we will only go as many as were expanded.
                 for (; row < rgipes.Count && ((row - start) <= count); row++)
                 {
                     if (ipeHier.GetEntry(i).NonParentEquals(rgipes[row]))
@@ -1988,7 +1870,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
 
-                // didn't find it...
+                // Didn't find it.
                 if (targetEntry is null)
                 {
                     break;
@@ -2012,7 +1894,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return InvalidPosition;
             }
 
-            Point pt = new Point(RowLabel, 0);
+            var pt = new Point(RowLabel, 0);
             if (x > InternalLabelWidth + _location.X)
             {
                 pt.X = RowValue;
@@ -2033,22 +1915,22 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private GridEntryCollection GetAllGridEntries()
         {
-            return GetAllGridEntries(false);
+            return GetAllGridEntries(updateCache: false);
         }
 
-        private GridEntryCollection GetAllGridEntries(bool fUpdateCache)
+        private GridEntryCollection GetAllGridEntries(bool updateCache)
         {
             if (_visibleRows == -1 || TotalProps == -1 || !HasEntries)
             {
                 return null;
             }
 
-            if (_allGridEntries is not null && !fUpdateCache)
+            if (_allGridEntries is not null && !updateCache)
             {
                 return _allGridEntries;
             }
 
-            GridEntry[] rgipes = new GridEntry[TotalProps];
+            var rgipes = new GridEntry[TotalProps];
             try
             {
                 GetGridEntriesFromOutline(_topLevelGridEntries, 0, 0, rgipes);
@@ -2171,7 +2053,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             int depth = gridEntry.PropertyDepth;
             if (depth > 0)
             {
-                GridEntry[] entries = new GridEntry[depth + 1];
+                var entries = new GridEntry[depth + 1];
 
                 while (gridEntry is not null && depth >= 0)
                 {
@@ -2186,12 +2068,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             return new GridEntryCollection(null, new GridEntry[] { gridEntry });
         }
 
-        private /*protected virtual*/ GridEntry GetGridEntryFromRow(int row)
+        private GridEntry GetGridEntryFromRow(int row)
         {
             return GetGridEntryFromOffset(row + GetScrollOffset());
         }
 
-        private /*protected virtual*/ GridEntry GetGridEntryFromOffset(int offset)
+        private GridEntry GetGridEntryFromOffset(int offset)
         {
             GridEntryCollection rgipesAll = GetAllGridEntries();
             if (rgipesAll is not null)
@@ -2205,8 +2087,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return null;
         }
 
-        private /*protected virtual*/ int GetGridEntriesFromOutline(GridEntryCollection rgipe, int cCur,
-                                                 int cTarget, GridEntry[] rgipeTarget)
+        private int GetGridEntriesFromOutline(GridEntryCollection rgipe, int cCur, int cTarget, GridEntry[] rgipeTarget)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:GetGridEntriesFromOutline");
             if (rgipe is null || rgipe.Count == 0)
@@ -2214,7 +2095,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return cCur;
             }
 
-            cCur--; // want to account for each entry as we find it.
+            cCur--; // Want to account for each entry as we find it.
 
             for (int cLocal = 0; cLocal < rgipe.Count; cLocal++)
             {
@@ -2271,13 +2152,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public Rectangle GetRectangle(int row, int flRow)
         {
-            Rectangle rect = new Rectangle(0, 0, 0, 0);
+            var rect = new Rectangle(0, 0, 0, 0);
             Size size = GetOurSize();
 
             rect.X = _location.X;
 
-            bool fLabel = ((flRow & RowLabel) != 0);
-            bool fValue = ((flRow & RowValue) != 0);
+            bool fLabel = (flRow & RowLabel) != 0;
+            bool fValue = (flRow & RowValue) != 0;
 
             if (fLabel && fValue)
             {
@@ -2295,7 +2176,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 rect.Width = size.Width - InternalLabelWidth;
             }
 
-            rect.Y = (row) * (RowHeight + 1) + 1 + _location.Y;
+            rect.Y = row * (RowHeight + 1) + 1 + _location.Y;
             rect.Height = RowHeight;
 
             return rect;
@@ -2375,7 +2256,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         private void LayoutWindow(bool invalidate)
         {
             Rectangle rect = ClientRectangle;
-            Size sizeWindow = new Size(rect.Width, rect.Height);
+            var sizeWindow = new Size(rect.Width, rect.Height);
 
             if (_scrollBar is not null)
             {
@@ -2415,14 +2296,14 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:InvalidateRows");
 
-            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Invalidating rows " + startRow.ToString(CultureInfo.InvariantCulture) + " through " + endRow.ToString(CultureInfo.InvariantCulture));
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"Invalidating rows {startRow} through {endRow}");
             Rectangle rect;
 
-            // invalidate from the start row down
+            // Invalidate from the start row down.
             if (endRow == -1)
             {
                 rect = GetRectangle(startRow, type);
-                rect.Height = (Size.Height - rect.Y) - 1;
+                rect.Height = Size.Height - rect.Y - 1;
                 Invalidate(rect);
             }
             else
@@ -2483,14 +2364,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private bool IsScrollValueValid(int newValue)
         {
-            /*Debug.WriteLine("se.newValue = " + se.newValue.ToString());
-            Debug.WriteLine("ScrollBar.Value = " + ScrollBar.Value.ToString());
-            Debug.WriteLine("visibleRows = " + visibleRows.ToString());
-            Debug.WriteLine("totalProps = " + totalProps.ToString());
-            Debug.WriteLine("ScrollBar.Max = " + ScrollBar.Maximum.ToString());
-            Debug.WriteLine("ScrollBar.LargeChange = " + ScrollBar.LargeChange.ToString());*/
-
-            // is this move valid?
+            // Is this move valid?
             if (newValue == ScrollBar.Value ||
                 newValue < 0 ||
                 newValue > ScrollBar.Maximum ||
@@ -2529,19 +2403,19 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             int oldLabelWidth = InternalLabelWidth;
 
-            _labelRatio = ((double)widthPS / (double)(pos - startPS));
+            _labelRatio = widthPS / (double)(pos - startPS);
 
             SetConstants();
 
             if (_selectedRow != -1)
             {
-                // do this to move any editor we have
+                // Do this to move any editor we have.
                 SelectRow(_selectedRow);
             }
 
             Rectangle r = ClientRectangle;
 
-            // if we're moving to the left, just invalidate the values
+            // If we're moving to the left, just invalidate the values.
             if (oldLabelWidth > InternalLabelWidth)
             {
                 int left = InternalLabelWidth - _requiredLabelPaintMargin;
@@ -2549,8 +2423,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else
             {
-                // to the right, just invalidate from where the splitter was
-                // to the right
+                // To the right, just invalidate from where the splitter was.
                 r.X = oldLabelWidth - _requiredLabelPaintMargin;
                 r.Width -= r.X;
                 Invalidate(r);
@@ -2632,17 +2505,15 @@ namespace System.Windows.Forms.PropertyGridInternal
                 UpdateHelpAttributes(null, _selectedGridEntry);
             }
 
-            // For empty GridView, draw a focus-indicator rectangle, just inside GridView borders
+            // For empty GridView, draw a focus-indicator rectangle, just inside GridView borders.
             if (TotalProps <= 0)
             {
                 int doubleOffset = 2 * _offset2Units;
 
                 if ((Size.Width > doubleOffset) && (Size.Height > doubleOffset))
                 {
-                    using (Graphics g = CreateGraphicsInternal())
-                    {
-                        ControlPaint.DrawFocusRectangle(g, new Rectangle(_offset2Units, _offset2Units, Size.Width - doubleOffset, Size.Height - doubleOffset));
-                    }
+                    using Graphics g = CreateGraphicsInternal();
+                    ControlPaint.DrawFocusRectangle(g, new Rectangle(_offset2Units, _offset2Units, Size.Width - doubleOffset, Size.Height - doubleOffset));
                 }
             }
         }
@@ -2650,14 +2521,14 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            SystemEvents.UserPreferenceChanged += new UserPreferenceChangedEventHandler(OnSysColorChange);
+            SystemEvents.UserPreferenceChanged += OnSysColorChange;
         }
 
         protected override void OnHandleDestroyed(EventArgs e)
         {
-            SystemEvents.UserPreferenceChanged -= new UserPreferenceChangedEventHandler(OnSysColorChange);
+            SystemEvents.UserPreferenceChanged -= OnSysColorChange;
+
             // We can leak this if we aren't disposed.
-            //
             if (_toolTip is not null && !RecreatingHandle)
             {
                 _toolTip.Dispose();
@@ -2675,7 +2546,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
                 Edit.Text = gridEntry.GetPropertyTextValue(DropDownListBox.SelectedItem);
                 Edit.Focus();
-                SelectEdit(false);
+                SelectEdit();
             }
 
             SetFlag(FlagDropDownCommit, true);
@@ -2689,7 +2560,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         private void OnListClick(object sender, EventArgs e)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnListClick");
-            GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
+            _ = GetGridEntryFromRow(_selectedRow);
 
             if (DropDownListBox.Items.Count == 0)
             {
@@ -2702,8 +2573,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 object value = DropDownListBox.SelectedItem;
 
-                // don't need the commit because we're committing anyway.
-                //
+                // Don't need the commit because we're committing anyway.
                 SetFlag(FlagDropDownCommit, false);
                 if (value is not null && !CommitText((string)value))
                 {
@@ -2724,7 +2594,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             string text = (string)DropDownListBox.Items[die.Index];
 
-            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing list item, value='" + text + "'");
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"Drawing list item, value='{text}'");
             die.DrawBackground();
             die.DrawFocusRectangle();
 
@@ -2745,7 +2615,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             catch (FormatException ex)
             {
-                ShowFormatExceptionMessage(gridEntry.PropertyLabel, text, ex);
+                ShowFormatExceptionMessage(gridEntry.PropertyLabel, ex);
                 if (DropDownListBox.IsHandleCreated)
                 {
                     DropDownListBox.Visible = false;
@@ -2797,7 +2667,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // For empty GridView, clear the focus indicator that was painted in OnGotFocus()
             if (TotalProps <= 0)
             {
-                Rectangle clearRect = new Rectangle(1, 1, Size.Width - 2, Size.Height - 2);
+                var clearRect = new Rectangle(1, 1, Size.Width - 2, Size.Height - 2);
                 Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"Filling empty gridview rect={clearRect}");
 
                 Color color = BackColor;
@@ -2883,49 +2753,51 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             object value = gridEntry.PropertyValue;
             object[] rgvalues = gridEntry.GetPropertyValueList();
-            if (rgvalues is not null)
+            if (rgvalues is null)
             {
-                for (int i = 0; i < rgvalues.Length; i++)
+                return false;
+            }
+
+            for (int i = 0; i < rgvalues.Length; i++)
+            {
+                object rgvalue = rgvalues[i];
+                if (value is not null && rgvalue is not null && value.GetType() != rgvalue.GetType() && gridEntry.TypeConverter.CanConvertTo(gridEntry, value.GetType()))
                 {
-                    object rgvalue = rgvalues[i];
-                    if (value is not null && rgvalue is not null && value.GetType() != rgvalue.GetType() && gridEntry.TypeConverter.CanConvertTo(gridEntry, value.GetType()))
-                    {
-                        rgvalue = gridEntry.TypeConverter.ConvertTo(gridEntry, CultureInfo.CurrentCulture, rgvalue, value.GetType());
-                    }
+                    rgvalue = gridEntry.TypeConverter.ConvertTo(gridEntry, CultureInfo.CurrentCulture, rgvalue, value.GetType());
+                }
 
-                    bool equal = (value == rgvalue) || (value is not null && value.Equals(rgvalue));
+                bool equal = (value == rgvalue) || (value is not null && value.Equals(rgvalue));
 
-                    if (!equal && value is string && rgvalue is not null)
-                    {
-                        equal = 0 == string.Compare((string)value, rgvalue.ToString(), true, CultureInfo.CurrentCulture);
-                    }
+                if (!equal && value is string @string && rgvalue is not null)
+                {
+                    equal = 0 == string.Compare(@string, rgvalue.ToString(), true, CultureInfo.CurrentCulture);
+                }
 
-                    if (equal)
+                if (equal)
+                {
+                    object valueNew;
+                    if (keyCode == Keys.Up)
                     {
-                        object valueNew = null;
-                        if (keyCode == Keys.Up)
+                        if (i == 0)
                         {
-                            if (i == 0)
-                            {
-                                return true;
-                            }
-
-                            valueNew = rgvalues[i - 1];
-                        }
-                        else
-                        {
-                            if (i == rgvalues.Length - 1)
-                            {
-                                return true;
-                            }
-
-                            valueNew = rgvalues[i + 1];
+                            return true;
                         }
 
-                        CommitValue(gridEntry, valueNew, closeDropDown);
-                        SelectEdit(false);
-                        return true;
+                        valueNew = rgvalues[i - 1];
                     }
+                    else
+                    {
+                        if (i == rgvalues.Length - 1)
+                        {
+                            return true;
+                        }
+
+                        valueNew = rgvalues[i + 1];
+                    }
+
+                    CommitValue(gridEntry, valueNew, closeDropDown);
+                    SelectEdit();
+                    return true;
                 }
             }
 
@@ -2981,19 +2853,17 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnEditLostFocus");
 
-            // believe it or not, this can actually happen.
+            // Believe it or not this can actually happen.
             if (Edit.Focused || (_errorState == ERROR_MSGBOX_UP) || (_errorState == ERROR_THROWN) || GetInPropertySet())
             {
                 return;
             }
 
-            // check to see if the focus is on the drop down or one of it's children
-            // if so, return;
+            // Check to see if the focus is on the drop down or one of it's children. If so, return.
             if (_dropDownHolder is not null && _dropDownHolder.Visible)
             {
                 bool found = false;
-                for (IntPtr hwnd = User32.GetForegroundWindow();
-                    hwnd != IntPtr.Zero; hwnd = User32.GetParent(hwnd))
+                for (IntPtr hwnd = User32.GetForegroundWindow(); hwnd != IntPtr.Zero; hwnd = User32.GetParent(hwnd))
                 {
                     if (hwnd == _dropDownHolder.Handle)
                     {
@@ -3012,14 +2882,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            // if the focus isn't going to a child of the view
+            // If the focus isn't going to a child of the view
             if (!Commit())
             {
                 Edit.Focus();
                 return;
             }
 
-            // change our focus state.
+            // Change our focus state.
             InvokeLostFocus(this, EventArgs.Empty);
         }
 
@@ -3043,9 +2913,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            // check if the click happened within the double click time since the row was selected.
-            // this allows the edits to be selected with two clicks instead of 3 (select row, double click).
-            //
+            // Check if the click happened within the double click time since the row was selected.
+            // This allows the edits to be selected with two clicks instead of 3 (select row, double click).
             long timeStamp = DateTime.Now.Ticks;
             int delta = (int)((timeStamp - _rowSelectTime) / 10000); // make it milliseconds
 
@@ -3138,7 +3007,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     if (!success)
                     {
                         Edit.Focus();
-                        SelectEdit(false);
+                        SelectEdit();
                         return true;
                     }
                 }
@@ -3177,11 +3046,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             Keys keyCode = ke.KeyCode;
             bool fallingThrough = false;
 
-            // Microsoft, we have to do this here because if we are
-            // hosted in a non-windows forms dialog, we never get a chance to
-            // peek at the messages, we just get called,
-            // so we have to do this here...
-            //
+            // We have to do this here because if we are hosted in a non-windows forms dialog, we never get a chance to
+            // peek at the messages, we just get called.
             if (keyCode == Keys.Tab)
             {
                 if (ProcessDialogKey(ke.KeyData))
@@ -3191,7 +3057,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            // Alt-Arrow support... sigh...
+            // Alt-Arrow support..
             if (keyCode == Keys.Down && fAlt && DropDownButton.Visible)
             {
                 F4Selection(false);
@@ -3215,14 +3081,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     case Keys.Up:
                     case Keys.Down:
-                        int pos = (keyCode == Keys.Up ? _selectedRow - 1 : _selectedRow + 1);
+                        int pos = keyCode == Keys.Up ? _selectedRow - 1 : _selectedRow + 1;
                         SelectGridEntry(GetGridEntryFromRow(pos), true);
                         SetFlag(FlagNoDefault, false);
                         return;
                     case Keys.Left:
                         if (fControl)
                         {
-                            // move the splitter 3 pixels to the left
+                            // Move the splitter 3 pixels to the left
                             MoveSplitterTo(InternalLabelWidth - 3);
                             return;
                         }
@@ -3233,7 +3099,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         else
                         {
-                            // Handle non-expand/collapse case of left & right as up & down
+                            // Handle non-expand/collapse case of left & right as up & down.
                             SelectGridEntry(GetGridEntryFromRow(_selectedRow - 1), true);
                         }
 
@@ -3241,7 +3107,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     case Keys.Right:
                         if (fControl)
                         {
-                            // move the splitter 3 pixels to the right
+                            // Move the splitter 3 pixels to the right.
                             MoveSplitterTo(InternalLabelWidth + 3);
                             return;
                         }
@@ -3260,7 +3126,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         else
                         {
-                            // Handle non-expand/collapse case of left & right as up & down
+                            // Handle non-expand/collapse case of left & right as up & down.
                             SelectGridEntry(GetGridEntryFromRow(_selectedRow + 1), true);
                         }
 
@@ -3279,7 +3145,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     case Keys.Home:
                     case Keys.End:
                         GridEntryCollection rgipes = GetAllGridEntries();
-                        int pos2 = (keyCode == Keys.Home ? 0 : rgipes.Count - 1);
+                        int pos2 = keyCode == Keys.Home ? 0 : rgipes.Count - 1;
                         SelectGridEntry(rgipes.GetEntry(pos2), true);
                         return;
                     case Keys.Add:
@@ -3293,7 +3159,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
 
                         SetFlag(FlagIsSpecialKey, true);
-                        bool expand = (keyCode == Keys.Add || keyCode == Keys.Oemplus);
+                        bool expand = keyCode == Keys.Add || keyCode == Keys.Oemplus;
                         SetExpand(gridEntry, expand);
                         Invalidate();
                         ke.Handled = true;
@@ -3312,11 +3178,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                         ke.Handled = false;
                         return;
 
-                    case Keys.Prior:  //PAGE_UP:
-                    case Keys.Next: //PAGE_DOWN
+                    case Keys.Prior:  // PAGE_UP
+                    case Keys.Next:   // PAGE_DOWN
 
-                        bool next = (keyCode == Keys.Next);
-                        //int rowGoal = next ? visibleRows - 1 : 0;
+                        bool next = keyCode == Keys.Next;
                         int offset = next ? _visibleRows - 1 : 1 - _visibleRows;
 
                         int row = _selectedRow;
@@ -3327,13 +3192,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
 
                         if (_selectedRow != -1)
-                        { // actual paging.
+                        {
+                            // Actual paging.
                             int start = GetScrollOffset();
                             SetScrollOffset(start + offset);
                             SetConstants();
                             if (GetScrollOffset() != (start + offset))
                             {
-                                // we didn't make a full page
+                                // We didn't make a full page.
                                 if (next)
                                 {
                                     row = _visibleRows - 1;
@@ -3349,7 +3215,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         Refresh();
                         return;
 
-                    // Copy/paste support...
+                    // Copy/paste support.
 
                     case Keys.Insert:
                         if (fShift && !fControl && !fAlt)
@@ -3360,7 +3226,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         goto case Keys.C;
                     case Keys.C:
-                        // copy text in current property
+                        // Copy text in current property.
                         if (fControl && !fAlt && !fShift)
                         {
                             DoCopyCommand();
@@ -3369,7 +3235,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         break;
                     case Keys.Delete:
-                        // cut text in current property
+                        // Cut text in current property.
                         if (fShift && !fControl && !fAlt)
                         {
                             fallingThrough = true;
@@ -3378,7 +3244,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         break;
                     case Keys.X:
-                        // cut text in current property
+                        // Cut text in current property.
                         if (fallingThrough || (fControl && !fAlt && !fShift))
                         {
                             Clipboard.SetDataObject(gridEntry.GetPropertyTextValue());
@@ -3388,7 +3254,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         break;
                     case Keys.V:
-                        // paste the text
+                        // Paste the text.
                         if (fallingThrough || (fControl && !fAlt && !fShift))
                         {
                             DoPasteCommand();
@@ -3412,42 +3278,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            /* Due to conflicts with other VS commands,
-               we are removing this functionality.
-
-               // Ctrl + Shift + 'X' selects the property that starts with 'X'
-               if (fBoth) {
-                   // now get the array to work with.
-                   GridEntry[] rgipes = GetAllGridEntries();
-                   int cLength = rgipes.Length;
-
-                   // now get our char.
-                   string strCh = (new string(new char[] {(char)ke.KeyCode})).ToLower(CultureInfo.InvariantCulture);
-
-                   int cCur = -1;
-                   if (gridEntry is not null)
-                       for (int i = 0; i < cLength; i++) {
-                           if (rgipes[i] == gridEntry) {
-                               cCur = i;
-                               break;
-                           }
-                       }
-
-                   cCur += 1; // this indicated where we start...
-                   // find next label that starts with this letter.
-                   for (int i = 0; i < cLength; i++) {
-                       GridEntry ipeCur = rgipes[(i + cCur) % cLength];
-                       if (ipeCur.PropertyLabel.ToLower(CultureInfo.InvariantCulture).StartsWith(strCh)) {
-                           if (gridEntry != ipeCur) {
-                               SelectGridEntry(ipeCur,true);
-                               return;
-                           }
-                           break;
-                       }
-                   }
-               }
-            */
-
             if (_selectedGridEntry is not null && _selectedGridEntry.Enumerable &&
                 _dropDownHolder is not null && _dropDownHolder.Visible &&
                 (keyCode == Keys.Up || keyCode == Keys.Down))
@@ -3461,12 +3291,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected override void OnKeyPress(KeyPressEventArgs ke)
         {
-            bool fControl = false; //ke.getControl();
-            bool fShift = false; //ke.getShift();
+            bool fControl = false;
+            bool fShift = false;
             bool fBoth = fControl && fShift;
             if (!fBoth && WillFilterKeyPress(ke.KeyChar))
             {
-                // find next property with letter typed.
+                // Find next property with letter typed.
                 FilterKeyPress(ke.KeyChar);
             }
 
@@ -3475,8 +3305,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected override void OnMouseDown(MouseEventArgs me)
         {
-            // check for a splitter
-            if (me.Button == MouseButtons.Left && SplitterInside(me.X, me.Y) && TotalProps != 0)
+            // Check for a splitter
+            if (me.Button == MouseButtons.Left && SplitterInside(me.X) && TotalProps != 0)
             {
                 if (!Commit())
                 {
@@ -3496,7 +3326,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            // are ew on a propentry?
+            // Are we on a propentry?
             Point pos = FindPosition(me.X, me.Y);
 
             if (pos == InvalidPosition)
@@ -3504,19 +3334,17 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            // Notify that prop entry of the click...but normalize
-            // it's coords first...we really  just need the x, y
+            // Notify that prop entry of the click, but normalize it's coords first. We really just need the x, y.
             GridEntry gridEntry = GetGridEntryFromRow(pos.Y);
 
             if (gridEntry is not null)
             {
-                // get the origin of this pe
+                // Get the origin of this pe.
                 Rectangle r = GetRectangle(pos.Y, RowLabel);
 
                 _lastMouseDown = new Point(me.X, me.Y);
 
-                // offset the mouse points
-                // notify the prop entry
+                // Offset the mouse points & notify the prop entry.
                 if (me.Button == MouseButtons.Left)
                 {
                     gridEntry.OnMouseClick(me.X - r.X, me.Y - r.Y, me.Clicks, me.Button);
@@ -3532,12 +3360,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        // this will make tool tip go away.
         protected override void OnMouseLeave(EventArgs e)
         {
             if (!GetFlag(FlagIsSplitterMove))
             {
-                Cursor = Cursors.Default; // Cursor = null;;
+                Cursor = Cursors.Default;
             }
 
             base.OnMouseLeave(e);
@@ -3546,30 +3373,30 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected override void OnMouseMove(MouseEventArgs me)
         {
             int rowMoveCur;
-            Point pt = Point.Empty;
+            Point point;
             bool onLabel = false;
 
             if (me is null)
             {
                 rowMoveCur = -1;
-                pt = InvalidPosition;
+                point = InvalidPosition;
             }
             else
             {
-                pt = FindPosition(me.X, me.Y);
-                if (pt == InvalidPosition || (pt.X != RowLabel && pt.X != RowValue))
+                point = FindPosition(me.X, me.Y);
+                if (point == InvalidPosition || (point.X != RowLabel && point.X != RowValue))
                 {
                     rowMoveCur = -1;
                     ToolTip.ToolTip = string.Empty;
                 }
                 else
                 {
-                    rowMoveCur = pt.Y;
-                    onLabel = pt.X == RowLabel;
+                    rowMoveCur = point.Y;
+                    onLabel = point.X == RowLabel;
                 }
             }
 
-            if (pt == InvalidPosition || me is null)
+            if (point == InvalidPosition || me is null)
             {
                 return;
             }
@@ -3579,7 +3406,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 MoveSplitterTo(me.X);
             }
 
-            if ((rowMoveCur != TipRow || pt.X != TipColumn) && !GetFlag(FlagIsSplitterMove))
+            if ((rowMoveCur != TipRow || point.X != TipColumn) && !GetFlag(FlagIsSplitterMove))
             {
                 GridEntry gridItem = GetGridEntryFromRow(rowMoveCur);
                 string tip = string.Empty;
@@ -3587,12 +3414,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (gridItem is not null)
                 {
-                    Rectangle itemRect = GetRectangle(pt.Y, pt.X);
+                    Rectangle itemRect = GetRectangle(point.Y, point.X);
                     if (onLabel && gridItem.GetLabelToolTipLocation(me.X - itemRect.X, me.Y - itemRect.Y) != InvalidPoint)
                     {
                         tip = gridItem.LabelToolTipText;
                         TipRow = rowMoveCur;
-                        TipColumn = pt.X;
+                        TipColumn = point.X;
                     }
                     else if (!onLabel && gridItem.ValueToolTipLocation != InvalidPoint && !Edit.Focused)
                     {
@@ -3602,7 +3429,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
 
                         TipRow = rowMoveCur;
-                        TipColumn = pt.X;
+                        TipColumn = point.X;
                     }
                 }
 
@@ -3612,7 +3439,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (User32.IsChild(foregroundWindow, new HandleRef(this, Handle)).IsTrue())
                 {
                     // Don't show the tips if a dropdown is showing
-                    if ((_dropDownHolder is null || _dropDownHolder.Component is null) || rowMoveCur == _selectedRow)
+                    if (_dropDownHolder is null || _dropDownHolder.Component is null || rowMoveCur == _selectedRow)
                     {
                         ToolTip.ToolTip = tip;
                     }
@@ -3623,7 +3450,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            if (TotalProps != 0 && (SplitterInside(me.X, me.Y) || GetFlag(FlagIsSplitterMove)))
+            if (TotalProps != 0 && (SplitterInside(me.X) || GetFlag(FlagIsSplitterMove)))
             {
                 Cursor = Cursors.VSplit;
             }
@@ -3668,10 +3495,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.Assert(_cumulativeVerticalWheelDelta > -NativeMethods.WHEEL_DELTA, "cumulativeVerticalWheelDelta is too small");
             Debug.Assert(_cumulativeVerticalWheelDelta < NativeMethods.WHEEL_DELTA, "cumulativeVerticalWheelDelta is too big");
 
-            // Should this only work if the Edit has focus?  anyway
-            // we use the mouse wheel to change the values in the dropdown if it's
-            // an enumerable value.
-            //
+            // Should this only work if the Edit has focus?
+            // We use the mouse wheel to change the values in the dropdown if it's an enumerable value.
             if (_selectedGridEntry is not null && _selectedGridEntry.Enumerable && Edit.Focused && _selectedGridEntry.IsValueEditable)
             {
                 int index = GetCurrentValueIndex(_selectedGridEntry);
@@ -3702,7 +3527,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             int initialOffset = GetScrollOffset();
             _cumulativeVerticalWheelDelta += me.Delta;
-            float partialNotches = (float)_cumulativeVerticalWheelDelta / (float)NativeMethods.WHEEL_DELTA;
+            float partialNotches = _cumulativeVerticalWheelDelta / (float)NativeMethods.WHEEL_DELTA;
             int fullNotches = (int)partialNotches;
 
             if (wheelScrollLines == -1)
@@ -3735,8 +3560,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             else
             {
                 // SystemInformation.MouseWheelScrollLines doesn't work under terminal server,
-                // it default to the notches per scroll.
-                int scrollBands = (int)((float)wheelScrollLines * partialNotches);
+                // it defaults to the notches per scroll.
+                int scrollBands = (int)(wheelScrollLines * partialNotches);
 
                 if (scrollBands != 0)
                 {
@@ -3756,7 +3581,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         else
                         {
-                            _cumulativeVerticalWheelDelta -= (int)((float)scrollBands * ((float)NativeMethods.WHEEL_DELTA / (float)wheelScrollLines));
+                            _cumulativeVerticalWheelDelta -= (int)(scrollBands * (NativeMethods.WHEEL_DELTA / (float)wheelScrollLines));
                         }
                     }
                     else
@@ -3767,7 +3592,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         else
                         {
-                            _cumulativeVerticalWheelDelta -= (int)((float)scrollBands * ((float)NativeMethods.WHEEL_DELTA / (float)wheelScrollLines));
+                            _cumulativeVerticalWheelDelta -= (int)(scrollBands * (NativeMethods.WHEEL_DELTA / (float)wheelScrollLines));
                         }
                     }
 
@@ -3796,7 +3621,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected override void OnPaint(PaintEventArgs pe)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnPaint");
-            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "On paint called.  Rect=" + pe.ClipRectangle.ToString());
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"On paint called.  Rect={pe.ClipRectangle}");
             Graphics g = pe.Graphics;
 
             int yPos = 0;
@@ -3805,15 +3630,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             Rectangle clipRect = pe.ClipRectangle;
 
-            // give ourselves a little breathing room to account for lines, etc., as well
-            // as the entries themselves.
+            // Give ourselves a little breathing room to account for lines, etc., as well as the entries themselves.
             clipRect.Inflate(0, 2);
 
             try
             {
                 Size sizeWindow = Size;
 
-                // figure out what rows we're painting
+                // Figure out what rows we're painting.
                 Point posStart = FindPosition(clipRect.X, clipRect.Y);
                 Point posEnd = FindPosition(clipRect.X, clipRect.Y + clipRect.Height);
                 if (posStart != InvalidPosition)
@@ -3854,17 +3678,17 @@ namespace System.Windows.Forms.PropertyGridInternal
                     cPropsVisible--;
                 }
 
-                // if we actually have some properties, then start drawing the grid
+                // If we actually have some properties, then start drawing the grid.
                 if (TotalProps > 0)
                 {
-                    // draw splitter
+                    // Draw splitter.
                     cPropsVisible = Math.Min(cPropsVisible, endRow + 1);
 
                     Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing splitter");
                     using var splitterPen = OwnerGrid.LineColor.GetCachedPenScope(GetSplitterWidth());
-                    g.DrawLine(splitterPen, _labelWidth, loc.Y, _labelWidth, (cPropsVisible) * (RowHeight + 1) + loc.Y);
+                    g.DrawLine(splitterPen, _labelWidth, loc.Y, _labelWidth, cPropsVisible * (RowHeight + 1) + loc.Y);
 
-                    // draw lines.
+                    // Draw lines.
                     Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing lines");
                     using var linePen = g.FindNearestColor(OwnerGrid.LineColor).GetCachedPenScope();
 
@@ -3872,25 +3696,25 @@ namespace System.Windows.Forms.PropertyGridInternal
                     int cLineEnd = loc.X + size.Width;
                     int cLineStart = loc.X;
 
-                    // draw values.
+                    // Draw values.
                     int totalWidth = GetTotalWidth() + 1;
 
-                    // draw labels. set clip rect.
+                    // Draw labels. set clip rect.
                     for (int i = startRow; i < cPropsVisible; i++)
                     {
                         try
                         {
-                            // draw the line
-                            cHeightCurRow = (i) * (RowHeight + 1) + loc.Y;
+                            // Draw the line.
+                            cHeightCurRow = i * (RowHeight + 1) + loc.Y;
                             g.DrawLine(linePen, cLineStart, cHeightCurRow, cLineEnd, cHeightCurRow);
 
-                            // draw the value
+                            // Draw the value.
                             DrawValueEntry(g, i, ref clipRect);
 
-                            // draw the label
+                            // Draw the label.
                             Rectangle rect = GetRectangle(i, RowLabel);
                             yPos = rect.Y + rect.Height;
-                            DrawLabel(g, i, rect, (i == _selectedRow), false, ref clipRect);
+                            DrawLabel(g, i, rect, i == _selectedRow, false, ref clipRect);
                             if (i == _selectedRow)
                             {
                                 Edit.Invalidate();
@@ -3903,23 +3727,23 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                     }
 
-                    // draw the bottom line
-                    cHeightCurRow = (cPropsVisible) * (RowHeight + 1) + loc.Y;
+                    // Draw the bottom line
+                    cHeightCurRow = cPropsVisible * (RowHeight + 1) + loc.Y;
                     g.DrawLine(linePen, cLineStart, cHeightCurRow, cLineEnd, cHeightCurRow);
                 }
 
-                // fill anything left with window
+                // Fill anything left.
                 if (yPos < Size.Height)
                 {
                     yPos++;
-                    Rectangle clearRect = new Rectangle(1, yPos, Size.Width - 2, Size.Height - yPos - 1);
+                    var clearRect = new Rectangle(1, yPos, Size.Width - 2, Size.Height - yPos - 1);
                     Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"Filling remaining area rect={clearRect}");
 
                     using var backBrush = BackColor.GetCachedSolidBrushScope();
                     g.FillRectangle(backBrush, clearRect);
                 }
 
-                // Draw outside border
+                // Draw outside border.
                 using var borderPen = OwnerGrid.ViewBorderColor.GetCachedPenScope();
                 g.DrawRectangle(borderPen, 0, 0, sizeWindow.Width - 1, sizeWindow.Height - 1);
 
@@ -3928,16 +3752,14 @@ namespace System.Windows.Forms.PropertyGridInternal
             catch
             {
                 Debug.Fail("Caught exception in OnPaint");
-                // Do nothing.
             }
         }
 
         private void OnGridEntryLabelDoubleClick(object s, EventArgs e)
         {
-            GridEntry gridEntry = (GridEntry)s;
+            var gridEntry = (GridEntry)s;
 
-            // if we've changed since the click (probably because we moved a row into view), bail
-            //
+            // If we've changed since the click (probably because we moved a row into view), bail.
             if (gridEntry != _lastClickedEntry)
             {
                 return;
@@ -3949,9 +3771,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void OnGridEntryValueDoubleClick(object s, EventArgs e)
         {
-            GridEntry gridEntry = (GridEntry)s;
-            // if we've changed since the click (probably because we moved a row into view), bail
-            //
+            var gridEntry = (GridEntry)s;
+
+            // If we've changed since the click (probably because we moved a row into view), bail.
             if (gridEntry != _lastClickedEntry)
             {
                 return;
@@ -3969,7 +3791,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void OnGridEntryOutlineClick(object s, EventArgs e)
         {
-            GridEntry gridEntry = (GridEntry)s;
+            var gridEntry = (GridEntry)s;
             Debug.Assert(gridEntry.Expandable, "non-expandable IPE firing outline click");
 
             Cursor oldCursor = Cursor;
@@ -4000,8 +3822,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (_lastMouseDown != InvalidPosition)
             {
-                // clear the row select time so we don't interpret this as a double click.
-                //
+                // Clear the row select time so we don't interpret this as a double click.
                 _rowSelectTime = 0;
 
                 Point editPoint = PointToScreen(_lastMouseDown);
@@ -4068,17 +3889,16 @@ namespace System.Windows.Forms.PropertyGridInternal
             base.OnVisibleChanged(e);
         }
 
-        // a GridEntry recreated its children
         protected virtual void OnRecreateChildren(object s, GridEntryRecreateChildrenEventArgs e)
         {
-            GridEntry parent = (GridEntry)s;
+            var parent = (GridEntry)s;
 
             if (parent.Expanded)
             {
-                GridEntry[] entries = new GridEntry[_allGridEntries.Count];
+                var entries = new GridEntry[_allGridEntries.Count];
                 _allGridEntries.CopyTo(entries, 0);
 
-                // find the index of the gridEntry that fired the event in our main list.
+                // Find the index of the gridEntry that fired the event in our main list.
                 int parentIndex = -1;
                 for (int i = 0; i < entries.Length; i++)
                 {
@@ -4091,37 +3911,42 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 Debug.Assert(parentIndex != -1, "parent GridEntry not found in allGridEntries");
 
-                // clear our existing handlers
+                // Clear our existing handlers.
                 ClearGridEntryEvents(_allGridEntries, parentIndex + 1, e.OldChildCount);
 
-                // resize the array if it's changed
+                // Resize the array if it's changed.
                 if (e.OldChildCount != e.NewChildCount)
                 {
                     int newArraySize = entries.Length + (e.NewChildCount - e.OldChildCount);
-                    GridEntry[] newEntries = new GridEntry[newArraySize];
+                    var newEntries = new GridEntry[newArraySize];
 
-                    // copy the existing entries up to the parent
+                    // Copy the existing entries up to the parent.
                     Array.Copy(entries, 0, newEntries, 0, parentIndex + 1);
 
-                    // copy the entries after the spot we'll be putting the new ones
-                    Array.Copy(entries, parentIndex + e.OldChildCount + 1, newEntries, parentIndex + e.NewChildCount + 1, entries.Length - (parentIndex + e.OldChildCount + 1));
+                    // Copy the entries after the spot we'll be putting the new ones.
+                    Array.Copy(
+                        entries,
+                        parentIndex + e.OldChildCount + 1,
+                        newEntries,
+                        parentIndex + e.NewChildCount + 1,
+                        entries.Length - (parentIndex + e.OldChildCount + 1));
 
                     entries = newEntries;
                 }
 
-                // from that point, replace the children with the new children.
+                // From that point, replace the children with the new children.
                 GridEntryCollection children = parent.Children;
                 int childCount = children.Count;
 
-                Debug.Assert(childCount == e.NewChildCount, "parent reports " + childCount + " new children, event reports " + e.NewChildCount);
+                Debug.Assert(childCount == e.NewChildCount, $"parent reports {childCount} new children, event reports {e.NewChildCount}");
 
-                // replace the changed items
+                // Replace the changed items.
                 for (int i = 0; i < childCount; i++)
                 {
                     entries[parentIndex + i + 1] = children.GetEntry(i);
                 }
 
-                // reset the array, rehook the handlers.
+                // Reset the array, rehook the handlers.
                 _allGridEntries.Clear();
                 _allGridEntries.AddRange(entries);
                 AddGridEntryEvents(_allGridEntries, parentIndex + 1, childCount);
@@ -4142,22 +3967,18 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             Rectangle newRect = ClientRectangle;
             int yDelta = _lastClientRect == Rectangle.Empty ? 0 : newRect.Height - _lastClientRect.Height;
-            bool lastRow = (_selectedRow + 1) == _visibleRows;
 
-            // if we are hiding or showing the scroll bar, update the selected row
-            // or if we are changing widths
-            //
-            bool sbVisible = ScrollBar.Visible;
+            // If we are changing widths, update the selected row.
 
             if (!_lastClientRect.IsEmpty && newRect.Width > _lastClientRect.Width)
             {
-                Rectangle rectInvalidate = new Rectangle(_lastClientRect.Width - 1, 0, newRect.Width - _lastClientRect.Width + 1, _lastClientRect.Height);
+                var rectInvalidate = new Rectangle(_lastClientRect.Width - 1, 0, newRect.Width - _lastClientRect.Width + 1, _lastClientRect.Height);
                 Invalidate(rectInvalidate);
             }
 
             if (!_lastClientRect.IsEmpty && yDelta > 0)
             {
-                Rectangle rectInvalidate = new Rectangle(0, _lastClientRect.Height - 1, _lastClientRect.Width, newRect.Height - _lastClientRect.Height + 1);
+                var rectInvalidate = new Rectangle(0, _lastClientRect.Height - 1, _lastClientRect.Width, newRect.Height - _lastClientRect.Height + 1);
                 Invalidate(rectInvalidate);
             }
 
@@ -4177,18 +3998,20 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             LayoutWindow(false);
 
-            bool selectionVisible = (_selectedGridEntry is not null && _selectedRow >= 0 && _selectedRow <= _visibleRows);
+            bool selectionVisible = _selectedGridEntry is not null && _selectedRow >= 0 && _selectedRow <= _visibleRows;
             SelectGridEntry(_selectedGridEntry, selectionVisible);
             _lastClientRect = newRect;
         }
 
         private void OnScroll(object sender, ScrollEventArgs se)
         {
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnScroll(" + ScrollBar.Value.ToString(CultureInfo.InvariantCulture) + " -> " + se.NewValue.ToString(CultureInfo.InvariantCulture) + ")");
+            Debug.WriteLineIf(
+                CompModSwitches.DebugGridView.TraceVerbose,
+                $"PropertyGridView:OnScroll({ScrollBar.Value} -> {se.NewValue})");
 
             if (!Commit() || !IsScrollValueValid(se.NewValue))
             {
-                // cancel the move
+                // Cancel the move
                 se.NewValue = ScrollBar.Value;
                 return;
             }
@@ -4204,9 +4027,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             ScrollBar.Value = se.NewValue;
             if (oldGridEntry is not null)
             {
-                // we need to zero out the selected row so we don't try to commit again...since selectedRow is now bogus.
+                // We need to zero out the selected row so we don't try to commit again since selectedRow is now bogus.
                 _selectedRow = -1;
-                SelectGridEntry(oldGridEntry, (ScrollBar.Value == TotalProps ? true : false));
+                SelectGridEntry(oldGridEntry, fPageIn: ScrollBar.Value == TotalProps);
                 int newRow = GetRowFromGridEntry(oldGridEntry);
                 if (oldRow != newRow)
                 {
@@ -4246,12 +4069,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (fEnum && !fBtnDropDown)
                 {
                     DropDownListBox.Items.Clear();
-                    object value = gridEntry.PropertyValue;
+                    _ = gridEntry.PropertyValue;
                     object[] rgItems = gridEntry.GetPropertyValueList();
                     int maxWidth = 0;
 
-                    // The listbox draws with GDI, not GDI+.  So, we
-                    // use a normal DC here.
+                    // The listbox draws with GDI, not GDI+.  So we use a normal DC here.
 
                     using var hdc = new User32.GetDcScope(DropDownListBox.Handle);
 
@@ -4259,7 +4081,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     int iSel = -1;
 
                     // This creates a copy of the given Font, and as such we need to delete it
-                    Gdi32.HFONT hFont = (Gdi32.HFONT)Font.ToHfont();
+                    var hFont = (Gdi32.HFONT)Font.ToHfont();
                     using (var fontScope = new Gdi32.ObjectScope(hFont))
                     {
                         using var fontSelection = new Gdi32.SelectObjectScope(hdc, hFont);
@@ -4268,7 +4090,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         if (rgItems is not null && rgItems.Length > 0)
                         {
                             string s;
-                            Size textSize = new Size();
+                            var textSize = new Size();
 
                             for (int i = 0; i < rgItems.Length; i++)
                             {
@@ -4332,14 +4154,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     Refresh();
 
-                    // We can't do this because
-                    // some dialogs are non-modal, and
-                    // this will pull focus from them.
-                    //
-                    //if (fBtnDialog) {
-                    //      this.Focus();
-                    //}
-
                     if (FocusInside)
                     {
                         SelectGridEntry(gridEntry, false);
@@ -4356,19 +4170,20 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             User32.SendMessageW(ToolTip, (User32.WM)ComCtl32.TTM.ADJUSTRECT, (IntPtr)1, ref rect);
 
-            // now offset it back to screen coords
+            // Now offset it back to screen coords.
             Point locPoint = parent.PointToScreen(new Point(rect.left, rect.top));
 
-            ToolTip.Location = locPoint;   // set the position once so it updates it's size with it's real width.
+            // Set the position once so it updates it's size with it's real width.
+            ToolTip.Location = locPoint;
 
-            int overHang = (ToolTip.Location.X + ToolTip.Size.Width) - SystemInformation.VirtualScreen.Width;
+            int overHang = ToolTip.Location.X + ToolTip.Size.Width - SystemInformation.VirtualScreen.Width;
             if (overHang > 0)
             {
                 locPoint.X -= overHang;
                 ToolTip.Location = locPoint;
             }
 
-            // tell the control we've repositioned it.
+            // Tell the control we've repositioned it.
             ToolTip.Visible = true;
         }
 
@@ -4398,15 +4213,16 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         bool forward = (keyData & Keys.Shift) == 0;
 
-                        Control focusedControl = Control.FromHandle(User32.GetFocus());
+                        Control focusedControl = FromHandle(User32.GetFocus());
 
                         if (focusedControl is null || !IsMyChild(focusedControl))
                         {
                             if (forward)
                             {
                                 TabSelection();
-                                focusedControl = Control.FromHandle(User32.GetFocus());
-                                // make sure the value actually took the focus
+                                focusedControl = FromHandle(User32.GetFocus());
+
+                                // Make sure the value actually took the focus
                                 if (IsMyChild(focusedControl))
                                 {
                                     return true;
@@ -4423,7 +4239,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                         else
                         {
-                            // one of our editors has focus
+                            // One of our editors has focus.
 
                             if (Edit.Focused)
                             {
@@ -4439,8 +4255,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                                         DialogButton.Focus();
                                         return true;
                                     }
-
-                                    // fall through
                                 }
                                 else
                                 {
@@ -4455,8 +4269,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                                     Edit.Focus();
                                     return true;
                                 }
-
-                                // fall through
                             }
                         }
 
@@ -4469,7 +4281,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     case Keys.Return:
                         if (DialogButton.Focused || DropDownButton.Focused)
                         {
-                            OnBtnClick((DialogButton.Focused ? DialogButton : DropDownButton), EventArgs.Empty);
+                            OnBtnClick(DialogButton.Focused ? DialogButton : DropDownButton, EventArgs.Empty);
                             return true;
                         }
                         else if (_selectedGridEntry is not null && _selectedGridEntry.Expandable)
@@ -4497,7 +4309,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        internal /*public virtual*/ void RecursivelyExpand(GridEntry gridEntry, bool fInit, bool expand, int maxExpands)
+        internal void RecursivelyExpand(GridEntry gridEntry, bool fInit, bool expand, int maxExpands)
         {
             if (gridEntry is null || (expand && --maxExpands < 0))
             {
@@ -4528,11 +4340,13 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             Refresh(false, -1, -1);
 
-            //resetting gridoutline rect to recalculate before repaint when viewsort property changed. This is necessary especially when user
-            // changes sort and move to a secondary monitor with different DPI and change view sort back to original.
+            // Resetting gridoutline rect to recalculate before repaint when viewsort property changed.
+            // This is necessary especially when user changes sort and move to a secondary monitor with different
+            // DPI and change view sort back to original.
+
             if (_topLevelGridEntries is not null && DpiHelper.IsScalingRequirementMet)
             {
-                var outlineRectIconSize = GetOutlineIconSize();
+                int outlineRectIconSize = GetOutlineIconSize();
                 foreach (GridEntry gridentry in _topLevelGridEntries)
                 {
                     if (gridentry.OutlineRect.Height != outlineRectIconSize || gridentry.OutlineRect.Width != outlineRectIconSize)
@@ -4542,7 +4356,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            // make sure we got everything
+            // Make sure we got everything
             Invalidate();
         }
 
@@ -4551,17 +4365,15 @@ namespace System.Windows.Forms.PropertyGridInternal
             Refresh(fullRefresh, -1, -1);
         }
 
-        GridPositionData positionData;
-
         private void Refresh(bool fullRefresh, int rowStart, int rowEnd)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Refresh");
-            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Refresh called for rows " + rowStart.ToString(CultureInfo.InvariantCulture) + " through " + rowEnd.ToString(CultureInfo.InvariantCulture));
+            Debug.WriteLineIf(
+                s_gridViewDebugPaint.TraceVerbose,
+                $"Refresh called for rows {rowStart} through {rowEnd}");
             SetFlag(FlagNeedsRefresh, true);
             GridEntry gridEntry = null;
 
-            // There are cases here where the grid could get be disposed.
-            // so just bail.
             if (IsDisposed)
             {
                 return;
@@ -4584,7 +4396,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 int oldLength = TotalProps;
                 object oldObject = _topLevelGridEntries is null || _topLevelGridEntries.Count == 0 ? null : ((GridEntry)_topLevelGridEntries[0]).GetValueOwner();
 
-                // walk up to the main IPE and refresh it.
+                // Walk up to the main IPE and refresh it.
                 if (fullRefresh)
                 {
                     OwnerGrid.RefreshProperties(true);
@@ -4592,7 +4404,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (oldLength > 0 && !GetFlag(FlagNoDefault))
                 {
-                    positionData = CaptureGridPositionData();
+                    _positionData = CaptureGridPositionData();
                     CommonEditorHide(true);
                 }
 
@@ -4616,14 +4428,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     SetConstants();
 
-                    if (positionData is not null)
+                    if (_positionData is not null)
                     {
-                        gridEntry = positionData.Restore(this);
+                        gridEntry = _positionData.Restore(this);
 
-                        // Upon restoring the grid entry position, we don't
-                        // want to page it in
-                        //
-                        object newObject = _topLevelGridEntries is null || _topLevelGridEntries.Count == 0 ? null : ((GridEntry)_topLevelGridEntries[0]).GetValueOwner();
+                        // Upon restoring the grid entry position, we don't want to page it in.
+                        object newObject = _topLevelGridEntries is null || _topLevelGridEntries.Count == 0
+                            ? null
+                            : ((GridEntry)_topLevelGridEntries[0]).GetValueOwner();
                         pageInGridEntry = (gridEntry is null) || oldLength != newLength || newObject != oldObject;
                     }
 
@@ -4650,7 +4462,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 // Release the old positionData which contains reference to previous selected objects.
-                positionData = null;
+                _positionData = null;
                 _lastClickedEntry = null;
             }
 
@@ -4664,7 +4476,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            // in case we added or removed properties
+            // In case we added or removed properties.
 
             OwnerGrid.ClearValueCaches();
 
@@ -4786,7 +4598,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return true;
         }
 
-        private void SelectEdit(bool caretAtEnd)
+        private void SelectEdit()
         {
             if (_edit is not null)
             {
@@ -4794,41 +4606,33 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        // select functions... selectGridEntry and selectRow will select a Row
-        // and install the appropriate editors.
-        //
-        internal /*protected virtual*/ void SelectGridEntry(GridEntry gridEntry, bool fPageIn)
+        internal void SelectGridEntry(GridEntry gridEntry, bool fPageIn)
         {
             if (gridEntry is null)
             {
                 return;
             }
 
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:SelectGridEntry(" + gridEntry.PropertyLabel + ")");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"PropertyGridView:SelectGridEntry({gridEntry.PropertyLabel})");
 
             int row = GetRowFromGridEntry(gridEntry);
             if (row + GetScrollOffset() < 0)
             {
-                // throw exception? return false?
                 return;
             }
 
             int maxRows = (int)Math.Ceiling(((double)GetOurSize().Height) / (1 + RowHeight));
 
             // Determine whether or not we need to page-in this GridEntry
-            //
 
             if (!fPageIn || (row >= 0 && row < (maxRows - 1)))
             {
                 // No need to page-in: either fPageIn is false or the row is already in view
-                //
                 SelectRow(row);
             }
             else
             {
                 // Page-in the selected GridEntry
-                //
-
                 _selectedRow = -1; // clear the selected row since it's no longer a valid number
 
                 int cOffset = GetScrollOffset();
@@ -4840,7 +4644,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 else
                 {
-                    // try to put it one row up from the bottom
+                    // Try to put it one row up from the bottom.
                     int newOffset = row + cOffset - (maxRows - 2);
 
                     if (newOffset >= ScrollBar.Minimum && newOffset < ScrollBar.Maximum)
@@ -4856,7 +4660,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void SelectRow(int row)
         {
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:SelectRow(" + row.ToString(CultureInfo.InvariantCulture) + ")");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"PropertyGridView:SelectRow({row})");
 
             if (!GetFlag(FlagIsNewSelection))
             {
@@ -4877,7 +4681,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             GridEntry gridEntry = GetGridEntryFromRow(row);
 
             // Update our reset command.
-            //
             if (row != _selectedRow)
             {
                 UpdateResetCommand(gridEntry);
@@ -4890,13 +4693,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             UpdateHelpAttributes(_selectedGridEntry, gridEntry);
 
-            // tell the old selection it's not focused any more
+            // Tell the old selection it's not focused any more.
             if (_selectedGridEntry is not null)
             {
                 _selectedGridEntry.HasFocus = false;
             }
 
-            // selection not visible.
+            // Selection not visible.
             if (row < 0 || row >= _visibleRows)
             {
                 CommonEditorHide();
@@ -4906,7 +4709,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            // leave current selection.
+            // Leave current selection.
             if (gridEntry is null)
             {
                 return;
@@ -4928,31 +4731,33 @@ namespace System.Windows.Forms.PropertyGridInternal
             Rectangle rect = GetRectangle(row, RowValue);
             string s = gridEntry.GetPropertyTextValue();
 
-            // what components are we using?
+            // What components are we using?
             bool fBtnDropDown = gridEntry.NeedsDropDownButton | gridEntry.Enumerable;
             bool fBtnDialog = gridEntry.NeedsCustomEditorButton;
-            bool fEdit = gridEntry.IsTextEditable;
             bool fPaint = gridEntry.IsCustomPaint;
 
             rect.X += 1;
             rect.Width -= 1;
 
-            // we want to allow builders on read-only properties
+            // We want to allow builders on read-only properties
             if ((fBtnDialog || fBtnDropDown) && !gridEntry.ShouldRenderReadOnly && FocusInside)
             {
-                Control btn = fBtnDropDown ? (Control)DropDownButton : (Control)DialogButton;
-                Size sizeBtn = DpiHelper.IsScalingRequirementMet ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight) :
-                                                                               new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
-                Rectangle rectTarget = new Rectangle(rect.X + rect.Width - sizeBtn.Width,
-                                                      rect.Y,
-                                                      sizeBtn.Width, rect.Height);
-                CommonEditorUse(btn, rectTarget);
-                sizeBtn = btn.Size;
-                rect.Width -= (sizeBtn.Width);
-                btn.Invalidate();
+                Control button = fBtnDropDown ? DropDownButton : DialogButton;
+                Size sizeBtn = DpiHelper.IsScalingRequirementMet
+                    ? new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight)
+                    : new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
+
+                var rectTarget = new Rectangle(
+                    rect.X + rect.Width - sizeBtn.Width, rect.Y,
+                    sizeBtn.Width, rect.Height);
+
+                CommonEditorUse(button, rectTarget);
+                sizeBtn = button.Size;
+                rect.Width -= sizeBtn.Width;
+                button.Invalidate();
             }
 
-            // if we're painting the value, size the rect between the button and the painted value
+            // If we're painting the value, size the rect between the button and the painted value
             if (fPaint)
             {
                 rect.X += _paintIndent + 1;
@@ -4964,7 +4769,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 rect.Width -= EditIndent + 1;
             }
 
-            if ((GetFlag(FlagIsNewSelection) || !Edit.Focused) && (s is not null && !s.Equals(Edit.Text)))
+            if ((GetFlag(FlagIsNewSelection) || !Edit.Focused) && s is not null && !s.Equals(Edit.Text))
             {
                 Edit.Text = s;
                 _originalTextValue = s;
@@ -5005,7 +4810,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             _selectedGridEntry = gridEntry;
             OwnerGrid.SetStatusBox(gridEntry.PropertyLabel, gridEntry.PropertyDescription);
 
-            // tell the new focused item that it now has focus
+            // Tell the new focused item that it now has focus
             if (_selectedGridEntry is not null)
             {
                 _selectedGridEntry.HasFocus = FocusInside;
@@ -5015,8 +4820,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 Focus();
             }
-
-            //
 
             InvalidateRow(oldSel);
 
@@ -5050,7 +4853,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (size.Width >= 0)
             {
                 _labelRatio = Math.Max(Math.Min(_labelRatio, 9), 1.1);
-                _labelWidth = _location.X + (int)((double)size.Width / _labelRatio);
+                _labelWidth = _location.X + (int)(size.Width / _labelRatio);
             }
 
             int oldWidth = _labelWidth;
@@ -5068,16 +4871,15 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (adjustWidth && size.Width >= 0)
             {
-                _labelRatio = ((double)GetOurSize().Width / (double)(oldWidth - _location.X));
-                //labelWidth = loc.X + (int) ((double)size.Width / labelRatio);
+                _labelRatio = GetOurSize().Width / (double)(oldWidth - _location.X);
             }
 
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tsize       :" + size.ToString());
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tlocation   :" + _location.ToString());
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tvisibleRows:" + (_visibleRows).ToString(CultureInfo.InvariantCulture));
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tlabelWidth :" + (_labelWidth).ToString(CultureInfo.InvariantCulture));
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tlabelRatio :" + (_labelRatio).ToString(CultureInfo.InvariantCulture));
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\trowHeight  :" + (RowHeight).ToString(CultureInfo.InvariantCulture));
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"\tsize       :{size}");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"\tlocation   :{_location}");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"\tvisibleRows:{_visibleRows}");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"\tlabelWidth :{_labelWidth}");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"\tlabelRatio :{_labelRatio}");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"\trowHeight  :{RowHeight}");
 #if DEBUG
             if (rgipesAll is null)
             {
@@ -5085,7 +4887,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else
             {
-                Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "\tIPE Count  :" + (rgipesAll.Count).ToString(CultureInfo.InvariantCulture));
+                Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"\tIPE Count  :{rgipesAll.Count}");
             }
 #endif
         }
@@ -5114,7 +4916,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         break;
                 }
 
-                Debug.WriteLine("PropertyGridView:SetCommitError(error=" + err + ", capture=" + capture.ToString() + ")");
+                Debug.WriteLine($"PropertyGridView:SetCommitError(error={err}, capture={capture})");
             }
 #endif
             _errorState = error;
@@ -5126,68 +4928,68 @@ namespace System.Windows.Forms.PropertyGridInternal
             Edit.HookMouseDown = capture;
         }
 
-        internal /*public virtual*/ void SetExpand(GridEntry gridEntry, bool value)
+        internal void SetExpand(GridEntry gridEntry, bool value)
         {
-            if (gridEntry is not null && gridEntry.Expandable)
+            if (gridEntry is null || !gridEntry.Expandable)
             {
-                int row = GetRowFromGridEntry(gridEntry);
-                int countFromEnd = _visibleRows - row;
-                int curRow = _selectedRow;
+                return;
+            }
 
-                // if the currently selected row is below us, we need to commit now
-                // or the offsets will be wrong
-                if (_selectedRow != -1 && row < _selectedRow && Edit.Visible)
+            int row = GetRowFromGridEntry(gridEntry);
+            int curRow = _selectedRow;
+
+            // If the currently selected row is below us, we need to commit now or the offsets will be wrong.
+            if (_selectedRow != -1 && row < _selectedRow && Edit.Visible)
+            {
+                // This will cause the commit.
+                Focus();
+            }
+
+            int offset = GetScrollOffset();
+            int items = TotalProps;
+
+            gridEntry.InternalExpanded = value;
+
+            var oldExpandedState = value ? UiaCore.ExpandCollapseState.Collapsed : UiaCore.ExpandCollapseState.Expanded;
+            var newExpandedState = value ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
+            _selectedGridEntry?.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
+                UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
+                oldExpandedState,
+                newExpandedState);
+
+            RecalculateProps();
+            GridEntry ipeSelect = _selectedGridEntry;
+            if (!value)
+            {
+                for (GridEntry ipeCur = ipeSelect; ipeCur is not null; ipeCur = ipeCur.ParentGridEntry)
                 {
-                    // this will cause the commit
-                    Focus();
-                }
-
-                int offset = GetScrollOffset();
-                int items = TotalProps;
-
-                gridEntry.InternalExpanded = value;
-
-                var oldExpandedState = value ? UiaCore.ExpandCollapseState.Collapsed : UiaCore.ExpandCollapseState.Expanded;
-                var newExpandedState = value ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
-                _selectedGridEntry?.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
-                    UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
-                    oldExpandedState,
-                    newExpandedState);
-
-                RecalculateProps();
-                GridEntry ipeSelect = _selectedGridEntry;
-                if (!value)
-                {
-                    for (GridEntry ipeCur = ipeSelect; ipeCur is not null; ipeCur = ipeCur.ParentGridEntry)
+                    if (ipeCur.Equals(gridEntry))
                     {
-                        if (ipeCur.Equals(gridEntry))
-                        {
-                            ipeSelect = gridEntry;
-                        }
+                        ipeSelect = gridEntry;
                     }
                 }
-
-                row = GetRowFromGridEntry(gridEntry);
-
-                SetConstants();
-
-                int newItems = TotalProps - items;
-
-                if (value && newItems > 0 && newItems < _visibleRows && (row + (newItems)) >= _visibleRows && newItems < curRow)
-                {
-                    // scroll to show the newly opened items.
-                    SetScrollOffset((TotalProps - items) + offset);
-                }
-
-                Invalidate();
-
-                SelectGridEntry(ipeSelect, false);
-
-                int scroll = GetScrollOffset();
-                SetScrollOffset(0);
-                SetConstants();
-                SetScrollOffset(scroll);
             }
+
+            row = GetRowFromGridEntry(gridEntry);
+
+            SetConstants();
+
+            int newItems = TotalProps - items;
+
+            if (value && newItems > 0 && newItems < _visibleRows && (row + newItems) >= _visibleRows && newItems < curRow)
+            {
+                // Scroll to show the newly opened items.
+                SetScrollOffset(TotalProps - items + offset);
+            }
+
+            Invalidate();
+
+            SelectGridEntry(ipeSelect, false);
+
+            int scroll = GetScrollOffset();
+            SetScrollOffset(0);
+            SetConstants();
+            SetScrollOffset(scroll);
         }
 
         private void SetFlag(short flag, bool value)
@@ -5215,7 +5017,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        // C#r
         internal virtual bool _Commit()
         {
             return Commit();
@@ -5259,7 +5060,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (!success)
                 {
                     Edit.Focus();
-                    SelectEdit(false);
+                    SelectEdit();
                 }
                 else
                 {
@@ -5290,7 +5091,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal bool CommitValue(GridEntry ipeCur, object value, bool closeDropDown = true)
         {
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:CommitValue(" + (value is null ? "null" : value.ToString()) + ")");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"PropertyGridView:CommitValue({value?.ToString() ?? "null"})");
 
             int propCount = ipeCur.ChildCount;
             bool capture = Edit.HookMouseDown;
@@ -5302,8 +5103,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             catch
             {
-                // if the getter is failing, we still want to let
-                // the set happen.
+                // If the getter is failing, we still want to let the set happen.
             }
 
             try
@@ -5312,10 +5112,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     SetFlag(FlagInPropertySet, true);
 
-                    //if this propentry is enumerable, then once a value is selected from the editor,
-                    //we'll want to close the drop down (like true/false).  Otherwise, if we're
-                    //working with Anchor for ex., then we should be able to select different values
-                    //from the editor, without having it close every time.
+                    // If this propentry is enumerable, then once a value is selected from the editor,
+                    // we'll want to close the drop down (like true/false).  Otherwise, if we're
+                    // working with Anchor for ex., then we should be able to select different values
+                    // from the editor, without having it close every time.
                     if (ipeCur is not null &&
                         ipeCur.Enumerable &&
                         closeDropDown)
@@ -5337,7 +5137,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 catch (Exception ex)
                 {
                     SetCommitError(ERROR_THROWN);
-                    ShowInvalidMessage(ipeCur.PropertyLabel, value, ex);
+                    ShowInvalidMessage(ipeCur.PropertyLabel, ex);
                     return false;
                 }
             }
@@ -5359,7 +5159,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             _originalTextValue = text;
 
             // Update our reset command.
-            //
             UpdateResetCommand(ipeCur);
 
             if (ipeCur.ChildCount != propCount)
@@ -5369,13 +5168,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 SelectGridEntry(ipeCur, true);
             }
 
-            // in case this guy got disposed...
             if (ipeCur.Disposed)
             {
-                bool editfocused = (_edit is not null && _edit.Focused);
+                bool editfocused = _edit is not null && _edit.Focused;
 
-                // reselect the row to find the replacement.
-                //
+                // Reselect the row to find the replacement.
                 SelectGridEntry(ipeCur, true);
                 ipeCur = _selectedGridEntry;
 
@@ -5392,9 +5189,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private bool CommitText(string text)
         {
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:CommitValue(" + (text is null ? "null" : text.ToString()) + ")");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"PropertyGridView:CommitValue({text ?? "null"})");
 
-            object value = null;
+            object value;
 
             GridEntry ipeCur = _selectedGridEntry;
 
@@ -5416,7 +5213,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             catch (Exception ex)
             {
                 SetCommitError(ERROR_THROWN);
-                ShowInvalidMessage(ipeCur.PropertyLabel, text, ex);
+                ShowInvalidMessage(ipeCur.PropertyLabel, ex);
                 return false;
             }
 
@@ -5463,7 +5260,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 else if (GetScrollOffset() > TotalProps)
                 {
-                    SetScrollOffset((TotalProps + 1) - _visibleRows);
+                    SetScrollOffset(TotalProps + 1 - _visibleRows);
                 }
 
                 bool fHidden = !ScrollBar.Visible;
@@ -5482,11 +5279,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         if (_labelWidth > _location.X + size.Width)
                         {
-                            _labelWidth = _location.X + (int)((double)size.Width / _labelRatio);
+                            _labelWidth = _location.X + (int)(size.Width / _labelRatio);
                         }
                         else
                         {
-                            _labelRatio = ((double)GetOurSize().Width / (double)(_labelWidth - _location.X));
+                            _labelRatio = GetOurSize().Width / (double)(_labelWidth - _location.X);
                         }
                     }
 
@@ -5502,9 +5299,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         ///  use this method rather than showing the dialog directly, as this will
         ///  properly position the dialog and provide it a dialog owner.
         /// </summary>
-        public DialogResult /* IWindowsFormsEditorService. */ ShowDialog(Form dialog)
+        public DialogResult ShowDialog(Form dialog)
         {
-            // try to shift down if sitting right on top of existing owner.
+            // Try to shift down if sitting right on top of existing owner.
             if (dialog.StartPosition == FormStartPosition.CenterScreen)
             {
                 Control topControl = this;
@@ -5519,7 +5316,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         dialog.StartPosition = FormStartPosition.Manual;
                         Point location = topControl.Location;
-                        //
                         location.Offset(25, 25);
                         dialog.Location = location;
                     }
@@ -5528,7 +5324,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             IntPtr priorFocus = User32.GetFocus();
 
-            IUIService service = (IUIService)GetService(typeof(IUIService));
+            var service = (IUIService)GetService(typeof(IUIService));
             DialogResult result;
             if (service is not null)
             {
@@ -5547,21 +5343,13 @@ namespace System.Windows.Forms.PropertyGridInternal
             return result;
         }
 
-        private void ShowFormatExceptionMessage(string propName, object value, Exception ex)
+        private void ShowFormatExceptionMessage(string propName, Exception ex)
         {
-            if (value is null)
-            {
-                value = "(null)";
-            }
+            propName ??= "(unknown)";
 
-            if (propName is null)
-            {
-                propName = "(unknown)";
-            }
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"PropertyGridView:ShowFormatExceptionMessage(prop={propName})");
 
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:ShowFormatExceptionMessage(prop=" + propName + ")");
-
-            // we have to uninstall our hook so the user can push the button!
+            // We have to uninstall our hook so the user can push the button!
             bool hooked = Edit.HookMouseDown;
             Edit.DisableMouseHook = true;
             SetCommitError(ERROR_MSGBOX_UP, false);
@@ -5574,25 +5362,22 @@ namespace System.Windows.Forms.PropertyGridInternal
             var mouseMsg = new User32.MSG();
             while (User32.PeekMessageW(ref mouseMsg,
                 IntPtr.Zero,
-                (User32.WM)User32.WM.MOUSEFIRST,
-                (User32.WM)User32.WM.MOUSELAST,
+                User32.WM.MOUSEFIRST,
+                User32.WM.MOUSELAST,
                 User32.PM.REMOVE).IsTrue())
             {
                 // No-op.
             }
 
-            // These things are just plain useless.
-            //
             if (ex is Reflection.TargetInvocationException)
             {
                 ex = ex.InnerException;
             }
 
             // Try to find an exception message to display
-            //
             string exMessage = ex.Message;
 
-            bool revert = false;
+            bool revert;
 
             while (exMessage is null || exMessage.Length == 0)
             {
@@ -5605,7 +5390,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 exMessage = ex.Message;
             }
 
-            IUIService uiSvc = (IUIService)GetService(typeof(IUIService));
+            var uiSvc = (IUIService)GetService(typeof(IUIService));
 
             ErrorDialog.Message = SR.PBRSFormatExceptionMessage;
             ErrorDialog.Text = SR.PBRSErrorTitle;
@@ -5613,11 +5398,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (uiSvc is not null)
             {
-                revert = (DialogResult.Cancel == uiSvc.ShowDialog(ErrorDialog));
+                revert = DialogResult.Cancel == uiSvc.ShowDialog(ErrorDialog);
             }
             else
             {
-                revert = (DialogResult.Cancel == ShowDialog(ErrorDialog));
+                revert = DialogResult.Cancel == ShowDialog(ErrorDialog);
             }
 
             Edit.DisableMouseHook = false;
@@ -5635,19 +5420,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        internal void ShowInvalidMessage(string propName, object value, Exception ex)
+        internal void ShowInvalidMessage(string propName, Exception ex)
         {
-            if (value is null)
-            {
-                value = "(null)";
-            }
+            propName ??= "(unknown)";
 
-            if (propName is null)
-            {
-                propName = "(unknown)";
-            }
-
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:ShowInvalidMessage(prop=" + propName + ")");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"PropertyGridView:ShowInvalidMessage(prop={propName})");
 
             // we have to uninstall our hook so the user can push the button!
             bool hooked = Edit.HookMouseDown;
@@ -5665,18 +5442,15 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // No-op.
             }
 
-            // These things are just plain useless.
-            //
             if (ex is Reflection.TargetInvocationException)
             {
                 ex = ex.InnerException;
             }
 
             // Try to find an exception message to display
-            //
             string exMessage = ex.Message;
 
-            bool revert = false;
+            bool revert;
 
             while (exMessage is null || exMessage.Length == 0)
             {
@@ -5689,7 +5463,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 exMessage = ex.Message;
             }
 
-            IUIService uiSvc = (IUIService)GetService(typeof(IUIService));
+            var uiSvc = (IUIService)GetService(typeof(IUIService));
 
             ErrorDialog.Message = SR.PBRSErrorInvalidPropertyValue;
             ErrorDialog.Text = SR.PBRSErrorTitle;
@@ -5697,11 +5471,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (uiSvc is not null)
             {
-                revert = (DialogResult.Cancel == uiSvc.ShowDialog(ErrorDialog));
+                revert = DialogResult.Cancel == uiSvc.ShowDialog(ErrorDialog);
             }
             else
             {
-                revert = (DialogResult.Cancel == ShowDialog(ErrorDialog));
+                revert = DialogResult.Cancel == ShowDialog(ErrorDialog);
             }
 
             Edit.DisableMouseHook = false;
@@ -5719,10 +5493,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        private bool SplitterInside(int x, int y)
-        {
-            return (Math.Abs(x - InternalLabelWidth) < 4);
-        }
+        private bool SplitterInside(int x) => Math.Abs(x - InternalLabelWidth) < 4;
 
         private void TabSelection()
         {
@@ -5735,7 +5506,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (Edit.Visible)
             {
                 Edit.Focus();
-                SelectEdit(false);
+                SelectEdit();
             }
             else if (_dropDownHolder is not null && _dropDownHolder.Visible)
             {
@@ -5757,8 +5528,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void UpdateHelpAttributes(GridEntry oldEntry, GridEntry newEntry)
         {
-            // Update the help context with the current property
-            //
+            // Update the help context with the current property.
             IHelpService hsvc = GetHelpService();
             if (hsvc is null || oldEntry == newEntry)
             {
@@ -5800,51 +5570,53 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void UpdateUIBasedOnFont(bool layoutRequired)
         {
-            if (IsHandleCreated && GetFlag(FlagNeedUpdateUIBasedOnFont))
+            if (!IsHandleCreated || !GetFlag(FlagNeedUpdateUIBasedOnFont))
             {
-                try
+                return;
+            }
+
+            try
+            {
+                if (_listBox is not null)
                 {
-                    if (_listBox is not null)
+                    DropDownListBox.ItemHeight = RowHeight + 2;
+                }
+
+                if (_buttonDropDown is not null)
+                {
+                    bool isScalingRequirementMet = DpiHelper.IsScalingRequirementMet;
+                    if (isScalingRequirementMet)
                     {
-                        DropDownListBox.ItemHeight = RowHeight + 2;
+                        _buttonDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight);
+                    }
+                    else
+                    {
+                        _buttonDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
                     }
 
-                    if (_buttonDropDown is not null)
+                    if (_buttonDialog is not null)
                     {
-                        var isScalingRequirementMet = DpiHelper.IsScalingRequirementMet;
+                        DialogButton.Size = DropDownButton.Size;
                         if (isScalingRequirementMet)
                         {
-                            _buttonDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeightForDpi(_deviceDpi), RowHeight);
-                        }
-                        else
-                        {
-                            _buttonDropDown.Size = new Size(SystemInformation.VerticalScrollBarArrowHeight, RowHeight);
-                        }
-
-                        if (_buttonDialog is not null)
-                        {
-                            DialogButton.Size = DropDownButton.Size;
-                            if (isScalingRequirementMet)
-                            {
-                                _buttonDialog.Image = CreateResizedBitmap("dotdotdot", DOTDOTDOT_ICONWIDTH, DOTDOTDOT_ICONHEIGHT);
-                            }
-                        }
-
-                        if (isScalingRequirementMet)
-                        {
-                            _buttonDropDown.Image = CreateResizedBitmap("Arrow", DOWNARROW_ICONWIDTH, DOWNARROW_ICONHEIGHT);
+                            _buttonDialog.Image = CreateResizedBitmap("dotdotdot", DOTDOTDOT_ICONWIDTH, DOTDOTDOT_ICONHEIGHT);
                         }
                     }
 
-                    if (layoutRequired)
+                    if (isScalingRequirementMet)
                     {
-                        LayoutWindow(true);
+                        _buttonDropDown.Image = CreateResizedBitmap("Arrow", DOWNARROW_ICONWIDTH, DOWNARROW_ICONHEIGHT);
                     }
                 }
-                finally
+
+                if (layoutRequired)
                 {
-                    SetFlag(FlagNeedUpdateUIBasedOnFont, false);
+                    LayoutWindow(invalidate: true);
                 }
+            }
+            finally
+            {
+                SetFlag(FlagNeedUpdateUIBasedOnFont, false);
             }
         }
 
@@ -5871,38 +5643,33 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (TotalProps > 0)
             {
-                IMenuCommandService mcs = (IMenuCommandService)GetService(typeof(IMenuCommandService));
+                var mcs = (IMenuCommandService)GetService(typeof(IMenuCommandService));
                 if (mcs is not null)
                 {
                     MenuCommand reset = mcs.FindCommand(PropertyGridCommands.Reset);
                     if (reset is not null)
                     {
-                        reset.Enabled = gridEntry is null ? false : gridEntry.CanResetPropertyValue();
+                        reset.Enabled = gridEntry is not null && gridEntry.CanResetPropertyValue();
                     }
                 }
             }
         }
 
-        // a mini version of process dialog key
-        // for responding to WM_GETDLGCODE
         internal bool WantsTab(bool forward)
         {
             if (forward)
             {
                 if (Focused)
                 {
-                    // we want a tab if the grid has focus and
-                    // we have a button or an Edit
-                    if (DropDownButton.Visible ||
-                        DialogButton.Visible ||
-                        Edit.Visible)
+                    // We want a tab if the grid has focus and we have a button or an Edit.
+                    if (DropDownButton.Visible || DialogButton.Visible || Edit.Visible)
                     {
                         return true;
                     }
                 }
                 else if (Edit.Focused && (DropDownButton.Visible || DialogButton.Visible))
                 {
-                    // if the Edit has focus, and we have a button, we want the tab as well
+                    // If the Edit has focus, and we have a button, we want the tab as well.
                     return true;
                 }
 
@@ -5923,7 +5690,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (m.LParam != IntPtr.Zero)
             {
-                User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+                var nmhdr = (User32.NMHDR*)m.LParam;
 
                 if (nmhdr->hwndFrom == ToolTip.Handle)
                 {
@@ -5932,13 +5699,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                         case ComCtl32.TTN.POP:
                             break;
                         case ComCtl32.TTN.SHOW:
-                            // we want to move the tooltip over where our text would be
+                            // We want to move the tooltip over where our text would be.
                             Point mouseLoc = Cursor.Position;
-
-                            // convert to window coords
                             mouseLoc = PointToClient(mouseLoc);
-
-                            // figure out where we are and apply the offset
                             mouseLoc = FindPosition(mouseLoc.X, mouseLoc.Y);
 
                             if (mouseLoc == InvalidPosition)
@@ -5953,11 +5716,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                                 break;
                             }
 
-                            // get the proper rectangle
+                            // Get the proper rectangle.
                             Rectangle itemRect = GetRectangle(mouseLoc.Y, mouseLoc.X);
                             Point tipPt = Point.Empty;
 
-                            // and if we need a tooltip, move the tooltip control to that point.
+                            // If we need a tooltip, move the tooltip control to that point.
                             if (mouseLoc.X == RowLabel)
                             {
                                 tipPt = curEntry.GetLabelToolTipLocation(mouseLoc.X - itemRect.X, mouseLoc.Y - itemRect.Y);
@@ -5995,11 +5758,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                     Invalidate();
                     break;
 
-                // Microsoft -- if we get focus in the error
-                // state, make sure we push it back to the
-                // Edit or bad bad things can happen with
-                // our state...
-                //
+                // If we get focus in the error state, make sure we push it back to the
+                // Edit or bad bad things can happen with our state.
                 case (int)User32.WM.SETFOCUS:
                     if (!GetInPropertySet() && Edit.Visible && (_errorState != ERROR_NONE || !Commit()))
                     {
@@ -6029,9 +5789,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         if ((ModifierKeys & Keys.Shift) == 0)
                         {
-                            // if we're going backwards, we don't want the tab.
-                            // otherwise, we only want it if we have an edit...
-                            //
+                            // If we're going backwards, we don't want the tab.
+                            // Otherwise we only want it if we have an edit.
                             if (_edit.Visible)
                             {
                                 flags |= (int)User32.DLGC.WANTTAB;
@@ -6039,12 +5798,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                         }
                     }
 
-                    m.Result = (IntPtr)(flags);
+                    m.Result = (IntPtr)flags;
                     return;
 
                 case (int)User32.WM.MOUSEMOVE:
 
-                    // check if it's the same position, of so eat the message
+                    // Check if it's the same position, of so eat the message.
                     if (unchecked((int)(long)m.LParam) == _lastMouseMove)
                     {
                         return;
@@ -6072,10 +5831,8 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <summary>
-        ///  rescale constants for the DPI change
+        ///  Rescale constants for the DPI change
         /// </summary>
-        /// <param name="deviceDpiOld"></param>
-        /// <param name="deviceDpiNew"></param>
         protected override void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
         {
             base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
@@ -6083,7 +5840,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <summary>
-        ///  Rescale constants on this object
+        ///  Rescale constants on this object.
         /// </summary>
         private void RescaleConstants()
         {
@@ -6107,7 +5864,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <summary>
-        ///  private method to recursively reset outlinerect for grid entries ( both visible and invisible)
+        ///  Recursively reset outline rect for grid entries (both visible and invisible)
         /// </summary>
         private void ResetOutline(GridEntry entry)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
@@ -14,35 +14,49 @@ namespace System.Windows.Forms.PropertyGridInternal
 {
     internal class SingleSelectRootGridEntry : GridEntry, IRootGridEntry
     {
-        protected object objValue;
-        protected string objValueClassName;
-        protected GridEntry propDefault;
-        protected IDesignerHost host;
-        protected IServiceProvider baseProvider;
-        protected PropertyTab tab;
-        protected PropertyGridView gridEntryHost;
-        protected AttributeCollection browsableAttributes;
-        private IComponentChangeService changeService;
-        protected bool forceReadOnlyChecked;
+        protected object _objValue;
+        private string _objValueClassName;
+        private GridEntry _propDefault;
+        private IDesignerHost _host;
+        private IServiceProvider _baseProvider;
+        private PropertyTab _tab;
+        private PropertyGridView _gridEntryHost;
+        private AttributeCollection _browsableAttributes;
+        private IComponentChangeService _changeService;
+        protected bool _forceReadOnlyChecked;
 
-        internal SingleSelectRootGridEntry(PropertyGridView gridEntryHost, object value, GridEntry parent, IServiceProvider baseProvider, IDesignerHost host, PropertyTab tab, PropertySort sortType)
-        : base(gridEntryHost.OwnerGrid, parent)
+        internal SingleSelectRootGridEntry(
+            PropertyGridView gridEntryHost,
+            object value,
+            GridEntry parent,
+            IServiceProvider baseProvider,
+            IDesignerHost host,
+            PropertyTab tab,
+            PropertySort sortType)
+            : base(gridEntryHost.OwnerGrid, parent)
         {
             Debug.Assert(value is not null, "Can't browse a null object!");
-            this.host = host;
-            this.gridEntryHost = gridEntryHost;
-            this.baseProvider = baseProvider;
-            this.tab = tab;
-            objValue = value;
-            objValueClassName = TypeDescriptor.GetClassName(objValue);
+            _host = host;
+            _gridEntryHost = gridEntryHost;
+            _baseProvider = baseProvider;
+            _tab = tab;
+            _objValue = value;
+            _objValueClassName = TypeDescriptor.GetClassName(_objValue);
 
             IsExpandable = true;
-            // default to categories
+
+            // Default to categories.
             PropertySort = sortType;
             InternalExpanded = true;
         }
 
-        internal SingleSelectRootGridEntry(PropertyGridView view, object value, IServiceProvider baseProvider, IDesignerHost host, PropertyTab tab, PropertySort sortType) : this(view, value, null, baseProvider, host, tab, sortType)
+        internal SingleSelectRootGridEntry(
+            PropertyGridView view,
+            object value,
+            IServiceProvider baseProvider,
+            IDesignerHost host,
+            PropertyTab tab,
+            PropertySort sortType) : this(view, value, null, baseProvider, host, tab, sortType)
         {
         }
 
@@ -53,12 +67,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (browsableAttributes is null)
+                if (_browsableAttributes is null)
                 {
-                    browsableAttributes = new AttributeCollection(new Attribute[] { BrowsableAttribute.Yes });
+                    _browsableAttributes = new AttributeCollection(new Attribute[] { BrowsableAttribute.Yes });
                 }
 
-                return browsableAttributes;
+                return _browsableAttributes;
             }
             set
             {
@@ -70,16 +84,16 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 bool same = true;
 
-                if (browsableAttributes is not null && value is not null && browsableAttributes.Count == value.Count)
+                if (_browsableAttributes is not null && value is not null && _browsableAttributes.Count == value.Count)
                 {
-                    Attribute[] attr1 = new Attribute[browsableAttributes.Count];
-                    Attribute[] attr2 = new Attribute[value.Count];
+                    var attr1 = new Attribute[_browsableAttributes.Count];
+                    var attr2 = new Attribute[value.Count];
 
-                    browsableAttributes.CopyTo(attr1, 0);
+                    _browsableAttributes.CopyTo(attr1, 0);
                     value.CopyTo(attr2, 0);
 
-                    Array.Sort(attr1, GridEntry.AttributeTypeSorter);
-                    Array.Sort(attr2, GridEntry.AttributeTypeSorter);
+                    Array.Sort(attr1, AttributeTypeSorter);
+                    Array.Sort(attr2, AttributeTypeSorter);
                     for (int i = 0; i < attr1.Length; i++)
                     {
                         if (!attr1[i].Equals(attr2[i]))
@@ -94,7 +108,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     same = false;
                 }
 
-                browsableAttributes = value;
+                _browsableAttributes = value;
 
                 if (!same && Children is not null && Children.Count > 0)
                 {
@@ -107,72 +121,48 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (changeService is null)
+                if (_changeService is null)
                 {
-                    changeService = (IComponentChangeService)GetService(typeof(IComponentChangeService));
+                    _changeService = (IComponentChangeService)GetService(typeof(IComponentChangeService));
                 }
 
-                return changeService;
+                return _changeService;
             }
         }
 
-        internal override bool AlwaysAllowExpand
-        {
-            get
-            {
-                return true;
-            }
-        }
+        internal override bool AlwaysAllowExpand => true;
 
         public override PropertyTab CurrentTab
         {
-            get
-            {
-                return tab;
-            }
-            set
-            {
-                tab = value;
-            }
+            get => _tab;
+            set => _tab = value;
         }
 
         internal override GridEntry DefaultChild
         {
-            get
-            {
-                return propDefault;
-            }
-            set
-            {
-                propDefault = value;
-            }
+            get => _propDefault;
+            set => _propDefault = value;
         }
 
         internal override IDesignerHost DesignerHost
         {
-            get
-            {
-                return host;
-            }
-            set
-            {
-                host = value;
-            }
+            get => _host;
+            set => _host = value;
         }
 
         internal override bool ForceReadOnly
         {
             get
             {
-                if (!forceReadOnlyChecked)
+                if (!_forceReadOnlyChecked)
                 {
-                    ReadOnlyAttribute readOnlyAttr = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(objValue)[typeof(ReadOnlyAttribute)];
-                    if ((readOnlyAttr is not null && !readOnlyAttr.IsDefaultAttribute()) || TypeDescriptor.GetAttributes(objValue).Contains(InheritanceAttribute.InheritedReadOnly))
+                    var readOnlyAttr = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(_objValue)[typeof(ReadOnlyAttribute)];
+                    if ((readOnlyAttr is not null && !readOnlyAttr.IsDefaultAttribute()) || TypeDescriptor.GetAttributes(_objValue).Contains(InheritanceAttribute.InheritedReadOnly))
                     {
                         _flags |= FLAG_FORCE_READONLY;
                     }
 
-                    forceReadOnlyChecked = true;
+                    _forceReadOnlyChecked = true;
                 }
 
                 return base.ForceReadOnly || (GridEntryHost is not null && !GridEntryHost.Enabled);
@@ -181,40 +171,27 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal override PropertyGridView GridEntryHost
         {
-            get
-            {
-                return gridEntryHost;
-            }
-            set
-            {
-                gridEntryHost = value;
-            }
+            get => _gridEntryHost;
+            set => _gridEntryHost = value;
         }
 
-        public override GridItemType GridItemType
-        {
-            get
-            {
-                return GridItemType.Root;
-            }
-        }
+        public override GridItemType GridItemType => GridItemType.Root;
 
         /// <summary>
-        ///  Retrieves the keyword that the VS help dynamic help window will
-        ///  use when this IPE is selected.
+        ///  Retrieves the keyword that the VS help dynamic help window will use when this IPE is selected.
         /// </summary>
         public override string HelpKeyword
         {
             get
             {
-                HelpKeywordAttribute helpAttribute = (HelpKeywordAttribute)TypeDescriptor.GetAttributes(objValue)[typeof(HelpKeywordAttribute)];
+                var helpAttribute = (HelpKeywordAttribute)TypeDescriptor.GetAttributes(_objValue)[typeof(HelpKeywordAttribute)];
 
                 if (helpAttribute is not null && !helpAttribute.IsDefaultAttribute())
                 {
                     return helpAttribute.HelpKeyword;
                 }
 
-                return objValueClassName;
+                return _objValueClassName;
             }
         }
 
@@ -222,20 +199,20 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (objValue is IComponent)
+                if (_objValue is IComponent component)
                 {
-                    ISite site = ((IComponent)objValue).Site;
+                    ISite site = component.Site;
                     if (site is null)
                     {
-                        return objValue.GetType().Name;
+                        return _objValue.GetType().Name;
                     }
 
                     return site.Name;
                 }
 
-                if (objValue is not null)
+                if (_objValue is not null)
                 {
-                    return objValue.ToString();
+                    return _objValue.ToString();
                 }
 
                 return null;
@@ -243,20 +220,16 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <summary>
-        ///  Gets or sets the value for the property that is represented
-        ///  by this GridEntry.
+        ///  Gets or sets the value for the property that is represented by this GridEntry.
         /// </summary>
         public override object PropertyValue
         {
-            get
-            {
-                return objValue;
-            }
+            get => _objValue;
             set
             {
-                object old = objValue;
-                objValue = value;
-                objValueClassName = TypeDescriptor.GetClassName(objValue);
+                object old = _objValue;
+                _objValue = value;
+                _objValueClassName = TypeDescriptor.GetClassName(_objValue);
                 OwnerGrid.ReplaceSelectedObject(old, value);
             }
         }
@@ -272,16 +245,16 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (disposing)
             {
-                host = null;
-                baseProvider = null;
-                tab = null;
-                gridEntryHost = null;
-                changeService = null;
+                _host = null;
+                _baseProvider = null;
+                _tab = null;
+                _gridEntryHost = null;
+                _changeService = null;
             }
 
-            objValue = null;
-            objValueClassName = null;
-            propDefault = null;
+            _objValue = null;
+            _objValueClassName = null;
+            _propDefault = null;
             base.Dispose(disposing);
         }
 
@@ -289,33 +262,33 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             object service = null;
 
-            if (host is not null)
+            if (_host is not null)
             {
-                service = host.GetService(serviceType);
+                service = _host.GetService(serviceType);
             }
 
-            if (service is null && baseProvider is not null)
+            if (service is null && _baseProvider is not null)
             {
-                service = baseProvider.GetService(serviceType);
+                service = _baseProvider.GetService(serviceType);
             }
 
             return service;
         }
 
         /// <summary>
-        ///  Reset the Browsable attributes to the default (BrowsableAttribute.Yes)
+        ///  Reset the Browsable attributes to the default (BrowsableAttribute.Yes).
         /// </summary>
         public void ResetBrowsableAttributes()
         {
-            browsableAttributes = new AttributeCollection(new Attribute[] { BrowsableAttribute.Yes });
+            _browsableAttributes = new AttributeCollection(new Attribute[] { BrowsableAttribute.Yes });
         }
 
         /// <summary>
-        ///  Sets the value of this GridEntry from text
+        ///  Sets the value of this GridEntry from text.
         /// </summary>
         public virtual void ShowCategories(bool fCategories)
         {
-            if (((PropertySort &= PropertySort.Categorized) != 0) != fCategories)
+            if ((PropertySort &= PropertySort.Categorized) != 0 != fCategories)
             {
                 if (fCategories)
                 {
@@ -326,7 +299,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     PropertySort &= ~PropertySort.Categorized;
                 }
 
-                // recreate the children
+                // Recreate the children.
                 if (Expandable && ChildCollection is not null)
                 {
                     CreateChildren();
@@ -336,72 +309,73 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal void CategorizePropEntries()
         {
-            if (Children.Count > 0)
+            if (Children.Count <= 0)
             {
-                GridEntry[] childEntries = new GridEntry[Children.Count];
-                Children.CopyTo(childEntries, 0);
+                return;
+            }
 
-                if ((PropertySort & PropertySort.Categorized) != 0)
+            var childEntries = new GridEntry[Children.Count];
+            Children.CopyTo(childEntries, 0);
+
+            if ((PropertySort & PropertySort.Categorized) == 0)
+            {
+                return;
+            }
+
+            // First, walk through all the entries and group them by their category by adding
+            // them to a hashtable of arraylists.
+
+            Hashtable bins = new();
+            for (int i = 0; i < childEntries.Length; i++)
+            {
+                GridEntry pe = childEntries[i];
+                Debug.Assert(pe is not null);
+                if (pe is not null)
                 {
-                    // first, walk through all the entires and
-                    // group them by their category by adding
-                    // them to a hashtable of arraylists.
-                    //
-                    Hashtable bins = new Hashtable();
-                    for (int i = 0; i < childEntries.Length; i++)
+                    string category = pe.PropertyCategory;
+                    var bin = (ArrayList)bins[category];
+                    if (bin is null)
                     {
-                        GridEntry pe = childEntries[i];
-                        Debug.Assert(pe is not null);
-                        if (pe is not null)
-                        {
-                            string category = pe.PropertyCategory;
-                            ArrayList bin = (ArrayList)bins[category];
-                            if (bin is null)
-                            {
-                                bin = new ArrayList();
-                                bins[category] = bin;
-                            }
-
-                            bin.Add(pe);
-                        }
+                        bin = new ArrayList();
+                        bins[category] = bin;
                     }
 
-                    // now walk through the hashtable
-                    // and create a categorygridentry for each
-                    // category that holds all the properties
-                    // of that category.
-                    //
-                    ArrayList propList = new ArrayList();
-                    IDictionaryEnumerator enumBins = (IDictionaryEnumerator)bins.GetEnumerator();
-                    while (enumBins.MoveNext())
-                    {
-                        ArrayList bin = (ArrayList)enumBins.Value;
-                        if (bin is not null)
-                        {
-                            string category = (string)enumBins.Key;
-                            if (bin.Count > 0)
-                            {
-                                GridEntry[] rgpes = new GridEntry[bin.Count];
-                                bin.CopyTo(rgpes, 0);
-                                try
-                                {
-                                    propList.Add(new CategoryGridEntry(OwnerGrid, this, category, rgpes));
-                                }
-                                catch
-                                {
-                                }
-                            }
-                        }
-                    }
-
-                    childEntries = new GridEntry[propList.Count];
-                    propList.CopyTo(childEntries, 0);
-                    Array.Sort(childEntries, GridEntryComparer.Default);
-
-                    ChildCollection.Clear();
-                    ChildCollection.AddRange(childEntries);
+                    bin.Add(pe);
                 }
             }
+
+            // Now walk through the hashtable and create a categorygridentry for each
+            // category that holds all the properties of that category.
+
+            ArrayList propList = new();
+            IDictionaryEnumerator enumBins = bins.GetEnumerator();
+            while (enumBins.MoveNext())
+            {
+                var bin = (ArrayList)enumBins.Value;
+                if (bin is not null)
+                {
+                    string category = (string)enumBins.Key;
+                    if (bin.Count > 0)
+                    {
+                        var rgpes = new GridEntry[bin.Count];
+                        bin.CopyTo(rgpes, 0);
+                        try
+                        {
+                            propList.Add(new CategoryGridEntry(OwnerGrid, this, category, rgpes));
+                        }
+                        catch
+                        {
+                        }
+                    }
+                }
+            }
+
+            childEntries = new GridEntry[propList.Count];
+            propList.CopyTo(childEntries, 0);
+            Array.Sort(childEntries, GridEntryComparer.Default);
+
+            ChildCollection.Clear();
+            ChildCollection.AddRange(childEntries);
         }
     }
 }


### PR DESCRIPTION
Clean code to get to 0 messages in the Error List pane for most PropertyGrid related classes.

- Tweak var rules to only complain when using var for intrinsics
- Clean up comments
