### PR TITLE
Fixing Entry not found exception for AdjustWindowRectExForDpi().

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -437,7 +437,7 @@ namespace System.Windows.Forms
 
                 CreateParams cp = CreateParams;
 
-                AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
+                AdjustWindowRectExForControlDpi(ref rect, cp.Style, false, cp.ExStyle);
                 _clientWidth = _width - (rect.right - rect.left);
                 _clientHeight = _height - (rect.bottom - rect.top);
             }
@@ -5786,7 +5786,7 @@ namespace System.Windows.Forms
             CreateParams cp = CreateParams;
 
             // We would need to get adornments metrics for both (old and new) Dpi in case application is in permonitor V2 mode and Dpi changed.
-            AdjustWindowRectEx(ref adornmentsAfterDpiChange, cp.Style, bMenu: false, cp.ExStyle);
+            AdjustWindowRectExForControlDpi(ref adornmentsAfterDpiChange, cp.Style, bMenu: false, cp.ExStyle);
 
             if (_oldDeviceDpi != _deviceDpi && OsVersion.IsWindows10_1703OrGreater)
             {
@@ -6872,11 +6872,16 @@ namespace System.Windows.Forms
             DpiHelper.ScaleBitmapLogicalToDevice(ref logicalBitmap, DeviceDpi);
         }
 
