### PR TITLE
Resolving "The LocalizedControlType of ImageAlign/TextAlign/Anchor/Dock property is inconsistent in Inspect" for Anchor property

### DIFF
--- a/src/System.Windows.Forms.Design/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Design/src/Resources/SR.resx
@@ -1207,4 +1207,10 @@ Press Ctrl+Enter to accept Text.</value>
   <data name="WindowsFormsTabOrderReadOnly" xml:space="preserve">
     <value>- Read Only</value>
   </data>
+  <data name="AccessibleActionCheck" xml:space="preserve">
+    <value>Check</value>
+  </data>
+  <data name="AccessibleActionUncheck" xml:space="preserve">
+    <value>Uncheck</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.cs.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Ovládací prvek {0} typu ActiveX nelze vytvořit, protože prvek není správně registrován.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">Editor ukotvení</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.de.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Das ActiveX-Steuerelement {0} konnte nicht erstellt werden, da es nicht ordnungsgemäß registriert ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">Anker-Editor</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.es.xlf
@@ -7,6 +7,16 @@
         <target state="translated">No se pudo crear el control ActiveX '{0}' porque no está registrado correctamente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">Editor de delimitadores</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.fr.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Impossible de créer le contrôle ActiveX '{0}', car il n'est pas correctement inscrit.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">Éditeur d'ancres</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.it.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Impossibile creare il controllo ActiveX '{0}' perché non è correttamente registrato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">Ancoraggio dell'editor.</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ja.xlf
@@ -7,6 +7,16 @@
         <target state="translated">正しく登録されていないため、ActiveX コントロール '{0}' を作成できませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">アンカー エディター</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ko.xlf
@@ -7,6 +7,16 @@
         <target state="translated">'{0}' ActiveX 컨트롤이 제대로 등록되어 있지 않으므로 이 컨트롤을 만들 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">앵커 편집기</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pl.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Nie można utworzyć formantu ActiveX '{0}', ponieważ nie został on zarejestrowany poprawnie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">Zakotwicz edytor</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.pt-BR.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Não foi possível criar o controle ActiveX '{0}' porque ele não está registrado corretamente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">Editor de Âncora</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.ru.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Невозможно создать элемент управления ActiveX '{0}', так как он не был должным образом зарегистрирован.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">Редактор привязки</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.tr.xlf
@@ -7,6 +7,16 @@
         <target state="translated">Uygun şekilde kayıtlı olmadığından '{0}' öğesinde ActiveX denetimi oluşturulamadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">Bağlantı Düzenleyicisi</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7,6 +7,16 @@
         <target state="translated">ActiveX 控件“{0}”未正确注册，因此未能创建该控件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">定位点编辑器</target>

--- a/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Design/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7,6 +7,16 @@
         <target state="translated">因為尚未正確註冊，所以無法建立 ActiveX 控制項 '{0}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AccessibleActionCheck">
+        <source>Check</source>
+        <target state="new">Check</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AccessibleActionUncheck">
+        <source>Uncheck</source>
+        <target state="new">Uncheck</target>
+        <note />
+      </trans-unit>
       <trans-unit id="AnchorEditorAccName">
         <source>Anchor Editor</source>
         <target state="translated">錨定編輯器</target>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/AnchorEditor.cs
