### PR TITLE
Fix issue 3982 "Use Environment.ProccessId"

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Drawing;
 using static Interop;
 
@@ -127,9 +126,7 @@ namespace System.Windows.Forms
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TextControlTypeId,
                         UiaCore.UIA.NamePropertyId => Name,
                         UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
-#pragma warning disable CA1837 // Use 'Environment.ProcessId'
-                        UiaCore.UIA.ProcessIdPropertyId => Process.GetCurrentProcess().Id,
-#pragma warning restore CA1837 // Use 'Environment.ProcessId'
+                        UiaCore.UIA.ProcessIdPropertyId => Environment.ProcessId,
                         UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                         UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                         UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListView.Focused && _owningListView.FocusedItem == _owningItem,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -843,5 +843,40 @@ namespace System.Windows.Forms.Tests
 
             return listView;
         }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_ProcessId_ReturnCorrectValue()
+        {
+            using ListView list = new();
+            ListViewItem listViewItem1 = new(new string[]
+            {
+            "Test 1",
+            "Item 1",
+            "Something 1"
+            }, -1);
+
+            ColumnHeader columnHeader1 = new();
+            ColumnHeader columnHeader2 = new();
+            ColumnHeader columnHeader3 = new();
+
+            list.Columns.AddRange(new ColumnHeader[]
+            {
+                columnHeader1,
+                columnHeader2,
+                columnHeader3
+            });
+            list.HideSelection = false;
+            list.Items.Add(listViewItem1);
+            list.View = View.Details;
+
+            AccessibleObject subItemAccObj1 = listViewItem1.AccessibilityObject.GetChild(0);
+            AccessibleObject subItemAccObj2 = listViewItem1.AccessibilityObject.GetChild(1);
+            AccessibleObject subItemAccObj3 = listViewItem1.AccessibilityObject.GetChild(2);
+
+            Assert.Equal(Environment.ProcessId, subItemAccObj1.GetPropertyValue(UiaCore.UIA.ProcessIdPropertyId));
+            Assert.Equal(Environment.ProcessId, subItemAccObj2.GetPropertyValue(UiaCore.UIA.ProcessIdPropertyId));
+            Assert.Equal(Environment.ProcessId, subItemAccObj3.GetPropertyValue(UiaCore.UIA.ProcessIdPropertyId));
+            Assert.False(list.IsHandleCreated);
+        }
     }
 }


### PR DESCRIPTION
Removed warning suppression
Placed Environment.ProccessId instead of value
Added unit test for ProccessId property

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3982  


## Proposed changes

- Remove warning suppression
- Place `Environment.ProccessId` instead of value

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- No

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![lvsi1 processId before](https://user-images.githubusercontent.com/58004471/124440769-a6926b80-dd83-11eb-81b0-bcfd28d79ee5.png)

### After

![lvsi1 processId after](https://user-images.githubusercontent.com/58004471/124440767-a5f9d500-dd83-11eb-9393-c1e19d5f5745.png)

## Test methodology <!-- How did you ensure quality? -->

- Inspect
- Unit test


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5200)