-        private protected void AdjustWindowRectEx(ref RECT rect, int style, bool bMenu, int exStyle)
+        private protected void AdjustWindowRectExForControlDpi(ref RECT rect, int style, bool bMenu, int exStyle)
+        {
+            AdjustWindowRectExForDpi(ref rect, style, bMenu, exStyle, _deviceDpi);
+        }
+
+        private void AdjustWindowRectExForDpi(ref RECT rect, int style, bool bMenu, int exStyle, int dpi)
         {
             if ((DpiHelper.IsPerMonitorV2Awareness || DpiHelper.IsScalingRequired) && OsVersion.IsWindows10_1703OrGreater)
             {
-                User32.AdjustWindowRectExForDpi(ref rect, style, bMenu.ToBOOL(), exStyle, (uint)_deviceDpi);
+                User32.AdjustWindowRectExForDpi(ref rect, style, bMenu.ToBOOL(), exStyle, (uint)dpi);
             }
             else
             {
@@ -10310,7 +10315,7 @@ namespace System.Windows.Forms
         {
             CreateParams cp = CreateParams;
             RECT adornments = default;
-            AdjustWindowRectEx(ref adornments, cp.Style, false, cp.ExStyle);
+            AdjustWindowRectExForControlDpi(ref adornments, cp.Style, false, cp.ExStyle);
             Size minSize = MinimumSize;
             Size maxSize = MaximumSize;
 
@@ -10809,7 +10814,7 @@ namespace System.Windows.Forms
         {
             RECT rect = new RECT(0, 0, width, height);
             CreateParams cp = CreateParams;
-            AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
+            AdjustWindowRectExForControlDpi(ref rect, cp.Style, false, cp.ExStyle);
             return rect.Size;
         }
 
@@ -11415,7 +11420,7 @@ namespace System.Windows.Forms
 
             CreateParams cp = CreateParams;
 
-            AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
+            AdjustWindowRectExForControlDpi(ref rect, cp.Style, false, cp.ExStyle);
             int clientWidth = width - (rect.right - rect.left);
             int clientHeight = height - (rect.bottom - rect.top);
             UpdateBounds(x, y, width, height, clientWidth, clientHeight);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -5785,7 +5785,7 @@ namespace System.Windows.Forms
             RECT adornmentsAfterDpiChange = default;
             CreateParams cp = CreateParams;
 
-            // We would need to get old adornments metrics as we will be deducting this from bounds and then scale it.
+            // We would need to get adornments metrics for both (old and new) Dpi in case application is in permonitor V2 mode and Dpi changed.
             AdjustWindowRectEx(ref adornmentsAfterDpiChange, cp.Style, bMenu: false, cp.ExStyle);
 
             if (_oldDeviceDpi != _deviceDpi && OsVersion.IsWindows10_1703OrGreater)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -5782,20 +5782,19 @@ namespace System.Windows.Forms
             // We should not include the window adornments in our calculation,
             // because windows scales them for us.
             RECT adornmentsBeforeDpiChange = default;
+            RECT adornmentsAfterDpiChange = default;
             CreateParams cp = CreateParams;
 
             // We would need to get old adornments metrics as we will be deducting this from bounds and then scale it.
-            User32.AdjustWindowRectExForDpi(ref adornmentsBeforeDpiChange, cp.Style, bMenu: false.ToBOOL(), cp.ExStyle, (uint)_oldDeviceDpi);
+            AdjustWindowRectEx(ref adornmentsAfterDpiChange, cp.Style, bMenu: false, cp.ExStyle);
 
-            // And now, we get new adornments to add to bounds after scaling
-            RECT adornmentsAfterDpiChange = default;
-            if (_oldDeviceDpi != _deviceDpi)
+            if (_oldDeviceDpi != _deviceDpi && OsVersion.IsWindows10_1703OrGreater)
             {
-                AdjustWindowRectEx(ref adornmentsAfterDpiChange, cp.Style, bMenu: false, cp.ExStyle);
+                User32.AdjustWindowRectExForDpi(ref adornmentsBeforeDpiChange, cp.Style, bMenu: false.ToBOOL(), cp.ExStyle, (uint)_oldDeviceDpi);
             }
             else
             {
-                adornmentsAfterDpiChange = adornmentsBeforeDpiChange;
+                adornmentsBeforeDpiChange = adornmentsAfterDpiChange;
             }
 
             // Do this even for auto sized controls.  They'll "snap back", but it is important to size them in case
@@ -6875,7 +6874,7 @@ namespace System.Windows.Forms
 
         private protected void AdjustWindowRectEx(ref RECT rect, int style, bool bMenu, int exStyle)
         {
-            if (DpiHelper.IsPerMonitorV2Awareness || DpiHelper.IsScalingRequired)
+            if ((DpiHelper.IsPerMonitorV2Awareness || DpiHelper.IsScalingRequired) && OsVersion.IsWindows10_1703OrGreater)
             {
                 User32.AdjustWindowRectExForDpi(ref rect, style, bMenu.ToBOOL(), exStyle, (uint)_deviceDpi);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -5790,7 +5790,7 @@ namespace System.Windows.Forms
 
             if (_oldDeviceDpi != _deviceDpi && OsVersion.IsWindows10_1703OrGreater)
             {
-                User32.AdjustWindowRectExForDpi(ref adornmentsBeforeDpiChange, cp.Style, bMenu: false.ToBOOL(), cp.ExStyle, (uint)_oldDeviceDpi);
+                AdjustWindowRectExForDpi(ref adornmentsBeforeDpiChange, cp.Style, bMenu: false, cp.ExStyle, _oldDeviceDpi);
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -3060,7 +3060,7 @@ namespace System.Windows.Forms
         private Size ComputeWindowSize(Size clientSize, int style, int exStyle)
         {
             RECT result = new RECT(0, 0, clientSize.Width, clientSize.Height);
-            AdjustWindowRectEx(ref result, style, false, exStyle);
+            AdjustWindowRectExForControlDpi(ref result, style, false, exStyle);
             return new Size(result.right - result.left, result.bottom - result.top);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
@@ -297,7 +297,7 @@ namespace System.Windows.Forms
             RECT rect = new RECT();
             CreateParams cp = CreateParams;
 
-            AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
+            AdjustWindowRectExForControlDpi(ref rect, cp.Style, false, cp.ExStyle);
 
             Rectangle bounds = Bounds;
             using var rgn1 = new Gdi32.RegionScope(0, 0, bounds.Width, bounds.Height);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms
                     RECT rect = new RECT();
                     CreateParams cp = CreateParams;
 
-                    AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
+                    AdjustWindowRectExForControlDpi(ref rect, cp.Style, false, cp.ExStyle);
 
                     // the coordinates we get back are negative, we need to translate this back to positive.
                     int offsetX = -rect.left; // one to get back to 0,0, another to translate


### PR DESCRIPTION
Making sure we call `AdjustWindowRectExForDpi` only on supported OS. This API is available in Windows 10 and above versions.

Fixes : https://developercommunity.visualstudio.com/t/unable-to-find-an-entry-point-named-Adj/1476945?entry=problem&space=61&q=AdjustWindowRectEx&viewtype=all

related #4797 

fixes #5278 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5260)