### PR TITLE
Rework casting IntPtr by using ParamToInt

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
@@ -1814,7 +1814,7 @@ namespace System.Windows.Forms.Design
                     else
                     {
                         //REVIEW This doesn't look 64-bit safe
-                        return (int)cX.Parent.Handle - (int)cY.Parent.Handle;
+                        return PARAM.ToInt(cX.Parent.Handle) - PARAM.ToInt(cY.Parent.Handle);
                     }
                 }
                 else if (cY != null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ComponentManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ComponentManager.cs
@@ -323,7 +323,7 @@ namespace System.Windows.Forms
 
                                     if (uReason != msoloop.Main)
                                     {
-                                        User32.PostQuitMessage((int)msg.wParam);
+                                        User32.PostQuitMessage(PARAM.ToInt(msg.wParam));
                                     }
 
                                     continueLoop = BOOL.FALSE;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -1067,7 +1067,7 @@ namespace System.Windows.Forms
         internal static void ParkHandle(HandleRef handle, IntPtr dpiAwarenessContext)
         {
             Debug.Assert(User32.IsWindow(handle).IsTrue(), "Handle being parked is not a valid window handle");
-            Debug.Assert(((int)User32.GetWindowLong(handle, User32.GWL.STYLE) & (int)User32.WS.CHILD) != 0, "Only WS_CHILD windows should be parked.");
+            Debug.Assert((PARAM.ToInt(User32.GetWindowLong(handle, User32.GWL.STYLE)) & (int)User32.WS.CHILD) != 0, "Only WS_CHILD windows should be parked.");
 
             ThreadContext threadContext = GetContextForHandle(handle);
             if (threadContext is not null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -404,10 +404,10 @@ namespace System.Windows.Forms
                     IntPtr hwndHdr = User32.SendMessageW(ListView, (User32.WM)LVM.GETHEADER);
                     if (hwndHdr != IntPtr.Zero)
                     {
-                        int nativeColumnCount = (int)User32.SendMessageW(hwndHdr, (User32.WM)HDM.GETITEMCOUNT);
+                        int nativeColumnCount = PARAM.ToInt(User32.SendMessageW(hwndHdr, (User32.WM)HDM.GETITEMCOUNT));
                         if (Index < nativeColumnCount)
                         {
-                            _width = (int)User32.SendMessageW(ListView, (User32.WM)LVM.GETCOLUMNWIDTH, (IntPtr)Index);
+                            _width = PARAM.ToInt(User32.SendMessageW(ListView, (User32.WM)LVM.GETCOLUMNWIDTH, (IntPtr)Index));
                         }
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -752,7 +752,7 @@ namespace System.Windows.Forms
         {
             if (ImeSupported && ImeModeConversion.InputLanguageTable != ImeModeConversion.UnsupportedTable && !IgnoreWmImeNotify)
             {
-                int wparam = (int)m.WParam;
+                int wparam = PARAM.ToInt(m.WParam);
 
                 // The WM_IME_NOTIFY message is not consistent across the different IMEs, particularly the notification type
                 // we care about (IMN_SETCONVERSIONMODE & IMN_SETOPENSTATUS).

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -9515,7 +9515,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal void ProcessUICues(ref Message msg)
         {
-            Keys keyCode = (Keys)((int)msg.WParam) & Keys.KeyCode;
+            Keys keyCode = (Keys)(PARAM.ToInt(msg.WParam)) & Keys.KeyCode;
 
             if (keyCode != Keys.F10 && keyCode != Keys.Menu && keyCode != Keys.Tab)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -523,7 +523,7 @@ namespace System.Windows.Forms
         public override int GetHashCode()
         {
             // Handle is a 64-bit value in 64-bit machines, uncheck here to avoid overflow exceptions.
-            return unchecked((int)_handle);
+            return unchecked(PARAM.ToInt(_handle));
         }
 
         public override bool Equals(object? obj)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -263,7 +263,7 @@ namespace System.Windows.Forms
 
         protected override bool ProcessKeyEventArgs(ref Message m)
         {
-            switch ((Keys)(int)m.WParam)
+            switch ((Keys)PARAM.ToInt(m.WParam))
             {
                 case Keys.Enter:
                     if (m.Msg == (int)User32.WM.CHAR &&

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FontDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FontDialog.cs
@@ -355,15 +355,15 @@ namespace System.Windows.Forms
             switch ((User32.WM)msg)
             {
                 case User32.WM.COMMAND:
-                    if ((int)wparam == 0x402)
+                    if (PARAM.ToInt(wparam) == 0x402)
                     {
                         var logFont = new User32.LOGFONTW();
                         User32.SendMessageW(hWnd, User32.WM.CHOOSEFONT_GETLOGFONT, IntPtr.Zero, ref logFont);
                         UpdateFont(ref logFont);
-                        int index = (int)User32.SendDlgItemMessageW(hWnd, User32.DialogItemID.cmb4, (User32.WM)User32.CB.GETCURSEL);
+                        int index = PARAM.ToInt(User32.SendDlgItemMessageW(hWnd, User32.DialogItemID.cmb4, (User32.WM)User32.CB.GETCURSEL));
                         if (index != User32.CB_ERR)
                         {
-                            UpdateColor((int)User32.SendDlgItemMessageW(hWnd, User32.DialogItemID.cmb4, (User32.WM)User32.CB.GETITEMDATA, (IntPtr)index));
+                            UpdateColor(PARAM.ToInt(User32.SendDlgItemMessageW(hWnd, User32.DialogItemID.cmb4, (User32.WM)User32.CB.GETITEMDATA, (IntPtr)index)));
                         }
 
                         if (NativeWindow.WndProcShouldBeDebuggable)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -6498,7 +6498,7 @@ namespace System.Windows.Forms
                 base.WndProc(ref m);
                 if (MdiControlStrip is null && MdiParentInternal != null && MdiParentInternal.ActiveMdiChildInternal == this)
                 {
-                    int wParam = m.WParam.ToInt32();
+                    int wParam = PARAM.ToInt(m.WParam);
                     MdiParentInternal.UpdateMdiControlStrip(wParam == (int)User32.WINDOW_SIZE.MAXIMIZED);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Returns the culture of the current input language.
         /// </summary>
-        public CultureInfo Culture => new CultureInfo((int)_handle & 0xFFFF);
+        public CultureInfo Culture => new CultureInfo(PARAM.ToInt(_handle) & 0xFFFF);
 
         /// <summary>
         ///  Gets or sets the input language for the current thread.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
@@ -222,7 +222,7 @@ namespace System.Windows.Forms
                         iItem = displayIndex
                     };
                     User32.SendMessageW(owner, (User32.WM)LVM.GETITEMW, IntPtr.Zero, ref lvItem);
-                    return (int)lvItem.lParam;
+                    return PARAM.ToInt(lvItem.lParam);
                 }
                 else
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
@@ -2778,12 +2778,12 @@ namespace System.Windows.Forms
                 byte imeConversionType = imeConversionNone;
 
                 // Check if there's an update to the composition string:
-                if ((m.LParam.ToInt32() & (int)Imm32.GCS.COMPSTR) != 0)
+                if ((PARAM.ToInt(m.LParam) & (int)Imm32.GCS.COMPSTR) != 0)
                 {
                     // The character in the composition has been updated but not yet converted.
                     imeConversionType = imeConversionUpdate;
                 }
-                else if ((m.LParam.ToInt32() & (int)Imm32.GCS.RESULTSTR) != 0)
+                else if ((PARAM.ToInt(m.LParam) & (int)Imm32.GCS.RESULTSTR) != 0)
                 {
                     // The character(s) in the composition has been fully converted.
                     imeConversionType = imeConversionCompleted;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1823,7 +1823,7 @@ namespace System.Windows.Forms
                 sa[0] = DateTimePicker.DateTimeToSysTime(minDate);
                 sa[1] = DateTimePicker.DateTimeToSysTime(maxDate);
                 GDTR flags = GDTR.MIN | GDTR.MAX;
-                if ((int)User32.SendMessageW(this, (User32.WM)MCM.SETRANGE, (IntPtr)flags, ref sa[0]) == 0)
+                if (User32.SendMessageW(this, (User32.WM)MCM.SETRANGE, (IntPtr)flags, ref sa[0]) == IntPtr.Zero)
                 {
                     throw new InvalidOperationException(string.Format(SR.MonthCalendarRange, minDate.ToShortDateString(), maxDate.ToShortDateString()));
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -743,7 +743,7 @@ namespace System.Windows.Forms
             switch ((User32.WM)msg.Msg)
             {
                 case (User32.WM)WM_TRAYMOUSEMESSAGE:
-                    switch ((int)msg.LParam)
+                    switch (PARAM.ToInt(msg.LParam))
                     {
                         case (int)User32.WM.LBUTTONDBLCLK:
                             WmMouseDown(ref msg, MouseButtons.Left, 2);
@@ -798,7 +798,7 @@ namespace System.Windows.Forms
                 case User32.WM.COMMAND:
                     if (IntPtr.Zero == msg.LParam)
                     {
-                        if (Command.DispatchID((int)msg.WParam & 0xFFFF))
+                        if (Command.DispatchID(PARAM.ToInt(msg.WParam) & 0xFFFF))
                         {
                             return;
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -795,7 +795,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmKeyDown(ref Message msg)
         {
-            Keys keyData = (Keys)((int)msg.WParam | (int)ModifierKeys);
+            Keys keyData = (Keys)(PARAM.ToInt(msg.WParam) | (int)ModifierKeys);
             Point locPos = Position;
             int pos = 0;
             int maxPos = 0;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs
@@ -414,7 +414,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Computes and retrieves a hash code for an object.
         /// </summary>
-        public override int GetHashCode() => (int)hmonitor;
+        public override int GetHashCode() => PARAM.ToInt(hmonitor);
 
         /// <summary>
         ///  Called by the SystemEvents class when our display settings are

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -2523,7 +2523,7 @@ namespace System.Windows.Forms
             {
                 if (m.Msg >= (int)User32.WM.KEYFIRST && m.Msg <= (int)User32.WM.KEYLAST)
                 {
-                    if ((m.Msg == (int)User32.WM.KEYDOWN && (int)m.WParam == (int)Keys.Escape)
+                    if ((m.Msg == (int)User32.WM.KEYDOWN && PARAM.ToInt(m.WParam) == (int)Keys.Escape)
                         || (m.Msg == (int)User32.WM.SYSKEYDOWN))
                     {
                         //Notify that splitMOVE was reverted ..

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -946,7 +946,7 @@ namespace System.Windows.Forms
 
         private int AddNativeTabPage(TabPage tabPage)
         {
-            int index = (int)SendMessage(ComCtl32.TCM.INSERTITEMW, (IntPtr)(_tabPageCount + 1), tabPage);
+            int index = PARAM.ToInt(SendMessage(ComCtl32.TCM.INSERTITEMW, (IntPtr)(_tabPageCount + 1), tabPage));
             User32.PostMessageW(this, _tabBaseReLayoutMessage);
             return index;
         }
@@ -1227,7 +1227,7 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                int retIndex = (int)SendMessage(ComCtl32.TCM.INSERTITEMW, (IntPtr)index, tabPage);
+                int retIndex = PARAM.ToInt(SendMessage(ComCtl32.TCM.INSERTITEMW, (IntPtr)index, tabPage));
                 if (retIndex >= 0)
                 {
                     Insert(retIndex, tabPage);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -2106,9 +2106,9 @@ namespace System.Windows.Forms
                     // This is the Chrome Panel collection editor scenario
                     // we had focus, then the Chrome panel was activated and we never went away
                     // when we get focus again, we should reactivate our message filter.
-                    Debug.WriteLineIf(ToolStrip.s_snapFocusDebug.TraceVerbose, "[ToolStripDropDown.WndProc] got a WM_ACTIVATE " + (((int)m.WParam == (int)User32.WA.ACTIVE) ? "WA_ACTIVE" : "WA_INACTIVE") + " - checkin if we need to set the active toolstrip");
+                    Debug.WriteLineIf(ToolStrip.s_snapFocusDebug.TraceVerbose, "[ToolStripDropDown.WndProc] got a WM_ACTIVATE " + ((PARAM.ToInt(m.WParam) == (int)User32.WA.ACTIVE) ? "WA_ACTIVE" : "WA_INACTIVE") + " - checkin if we need to set the active toolstrip");
 
-                    if ((int)m.WParam == (int)User32.WA.ACTIVE)
+                    if (PARAM.ToInt(m.WParam) == (int)User32.WA.ACTIVE)
                     {
                         if (Visible)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.ModalMenuFilter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.ModalMenuFilter.cs
@@ -282,7 +282,7 @@ namespace System.Windows.Forms
 
             internal static void ProcessMenuKeyDown(ref Message m)
             {
-                Keys keyData = (Keys)(int)m.WParam;
+                Keys keyData = (Keys)PARAM.ToInt(m.WParam);
 
                 if (Control.FromHandle(m.HWnd) is ToolStrip toolStrip && !toolStrip.IsDropDown)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -789,7 +789,7 @@ namespace System.Windows.Forms
             };
             User32.GetMenuItemInfoW(new HandleRef(this, _nativeMenuHandle), _nativeMenuCommandID, /*fByPosition instead of ID=*/ BOOL.FALSE, ref info);
 
-            if (info.hbmpItem != IntPtr.Zero && info.hbmpItem.ToInt32() > (int)User32.HBMMENU.POPUP_MINIMIZE)
+            if (info.hbmpItem != IntPtr.Zero && PARAM.ToInt(info.hbmpItem) > (int)User32.HBMMENU.POPUP_MINIMIZE)
             {
                 return Bitmap.FromHbitmap(info.hbmpItem);
             }
@@ -797,7 +797,7 @@ namespace System.Windows.Forms
             // its a system defined bitmap
             int buttonToUse = -1;
 
-            switch (info.hbmpItem.ToInt32())
+            switch (PARAM.ToInt(info.hbmpItem))
             {
                 case (int)User32.HBMMENU.MBAR_CLOSE:
                 case (int)User32.HBMMENU.MBAR_CLOSE_D:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -244,7 +244,7 @@ namespace System.Windows.Forms
                 unsafe
                 { *((IntPtr*)&rc.left) = Handle; }
                 // wparam: 1=include only text, 0=include entire line
-                if ((int)User32.SendMessageW(tv, (User32.WM)TVM.GETITEMRECT, (IntPtr)1, ref rc) == 0)
+                if (User32.SendMessageW(tv, (User32.WM)TVM.GETITEMRECT, (IntPtr)1, ref rc) == IntPtr.Zero)
                 {
                     // This means the node is not visible
                     //
@@ -273,7 +273,7 @@ namespace System.Windows.Forms
                     return Rectangle.Empty;
                 }
 
-                if ((int)User32.SendMessageW(tv, (User32.WM)TVM.GETITEMRECT, IntPtr.Zero, ref rc) == 0)
+                if (User32.SendMessageW(tv, (User32.WM)TVM.GETITEMRECT, IntPtr.Zero, ref rc) == IntPtr.Zero)
                 {
                     // This means the node is not visible
                     //
@@ -677,7 +677,7 @@ namespace System.Windows.Forms
                 unsafe
                 { *((IntPtr*)&rc.left) = Handle; }
 
-                bool visible = ((int)User32.SendMessageW(tv, (User32.WM)TVM.GETITEMRECT, (IntPtr)1, ref rc) != 0);
+                bool visible = User32.SendMessageW(tv, (User32.WM)TVM.GETITEMRECT, (IntPtr)1, ref rc) != IntPtr.Zero;
                 if (visible)
                 {
                     Size size = tv.ClientSize;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -1979,14 +1979,14 @@ namespace System.Windows.Forms
             // This seems to make the Treeview happy.
             if (CheckBoxes)
             {
-                int style = unchecked((int)User32.GetWindowLong(this, User32.GWL.STYLE));
+                int style = PARAM.ToInt(User32.GetWindowLong(this, User32.GWL.STYLE));
                 style |= (int)TVS.CHECKBOXES;
                 User32.SetWindowLong(this, User32.GWL.STYLE, (IntPtr)style);
             }
 
             if (ShowNodeToolTips && !DesignMode)
             {
-                int style = unchecked((int)User32.GetWindowLong(this, User32.GWL.STYLE));
+                int style = PARAM.ToInt(User32.GetWindowLong(this, User32.GWL.STYLE));
                 style |= (int)TVS.INFOTIP;
                 User32.SetWindowLong(this, User32.GWL.STYLE, (IntPtr)style);
             }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/MonthCalendar.MonthCalendarChildAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/MonthCalendar.MonthCalendarChildAccessibleObjectTests.cs
@@ -111,7 +111,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 
             Assert.Equal(3, accessibleObject.RuntimeId.Length);
             Assert.Equal(AccessibleObject.RuntimeIDFirstItem, accessibleObject.RuntimeId[0]);
-            Assert.Equal(control.Handle.ToInt32(), accessibleObject.RuntimeId[1]);
+            Assert.Equal(PARAM.ToInt(control.Handle), accessibleObject.RuntimeId[1]);
             Assert.Equal(accessibleObject.GetChildId(), accessibleObject.RuntimeId[2]);
             Assert.True(control.IsHandleCreated);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/COM2PictureConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/COM2PictureConverterTests.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Forms.Tests.ComponentModel.Com2Interop
             Icon errorIcon = SystemIcons.Error;
 
             var mock = new Mock<IPicture>(MockBehavior.Strict);
-            mock.Setup(m => m.Handle).Returns((int)errorIcon.Handle);
+            mock.Setup(m => m.Handle).Returns(PARAM.ToInt(errorIcon.Handle));
             mock.Setup(m => m.Type).Returns((short)PICTYPE.ICON);
 
             using Icon icon = (Icon)Instance.ConvertNativeToManaged(mock.Object, null);
@@ -65,7 +65,7 @@ namespace System.Windows.Forms.Tests.ComponentModel.Com2Interop
             try
             {
                 var mock = new Mock<IPicture>(MockBehavior.Strict);
-                mock.Setup(m => m.Handle).Returns((int)hBitmap);
+                mock.Setup(m => m.Handle).Returns(PARAM.ToInt(hBitmap));
                 mock.Setup(m => m.Type).Returns((short)PICTYPE.BITMAP);
 
                 using Bitmap bitmap = (Bitmap)Instance.ConvertNativeToManaged(mock.Object, null);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
@@ -1560,7 +1560,7 @@ namespace System.Windows.Forms.Tests
             control.KeyDown += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyDownCallCount++;
             };
@@ -1568,7 +1568,7 @@ namespace System.Windows.Forms.Tests
             control.KeyUp += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyUpCallCount++;
             };
@@ -1607,7 +1607,7 @@ namespace System.Windows.Forms.Tests
             control.KeyDown += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyDownCallCount++;
             };
@@ -1615,7 +1615,7 @@ namespace System.Windows.Forms.Tests
             control.KeyUp += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyUpCallCount++;
             };
@@ -1664,7 +1664,7 @@ namespace System.Windows.Forms.Tests
             control.KeyDown += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyDownCallCount++;
             };
@@ -1672,7 +1672,7 @@ namespace System.Windows.Forms.Tests
             control.KeyUp += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyUpCallCount++;
             };
@@ -1851,7 +1851,7 @@ namespace System.Windows.Forms.Tests
             control.KeyDown += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyDownCallCount++;
             };
@@ -1859,7 +1859,7 @@ namespace System.Windows.Forms.Tests
             control.KeyUp += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyUpCallCount++;
             };
@@ -1898,7 +1898,7 @@ namespace System.Windows.Forms.Tests
             control.KeyDown += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyDownCallCount++;
             };
@@ -1906,7 +1906,7 @@ namespace System.Windows.Forms.Tests
             control.KeyUp += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyUpCallCount++;
             };
@@ -1955,7 +1955,7 @@ namespace System.Windows.Forms.Tests
             control.KeyDown += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyDownCallCount++;
             };
@@ -1963,7 +1963,7 @@ namespace System.Windows.Forms.Tests
             control.KeyUp += (sender, e) =>
             {
                 Assert.Same(control, sender);
-                Assert.Equal((int)wParam, e.KeyValue);
+                Assert.Equal(PARAM.ToInt(wParam), e.KeyValue);
                 e.Handled = handled;
                 keyUpCallCount++;
             };


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- Rework cast using `(int)` and `ToInt32` constructions to `PARAM.ToInt` method

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5203)