### PR TITLE
Implementing invoke action of UpDownButton

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObject.cs
@@ -22,42 +22,9 @@ namespace System.Windows.Forms
 
                     public DirectionButtonAccessibleObject(UpDownButtonsAccessibleObject parent, bool up)
                     {
-                        _parent = parent;
+                        _parent = parent ?? throw new ArgumentNullException(nameof(parent));
                         _up = up;
                     }
-
-                    /// <summary>
-                    ///  Gets the runtime ID.
-                    /// </summary>
-                    internal override int[] RuntimeId => new int[]
-                    {
-                        _parent.RuntimeId[0],
-                        _parent.RuntimeId[1],
-                        _parent.RuntimeId[2],
-                        _up ? 1 : 0
-                    };
-
-                    internal override object GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
-                    {
-                        UiaCore.UIA.NamePropertyId => Name,
-                        UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
-                        UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
-                        UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
-                        UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
-                        UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
-                        _ => base.GetPropertyValue(propertyID),
-                    };
-
-                    internal override UiaCore.IRawElementProviderFragment FragmentNavigate(
-                        UiaCore.NavigateDirection direction) => direction switch
-                        {
-                            UiaCore.NavigateDirection.Parent => Parent,
-                            UiaCore.NavigateDirection.NextSibling => _up ? Parent.GetChild(1) : null,
-                            UiaCore.NavigateDirection.PreviousSibling => _up ? null : Parent.GetChild(0),
-                            _ => base.FragmentNavigate(direction),
-                        };
-
-                    internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => Parent;
 
                     public override Rectangle Bounds
                     {
@@ -82,6 +49,51 @@ namespace System.Windows.Forms
                         }
                     }
 
+                    public override string DefaultAction => SR.AccessibleActionPress;
+
+                    public override void DoDefaultAction()
+                    {
+                        UpDownButtons ownerControl = _parent._owner;
+                        if (!ownerControl.IsHandleCreated)
+                        {
+                            return;
+                        }
+
+                        int buttonId = _up ? (int)ButtonID.Up : (int)ButtonID.Down;
+                        ownerControl.OnUpDown(new UpDownEventArgs(buttonId));
+                    }
+
+                    internal override UiaCore.IRawElementProviderFragment FragmentNavigate(
+                        UiaCore.NavigateDirection direction) => direction switch
+                        {
+                            UiaCore.NavigateDirection.Parent => Parent,
+                            UiaCore.NavigateDirection.NextSibling => _up ? Parent.GetChild(1) : null,
+                            UiaCore.NavigateDirection.PreviousSibling => _up ? null : Parent.GetChild(0),
+                            _ => base.FragmentNavigate(direction),
+                        };
+
+                    internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => Parent;
+
+                    internal override object GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
+                    {
+                        UiaCore.UIA.NamePropertyId => Name,
+                        UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
+                        UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
+                        UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
+                        UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
+                        UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
+                        UiaCore.UIA.LegacyIAccessiblePatternId => IsPatternSupported(propertyID),
+                        UiaCore.UIA.InvokePatternId => IsPatternSupported(propertyID),
+                        _ => base.GetPropertyValue(propertyID),
+                    };
+
+                    internal override bool IsPatternSupported(UiaCore.UIA patternId)
+                    {
+                        return patternId == UiaCore.UIA.LegacyIAccessiblePatternId ||
+                            patternId == UiaCore.UIA.InvokePatternId ||
+                            base.IsPatternSupported(patternId);
+                    }
+
                     public override string Name
                     {
                         get => _up ? SR.UpDownBaseUpButtonAccName : SR.UpDownBaseDownButtonAccName;
@@ -91,6 +103,17 @@ namespace System.Windows.Forms
                     public override AccessibleObject Parent => _parent;
 
                     public override AccessibleRole Role => AccessibleRole.PushButton;
+
+                    /// <summary>
+                    ///  Gets the runtime ID.
+                    /// </summary>
+                    internal override int[] RuntimeId => new int[]
+                    {
+                        _parent.RuntimeId[0],
+                        _parent.RuntimeId[1],
+                        _parent.RuntimeId[2],
+                        _up ? 1 : 0
+                    };
                 }
             }
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
@@ -236,6 +236,7 @@ namespace WinformsControlsTest
             this.domainUpDown1.Size = new System.Drawing.Size(120, 20);
             this.domainUpDown1.TabIndex = 10;
             this.domainUpDown1.Text = "domainUpDown1";