@@ -69,10 +69,10 @@ namespace System.Windows.Forms.Design
             public AnchorUI(AnchorEditor editor)
             {
                 this.editor = editor;
-                left = new SpringControl(this);
-                right = new SpringControl(this);
-                top = new SpringControl(this);
-                bottom = new SpringControl(this);
+                left = new SpringControl(this) { AccessibleRole = AccessibleRole.CheckButton };
+                right = new SpringControl(this) { AccessibleRole = AccessibleRole.CheckButton };
+                top = new SpringControl(this) { AccessibleRole = AccessibleRole.CheckButton };
+                bottom = new SpringControl(this) { AccessibleRole = AccessibleRole.CheckButton };
                 tabOrder = new[] { left, top, right, bottom };
 
                 InitializeComponent();
@@ -376,6 +376,10 @@ namespace System.Windows.Forms.Design
                     {
                     }
 
+                    public override string DefaultAction => ((SpringControl)Owner).GetSolid()
+                        ? SR.AccessibleActionUncheck
+                        : SR.AccessibleActionCheck;
+
                     public override AccessibleStates State
                     {
                         get
@@ -384,7 +388,7 @@ namespace System.Windows.Forms.Design
 
                             if (((SpringControl)Owner).GetSolid())
                             {
-                                state |= AccessibleStates.Selected;
+                                state |= AccessibleStates.Checked;
                             }
 
                             return state;

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/AnchorEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/AnchorEditorTests.cs
@@ -7,6 +7,7 @@ using System.Drawing.Design;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using System.Reflection;
 
 namespace System.Windows.Forms.Design.Tests
 {
@@ -73,6 +74,26 @@ namespace System.Windows.Forms.Design.Tests
         {
             var editor = new AnchorEditor();
             Assert.False(editor.GetPaintValueSupported(context));
+        }
+
+        [Theory]
+        [InlineData("left")]
+        [InlineData("right")]
+        [InlineData("top")]
+        [InlineData("bottom")]
+        public void AnchorEditor_AnchorUI_ControlType_IsCheckButton(string fieldName)
+        {
+            AnchorEditor editor = new();
+            Type type = editor.GetType()
+                .GetNestedType("AnchorUI", BindingFlags.NonPublic | BindingFlags.Instance);
+            var anchorUI = (Control)Activator.CreateInstance(type, new object[] { editor });
+            var item = (Control)anchorUI.GetType()
+                .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance).GetValue(anchorUI);
+
+            object actual = item.AccessibilityObject.TestAccessor().Dynamic
+                .GetPropertyValue(Interop.UiaCore.UIA.ControlTypePropertyId);
+
+            Assert.Equal(Interop.UiaCore.UIA.CheckBoxControlTypeId, actual);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContentAlignmentEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Windows/Forms/Design/ContentAlignmentEditorTests.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing.Design;
+using Xunit;
+using System.Reflection;
+
+namespace System.Windows.Forms.Design.Tests
+{
+    public class ContentAlignmentEditorTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [Theory]
+        [InlineData("_topLeft")]
+        [InlineData("_topCenter")]
+        [InlineData("_topRight")]
+        [InlineData("_middleLeft")]
+        [InlineData("_middleCenter")]
+        [InlineData("_middleRight")]
+        [InlineData("_bottomLeft")]
+        [InlineData("_bottomCenter")]
+        [InlineData("_bottomRight")]
+        public void ContentAlignmentEditor_ContentAlignmentEditor_ContentUI_IsRadioButton(string fieldName)
+        {
+            ContentAlignmentEditor editor = new();
+            Type type = editor.GetType()
+                .GetNestedType("ContentUI", BindingFlags.NonPublic | BindingFlags.Instance);
+            var contentUI = (Control)Activator.CreateInstance(type);
+            var item = (Control)contentUI.GetType()
+                .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance).GetValue(contentUI);
+
+            object actual = item.AccessibilityObject.TestAccessor().Dynamic
+                .GetPropertyValue(Interop.UiaCore.UIA.ControlTypePropertyId);
+
+            Assert.Equal(Interop.UiaCore.UIA.RadioButtonControlTypeId, actual);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4102

## Proposed changes

- Rework LocalizedControlType of Anchor properties
- Added unit tests

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

The `LocalizedControlType` of following property is inconsistent in Inspect:
- For ImageAlign & TextAlign property, it's radio button.
- For Anchor property, it's panel.
- For Dock property, it's check box.

### After

#### ImageAlign & TextAlign
Nothing changes, because they work like a RadioButton and it's already radio button. 

#### Anchor
The `LocalizedControlType` of Anchor is check box now. The `DefaultAction` is `Check` or `Uncheck`, and `IsInvokePatternAvailable` is `true`.
Anchor control is pronounced correctly by Narrator (like `Top check box checked` or `unchecked`).

![anchor](https://user-images.githubusercontent.com/58004471/125757766-a1f0031a-8089-4cb7-95a3-71aa716e79e2.png)

####  Dock
Not resolved for DockEditor due difficulties fixing mistakes appear in narrator announcement for this control. Created new issue #5307 to fix LocalizedControlType and other properties of the Dock. 

![Dock after](https://user-images.githubusercontent.com/58004471/124886082-94f7d080-dfdc-11eb-99c0-e994fc1dfd95.png)

### In addiction
I don't change base of `DockEditorCheckBox` from CheckBox to RadioButton.
I found comment in the code: "Even though the selections are mutually exclusive, I'm using CheckBoxes instead of RadioButtons because RadioButtons fire Click events whenever they get focus, which is bad when the user is trying to tab to a specific control using the keyboard.".
So I've decided to check this. If we change base of `DockEditorCheckBox` to RadioButton then  the panel with options opens and closes fastly when we try to change Dock. So we have not able to change Dock value using special button.

#### GIF

![DockDeffect](https://user-images.githubusercontent.com/58004471/124887392-cf15a200-dfdd-11eb-82c0-3a76a65cca01.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manually test
- Unit test
- Accessibility test

## Accessibility testing

- Inspect
- Narrator
- Accessibility insight

## Test environment(s)
- .Net SDK: 6.0.100-rc.1.21370.2


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5216)