### PR TITLE
Fixing wrong color for label in high contrast mode (port to 3.1)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1259,7 +1259,7 @@ namespace System.Windows.Forms
             return (FlatStyle == FlatStyle.System || !UseCompatibleTextRendering);
         }
 
-// See ComboBox.cs GetComboHeight
+        // See ComboBox.cs GetComboHeight
         internal override Size GetPreferredSizeCore(Size proposedConstraints)
         {
             Size bordersAndPadding = GetBordersAndPadding();
@@ -1491,24 +1491,18 @@ namespace System.Windows.Forms
             }
 
             Color color;
-            if (Enabled && SystemInformation.HighContrast)
+
+            IntPtr hdc = e.Graphics.GetHdc();
+            try
             {
-                color = SystemColors.WindowText;
+                using (WindowsGraphics wg = WindowsGraphics.FromHdc(hdc))
+                {
+                    color = wg.GetNearestColor((Enabled) ? ForeColor : DisabledColor);
+                }
             }
-            else
+            finally
             {
-                IntPtr hdc = e.Graphics.GetHdc();
-                try
-                {
-                    using (WindowsGraphics wg = WindowsGraphics.FromHdc(hdc))
-                    {
-                        color = wg.GetNearestColor((Enabled) ? ForeColor : DisabledColor);
-                    }
-                }
-                finally
-                {
-                    e.Graphics.ReleaseHdc();
-                }
+                e.Graphics.ReleaseHdc();
             }
 
             // Do actual drawing


### PR DESCRIPTION
Fixes #5196

## Proposed changes
- Ported fix for .NET Framework 4.8 ([changeset](http://codeflow/extensions/launcher.html?server=https%3a%2f%2fdevdiv.visualstudio.com%2f&projectId=0bdbc590-a062-4c3f-b0f6-9383f67865ee&reviewId=179226&projectshortname=DevDiv))
- [This code](https://github.com/dotnet/winforms/blob/3fd1247e1c3f0edd2af4dff5114db998f8b96803/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs#L1308) was added to the .NET Framework, but later removed due to an ([792810](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/792810)) issue. Unfortunately, this line remains in the .NET Core 3.1 and next versions, so we see this bug. 

## Regression? 

- Yes (from .NET Core 3.1)

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manually
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
Microsoft Windows [Version 10.0.19041.388]
.NET Core SDK: 6.0.0-preview.7.21352.2

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5214)