### PR TITLE
Adding support expand-collapse pattern for DateTimePicker

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
@@ -5,6 +5,8 @@
 #nullable disable
 
 using static Interop;
+using static Interop.ComCtl32;
+using static Interop.User32;
 
 namespace System.Windows.Forms
 {
@@ -96,33 +98,25 @@ namespace System.Windows.Forms
             internal override bool IsIAccessibleExSupported() => true;
 
             internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                switch (propertyID)
+                => propertyID switch
                 {
-                    case UiaCore.UIA.IsTogglePatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.TogglePatternId);
-                    case UiaCore.UIA.LocalizedControlTypePropertyId:
+                    UiaCore.UIA.IsTogglePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TogglePatternId),
+                    UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId),
+                    UiaCore.UIA.LocalizedControlTypePropertyId =>
                         // We define a custom "LocalizedControlType" by default.
                         // If DateTimePicker.AccessibleRole value is customized by a user
                         // then "LocalizedControlType" value will be based on "ControlType"
                         // which depends on DateTimePicker.AccessibleRole.
-                        return Owner.AccessibleRole == AccessibleRole.Default
-                               ? s_dateTimePickerLocalizedControlTypeString
-                               : base.GetPropertyValue(propertyID);
-                    default:
-                        return base.GetPropertyValue(propertyID);
-                }
-            }
+                        Owner.AccessibleRole == AccessibleRole.Default
+                            ? s_dateTimePickerLocalizedControlTypeString
+                            : base.GetPropertyValue(propertyID),
+                    _ => base.GetPropertyValue(propertyID)
+                };
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
-            {
-                if (patternId == UiaCore.UIA.TogglePatternId && ((DateTimePicker)Owner).ShowCheckBox)
-                {
-                    return true;
-                }
-
-                return base.IsPatternSupported(patternId);
-            }
+                => (patternId == UiaCore.UIA.TogglePatternId && ((DateTimePicker)Owner).ShowCheckBox) ||
+                    patternId == UiaCore.UIA.ExpandCollapsePatternId ||
+                    base.IsPatternSupported(patternId);
 
             #region Toggle Pattern
 
@@ -143,6 +137,28 @@ namespace System.Windows.Forms
                     ((DateTimePicker)Owner).Checked = !((DateTimePicker)Owner).Checked;
                 }
             }
+
+            #endregion
+
+            #region Expand-Collapse Pattern
+
+            internal override void Expand()
+            {
+                if (Owner.IsHandleCreated && ExpandCollapseState == UiaCore.ExpandCollapseState.Collapsed)
+                {
+                    SendMessageW(Owner, WM.SYSKEYDOWN, (IntPtr)Keys.Down);
+                }
+            }
+
+            internal override void Collapse()
+            {
+                if (Owner.IsHandleCreated && ExpandCollapseState == UiaCore.ExpandCollapseState.Expanded)
+                {
+                    SendMessageW(Owner, (WM)DTM.CLOSEMONTHCAL);
+                }
+            }
+
+            internal override UiaCore.ExpandCollapseState ExpandCollapseState => ((DateTimePicker)Owner)._expandCollapseState;
 
             #endregion
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -54,6 +54,8 @@ namespace System.Windows.Forms
         private EventHandler _onValueChanged;
         private EventHandler _onRightToLeftLayoutChanged;
 
+        private UiaCore.ExpandCollapseState _expandCollapseState;
+
         // We need to restrict the available dates because of limitations in the comctl
         // DateTime and MonthCalendar controls
         //
@@ -1159,6 +1161,12 @@ namespace System.Windows.Forms
         protected virtual void OnCloseUp(EventArgs eventargs)
         {
             _onCloseUp?.Invoke(this, eventargs);
+            _expandCollapseState = UiaCore.ExpandCollapseState.Collapsed;
+
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            }
         }
 
         /// <summary>
