### PR TITLE
Fix which unblock usage of debug builds in NativeAOT

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms
         // Sequential version
         // assumes sequential enum members 0,1,2,3,4 -etc.
         //
-        public static bool IsEnumValid(Enum enumValue, int value, int minValue, int maxValue)
+        public static bool IsEnumValid<TEnum>(TEnum enumValue, int value, int minValue, int maxValue) where TEnum : struct, System.Enum
         {
             bool valid = (value >= minValue) && (value <= maxValue);
 #if DEBUG
@@ -84,18 +84,18 @@ namespace System.Windows.Forms
         private static Hashtable? enumValueInfo;
         public const int MAXCACHE = 300;  // we think we're going to get O(100) of these, put in a tripwire if it gets larger.
 
-        private class SequentialEnumInfo
+        private class SequentialEnumInfo<TEnum> where TEnum : struct, System.Enum
         {
-            public SequentialEnumInfo(Type t)
+            public SequentialEnumInfo()
             {
                 int actualMinimum = int.MaxValue;
                 int actualMaximum = int.MinValue;
                 int countEnumVals = 0;
 
-                foreach (int iVal in Enum.GetValues(t))
+                foreach (TEnum iVal in Enum.GetValues<TEnum>())
                 {
-                    actualMinimum = Math.Min(actualMinimum, iVal);
-                    actualMaximum = Math.Max(actualMaximum, iVal);
+                    actualMinimum = Math.Min(actualMinimum, Convert.ToInt32(iVal));
+                    actualMaximum = Math.Max(actualMaximum, Convert.ToInt32(iVal));
                     countEnumVals++;
                 }
 
@@ -112,7 +112,7 @@ namespace System.Windows.Forms
             public int MaxValue;
         }
 
-        private static void Debug_SequentialEnumIsDefinedCheck(Enum value, int minVal, int maxVal)
+        private static void Debug_SequentialEnumIsDefinedCheck<TEnum>(TEnum value, int minVal, int maxVal) where TEnum : struct, System.Enum
         {
             Type t = value.GetType();
 
@@ -121,16 +121,16 @@ namespace System.Windows.Forms
                 enumValueInfo = new Hashtable();
             }
 
-            SequentialEnumInfo? sequentialEnumInfo = null;
+            SequentialEnumInfo<TEnum>? sequentialEnumInfo = null;
 
             if (enumValueInfo.ContainsKey(t))
             {
-                sequentialEnumInfo = enumValueInfo[t] as SequentialEnumInfo;
+                sequentialEnumInfo = enumValueInfo[t] as SequentialEnumInfo<TEnum>;
             }
 
             if (sequentialEnumInfo is null)
             {
-                sequentialEnumInfo = new SequentialEnumInfo(t);
+                sequentialEnumInfo = new SequentialEnumInfo<TEnum>();
 
                 if (enumValueInfo.Count > MAXCACHE)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -2467,7 +2467,7 @@ namespace System.Windows.Forms
 
         protected void AutoResizeRows(int rowIndexStart, int rowsCount, DataGridViewAutoSizeRowMode autoSizeRowMode, bool fixedWidth)
         {
-            // not using ClientUtils.IsEnumValid here because DataGridViewAutoSizeRowCriteriaInternal is a flags enum.
+            // not using EnumValidator.Validate here because DataGridViewAutoSizeRowCriteriaInternal is a flags enum.
             if (((DataGridViewAutoSizeRowCriteriaInternal)autoSizeRowMode & InvalidDataGridViewAutoSizeRowCriteriaInternalMask) != 0)
             {
                 throw new InvalidEnumArgumentException(nameof(autoSizeRowMode), (int)autoSizeRowMode, typeof(DataGridViewAutoSizeRowMode));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/CommonProperties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/CommonProperties.cs
@@ -575,7 +575,7 @@ namespace System.Windows.Forms.Layout
 
             // If we are anchored we return DefaultDock
             value = mode == DockAnchorMode.Dock ? value : DefaultDock;
-            Debug.Assert(ClientUtils.IsEnumValid(value, (int)value, (int)DockStyle.None, (int)DockStyle.Fill), "Illegal value returned form xGetDock.");
+            SourceGenerated.EnumValidator.Validate(value);
 
             Debug.Assert(mode == DockAnchorMode.Dock || value == DefaultDock,
                 "xGetDock needs to return the DefaultDock style when not docked.");
@@ -608,7 +608,7 @@ namespace System.Windows.Forms.Layout
         internal static void xSetDock(IArrangedElement element, DockStyle value)
         {
             Debug.Assert(value != xGetDock(element), "PERF: Caller should guard against setting Dock to original value.");
-            Debug.Assert(ClientUtils.IsEnumValid(value, (int)value, (int)DockStyle.None, (int)DockStyle.Fill), "Illegal value passed to xSetDock.");
+            SourceGenerated.EnumValidator.Validate(value);
 
             BitVector32 state = GetLayoutState(element);
 


### PR DESCRIPTION
Only changes is `Enum.GetValues()` to `Enum.GetValue<TEnum>()`.
Other changes is just to make compiler happy.
This change affects even when compile in reflection mode, I see other opportinities where reflection can be trimmed.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5239)