### PR TITLE
Prevented unit tests failures (#5223)

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
@@ -10510,7 +10510,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new SubControl();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.False(control.ShowFocusCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, control.ShowFocusCues);
         }
 
         [WinFormsTheory]
@@ -10553,7 +10553,7 @@ namespace System.Windows.Forms.Tests
                 Site = mockSite.Object
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.False(control.ShowFocusCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, control.ShowFocusCues);
         }
 
         [WinFormsFact]
@@ -10561,7 +10561,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new SubControl();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.False(control.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, control.ShowKeyboardCues);
         }
 
         [WinFormsTheory]
@@ -10604,7 +10604,7 @@ namespace System.Windows.Forms.Tests
                 Site = mockSite.Object
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(designMode, control.ShowKeyboardCues);
+            Assert.Equal(designMode | SystemInformation.MenuAccessKeysUnderlined, control.ShowKeyboardCues);
         }
 
         public static IEnumerable<object[]> Site_Set_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
@@ -81,7 +81,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);
@@ -162,7 +162,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);
@@ -249,7 +249,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);
@@ -339,7 +339,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);
@@ -427,7 +427,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);
@@ -525,7 +525,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -112,7 +112,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(c.RightToLeft, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.Equal(c.Focused, item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(c.Size, item.Size);
             Assert.Null(item.Tag);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownItemTests.cs
@@ -84,7 +84,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);
@@ -173,7 +173,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);
@@ -272,7 +272,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);
@@ -380,7 +380,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
@@ -82,7 +82,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);
@@ -167,7 +167,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);
@@ -262,7 +262,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(23, 23), item.Size);
             Assert.Null(item.Tag);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripMenuItemTests.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Equal(Keys.None, item.ShortcutKeys);
             Assert.True(item.ShowShortcutKeys);
             Assert.Null(item.Site);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSeparatorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSeparatorTests.cs
@@ -80,7 +80,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(RightToLeft.Inherit, item.RightToLeft);
             Assert.False(item.RightToLeftAutoMirrorImage);
             Assert.False(item.Selected);
-            Assert.False(item.ShowKeyboardCues);
+            Assert.Equal(SystemInformation.MenuAccessKeysUnderlined, item.ShowKeyboardCues);
             Assert.Null(item.Site);
             Assert.Equal(new Size(6, 6), item.Size);
             Assert.Null(item.Tag);


### PR DESCRIPTION
Fixes #5223 (partially)

## Proposed changes

- The `SystemInformation.MenuAccessKeyUnderlined` property used as expected value for checking `Control.ShowKeyboardCues` and `Control.ShowFocusCues` default values for newly created controls in unit tests.

## Customer Impact

- None (unit-tests)

## Regression? 

- No

## Risk

- None

## Test methodology

- Run unit tests on PC with the "Underline access keys when available" option enabled and disabled.

## Test environment(s)

- .NET 6.0.100-preview.6.21317.3
- Windows 10 settings - "Ease of Access" -> "Keyboard" -> "Change how keybord shortcuts work"

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5224)