@@ -1167,6 +1175,7 @@ namespace System.Windows.Forms
         protected virtual void OnDropDown(EventArgs eventargs)
         {
             _onDropDown?.Invoke(this, eventargs);
+            _expandCollapseState = UiaCore.ExpandCollapseState.Expanded;
         }
 
         protected virtual void OnFormatChanged(EventArgs e)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DateTimePickerAccessibleObject_Ctor_Default()
         {
-            using DateTimePicker dateTimePicker = new DateTimePicker();
+            using DateTimePicker dateTimePicker = new();
 
             DateTimePickerAccessibleObject accessibleObject = new DateTimePickerAccessibleObject(dateTimePicker);
 
@@ -24,7 +24,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DateTimePickerAccessibleObject_ControlType_IsComboBox_IfAccessibleRoleIsDefault()
         {
-            using DateTimePicker dateTimePicker = new DateTimePicker();
+            using DateTimePicker dateTimePicker = new();
             // AccessibleRole is not set = Default
 
             object actual = dateTimePicker.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
@@ -36,7 +36,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DateTimePickerAccessibleObject_Role_IsComboBox_ByDefault()
         {
-            using DateTimePicker dateTimePicker = new DateTimePicker();
+            using DateTimePicker dateTimePicker = new();
             // AccessibleRole is not set = Default
 
             AccessibleRole actual = dateTimePicker.AccessibilityObject.Role;
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DateTimePickerAccessibleObject_LocalizedControlType_ReturnsExpected_IfAccessibleRoleIsDefault()
         {
-            using DateTimePicker dateTimePicker = new DateTimePicker();
+            using DateTimePicker dateTimePicker = new();
             // AccessibleRole is not set = Default
 
             object actual = dateTimePicker.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LocalizedControlTypePropertyId);
@@ -77,7 +77,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(DateTimePickerAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData))]
         public void DateTimePickerAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole(AccessibleRole role)
         {
-            using DateTimePicker dateTimePicker = new DateTimePicker();
+            using DateTimePicker dateTimePicker = new();
             dateTimePicker.AccessibleRole = role;
 
             object actual = dateTimePicker.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
@@ -91,13 +91,154 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(DateTimePickerAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData))]
         public void DateTimePickerAccessibleObject_GetPropertyValue_LocalizedControlType_IsNull_ForCustomRole(AccessibleRole role)
         {
-            using DateTimePicker dateTimePicker = new DateTimePicker();
+            using DateTimePicker dateTimePicker = new();
             dateTimePicker.AccessibleRole = role;
 
             object actual = dateTimePicker.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LocalizedControlTypePropertyId);
 
             Assert.Null(actual);
             Assert.False(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DateTimePickerAccessibleObject_IsExpandCollapsePatternSupported_Supported()
+        {
+            using DateTimePicker dateTimePicker = new();
+
+            var actual = (bool)dateTimePicker.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId);
+
+            Assert.True(actual);
+            Assert.False(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.ExpandCollapseState.Expanded)]
+        [InlineData((int)UiaCore.ExpandCollapseState.Collapsed)]
+        public void DateTimePickerAccessibleObject_ExpandCollapseState_ReturnsExpected(int expandCollapseState)
+        {
+            using DateTimePicker dateTimePicker = new();
+
+            var expected = (UiaCore.ExpandCollapseState)expandCollapseState;
+            var accessibleObject = (DateTimePickerAccessibleObject)dateTimePicker.AccessibilityObject;
+            dateTimePicker.TestAccessor().Dynamic._expandCollapseState = expected;
+
+            UiaCore.ExpandCollapseState actual = accessibleObject.ExpandCollapseState;
+
+            Assert.Equal(expected, actual);
+            Assert.False(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DateTimePickerAccessibleObject_Expand_IfHandleIsNotCreated_NothingChanges()
+        {
+            using DateTimePicker dateTimePicker = new();
+
+            var accessibleObject = (DateTimePickerAccessibleObject)dateTimePicker.AccessibilityObject;
+
+            // ExpandCollapseState is Collapsed before some actions
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+
+            accessibleObject.Expand();
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+            Assert.False(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DateTimePickerAccessibleObject_Collapse_IfHandleIsNotCreated_NothingChanges()
+        {
+            using DateTimePicker dateTimePicker = new();
+
+            var accessibleObject = (DateTimePickerAccessibleObject)dateTimePicker.AccessibilityObject;
+
+            // ExpandCollapseState is Collapsed before some actions
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+
+            dateTimePicker.TestAccessor().Dynamic._expandCollapseState = UiaCore.ExpandCollapseState.Expanded;
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Expanded, accessibleObject.ExpandCollapseState);
+
+            accessibleObject.Collapse();
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Expanded, accessibleObject.ExpandCollapseState);
+            Assert.False(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DateTimePickerAccessibleObject_Expand_IfControlAlreadyIsExpanded_NothingChanges()
+        {
+            using DateTimePicker dateTimePicker = new();
+
+            dateTimePicker.CreateControl();
+            var accessibleObject = (DateTimePickerAccessibleObject)dateTimePicker.AccessibilityObject;
+
+            // ExpandCollapseState is Collapsed before some actions
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+
+            dateTimePicker.TestAccessor().Dynamic._expandCollapseState = UiaCore.ExpandCollapseState.Expanded;
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Expanded, accessibleObject.ExpandCollapseState);
+
+            accessibleObject.Expand();
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Expanded, accessibleObject.ExpandCollapseState);
+            Assert.True(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DateTimePickerAccessibleObject_Collapse_IfControlAlreadyIsCollapsed_NothingChanges()
+        {
+            using DateTimePicker dateTimePicker = new();
+
+            dateTimePicker.CreateControl();
+            var accessibleObject = (DateTimePickerAccessibleObject)dateTimePicker.AccessibilityObject;
+
+            // ExpandCollapseState is Collapsed before some actions
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+
+            accessibleObject.Collapse();
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+            Assert.True(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DateTimePickerAccessibleObject_Expand_IfHandleIsCreated_ReturnsExpected()
+        {
+            using DateTimePicker dateTimePicker = new();
+
+            dateTimePicker.CreateControl();
+            var accessibleObject = (DateTimePickerAccessibleObject)dateTimePicker.AccessibilityObject;
+
+            // ExpandCollapseState is Collapsed before some actions
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+
+            accessibleObject.Expand();
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Expanded, accessibleObject.ExpandCollapseState);
+            Assert.True(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DateTimePickerAccessibleObject_Collapse_IfHandleIsCreated_ReturnsExpected()
+        {
+            using DateTimePicker dateTimePicker = new();
+
+            dateTimePicker.CreateControl();
+            var accessibleObject = (DateTimePickerAccessibleObject)dateTimePicker.AccessibilityObject;
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+
+            // If don't call Expand() on this control and just change state value instead
+            // then call Collapse() does't work correctly due to the control is not expanded factually
+            accessibleObject.Expand();
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Expanded, accessibleObject.ExpandCollapseState);
+
+            accessibleObject.Collapse();
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+            Assert.True(dateTimePicker.IsHandleCreated);
         }
     }
 }


### PR DESCRIPTION
Implemented expand-collapse pattern in DateTimePickerAccessibleObject class

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4099


## Proposed changes

- Implemented expand-collapse pattern in `DateTimePickerAccessibleObject` class
- Added unit tests

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improve user experience
- Follow accessibility standards

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots

### Before

- In the Accessibility Insight tool, an error 'An element of the given ControlType must support the ExpandCollapse pattern' appeared.

![image](https://user-images.githubusercontent.com/58004471/125923905-8b675d2a-ce20-4316-aec2-d6a1f1523c5b.png)

 - In the inspect tool, the `IsExpandCollapsePattermAvaliable` property value is false.

![dt bf](https://user-images.githubusercontent.com/58004471/125924138-8105662d-305f-4344-b376-6d356677b734.png)

### After

- In the Accessibility Insight tool, no error 'An element of the given ControlType must support the ExpandCollapse pattern' appeared.

![image](https://user-images.githubusercontent.com/58004471/125923453-71217fe4-6578-4b8b-ba2f-294cf485132e.png)

- In the inspect tool, the `IsExpandCollapsePattermAvaliable` property value is true and the `ExpandCollapseExpandCollapseState` property appear.

![dt after](https://user-images.githubusercontent.com/58004471/125923289-774f4718-d78e-428f-a4cb-9a1fac3f19c9.png)

- Updated notification in narrator.

![nb after](https://user-images.githubusercontent.com/58004471/125923242-3c04f74a-d1e6-4b8d-a854-473bb3942e3e.png)

## Test methodology <!-- How did you ensure quality? -->

- Manually test
- Unit test
- Accessibility test

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect
- Narrator
- Accessibility insight

## Test environment(s) <!-- Remove any that don't apply -->

- .NET SDK: 6.0.0-preview.7.21365.2

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5245)