### PR TITLE
Fixing color contrast for CheckedListBox

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -757,7 +757,7 @@ namespace System.Windows.Forms
                 if ((e.State & DrawItemState.Focus) == DrawItemState.Focus &&
                     (e.State & DrawItemState.NoFocusRect) != DrawItemState.NoFocusRect)
                 {
-                    ControlPaint.DrawFocusRectangle(e.Graphics, textBounds, foreColor, backColor);
+                    ControlPaint.DrawBlackWhiteFocusRectangle(e.Graphics, textBounds, backColor);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -1442,7 +1442,10 @@ namespace System.Windows.Forms
         internal static void DrawHighContrastFocusRectangle(Graphics graphics, Rectangle rectangle, Color color)
             => DrawFocusRectangle(graphics, rectangle, color, highContrast: true);
 
-        private static void DrawFocusRectangle(Graphics graphics, Rectangle rectangle, Color color, bool highContrast)
+        internal static void DrawBlackWhiteFocusRectangle(Graphics graphics, Rectangle rectangle, Color color)
+            => DrawFocusRectangle(graphics, rectangle, color, highContrast: false, blackAndWhite: true);
+
+        private static void DrawFocusRectangle(Graphics graphics, Rectangle rectangle, Color color, bool highContrast, bool blackAndWhite = false)
         {
             if (graphics is null)
                 throw new ArgumentNullException(nameof(graphics));
@@ -1451,7 +1454,7 @@ namespace System.Windows.Forms
             rectangle.Height--;
             graphics.DrawRectangle(
                 // We want the corner to be penned see GetFocusPen for more explanation
-                GetFocusPen(color, (rectangle.X + rectangle.Y) % 2 == 1, highContrast),
+                GetFocusPen(color, (rectangle.X + rectangle.Y) % 2 == 1, highContrast, blackAndWhite),
                 rectangle);
         }
 
@@ -2246,7 +2249,7 @@ namespace System.Windows.Forms
         ///  Retrieves the pen used to draw a focus rectangle around a control. The focus rectangle is typically drawn
         ///  when the control has keyboard focus.
         /// </summary>
-        private static Pen GetFocusPen(Color baseColor, bool odds, bool highContrast)
+        private static Pen GetFocusPen(Color baseColor, bool odds, bool highContrast, bool blackAndWhite)
         {
             if (t_focusPen is null
                 || t_hcFocusPen != highContrast
@@ -2271,6 +2274,11 @@ namespace System.Windows.Forms
                 {
                     // In highcontrast mode "baseColor" itself is used as the focus pen color.
                     color2 = baseColor;
+                }
+                else if (blackAndWhite)
+                {
+                    color1 = Color.White;
+                    color2 = Color.Black;
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #3059


## Proposed changes
- During investigation, we found that the orange color from the issue is obtained by inverting the blue (highlighted) color. Unfortunately, orange does not contrast well with most colors. Therefore, during the discussions, it was decided to change the orange color to white. Thus, we get a black and white dotted border that has the necessary contrast with the blue (highlighted) color and the colors that the user can set.
- Added "DrawBlackWhiteFocusRectangle" method. 
- Updated parameters for "DrawFocusRectangle" method.
- Added additional logic to the "GetFocusPen" method to get the required border colors.

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/125753812-c4bf468f-1b9d-4a88-8b7b-2f257b07d5e8.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/125753796-b73d976b-157c-47ba-b986-cd7a5da07378.png)


## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manually 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Accessibility Insights

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.0-preview.7.21363.9


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5242)