### PR TITLE
Add ServiceProvider extensions

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Primitives/src/Resources/SR.resx
@@ -126,4 +126,7 @@
   <data name="PropertyValueInvalidEntry" xml:space="preserve">
     <value>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</value>
   </data>
+  <data name="General_MissingService" xml:space="preserve">
+    <value>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nezpracovaná hodnota VT: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Nejméně jedna položka není platná v parametru IDictionary. Ověřte, zda všechny hodnoty odpovídají vlastnostem objektu.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Unbehandelter VT: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Mindestens ein Eintrag im IDictionary-Parameter ist ungültig. Stellen Sie sicher, dass alle Werte den Eigenschaften des Objekts entsprechen.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">VT no controlado: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Una o más entradas no son válidas en el parámetro IDictionary. Compruebe que todos los valores coinciden con las propiedades del objeto.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">VT non géré : {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Le paramètre IDictionary contient au moins une entrée non valide. Vérifiez que toutes les valeurs correspondent aux propriétés de l'objet.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">VT non gestito: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Una o più voci non valide nel parametro IDictionary. Verificare che tutti i valori corrispondano alle proprietà dell'oggetto.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">ハンドルされていない VT: {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">1 つ以上の有効ではないエントリが IDictionary パラメーターにあります。すべての値がオブジェクトのプロパティに一致していることを確認してください。</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">처리되지 않은 VT입니다. {0}</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">IDictionary 매개 변수에 잘못된 항목이 하나 이상 있습니다. 모든 값이 개체의 속성과 일치하는지 확인하십시오.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nieobsługiwany VT: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Jeden lub kilka wpisów jest nieprawidłowych w parametrze IDictionary. Sprawdź, czy wszystkie wartości pasują do właściwości obiektu.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">VT não tratado: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Uma ou mais entradas não são válidas no parâmetro IDictionary. Verifique se todos os valores correspondem às propriedades do objeto.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Необработанный VT: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Недействительны одна или больше записей в параметре IDictionary. Проверьте, все ли значения соответствуют свойствам этого объекта.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">İşlenmemiş VT: {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">IDictionary parametresindeki bir veya daha fazla girdi geçerli değil. Tüm değerlerin nesnenin özellikleriyle eşleştiğini doğrulayın.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">未处理的 VT: {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">在 IDictionary 参数中有一个或多个无效项。请验证所有值均与对象的属性匹配。</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">未處理的 VT: {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_MissingService">
+        <source>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</source>
+        <target state="new">The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">IDictionary 參數中有一或多個無效的項目。請確認所有值都符合物件的屬性。</target>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/ServiceExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/ServiceExtensions.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.ComponentModel.Design;
+using System.Diagnostics.CodeAnalysis;
+using System.Windows.Forms.Primitives.Resources;
+
+namespace System.Windows.Forms
+{
+    internal static class ServiceExtensions
+    {
+        /// <summary>
+        ///  Gets the service object of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the service object to get.</typeparam>
+        /// <param name="provider">The <see cref="IServiceProvider"/> to retrieve the service object from.</param>
+        /// <returns>A service object of type <typeparamref name="T"/> or <see langword="null"/> if there is no such service.</returns>
+        public static T? GetService<T>(this IServiceProvider provider)
+            where T : class
+            => provider.GetService(typeof(T)) as T;
+
+        /// <summary>
+        ///  Gets the service object of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the service object to get.</typeparam>
+        /// <param name="provider">The <see cref="IServiceProvider"/> to retrieve the service object from.</param>
+        /// <returns>A service object of type <typeparamref name="T"/>.</returns>
+        /// <exception cref="InvalidOperationException"/>
+        public static T GetRequiredService<T>(this IServiceProvider provider)
+            where T : class
+            => provider.GetRequiredService<T, T>();
+
+        /// <summary>
+        ///  Gets the service object of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the service object to get.</typeparam>
+        /// <param name="provider">The <see cref="IServiceProvider"/> to retrieve the service object from.</param>
+        /// <param name="service">If found, contains the service object when this method returns; otherwise, <see langword="null"/>.</param>
+        /// <returns>A service object of type <typeparamref name="T"/> or <see langword="null"/> if there is no such service.</returns>
+        public static bool TryGetService<T>(
+            this IServiceProvider? provider,
+            [NotNullWhen(true)] out T? service)
+            where T : class
+            => (service = provider?.GetService(typeof(T)) as T) != null;
+
+        /// <summary>
+        ///  Gets the service object of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the service object to get.</typeparam>
+        /// <param name="designerHost">The <see cref="IDesignerHost"/> to retrieve the service object from.</param>
+        /// <param name="service">If found, contains the service object when this method returns; otherwise, <see langword="null"/>.</param>
+        /// <returns>A service object of type <typeparamref name="T"/> or <see langword="null"/> if there is no such service.</returns>
+        public static bool TryGetService<T>(
+            this IDesignerHost? designerHost,
+            [NotNullWhen(true)] out T? service)
+            where T : class
+            => (service = designerHost?.GetService(typeof(T)) as T) != null;
+
+        /// <summary>
+        ///  Gets the service object of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the service object to get.</typeparam>
+        /// <param name="context">The <see cref="ITypeDescriptorContext"/> to retrieve the service object from.</param>
+        /// <param name="service">If found, contains the service object when this method returns; otherwise, <see langword="null"/>.</param>
+        /// <returns>A service object of type <typeparamref name="T"/> or <see langword="null"/> if there is no such service.</returns>
+        public static bool TryGetService<T>(
+            this ITypeDescriptorContext? context,
+            [NotNullWhen(true)] out T? service)
+            where T : class
+            => (service = context?.GetService(typeof(T)) as T) != null;
+
+        private static TInterface? GetService<TService, TInterface>(this IServiceProvider provider)
+            where TService : class
+            where TInterface : class
+            => provider.GetService(typeof(TService)) as TInterface;
+
+        private static TInterface GetRequiredService<TService, TInterface>(this IServiceProvider provider)
+            where TService : class
+            where TInterface : class
+        {
+            var service = provider.GetService<TService, TInterface>();
+
+            if (service is null)
+            {
+                throw new InvalidOperationException(string.Format(SR.General_MissingService, typeof(TInterface).FullName))
+                {
+                    HelpLink = SR.General_MissingService
+                };
+            }
+
+            return service;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/ServiceExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/ServiceExtensions.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Forms
             this IServiceProvider? provider,
             [NotNullWhen(true)] out T? service)
             where T : class
-            => (service = provider?.GetService(typeof(T)) as T) != null;
+            => (service = provider?.GetService(typeof(T)) as T) is not null;
 
         /// <summary>
         ///  Gets the service object of the specified type.
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
             this IDesignerHost? designerHost,
             [NotNullWhen(true)] out T? service)
             where T : class
-            => (service = designerHost?.GetService(typeof(T)) as T) != null;
+            => (service = designerHost?.GetService(typeof(T)) as T) is not null;
 
         /// <summary>
         ///  Gets the service object of the specified type.
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
             this ITypeDescriptorContext? context,
             [NotNullWhen(true)] out T? service)
             where T : class
-            => (service = context?.GetService(typeof(T)) as T) != null;
+            => (service = context?.GetService(typeof(T)) as T) is not null;
 
         private static TInterface? GetService<TService, TInterface>(this IServiceProvider provider)
             where TService : class

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -3,8 +3,8 @@
 ~abstract System.Windows.Forms.BindingManagerBase.GetListName(System.Collections.ArrayList listAccessors) -> string
 ~abstract System.Windows.Forms.BindingManagerBase.OnCurrentChanged(System.EventArgs e) -> void
 ~abstract System.Windows.Forms.BindingManagerBase.OnCurrentItemChanged(System.EventArgs e) -> void
-~abstract System.Windows.Forms.Design.PropertyTab.GetProperties(object component, System.Attribute[] attributes) -> System.ComponentModel.PropertyDescriptorCollection
-~abstract System.Windows.Forms.Design.PropertyTab.TabName.get -> string
+abstract System.Windows.Forms.Design.PropertyTab.GetProperties(object! component, System.Attribute![]? attributes) -> System.ComponentModel.PropertyDescriptorCollection!
+abstract System.Windows.Forms.Design.PropertyTab.TabName.get -> string?
 ~abstract System.Windows.Forms.FeatureSupport.GetVersionPresent(object feature) -> System.Version
 ~abstract System.Windows.Forms.ListControl.SetItemsCore(System.Collections.IList items) -> void
 ~override System.Resources.ResXFileRef.Converter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) -> bool
@@ -411,12 +411,12 @@
 ~override System.Windows.Forms.Design.ComponentEditorForm.OnActivated(System.EventArgs e) -> void
 ~override System.Windows.Forms.Design.ComponentEditorForm.OnHelpRequested(System.Windows.Forms.HelpEventArgs e) -> void
 ~override System.Windows.Forms.Design.ComponentEditorPage.CreateParams.get -> System.Windows.Forms.CreateParams
-~override System.Windows.Forms.Design.EventsTab.CanExtend(object extendee) -> bool
-~override System.Windows.Forms.Design.EventsTab.GetDefaultProperty(object obj) -> System.ComponentModel.PropertyDescriptor
-~override System.Windows.Forms.Design.EventsTab.GetProperties(object component, System.Attribute[] attributes) -> System.ComponentModel.PropertyDescriptorCollection
-~override System.Windows.Forms.Design.EventsTab.GetProperties(System.ComponentModel.ITypeDescriptorContext context, object component, System.Attribute[] attributes) -> System.ComponentModel.PropertyDescriptorCollection
-~override System.Windows.Forms.Design.EventsTab.HelpKeyword.get -> string
-~override System.Windows.Forms.Design.EventsTab.TabName.get -> string
+override System.Windows.Forms.Design.EventsTab.CanExtend(object! extendee) -> bool
+override System.Windows.Forms.Design.EventsTab.GetDefaultProperty(object! obj) -> System.ComponentModel.PropertyDescriptor?
+override System.Windows.Forms.Design.EventsTab.GetProperties(object! component, System.Attribute![]? attributes) -> System.ComponentModel.PropertyDescriptorCollection!
+override System.Windows.Forms.Design.EventsTab.GetProperties(System.ComponentModel.ITypeDescriptorContext? context, object! component, System.Attribute![]? attributes) -> System.ComponentModel.PropertyDescriptorCollection!
+override System.Windows.Forms.Design.EventsTab.HelpKeyword.get -> string!
+override System.Windows.Forms.Design.EventsTab.TabName.get -> string!
 ~override System.Windows.Forms.Design.ToolStripItemDesignerAvailabilityAttribute.Equals(object obj) -> bool
 ~override System.Windows.Forms.Design.WindowsFormsComponentEditor.EditComponent(System.ComponentModel.ITypeDescriptorContext context, object component) -> bool
 ~override System.Windows.Forms.DockingAttribute.Equals(object obj) -> bool
@@ -1987,7 +1987,7 @@
 ~System.Windows.Forms.Design.ComponentEditorPage.Icon.set -> void
 ~System.Windows.Forms.Design.ComponentEditorPage.PageSite.get -> System.Windows.Forms.IComponentEditorPageSite
 ~System.Windows.Forms.Design.ComponentEditorPage.PageSite.set -> void
-~System.Windows.Forms.Design.EventsTab.EventsTab(System.IServiceProvider sp) -> void
+System.Windows.Forms.Design.EventsTab.EventsTab(System.IServiceProvider? sp) -> void
 ~System.Windows.Forms.Design.IUIService.CanShowComponentEditor(object component) -> bool
 ~System.Windows.Forms.Design.IUIService.GetDialogOwnerWindow() -> System.Windows.Forms.IWin32Window
 ~System.Windows.Forms.Design.IUIService.ShowComponentEditor(object component, System.Windows.Forms.IWin32Window parent) -> bool
@@ -3544,14 +3544,14 @@
 ~virtual System.Windows.Forms.Design.ComponentEditorPage.SetComponent(System.ComponentModel.IComponent component) -> void
 ~virtual System.Windows.Forms.Design.ComponentEditorPage.SetSite(System.Windows.Forms.IComponentEditorPageSite site) -> void
 ~virtual System.Windows.Forms.Design.ComponentEditorPage.Title.get -> string
-~virtual System.Windows.Forms.Design.PropertyTab.Bitmap.get -> System.Drawing.Bitmap
-~virtual System.Windows.Forms.Design.PropertyTab.CanExtend(object extendee) -> bool
-~virtual System.Windows.Forms.Design.PropertyTab.Components.get -> object[]
-~virtual System.Windows.Forms.Design.PropertyTab.Components.set -> void
-~virtual System.Windows.Forms.Design.PropertyTab.GetDefaultProperty(object component) -> System.ComponentModel.PropertyDescriptor
-~virtual System.Windows.Forms.Design.PropertyTab.GetProperties(object component) -> System.ComponentModel.PropertyDescriptorCollection
-~virtual System.Windows.Forms.Design.PropertyTab.GetProperties(System.ComponentModel.ITypeDescriptorContext context, object component, System.Attribute[] attributes) -> System.ComponentModel.PropertyDescriptorCollection
-~virtual System.Windows.Forms.Design.PropertyTab.HelpKeyword.get -> string
+virtual System.Windows.Forms.Design.PropertyTab.Bitmap.get -> System.Drawing.Bitmap?
+virtual System.Windows.Forms.Design.PropertyTab.CanExtend(object! extendee) -> bool
+virtual System.Windows.Forms.Design.PropertyTab.Components.get -> object![]?
+virtual System.Windows.Forms.Design.PropertyTab.Components.set -> void
+virtual System.Windows.Forms.Design.PropertyTab.GetDefaultProperty(object! component) -> System.ComponentModel.PropertyDescriptor?
+virtual System.Windows.Forms.Design.PropertyTab.GetProperties(object! component) -> System.ComponentModel.PropertyDescriptorCollection!
+virtual System.Windows.Forms.Design.PropertyTab.GetProperties(System.ComponentModel.ITypeDescriptorContext? context, object! component, System.Attribute![]? attributes) -> System.ComponentModel.PropertyDescriptorCollection!
+virtual System.Windows.Forms.Design.PropertyTab.HelpKeyword.get -> string?
 ~virtual System.Windows.Forms.Design.WindowsFormsComponentEditor.EditComponent(System.ComponentModel.ITypeDescriptorContext context, object component, System.Windows.Forms.IWin32Window owner) -> bool
 ~virtual System.Windows.Forms.Design.WindowsFormsComponentEditor.GetComponentEditorPages() -> System.Type[]
 ~virtual System.Windows.Forms.ErrorProvider.OnRightToLeftChanged(System.EventArgs e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Annotated.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Annotated.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Windows.Forms
+{
+    public partial class Control
+    {
+        /// <summary>
+        ///  Gets the service object of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the service object to get.</typeparam>
+        /// <returns>A service object of type <typeparamref name="T"/> or <see langword="null"/> if there is no such service.</returns>
+        internal T? GetService<T>()
+            where T : class
+            => GetService(typeof(T)) as T;
+
+        /// <summary>
+        ///  Gets the service object of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the service object to get.</typeparam>
+        /// <param name="service">If found, contains the service object when this method returns; otherwise, <see langword="null"/>.</param>
+        /// <returns>A service object of type <typeparamref name="T"/> or <see langword="null"/> if there is no such service.</returns>
+        internal bool TryGetService<T>(
+            [NotNullWhen(true)] out T? service)
+            where T : class
+            => (service = GetService(typeof(T)) as T) != null;
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -32,8 +32,8 @@ namespace System.Windows.Forms
     ///  Defines the base class for controls, which are components with visual representation.
     /// </summary>
     /// <remarks>
-    /// Do not add instance variables to Control absolutely necessary. Every control on a form has the overhead of
-    /// all of these variables.
+    ///  Do not add instance variables to Control absolutely necessary. Every control on a form has the overhead of
+    ///  all of these variables.
     /// </remarks>
     [DefaultProperty(nameof(Text))]
     [DefaultEvent(nameof(Click))]
@@ -64,20 +64,20 @@ namespace System.Windows.Forms
         IHandle
     {
 #if DEBUG
-        internal static readonly TraceSwitch s_paletteTracing = new TraceSwitch(
+        internal static readonly TraceSwitch s_paletteTracing = new(
             "PaletteTracing",
             "Debug Palette code");
-        internal static readonly TraceSwitch s_controlKeyboardRouting = new TraceSwitch(
+        internal static readonly TraceSwitch s_controlKeyboardRouting = new(
             "ControlKeyboardRouting",
             "Debug Keyboard routing for controls");
-        private protected static readonly TraceSwitch s_focusTracing = new TraceSwitch(
+        private protected static readonly TraceSwitch s_focusTracing = new(
             "FocusTracing",
             "Debug focus/active control/enter/leave");
 
-        private static readonly BooleanSwitch s_assertOnControlCreateSwitch = new BooleanSwitch(
+        private static readonly BooleanSwitch s_assertOnControlCreateSwitch = new(
             "AssertOnControlCreate",
             "Assert when anything directly deriving from control is created.");
-        private protected static readonly BooleanSwitch s_traceMnemonicProcessing = new BooleanSwitch(
+        private protected static readonly BooleanSwitch s_traceMnemonicProcessing = new(
             "TraceCanProcessMnemonic",
             "Trace mnemonic processing calls to assure right child-parent call ordering.");
 
@@ -14322,9 +14322,6 @@ namespace System.Windows.Forms
             }
         }
 
-        internal virtual bool AllowsChildrenToShowToolTips()
-        {
-            return true;
-        }
+        internal virtual bool AllowsChildrenToShowToolTips() => true;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/PropertyTab.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/PropertyTab.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 
@@ -14,30 +12,28 @@ namespace System.Windows.Forms.Design
     /// </summary>
     public abstract class PropertyTab : IExtenderProvider
     {
-        private Bitmap _bitmap;
-        private bool _checkedBmp;
-
-        ~PropertyTab() => Dispose(false);
+        private Bitmap? _bitmap;
+        private bool _checkedBitmap;
 
         /// <summary>
         ///  Gets or sets a bitmap to display in the property tab.
         /// </summary>
-        public virtual Bitmap Bitmap
+        public virtual Bitmap? Bitmap
         {
             get
             {
-                if (!_checkedBmp && _bitmap is null)
+                if (!_checkedBitmap && _bitmap is null)
                 {
-                    string bmpName = GetType().Name;
+                    string bitmapName = GetType().Name;
                     try
                     {
-                        _bitmap = DpiHelper.GetBitmapFromIcon(GetType(), bmpName);
+                        _bitmap = DpiHelper.GetBitmapFromIcon(GetType(), bitmapName);
                     }
                     catch (Exception)
                     {
                     }
 
-                    _checkedBmp = true;
+                    _checkedBitmap = true;
                 }
 
                 return _bitmap;
@@ -47,18 +43,18 @@ namespace System.Windows.Forms.Design
         /// <summary>
         ///  Gets or sets the array of components the property tab is associated with.
         /// </summary>
-        public virtual object[] Components { get; set; }
+        public virtual object[]? Components { get; set; }
 
         /// <summary>
         ///  Gets or sets the name for the property tab.
         /// </summary>
-        public abstract string TabName { get; }
+        public abstract string? TabName { get; }
 
         /// <summary>
         ///  Gets or sets the help keyword that is to be associated with this tab. This
         ///  defaults to the tab name.
         /// </summary>
-        public virtual string HelpKeyword => TabName;
+        public virtual string? HelpKeyword => TabName;
 
         /// <summary>
         ///  Gets a value indicating whether the specified object be can extended.
@@ -75,42 +71,36 @@ namespace System.Windows.Forms.Design
         {
             if (disposing)
             {
-                if (_bitmap != null)
-                {
-                    _bitmap.Dispose();
-                    _bitmap = null;
-                }
+                _bitmap?.Dispose();
+                _bitmap = null;
             }
         }
+
+        ~PropertyTab() => Dispose(disposing: false);
 
         /// <summary>
         ///  Gets the default property of the specified component.
         /// </summary>
-        public virtual PropertyDescriptor GetDefaultProperty(object component)
-        {
-            return TypeDescriptor.GetDefaultProperty(component);
-        }
+        public virtual PropertyDescriptor? GetDefaultProperty(object component)
+            => TypeDescriptor.GetDefaultProperty(component);
 
         /// <summary>
         ///  Gets the properties of the specified component.
         /// </summary>
         public virtual PropertyDescriptorCollection GetProperties(object component)
-        {
-            return GetProperties(component, null);
-        }
+            => GetProperties(component, attributes: null);
 
         /// <summary>
-        ///  Gets the properties of the specified component which match the specified
-        ///  attributes.
+        ///  Gets the properties of the specified component which match the specified attributes.
         /// </summary>
-        public abstract PropertyDescriptorCollection GetProperties(object component, Attribute[] attributes);
+        public abstract PropertyDescriptorCollection GetProperties(object component, Attribute[]? attributes);
 
         /// <summary>
         ///  Gets the properties of the specified component.
         /// </summary>
-        public virtual PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object component, Attribute[] attributes)
-        {
-            return GetProperties(component, attributes);
-        }
+        public virtual PropertyDescriptorCollection GetProperties(
+            ITypeDescriptorContext? context,
+            object component,
+            Attribute[]? attributes) => GetProperties(component, attributes);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1897,16 +1897,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private IHelpService GetHelpService()
         {
-            if (_helpService is null && ServiceProvider is not null)
+            if (_helpService is null && ServiceProvider.TryGetService(out _topHelpService!))
             {
-                _topHelpService = (IHelpService)ServiceProvider.GetService(typeof(IHelpService));
-                if (_topHelpService is not null)
+                IHelpService localHelpService = _topHelpService.CreateLocalContext(HelpContextType.ToolWindowSelection);
+                if (localHelpService is not null)
                 {
-                    IHelpService localHelpService = _topHelpService.CreateLocalContext(HelpContextType.ToolWindowSelection);
-                    if (localHelpService is not null)
-                    {
-                        _helpService = localHelpService;
-                    }
+                    _helpService = localHelpService;
                 }
             }
 
@@ -5168,11 +5164,10 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             IntPtr priorFocus = User32.GetFocus();
 
-            var service = (IUIService)GetService(typeof(IUIService));
             DialogResult result;
-            if (service is not null)
+            if (TryGetService(out IUIService uiService))
             {
-                result = service.ShowDialog(dialog);
+                result = uiService.ShowDialog(dialog);
             }
             else
             {
@@ -5234,13 +5229,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 exMessage = ex.Message;
             }
 
-            var uiService = (IUIService)GetService(typeof(IUIService));
-
             ErrorDialog.Message = SR.PBRSFormatExceptionMessage;
             ErrorDialog.Text = SR.PBRSErrorTitle;
             ErrorDialog.Details = exMessage;
 
-            if (uiService is not null)
+            if (TryGetService(out IUIService uiService))
             {
                 revert = DialogResult.Cancel == uiService.ShowDialog(ErrorDialog);
             }
@@ -5307,13 +5300,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 exMessage = ex.Message;
             }
 
-            var uiService = (IUIService)GetService(typeof(IUIService));
-
             ErrorDialog.Message = SR.PBRSErrorInvalidPropertyValue;
             ErrorDialog.Text = SR.PBRSErrorTitle;
             ErrorDialog.Details = exMessage;
 
-            if (uiService is not null)
+            if (TryGetService(out IUIService uiService))
             {
                 revert = DialogResult.Cancel == uiService.ShowDialog(ErrorDialog);
             }
@@ -5485,16 +5476,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void UpdateResetCommand(GridEntry gridEntry)
         {
-            if (TotalProperties > 0)
+            if (TotalProperties > 0 && TryGetService(out IMenuCommandService menuCommandService))
             {
-                var menuCommandService = (IMenuCommandService)GetService(typeof(IMenuCommandService));
-                if (menuCommandService is not null)
+                MenuCommand reset = menuCommandService.FindCommand(PropertyGridCommands.Reset);
+                if (reset is not null)
                 {
-                    MenuCommand reset = menuCommandService.FindCommand(PropertyGridCommands.Reset);
-                    if (reset is not null)
-                    {
-                        reset.Enabled = gridEntry is not null && gridEntry.CanResetPropertyValue();
-                    }
+                    reset.Enabled = gridEntry is not null && gridEntry.CanResetPropertyValue();
                 }
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -2798,7 +2798,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void PropertyGrid_Site_SetInvalidDesignerHost_ThrowsInvalidCastException()
+        public void PropertyGrid_Site_SetInvalidDesignerHost_DoesNotThrowInvalidCastException()
         {
             var mockSite = new Mock<ISite>(MockBehavior.Strict);
             mockSite
@@ -2811,18 +2811,18 @@ namespace System.Windows.Forms.Tests
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
                 .Returns(new object());
             using var control = new PropertyGrid();
-            Assert.Throws<InvalidCastException>(() => control.Site = mockSite.Object);
+            control.Site = mockSite.Object;
             Assert.Same(mockSite.Object, control.Site);
             Assert.False(control.IsHandleCreated);
 
             // Set same.
-            Assert.Throws<InvalidCastException>(() => control.Site = mockSite.Object);
+            control.Site = mockSite.Object;
             Assert.Same(mockSite.Object, control.Site);
             Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsFact]
-        public void PropertyGrid_Site_SetInvalidDesignerHostComponentChangeService_ThrowsInvalidCastException()
+        public void PropertyGrid_Site_SetInvalidDesignerHostComponentChangeService_DoesNotThrowInvalidCastException()
         {
             var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
             mockDesignerHost
@@ -2845,18 +2845,18 @@ namespace System.Windows.Forms.Tests
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
                 .Returns(mockDesignerHost.Object);
             using var control = new PropertyGrid();
-            Assert.Throws<InvalidCastException>(() => control.Site = mockSite.Object);
+            control.Site = mockSite.Object;
             Assert.Same(mockSite.Object, control.Site);
             Assert.False(control.IsHandleCreated);
 
             // Set same.
-            Assert.Throws<InvalidCastException>(() => control.Site = mockSite.Object);
+            control.Site = mockSite.Object;
             Assert.Same(mockSite.Object, control.Site);
             Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsFact]
-        public void PropertyGrid_Site_SetInvalidDesignerHostPropertyValueUIService_ThrowsInvalidCastException()
+        public void PropertyGrid_Site_SetInvalidDesignerHostPropertyValueUIService_DoesNotThrowInvalidCastException()
         {
             var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
             mockDesignerHost
@@ -2879,12 +2879,12 @@ namespace System.Windows.Forms.Tests
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
                 .Returns(mockDesignerHost.Object);
             using var control = new PropertyGrid();
-            Assert.Throws<InvalidCastException>(() => control.Site = mockSite.Object);
+            control.Site = mockSite.Object;
             Assert.Same(mockSite.Object, control.Site);
             Assert.False(control.IsHandleCreated);
 
             // Set same.
-            Assert.Throws<InvalidCastException>(() => control.Site = mockSite.Object);
+            control.Site = mockSite.Object;
             Assert.Same(mockSite.Object, control.Site);
             Assert.False(control.IsHandleCreated);
         }


### PR DESCRIPTION
Add ServiceProvider extensions from the designer code. For try methods allow for null provider. Add internal overloads to Control.

Annotate PropertyTab and use the new overloads in some of the PropertyGrid classes.

Handle unexpected/null ISite.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5247)