+            this.domainUpDown1.Items.AddRange(new string[] { "First", "Second", "Third", "Fourth" });
             // 
             // Form1
             // 

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DirectionButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/DirectionButtonAccessibleObjectTests.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class DirectionButtonAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsTheory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void DirectionButtonAccessibleObject_Invoke_DoesNothing_IfControlIsNotCreated_InDomainUpDown(int childId)
+        {
+            using DomainUpDown domainUpDown = new();
+            domainUpDown.Items.AddRange(new string[] { "First", "Second", "Third" });
+            domainUpDown.SelectedIndex = 1; // Select the second item
+
+            // UpButton has 0 childId, DownButton has 1 childId
+            AccessibleObject directionButton = domainUpDown.AccessibilityObject.GetChild(1).GetChild(childId);
+            directionButton.Invoke();
+
+            // The selected index is not changed
+            Assert.Equal(1, domainUpDown.SelectedIndex);
+            Assert.False(domainUpDown.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0, 0)]
+        [InlineData(1, 2)]
+        public void DirectionButtonAccessibleObject_Invoke_ChangesValue_InDomainUpDown(int childId, int expectedIndex)
+        {
+            using DomainUpDown domainUpDown = new();
+            domainUpDown.Items.AddRange(new string[] { "First", "Second", "Third" });
+            domainUpDown.SelectedIndex = 1; // Select the second item
+            domainUpDown.CreateControl();
+
+            // UpButton has 0 childId, DownButton has 1 childId
+            AccessibleObject directionButton = domainUpDown.AccessibilityObject.GetChild(1).GetChild(childId);
+            directionButton.Invoke();
+
+            // The selected index is not changed
+            Assert.Equal(expectedIndex, domainUpDown.SelectedIndex);
+            Assert.True(domainUpDown.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void DirectionButtonAccessibleObject_Invoke_DoesNothing_IfControlIsNotCreated_InNumericUpDown(int childId)
+        {
+            using NumericUpDown numericUpDown = new();
+            int testValue = 10;
+            numericUpDown.Value = testValue;
+
+            // UpButton has 0 childId, DownButton has 1 childId
+            AccessibleObject directionButton = numericUpDown.AccessibilityObject.GetChild(1).GetChild(childId);
+            directionButton.Invoke();
+
+            // The value is not changed
+            Assert.Equal(testValue, numericUpDown.Value);
+            Assert.False(numericUpDown.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0, 10, 11)]
+        [InlineData(1, 10, 9)]
+        public void DirectionButtonAccessibleObject_Invoke_ChangesValue_InNumericUpDown(int childId, int testValue, int expected)
+        {
+            using NumericUpDown numericUpDown = new();
+            numericUpDown.Value = testValue;
+            numericUpDown.CreateControl();
+
+            // UpButton has 0 childId, DownButton has 1 childId
+            AccessibleObject directionButton = numericUpDown.AccessibilityObject.GetChild(1).GetChild(childId);
+            directionButton.Invoke();
+
+            Assert.Equal(expected, numericUpDown.Value);
+            Assert.True(numericUpDown.IsHandleCreated);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Overrided `DoDefaultAction` method in `DirectionButtonAccessibleObject` class
- Added unit tests
- Added init items list for domainUpDown1 placed on MultipleControls form

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The invoke action of `UpDownButtons` will be work correctly

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

If you trigger the Invoke action, the value is not updated

![InvokeBefore](https://user-images.githubusercontent.com/58004471/125041806-d7371580-e0a1-11eb-82bd-eb8dfb3b5bad.gif)

### After

You can see correct action result now

![invokeUpDownButton](https://user-images.githubusercontent.com/58004471/124738432-96b08e00-df21-11eb-8f09-3174239223a8.gif)

#### Fix after testing

The `LegacyIAccessible.DefaultAction` property value is "Press" (not null) now:

![action - press](https://user-images.githubusercontent.com/58004471/125456227-a34cfeb8-fa25-41fd-b0dc-fffe57020e6c.png)

![action - press2](https://user-images.githubusercontent.com/58004471/125456235-ce468eed-7833-4ee0-b71a-5f016b3cd10e.png)

## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit tests
- Accessibility tests


## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Inspect
- Accessibility Insights


## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->
- .NET SDK:
Version:   6.0.0-preview.7.21358.2

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5206)