### PR TITLE
Add missing assembly required to use local WinForms build

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -33,6 +33,7 @@ Add references to the binary(-ies) to your project ported to .NET. For example, 
 ```xml
 <ItemGroup>
     <Reference Include="[Drive]:[Path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\net6.0\System.Windows.Forms.dll" />
+    <Reference Include="[Drive]:[Path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\net6.0\System.Windows.Forms.Primitives.dll" />
 </ItemGroup>
 ```
 


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5241)