### PR TITLE
Adding "IsAccessibilityObjectCreated" property

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
@@ -19,21 +19,34 @@ namespace System.Windows.Forms
         public partial class ObjectCollection : IList, IComparer<Entry>
         {
             private readonly ComboBox _owner;
-            private readonly ComboBoxAccessibleObject _ownerComboBoxAccessibleObject;
+            private ComboBoxAccessibleObject _ownerComboBoxAccessibleObject;
             private List<Entry> _innerList;
 
             public ObjectCollection(ComboBox owner)
             {
                 _owner = owner;
+            }
 
-                if (_owner.AccessibilityObject is null)
+            private ComboBoxAccessibleObject OwnerComboBoxAccessibleObject
+            {
+                get
                 {
-                    throw new ArgumentException(nameof(owner));
-                }
+                    if (!_owner.IsAccessibilityObjectCreated)
+                    {
+                        return null;
+                    }
 
-                if (_owner.AccessibilityObject is ComboBoxAccessibleObject accessibleObject)
-                {
-                    _ownerComboBoxAccessibleObject = accessibleObject;
+                    if (_ownerComboBoxAccessibleObject is not null)
+                    {
+                        return _ownerComboBoxAccessibleObject;
+                    }
+
+                    if (_owner.AccessibilityObject is ComboBoxAccessibleObject accessibleObject)
+                    {
+                        _ownerComboBoxAccessibleObject = accessibleObject;
+                    }
+
+                    return _ownerComboBoxAccessibleObject;
                 }
             }
 
@@ -159,7 +172,7 @@ namespace System.Windows.Forms
                 {
                     if (!successful)
                     {
-                        _ownerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
+                        OwnerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
                         Remove(item);
                     }
                 }
@@ -248,7 +261,7 @@ namespace System.Windows.Forms
 
                 InnerList.Clear();
 
-                _ownerComboBoxAccessibleObject?.ItemAccessibleObjects.Clear();
+                OwnerComboBoxAccessibleObject?.ItemAccessibleObjects.Clear();
 
                 _owner._selectedIndex = -1;
                 if (_owner.AutoCompleteSource == AutoCompleteSource.ListItems)
@@ -363,7 +376,7 @@ namespace System.Windows.Forms
                             }
                             else
                             {
-                                _ownerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
+                                OwnerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
                                 InnerList.RemoveAt(index);
                             }
                         }
@@ -388,7 +401,7 @@ namespace System.Windows.Forms
                     _owner.NativeRemoveAt(index);
                 }
 
-                _ownerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
+                OwnerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
                 InnerList.RemoveAt(index);
 
                 if (!_owner.IsHandleCreated && index < _owner._selectedIndex)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -1961,7 +1961,7 @@ namespace System.Windows.Forms
         {
             base.OnMouseDown(e);
 
-            if (_childEdit is not null && ChildEditAccessibleObject.Bounds.Contains(PointToScreen(e.Location)))
+            if (IsAccessibilityObjectCreated && _childEdit is not null && ChildEditAccessibleObject.Bounds.Contains(PointToScreen(e.Location)))
             {
                 ChildEditAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextSelectionChangedEventId);
             }
@@ -2604,14 +2604,17 @@ namespace System.Windows.Forms
             }
 
             // Notify collapsed/expanded property change.
-            AccessibilityObject.RaiseAutomationPropertyChangedEvent(
-                UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
-                UiaCore.ExpandCollapseState.Collapsed,
-                UiaCore.ExpandCollapseState.Expanded);
-
-            if (AccessibilityObject is ComboBoxAccessibleObject accessibleObject)
+            if (IsAccessibilityObjectCreated)
             {
-                accessibleObject.SetComboBoxItemFocus();
+                AccessibilityObject.RaiseAutomationPropertyChangedEvent(
+                    UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
+                    UiaCore.ExpandCollapseState.Collapsed,
+                    UiaCore.ExpandCollapseState.Expanded);
+
+                if (AccessibilityObject is ComboBoxAccessibleObject accessibleObject)
+                {
+                    accessibleObject.SetComboBoxItemFocus();
+                }
             }
         }
 
@@ -2671,7 +2674,7 @@ namespace System.Windows.Forms
         {
             base.OnKeyUp(e);
 
-            if (_childEdit is not null && ContainsNavigationKeyCode(e.KeyCode))
+            if (IsAccessibilityObjectCreated && _childEdit is not null && ContainsNavigationKeyCode(e.KeyCode))
             {
                 ChildEditAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextSelectionChangedEventId);
             }
@@ -2781,23 +2784,26 @@ namespace System.Windows.Forms
                 return;
             }
 
-            if (AccessibilityObject is ComboBoxAccessibleObject accessibleObject &&
-                (DropDownStyle == ComboBoxStyle.DropDownList || DropDownStyle == ComboBoxStyle.DropDown))
+            if (IsAccessibilityObjectCreated)
             {
-                // Announce DropDown- and DropDownList-styled ComboBox item selection using keyboard
-                // in case when Level 3 is enabled and DropDown is not in expanded state. Simple-styled
-                // ComboBox selection is announced by TextProvider.
-                if (_dropDown)
+                if (AccessibilityObject is ComboBoxAccessibleObject accessibleObject &&
+                (DropDownStyle == ComboBoxStyle.DropDownList || DropDownStyle == ComboBoxStyle.DropDown))
                 {
-                    accessibleObject.SetComboBoxItemFocus();
+                    // Announce DropDown- and DropDownList-styled ComboBox item selection using keyboard
+                    // in case when Level 3 is enabled and DropDown is not in expanded state. Simple-styled
+                    // ComboBox selection is announced by TextProvider.
+                    if (_dropDown)
+                    {
+                        accessibleObject.SetComboBoxItemFocus();
+                    }
+
+                    accessibleObject.SetComboBoxItemSelection();
                 }
 
-                accessibleObject.SetComboBoxItemSelection();
-            }
-
-            if (_childEdit is not null)
-            {
-                ChildEditAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextSelectionChangedEventId);
+                if (_childEdit is not null)
+                {
+                    ChildEditAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextSelectionChangedEventId);
+                }
             }
 
             // set the position in the dataSource, if there is any
@@ -2962,7 +2968,7 @@ namespace System.Windows.Forms
                 base.OnTextChanged(e);
             }
 
-            if (_childEdit is not null)
+            if (IsAccessibilityObjectCreated &&_childEdit is not null)
             {
                 ChildEditAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextChangedEventId);
             }
@@ -3065,19 +3071,22 @@ namespace System.Windows.Forms
                 return;
             }
 
-            // Need to announce the focus on combo-box with new selected value on drop-down close.
-            // If do not do this focus in Level 3 stays on list item of unvisible list.
-            // This is necessary for DropDown style as edit should not take focus.
-            if (DropDownStyle == ComboBoxStyle.DropDown)
+            if (IsAccessibilityObjectCreated)
             {
-                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
-            }
+                // Need to announce the focus on combo-box with new selected value on drop-down close.
+                // If do not do this focus in Level 3 stays on list item of unvisible list.
+                // This is necessary for DropDown style as edit should not take focus.
+                if (DropDownStyle == ComboBoxStyle.DropDown)
+                {
+                    AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                }
 
-            // Notify Collapsed/expanded property change.
-            AccessibilityObject.RaiseAutomationPropertyChangedEvent(
-                UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
-                UiaCore.ExpandCollapseState.Expanded,
-                UiaCore.ExpandCollapseState.Collapsed);
+                // Notify Collapsed/expanded property change.
+                AccessibilityObject.RaiseAutomationPropertyChangedEvent(
+                    UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
+                    UiaCore.ExpandCollapseState.Expanded,
+                    UiaCore.ExpandCollapseState.Collapsed);
+            }
 
             // Collapsing the DropDown, so reset the flag.
             _dropDownWillBeClosed = false;
@@ -3248,8 +3257,11 @@ namespace System.Windows.Forms
         {
             base.ReleaseUiaProvider(handle);
 
-            var uiaProvider = AccessibilityObject as ComboBoxAccessibleObject;
-            uiaProvider?.ResetListItemAccessibleObjects();
+            if (IsAccessibilityObjectCreated)
+            {
+                var uiaProvider = AccessibilityObject as ComboBoxAccessibleObject;
+                uiaProvider?.ResetListItemAccessibleObjects();
+            }
         }
 
         private void ResetAutoCompleteCustomSource()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1684,6 +1684,11 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///  Indicates whether or not this control has an accessible object associated with it.
+        /// </summary>
+        internal bool IsAccessibilityObjectCreated => Properties.GetObject(s_accessibilityProperty) is ControlAccessibleObject;
+
+        /// <summary>
         ///  Retrieves the Win32 thread ID of the thread that created the
         ///  handle for this control.  If the control's handle hasn't been
         ///  created yet, this method will return the current thread's ID.
@@ -9912,7 +9917,7 @@ namespace System.Windows.Forms
                 UiaCore.UiaReturnRawElementProvider(new HandleRef(this, handle), IntPtr.Zero, IntPtr.Zero, null);
             }
 
-            if (OsVersion.IsWindows8OrGreater && Properties.GetObject(s_accessibilityProperty) is object)
+            if (OsVersion.IsWindows8OrGreater && IsAccessibilityObjectCreated)
             {
                 var intAccessibleObject = new InternalAccessibleObject(AccessibilityObject);
                 UiaCore.UiaDisconnectProvider(intAccessibleObject);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using static System.Windows.Forms.ComboBox;
 using static Interop;
 
 namespace System.Windows.Forms.Tests
@@ -1845,16 +1846,273 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ComboBox_OnKeyUp_DoesNotInvoke_RaiseAutomationEvent_AccessibilityObjectIsNotCreated()
+        {
+            using CustomComboBox comboBox = new();
+            comboBox.CreateControl();
+            CustomComboBoxChildEditUiaProvider comboBoxChildEditUiaProvider = new(comboBox, comboBox.TestAccessor().Dynamic._childEdit.Handle);
+            comboBox.TestAccessor().Dynamic._childEditAccessibleObject = comboBoxChildEditUiaProvider;
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+
+            comboBox.OnKeyUp();
+
+            Assert.False(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+
+            // The "RaiseAutomationCallCount" method is called from "OnTextChanged" method
+            Assert.Equal(0, comboBoxChildEditUiaProvider.RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_OnKeyUp_Invoke_RaiseAutomationEvent_AccessibilityObjectIsCreated()
+        {
+            using CustomComboBox comboBox = new();
+            comboBox.CreateControl();
+            CustomComboBoxChildEditUiaProvider comboBoxChildEditUiaProvider = new(comboBox, comboBox.TestAccessor().Dynamic._childEdit.Handle);
+            comboBox.TestAccessor().Dynamic._childEditAccessibleObject = comboBoxChildEditUiaProvider;
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+
+            Assert.IsType<CustomComboBoxAccessibleObject>(comboBox.AccessibilityObject);
+
+            comboBox.OnKeyUp();
+
+            Assert.True(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+
+            // The "RaiseAutomationCallCount" method is called from "OnTextChanged" method
+            Assert.Equal(1, comboBoxChildEditUiaProvider.RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_OnMouseDown_DoesNotInvoke_RaiseAutomationEvent_AccessibilityObjectIsNotCreated()
+        {
+            using CustomComboBox comboBox = new();
+            comboBox.CreateControl();
+            CustomComboBoxChildEditUiaProvider comboBoxChildEditUiaProvider = new(comboBox, comboBox.TestAccessor().Dynamic._childEdit.Handle);
+            comboBox.TestAccessor().Dynamic._childEditAccessibleObject = comboBoxChildEditUiaProvider;
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+
+            comboBox.OnMouseDown(comboBox.PointToClient(comboBoxChildEditUiaProvider.Bounds.Location));
+
+            Assert.False(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+
+            // The "RaiseAutomationCallCount" method is called from "OnTextChanged" method
+            Assert.Equal(0, comboBoxChildEditUiaProvider.RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_OnMouseDown_Invoke_RaiseAutomationEvent_AccessibilityObjectIsCreated()
+        {
+            using CustomComboBox comboBox = new();
+            comboBox.CreateControl();
+            CustomComboBoxChildEditUiaProvider comboBoxChildEditUiaProvider = new(comboBox, comboBox.TestAccessor().Dynamic._childEdit.Handle);
+            comboBox.TestAccessor().Dynamic._childEditAccessibleObject = comboBoxChildEditUiaProvider;
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+
+            Assert.IsType<CustomComboBoxAccessibleObject>(comboBox.AccessibilityObject);
+
+            comboBox.OnMouseDown(comboBox.PointToClient(comboBoxChildEditUiaProvider.Bounds.Location));
+
+            Assert.True(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+
+            // The "RaiseAutomationCallCount" method is called from "OnTextChanged" method
+            Assert.Equal(1, comboBoxChildEditUiaProvider.RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_SelectedItem_Set_DoesNotInvoke_RaiseAutomationEvent_AccessibilityObjectIsCreated()
+        {
+            using CustomComboBox comboBox = new();
+            comboBox.CreateControl();
+            CustomComboBoxChildEditUiaProvider comboBoxChildEditUiaProvider = new(comboBox, comboBox.TestAccessor().Dynamic._childEdit.Handle);
+            comboBox.TestAccessor().Dynamic._childEditAccessibleObject = comboBoxChildEditUiaProvider;
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+            comboBox.SelectedItem = comboBox.Items[0];
+
+            Assert.False(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+            Assert.Equal(0, comboBoxChildEditUiaProvider.RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_SelectedItem_Set_Invoke_RaiseAutomationEvent_AccessibilityObjectIsCreated()
+        {
+            using CustomComboBox comboBox = new();
+            comboBox.CreateControl();
+            CustomComboBoxChildEditUiaProvider comboBoxChildEditUiaProvider = new(comboBox, comboBox.TestAccessor().Dynamic._childEdit.Handle);
+            comboBox.TestAccessor().Dynamic._childEditAccessibleObject = comboBoxChildEditUiaProvider;
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+
+            Assert.IsType<CustomComboBoxAccessibleObject>(comboBox.AccessibilityObject);
+
+            comboBox.SelectedItem = comboBox.Items[0];
+
+            Assert.True(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+
+            // The "RaiseAutomationEvent" method is called from "OnTextChanged" and "OnSelectedIndexChanged" methods
+            Assert.Equal(2, comboBoxChildEditUiaProvider.RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_Text_Set_DoesNotInvoke_RaiseAutomationEvent_AccessibilityObjectIsCreated()
+        {
+            using CustomComboBox comboBox = new();
+            comboBox.CreateControl();
+
+            CustomComboBoxChildEditUiaProvider comboBoxChildEditUiaProvider = new(comboBox, comboBox.TestAccessor().Dynamic._childEdit.Handle);
+            comboBox.TestAccessor().Dynamic._childEditAccessibleObject = comboBoxChildEditUiaProvider;
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+            comboBox.Text = "Test";
+
+            Assert.False(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+            Assert.Equal(0, comboBoxChildEditUiaProvider.RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_Text_Set_Invoke_RaiseAutomationEvent_AccessibilityObjectIsCreated()
+        {
+            using CustomComboBox comboBox = new();
+            comboBox.CreateControl();
+            CustomComboBoxChildEditUiaProvider comboBoxChildEditUiaProvider = new(comboBox, comboBox.TestAccessor().Dynamic._childEdit.Handle);
+            comboBox.TestAccessor().Dynamic._childEditAccessibleObject = comboBoxChildEditUiaProvider;
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+
+            Assert.IsType<CustomComboBoxAccessibleObject>(comboBox.AccessibilityObject);
+
+            comboBox.Text = "Test";
+
+            Assert.True(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+
+            // The "RaiseAutomationEvent" method is called from "OnTextChanged" method
+            Assert.Equal(1, comboBoxChildEditUiaProvider.RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_DroppedDown_Set_True_DoesNotInvoke_RaiseAutomationPropertyChangedEvent_AccessibilityObjectIsNotCreated()
+        {
+            using CustomComboBox comboBox = new();
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+            comboBox.DroppedDown = true;
+
+            Assert.False(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+            Assert.Equal(0, ((CustomComboBoxAccessibleObject)comboBox.AccessibilityObject).RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_DroppedDown_Set_False_DoesNotInvoke_RaiseAutomationPropertyChangedEvent_AccessibilityObjectIsNotCreated()
+        {
+            using CustomComboBox comboBox = new();
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+            comboBox.DroppedDown = true;
+            comboBox.DroppedDown = false;
+
+            Assert.False(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+            Assert.Equal(0, ((CustomComboBoxAccessibleObject)comboBox.AccessibilityObject).RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_DroppedDownProperty_Set_True_Invoke_RaiseAutomationPropertyChangedEvent_AccessibilityObjectIsCreated()
+        {
+            using CustomComboBox comboBox = new();
+
+            Assert.IsType<CustomComboBoxAccessibleObject>(comboBox.AccessibilityObject);
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+            comboBox.DroppedDown = true;
+
+            Assert.True(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+
+            // The "RaiseAutomationPropertyChangedEvent" method is called from "OnDropDown" method
+            Assert.Equal(1, ((CustomComboBoxAccessibleObject)comboBox.AccessibilityObject).RaiseAutomationCallCount);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_DroppedDownProperty_Set_False_Invoke_RaiseAutomationPropertyChangedEvent_AccessibilityObjectIsCreated()
+        {
+            using CustomComboBox comboBox = new();
+
+            Assert.IsType<CustomComboBoxAccessibleObject>(comboBox.AccessibilityObject);
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+            comboBox.DroppedDown = true;
+            comboBox.DroppedDown = false;
+
+            Assert.True(comboBox.IsAccessibilityObjectCreated);
+            Assert.True(comboBox.IsHandleCreated);
+
+            // The "RaiseAutomationPropertyChangedEvent" method is called from "OnDropDown" and "OnDropDownClosed" method
+            Assert.Equal(2, ((CustomComboBoxAccessibleObject)comboBox.AccessibilityObject).RaiseAutomationCallCount);
+        }
+
         private class CustomComboBox : ComboBox
         {
             protected override AccessibleObject CreateAccessibilityInstance()
                 => new CustomComboBoxAccessibleObject(this);
+
+            public void OnKeyUp() => base.OnKeyUp(new KeyEventArgs(Keys.Left));
+
+            public void OnMouseDown(Point p) => base.OnMouseDown(new MouseEventArgs(MouseButtons.Left, 1, p.X, p.Y, 0));
         }
 
         private class CustomComboBoxAccessibleObject : Control.ControlAccessibleObject
         {
             public CustomComboBoxAccessibleObject(ComboBox owner) : base(owner)
             { }
+
+            internal int RaiseAutomationCallCount;
+
+            internal override bool RaiseAutomationPropertyChangedEvent(UiaCore.UIA propertyId, object oldValue, object newValue)
+            {
+                RaiseAutomationCallCount++;
+                return base.RaiseAutomationPropertyChangedEvent(propertyId, oldValue, newValue);
+            }
+        }
+
+        private class CustomComboBoxChildEditUiaProvider : ComboBoxChildEditUiaProvider
+        {
+            public CustomComboBoxChildEditUiaProvider(ComboBox owner, IntPtr childEditControlhandle) : base(owner, childEditControlhandle)
+            {
+                RaiseAutomationCallCount = 0;
+            }
+
+            internal int RaiseAutomationCallCount;
+
+            internal override bool RaiseAutomationEvent(UiaCore.UIA eventId)
+            {
+                RaiseAutomationCallCount++;
+                return base.RaiseAutomationEvent(eventId);
+            }
         }
 
         private class SubComboBox : ComboBox

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Combobox.ObjectCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Combobox.ObjectCollectionTests.cs
@@ -1410,6 +1410,45 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(createControl, comboBox.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ComboBox_Item_RemoveAt_DoesNotCreateAccessibilityObject()
+        {
+            using ComboBox comboBox = new();
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+            comboBox.Items.Remove(1);
+
+            Assert.False(comboBox.IsAccessibilityObjectCreated);
+            Assert.False(comboBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_Item_Insert_DoesNotCreateAccessibilityObject()
+        {
+            using ComboBox comboBox = new();
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+            comboBox.Items.Insert(1, "Item3");
+
+            Assert.False(comboBox.IsAccessibilityObjectCreated);
+            Assert.False(comboBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ComboBox_Item_Clear_DoesNotCreateAccessibilityObject()
+        {
+            using ComboBox comboBox = new();
+
+            comboBox.Items.Add("item1");
+            comboBox.Items.Add("item2");
+            comboBox.Items.Clear();
+
+            Assert.False(comboBox.IsAccessibilityObjectCreated);
+            Assert.False(comboBox.IsHandleCreated);
+        }
+
         private ComboBox.ComboBoxAccessibleObject GetComboBoxAccessibleObject(ComboBox comboBox)
         {
             return (ComboBox.ComboBoxAccessibleObject)comboBox.AccessibilityObject;


### PR DESCRIPTION
## Proposed changes
- Added "IsAccessibilityObjectCreated" property
- The "IsAccessibilityObjectCreated" property is needed to get data about whether an accessibility object has been created. Currently, we only have access to the accessibility object through the "AccessibilityObject" property, which forces the accessibility object to be created when we try to access it. The "IsAccessibilityObjectCreated" property will help avoid using memory by unnecessary accessibility objects and prevent execution of unnecessary code when external accessibility tools are not active
<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
- No

## Regression? 
- No

## Risk
- Minimal

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.0-preview.7.21352.2

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5232)