### PR TITLE
Add support UIA provider for CheckedListBox control

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxAccessibleObject.cs
@@ -2,125 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class CheckedListBox
     {
-        internal class CheckedListBoxAccessibleObject : ControlAccessibleObject
+        internal class CheckedListBoxAccessibleObject : ListBoxAccessibleObject
         {
             public CheckedListBoxAccessibleObject(CheckedListBox owner) : base(owner)
-            {
-            }
+            { }
 
-            private CheckedListBox CheckedListBox
-            {
-                get
-                {
-                    return (CheckedListBox)Owner;
-                }
-            }
-
-            public override AccessibleObject GetChild(int index)
-            {
-                if (index >= 0 && index < CheckedListBox.Items.Count)
-                {
-                    return new CheckedListBoxItemAccessibleObject(CheckedListBox.GetItemText(CheckedListBox.Items[index]), index, this);
-                }
-                else
-                {
-                    return null;
-                }
-            }
-
-            public override int GetChildCount()
-            {
-                return CheckedListBox.Items.Count;
-            }
-
-            public override AccessibleObject GetFocused()
-            {
-                if (!CheckedListBox.IsHandleCreated)
-                {
-                    return null;
-                }
-
-                int index = CheckedListBox.FocusedIndex;
-
-                if (index >= 0)
-                {
-                    return GetChild(index);
-                }
-
-                return null;
-            }
-
-            public override AccessibleObject GetSelected()
-            {
-                if (!CheckedListBox.IsHandleCreated)
-                {
-                    return null;
-                }
-
-                int index = CheckedListBox.SelectedIndex;
-
-                if (index >= 0)
-                {
-                    return GetChild(index);
-                }
-
-                return null;
-            }
-
-            public override AccessibleObject HitTest(int x, int y)
-            {
-                if (!CheckedListBox.IsHandleCreated)
-                {
-                    return null;
-                }
-
-                // Within a child element?
-                //
-                int count = GetChildCount();
-
-                for (int index = 0; index < count; ++index)
-                {
-                    AccessibleObject child = GetChild(index);
-
-                    if (child.Bounds.Contains(x, y))
-                    {
-                        return child;
-                    }
-                }
-
-                // Within the CheckedListBox bounds?
-                //
-                if (Bounds.Contains(x, y))
-                {
-                    return this;
-                }
-
-                return null;
-            }
-
-            public override AccessibleObject Navigate(AccessibleNavigation direction)
-            {
-                if (GetChildCount() > 0)
-                {
-                    if (direction == AccessibleNavigation.FirstChild)
-                    {
-                        return GetChild(0);
-                    }
-
-                    if (direction == AccessibleNavigation.LastChild)
-                    {
-                        return GetChild(GetChildCount() - 1);
-                    }
-                }
-
-                return base.Navigate(direction);
-            }
+            private protected override ListBoxItemAccessibleObject CreateItemAccessibleObject(ListBox listBox, ItemArray.Entry item)
+                => new CheckedListBoxItemAccessibleObject((CheckedListBox)listBox, item, this);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -845,6 +845,16 @@ namespace System.Windows.Forms
         protected virtual void OnItemCheck(ItemCheckEventArgs ice)
         {
             _onItemCheck?.Invoke(this, ice);
+
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibleObject checkedItem = AccessibilityObject.GetChild(ice.Index);
+
+                if (checkedItem is not null)
+                {
+                    checkedItem.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.ToggleToggleStatePropertyId, ice.CurrentValue, ice.NewValue);
+                }
+            }
         }
 
         protected override void OnMeasureItem(MeasureItemEventArgs e)
@@ -1034,7 +1044,5 @@ namespace System.Windows.Forms
                     break;
             }
         }
-
-        internal override bool SupportsUiaProviders => false;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
@@ -72,6 +72,9 @@ namespace System.Windows.Forms
                 }
             }
 
+            private protected virtual ListBoxItemAccessibleObject CreateItemAccessibleObject(ListBox listBox, ItemArray.Entry item)
+                => new(listBox, item, this);
+
             /// <summary>
             ///  Return the child object at the given screen coordinates.
             /// </summary>
@@ -155,6 +158,10 @@ namespace System.Windows.Forms
                         return IsPatternSupported(UiaCore.UIA.ScrollPatternId);
                     case UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId:
                         return IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId);
+                    case UiaCore.UIA.IsEnabledPropertyId:
+                        return _owningListBox.Enabled;
+                    case UiaCore.UIA.RuntimeIdPropertyId:
+                        return RuntimeId;
                     default:
                         return base.GetPropertyValue(propertyID);
                 }
@@ -246,7 +253,7 @@ namespace System.Windows.Forms
 
                 if (!_itemAccessibleObjects.ContainsKey(item))
                 {
-                    _itemAccessibleObjects.Add(item, new ListBoxItemAccessibleObject(_owningListBox, item, this));
+                    _itemAccessibleObjects.Add(item, CreateItemAccessibleObject(_owningListBox, item));
                 }
 
                 return _itemAccessibleObjects[item];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms
                 _owningAccessibleObject = owningAccessibleObject ?? throw new ArgumentNullException(nameof(owningAccessibleObject));
             }
 
-            private int CurrentIndex
+            private protected int CurrentIndex
                 => _owningListBox.Items.InnerArray.IndexOf(_itemEntry);
 
             internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => _owningAccessibleObject;
@@ -42,6 +42,8 @@ namespace System.Windows.Forms
 
             internal override UiaCore.IRawElementProviderSimple ItemSelectionContainer
                 => _owningAccessibleObject;
+
+            public override AccessibleObject Parent => _owningAccessibleObject;
 
             /// <summary>
             ///  Gets the runtime ID.
@@ -116,10 +118,7 @@ namespace System.Windows.Forms
             /// </summary>
             public override string? Name
             {
-                get
-                {
-                    return _owningListBox.GetItemText(_itemEntry.Item);
-                }
+                get => _owningListBox.GetItemText(_itemEntry.Item);
                 set => base.Name = value;
             }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.Designer.cs
@@ -143,7 +143,6 @@ namespace WinformsControlsTest
             this.Name = "ListViewTest";
             this.Text = "ListView Test";
             this.ResumeLayout(false);
-
         }
 
         #endregion

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.Designer.cs
@@ -52,187 +52,164 @@ namespace WinformsControlsTest
             this.domainUpDown1 = new System.Windows.Forms.DomainUpDown();
             this.linkLabel1 = new System.Windows.Forms.LinkLabel();
             this.linkLabel2 = new System.Windows.Forms.LinkLabel();
+            this.checkedListBox2 = new System.Windows.Forms.CheckedListBox();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.tabPage2.SuspendLayout();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
             this.SuspendLayout();
-            //
+            // 
             // progressBar1
-            //
+            // 
             this.progressBar1.Location = new System.Drawing.Point(0, 0);
             this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(284, 23);
+            this.progressBar1.Size = new System.Drawing.Size(331, 27);
             this.progressBar1.TabIndex = 0;
-            //
+            // 
             // backgroundWorker1
-            //
+            // 
             this.backgroundWorker1.WorkerReportsProgress = true;
             this.backgroundWorker1.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundWorker1_DoWork);
             this.backgroundWorker1.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.backgroundWorker1_ProgressChanged);
-            //
+            // 
             // button1
-            //
+            // 
             this.button1.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.button1.Location = new System.Drawing.Point(13, 43);
+            this.button1.Location = new System.Drawing.Point(15, 50);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
+            this.button1.Size = new System.Drawing.Size(88, 27);
             this.button1.TabIndex = 1;
             this.button1.Text = "button1";
             this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += Button1_Click;
-            //
+            // 
             // label1
-            //
+            // 
             this.label1.AccessibleDescription = "Test Label AccessibleDescription";
             this.label1.AccessibleName = "Test Label AccessibleName";
             this.label1.AccessibleRole = System.Windows.Forms.AccessibleRole.Indicator;
             this.label1.AutoSize = true;
             this.label1.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.label1.Location = new System.Drawing.Point(13, 73);
+            this.label1.Location = new System.Drawing.Point(15, 84);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(35, 13);
+            this.label1.Size = new System.Drawing.Size(38, 15);
             this.label1.TabIndex = 2;
             this.label1.Text = "label1";
             // 
-            // linkLabel1
-            // 
-            this.linkLabel1.AutoSize = true;
-            this.linkLabel1.Location = new System.Drawing.Point(53, 73);
-            this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(60, 15);
-            this.linkLabel1.TabIndex = 3;
-            this.linkLabel1.Text = "linkLabel1";
-            // 
-            // linkLabel2
-            // 
-            this.linkLabel2.AutoSize = true;
-            this.linkLabel2.LinkArea = new System.Windows.Forms.LinkArea(0, 4);
-            this.linkLabel2.Location = new System.Drawing.Point(361, 200);
-            this.linkLabel2.Name = "linkLabel2";
-            this.linkLabel2.Size = new System.Drawing.Size(92, 17);
-            this.linkLabel2.TabIndex = 4;
-            this.linkLabel2.Text = "Home MSN Github";
-            this.linkLabel2.Links.Add(5, 3, "www.msn.com");
-            this.linkLabel2.Links.Add(9, 6, "www.github.com");
-            //
             // maskedTextBox1
-            //
-            this.maskedTextBox1.Location = new System.Drawing.Point(13, 90);
+            // 
+            this.maskedTextBox1.Location = new System.Drawing.Point(15, 104);
             this.maskedTextBox1.Name = "maskedTextBox1";
-            this.maskedTextBox1.Size = new System.Drawing.Size(100, 20);
+            this.maskedTextBox1.Size = new System.Drawing.Size(116, 23);
             this.maskedTextBox1.TabIndex = 5;
             this.maskedTextBox1.Text = "Masked";
-            //
+            // 
             // richTextBox1
-            //
-            this.richTextBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.richTextBox1.Location = new System.Drawing.Point(13, 117);
+            // 
+            this.richTextBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            this.richTextBox1.Location = new System.Drawing.Point(15, 135);
             this.richTextBox1.Name = "richTextBox1";
-            this.richTextBox1.Size = new System.Drawing.Size(100, 96);
+            this.richTextBox1.Size = new System.Drawing.Size(116, 110);
             this.richTextBox1.TabIndex = 6;
             this.richTextBox1.Text = "LLLL";
-            //
+            // 
             // textBox1
-            //
-            this.textBox1.Location = new System.Drawing.Point(13, 229);
+            // 
+            this.textBox1.Location = new System.Drawing.Point(15, 264);
             this.textBox1.Name = "textBox1";
             this.textBox1.PlaceholderText = "Type some text here...";
-            this.textBox1.Size = new System.Drawing.Size(100, 20);
+            this.textBox1.Size = new System.Drawing.Size(116, 23);
             this.textBox1.TabIndex = 7;
             this.textBox1.Text = "LLLLL";
-            //
+            // 
             // tabControl1
-            //
+            // 
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage2);
-            this.tabControl1.Location = new System.Drawing.Point(121, 43);
+            this.tabControl1.Location = new System.Drawing.Point(141, 50);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
             this.tabControl1.ShowToolTips = true;
-            this.tabControl1.Size = new System.Drawing.Size(200, 100);
+            this.tabControl1.Size = new System.Drawing.Size(233, 115);
             this.tabControl1.TabIndex = 8;
-            //
+            // 
             // tabPage1
-            //
+            // 
             this.tabPage1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.tabPage1.Controls.Add(this.comboBox1);
-            this.tabPage1.Location = new System.Drawing.Point(4, 22);
+            this.tabPage1.Location = new System.Drawing.Point(4, 24);
             this.tabPage1.Name = "tabPage1";
-            this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(192, 74);
+            this.tabPage1.Size = new System.Drawing.Size(225, 87);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "tabPage1";
             this.tabPage1.ToolTipText = "I am tabPage1!";
             this.tabPage1.UseVisualStyleBackColor = true;
-            //
+            // 
             // comboBox1
-            //
+            // 
             this.comboBox1.FormattingEnabled = true;
-            this.comboBox1.Location = new System.Drawing.Point(19, 26);
+            this.comboBox1.Location = new System.Drawing.Point(22, 30);
             this.comboBox1.Name = "comboBox1";
-            this.comboBox1.Size = new System.Drawing.Size(121, 21);
+            this.comboBox1.Size = new System.Drawing.Size(140, 23);
             this.comboBox1.TabIndex = 0;
-            //
+            // 
             // tabPage2
-            //
+            // 
             this.tabPage2.Controls.Add(this.checkBox1);
-            this.tabPage2.Location = new System.Drawing.Point(4, 22);
+            this.tabPage2.Location = new System.Drawing.Point(4, 24);
             this.tabPage2.Name = "tabPage2";
-            this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(192, 74);
+            this.tabPage2.Size = new System.Drawing.Size(225, 87);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "tabPage2";
             this.tabPage2.ToolTipText = "I am tabPage2!\r\nI am multiline tooltip!";
             this.tabPage2.UseVisualStyleBackColor = true;
-            //
+            // 
             // checkBox1
-            //
+            // 
             this.checkBox1.AutoSize = true;
-            this.checkBox1.Location = new System.Drawing.Point(7, 19);
+            this.checkBox1.Location = new System.Drawing.Point(8, 22);
             this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(80, 17);
+            this.checkBox1.Size = new System.Drawing.Size(83, 19);
             this.checkBox1.TabIndex = 0;
             this.checkBox1.Text = "checkBox1";
             this.checkBox1.UseVisualStyleBackColor = true;
-            //
+            // 
             // radioButton2
-            //
-            this.radioButton2.Location = new System.Drawing.Point(16, 48);
+            // 
+            this.radioButton2.Location = new System.Drawing.Point(19, 55);
             this.radioButton2.Name = "radioButton2";
-            this.radioButton2.Size = new System.Drawing.Size(85, 17);
+            this.radioButton2.Size = new System.Drawing.Size(99, 20);
             this.radioButton2.TabIndex = 1;
             this.radioButton2.TabStop = true;
             this.radioButton2.Text = "radioButton2";
             this.radioButton2.UseVisualStyleBackColor = true;
-            //
+            // 
             // radioButton1
-            //
-            this.radioButton1.Location = new System.Drawing.Point(16, 25);
+            // 
+            this.radioButton1.Location = new System.Drawing.Point(19, 29);
             this.radioButton1.Name = "radioButton1";
-            this.radioButton1.Size = new System.Drawing.Size(85, 17);
+            this.radioButton1.Size = new System.Drawing.Size(99, 20);
             this.radioButton1.TabIndex = 0;
             this.radioButton1.TabStop = true;
             this.radioButton1.Text = "radioButton1";
             this.radioButton1.UseVisualStyleBackColor = true;
-            //
+            // 
             // groupBox1
-            //
+            // 
             this.groupBox1.AccessibleDescription = "Test GroupBox AccessibleDescription";
             this.groupBox1.AccessibleName = "Test GroupBox AccessibleName";
             this.groupBox1.AccessibleRole = System.Windows.Forms.AccessibleRole.Table;
             this.groupBox1.Controls.Add(this.radioButton2);
             this.groupBox1.Controls.Add(this.radioButton1);
-            this.groupBox1.Location = new System.Drawing.Point(125, 171);
+            this.groupBox1.Location = new System.Drawing.Point(146, 197);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(177, 81);
+            this.groupBox1.Size = new System.Drawing.Size(206, 93);
             this.groupBox1.TabIndex = 9;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "groupBox1";
-            //
+            // 
             // checkedListBox1
-            //
+            // 
             this.checkedListBox1.BackColor = System.Drawing.SystemColors.Window;
             this.checkedListBox1.FormattingEnabled = true;
             this.checkedListBox1.Items.AddRange(new object[] {
@@ -240,32 +217,73 @@ namespace WinformsControlsTest
             "California",
             "Florida",
             "New York"});
-            this.checkedListBox1.Location = new System.Drawing.Point(327, 19);
+            this.checkedListBox1.Location = new System.Drawing.Point(378, 49);
             this.checkedListBox1.Name = "checkedListBox1";
-            this.checkedListBox1.Size = new System.Drawing.Size(202, 94);
+            this.checkedListBox1.Size = new System.Drawing.Size(140, 112);
             this.checkedListBox1.TabIndex = 10;
-            //
+            // 
             // numericUpDown1
-            //
-            this.numericUpDown1.Location = new System.Drawing.Point(361, 134);
+            // 
+            this.numericUpDown1.Location = new System.Drawing.Point(378, 197);
             this.numericUpDown1.Name = "numericUpDown1";
-            this.numericUpDown1.Size = new System.Drawing.Size(120, 20);
+            this.numericUpDown1.Size = new System.Drawing.Size(140, 23);
             this.numericUpDown1.TabIndex = 11;
-            //
+            // 
             // domainUpDown1
-            //
-            this.domainUpDown1.Location = new System.Drawing.Point(361, 171);
+            // 
+            this.domainUpDown1.Items.Add("First");
+            this.domainUpDown1.Items.Add("Second");
+            this.domainUpDown1.Items.Add("Third");
+            this.domainUpDown1.Items.Add("Fourth");
+            this.domainUpDown1.Location = new System.Drawing.Point(378, 227);
             this.domainUpDown1.Name = "domainUpDown1";
-            this.domainUpDown1.Size = new System.Drawing.Size(120, 20);
+            this.domainUpDown1.Size = new System.Drawing.Size(140, 23);
             this.domainUpDown1.TabIndex = 12;
             this.domainUpDown1.Text = "domainUpDown1";
-            this.domainUpDown1.Items.AddRange(new string[] { "First", "Second", "Third", "Fourth" });
             // 
-            // Form1
+            // linkLabel1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.linkLabel1.AutoSize = true;
+            this.linkLabel1.Location = new System.Drawing.Point(62, 84);
+            this.linkLabel1.Name = "linkLabel1";
+            this.linkLabel1.Size = new System.Drawing.Size(60, 15);
+            this.linkLabel1.TabIndex = 3;
+            this.linkLabel1.TabStop = true;
+            this.linkLabel1.Text = "linkLabel1";
+            // 
+            // linkLabel2
+            // 
+            this.linkLabel2.AutoSize = true;
+            this.linkLabel2.Location = new System.Drawing.Point(378, 255);
+            this.linkLabel2.Name = "linkLabel2";
+            this.linkLabel2.Size = new System.Drawing.Size(108, 21);
+            this.linkLabel2.TabIndex = 4;
+            this.linkLabel2.TabStop = true;
+            this.linkLabel2.Text = "Home MSN Github";
+            this.linkLabel2.UseCompatibleTextRendering = true;
+            // 
+            // checkedListBox2
+            // 
+            this.checkedListBox2.BackColor = System.Drawing.SystemColors.Window;
+            this.checkedListBox2.FormattingEnabled = true;
+            this.checkedListBox2.Items.AddRange(new object[] {
+            "Beijing",
+            "Moscow",
+            "Ivanovo",
+            "ShangHai",
+            "Vichuga",
+            "Tokyo"});
+            this.checkedListBox2.Location = new System.Drawing.Point(525, 49);
+            this.checkedListBox2.Name = "checkedListBox2";
+            this.checkedListBox2.Size = new System.Drawing.Size(140, 58);
+            this.checkedListBox2.TabIndex = 13;
+            // 
+            // MultipleControls
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(639, 397);
+            this.ClientSize = new System.Drawing.Size(746, 458);
+            this.Controls.Add(this.checkedListBox2);
             this.Controls.Add(this.domainUpDown1);
             this.Controls.Add(this.numericUpDown1);
             this.Controls.Add(this.checkedListBox1);
@@ -279,7 +297,7 @@ namespace WinformsControlsTest
             this.Controls.Add(this.progressBar1);
             this.Controls.Add(this.linkLabel1);
             this.Controls.Add(this.linkLabel2);
-            this.Name = "Form1";
+            this.Name = "MultipleControls";
             this.Text = "These look ok";
             this.Load += new System.EventHandler(this.Test3_Load);
             this.tabControl1.ResumeLayout(false);
@@ -315,5 +333,6 @@ namespace WinformsControlsTest
         private System.Windows.Forms.DomainUpDown domainUpDown1;
         private System.Windows.Forms.LinkLabel linkLabel1;
         private System.Windows.Forms.LinkLabel linkLabel2;
+        private System.Windows.Forms.CheckedListBox checkedListBox2;
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/CheckedListBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/CheckedListBoxAccessibleObjectTests.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 
         [WinFormsTheory]
         [InlineData(true, (int)UiaCore.UIA.ListControlTypeId)]
-        [InlineData(false, (int)UiaCore.UIA.PaneControlTypeId)]
+        [InlineData(false, (int)UiaCore.UIA.ListControlTypeId)]
         public void CheckedListBoxAccessibleObject_ControlType_IsExpected_IfAccessibleRoleIsDefault(bool createControl, int expectedType)
         {
             using CheckedListBox checkedListBox = new CheckedListBox();
@@ -102,6 +102,65 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 
             Assert.Equal(expectedRole, actual);
             Assert.Equal(createControl, checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0)]
+        [InlineData(3)]
+        public void CheckedListBoxAccessibleObject_GetChildCount_ReturnsExpected(int childCount)
+        {
+            using CheckedListBox checkedListBox = new();
+
+            for (int i = 0; i < childCount; i++)
+            {
+                checkedListBox.Items.Add(i);
+            }
+
+            int actual = checkedListBox.AccessibilityObject.GetChildCount();
+
+            Assert.Equal(childCount, actual);
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxAccessibleObject_RuntimeId_NotNull()
+        {
+            using CheckedListBox checkedListBox = new();
+
+            Assert.NotNull(checkedListBox.AccessibilityObject.RuntimeId);
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxAccessibleObject_FragmentNavigate_NavigateToFirstChild_IsExpected()
+        {
+            using CheckedListBox checkedListBox = new();
+            AccessibleObject accessibleObject = checkedListBox.AccessibilityObject;
+
+            checkedListBox.Items.Add(0);
+            checkedListBox.Items.Add(1);
+            checkedListBox.Items.Add(2);
+
+            AccessibleObject expected = accessibleObject.GetChild(0);
+
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxAccessibleObject_FragmentNavigate_NavigateToLastChild_IsExpected()
+        {
+            using CheckedListBox checkedListBox = new();
+            AccessibleObject accessibleObject = checkedListBox.AccessibilityObject;
+
+            checkedListBox.Items.Add(0);
+            checkedListBox.Items.Add(1);
+            checkedListBox.Items.Add(2);
+
+            AccessibleObject expected = accessibleObject.GetChild(2);
+
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(checkedListBox.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxItemAccessibleObjectTests.cs
@@ -1,0 +1,291 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static System.Windows.Forms.CheckedListBox;
+using static Interop;
+
+namespace System.Windows.Forms.Tests.AccessibleObjects
+{
+    public class CheckedListBoxItemAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void CheckedListBoxItemAccessibleObject_Ctor_OwningCheckedListBoxIsNull_RaiseException()
+        {
+            using CheckedListBox checkedListBox = new();
+            var accessibleObject = (CheckedListBoxAccessibleObject)checkedListBox.AccessibilityObject;
+
+            Assert.Throws<ArgumentNullException>(() => { new CheckedListBoxItemAccessibleObject(null, new ItemArray.Entry("A"), accessibleObject); });
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxItemAccessibleObject_Ctor_ItemCheckedListBoxIsNull_RaiseException()
+        {
+            using CheckedListBox checkedListBox = new();
+            var accessibleObject = (CheckedListBoxAccessibleObject)checkedListBox.AccessibilityObject;
+
+            Assert.Throws<ArgumentNullException>(() => { new CheckedListBoxItemAccessibleObject(checkedListBox, null, accessibleObject); });
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxItemAccessibleObject_Ctor_ParentAccessibleObjectIsNull_RaiseException()
+        {
+            using CheckedListBox checkedListBox = new();
+
+            Assert.Throws<ArgumentNullException>(() => { new CheckedListBoxItemAccessibleObject(checkedListBox, new ItemArray.Entry("A"), null); });
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("A")]
+        [InlineData("")]
+        public void CheckedListBoxItemAccessibleObject_Name_ReturnsExpected(string testName)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add(testName);
+
+            Assert.Equal(testName, checkedListBox.AccessibilityObject.GetChild(0).Name);
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxItemAccessibleObject_Role_IsCheckButton()
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+
+            Assert.Equal(AccessibleRole.CheckButton, checkedListBox.AccessibilityObject.GetChild(0).Role);
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxItemAccessibleObject_CurrentIndex_IsExpected()
+        {
+            using CheckedListBox checkedListBox = new();
+
+            checkedListBox.Items.Add(0);
+            checkedListBox.Items.Add(1);
+            checkedListBox.Items.Add(2);
+
+            AccessibleObject accessibleObject = checkedListBox.AccessibilityObject;
+
+            Assert.Equal(0, accessibleObject.GetChild(0).TestAccessor().Dynamic.CurrentIndex);
+            Assert.Equal(1, accessibleObject.GetChild(1).TestAccessor().Dynamic.CurrentIndex);
+            Assert.Equal(2, accessibleObject.GetChild(2).TestAccessor().Dynamic.CurrentIndex);
+
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.TogglePatternId)]
+        [InlineData((int)UiaCore.UIA.InvokePatternId)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        [InlineData((int)UiaCore.UIA.ValuePatternId)]
+        public void CheckedListBoxItemAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+
+            AccessibleObject itemAccessibleObject = checkedListBox.AccessibilityObject.GetChild(0);
+
+            Assert.True(itemAccessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxItemAccessibleObject_RuntimeId_NotNull()
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+
+            Assert.NotNull(checkedListBox.AccessibilityObject.GetChild(0).RuntimeId);
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void CheckedListBoxItemAccessibleObject_FragmentNavigate_Parent_IsExpected(int itemIndex)
+        {
+            using CheckedListBox checkedListBox = new();
+            AccessibleObject expected = checkedListBox.AccessibilityObject;
+
+            checkedListBox.Items.Add(0);
+            checkedListBox.Items.Add(1);
+            checkedListBox.Items.Add(2);
+
+            AccessibleObject itemAccessibleObject = checkedListBox.AccessibilityObject.GetChild(itemIndex);
+            UiaCore.IRawElementProviderFragment actual = itemAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent);
+
+            Assert.Equal(expected, actual);
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxItemAccessibleObject_FragmentNavigate_NextSibling_IsExpected()
+        {
+            using CheckedListBox checkedListBox = new();
+
+            checkedListBox.Items.Add(0);
+            checkedListBox.Items.Add(1);
+            checkedListBox.Items.Add(2);
+
+            AccessibleObject itemAccessibleObject1 = checkedListBox.AccessibilityObject.GetChild(0);
+            AccessibleObject itemAccessibleObject2 = checkedListBox.AccessibilityObject.GetChild(1);
+            AccessibleObject itemAccessibleObject3 = checkedListBox.AccessibilityObject.GetChild(2);
+
+            Assert.Equal(itemAccessibleObject2, itemAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(itemAccessibleObject3, itemAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(itemAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxItemAccessibleObject_FragmentNavigate_PreviousSibling_IsExpected()
+        {
+            using CheckedListBox checkedListBox = new();
+
+            checkedListBox.Items.Add(0);
+            checkedListBox.Items.Add(1);
+            checkedListBox.Items.Add(2);
+
+            AccessibleObject itemAccessibleObject1 = checkedListBox.AccessibilityObject.GetChild(0);
+            AccessibleObject itemAccessibleObject2 = checkedListBox.AccessibilityObject.GetChild(1);
+            AccessibleObject itemAccessibleObject3 = checkedListBox.AccessibilityObject.GetChild(2);
+
+            Assert.Null(itemAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(itemAccessibleObject1, itemAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(itemAccessibleObject2, itemAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxItemAccessibleObject_DefaultAction_IfHandleIsNotCreated_ReturnsEmptyString()
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+
+            Assert.Equal(string.Empty, checkedListBox.AccessibilityObject.GetChild(0).DefaultAction);
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> CheckedListBoxItemAccessibleObject_DefaultAction_ControlType_IfHandleIsCreated_ReturnsExpected_TestData()
+        {
+            yield return new object[] { true, SR.AccessibleActionUncheck };
+            yield return new object[] { false, SR.AccessibleActionCheck };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(CheckedListBoxItemAccessibleObject_DefaultAction_ControlType_IfHandleIsCreated_ReturnsExpected_TestData))]
+        public void CheckedListBoxItemAccessibleObject_DefaultAction_IfHandleIsCreated_ReturnsExpected(bool isChecked, string expected)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+            checkedListBox.SetItemChecked(0, isChecked);
+            checkedListBox.CreateControl();
+
+            Assert.Equal(expected, checkedListBox.AccessibilityObject.GetChild(0).DefaultAction);
+            Assert.True(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CheckedListBoxItemAccessibleObject_Value_ReturnsExpected(bool isChecked)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+            checkedListBox.SetItemChecked(0, isChecked);
+
+            Assert.Equal(isChecked.ToString(), checkedListBox.AccessibilityObject.GetChild(0).Value);
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CheckedListBoxItemAccessibleObject_DoDefaultAction_IfHandleIsNotCreated_DoesNothing(bool isChecked)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+            checkedListBox.SetItemChecked(0, isChecked);
+
+            Assert.Equal(isChecked, checkedListBox.GetItemChecked(0));
+
+            checkedListBox.AccessibilityObject.GetChild(0).DoDefaultAction();
+
+            Assert.Equal(isChecked, checkedListBox.GetItemChecked(0));
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CheckedListBoxItemAccessibleObject_DoDefaultAction_IfHandleIsCreated_WorksExpected(bool isChecked)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+            checkedListBox.SetItemChecked(0, isChecked);
+            checkedListBox.CreateControl();
+
+            Assert.Equal(isChecked, checkedListBox.GetItemChecked(0));
+
+            checkedListBox.AccessibilityObject.GetChild(0).DoDefaultAction();
+
+            Assert.Equal(!isChecked, checkedListBox.GetItemChecked(0));
+            Assert.True(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, (int)UiaCore.ToggleState.On)]
+        [InlineData(false, (int)UiaCore.ToggleState.Off)]
+        public void CheckedListBoxItemAccessibleObject_ToggleState_ReturnsExpected(bool isChecked, int expected)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+            checkedListBox.SetItemChecked(0, isChecked);
+
+            Assert.Equal((UiaCore.ToggleState)expected, checkedListBox.AccessibilityObject.GetChild(0).ToggleState);
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CheckedListBoxItemAccessibleObject_Toggle_IfHandleIsNotCreated_DoesNothing(bool isChecked)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+            checkedListBox.SetItemChecked(0, isChecked);
+
+            Assert.Equal(isChecked, checkedListBox.GetItemChecked(0));
+
+            checkedListBox.AccessibilityObject.GetChild(0).Toggle();
+
+            Assert.Equal(isChecked, checkedListBox.GetItemChecked(0));
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CheckedListBoxItemAccessibleObject_Toggle_IfHandleIsCreated_WorksExpected(bool isChecked)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+            checkedListBox.SetItemChecked(0, isChecked);
+            checkedListBox.CreateControl();
+
+            Assert.Equal(isChecked, checkedListBox.GetItemChecked(0));
+
+            checkedListBox.AccessibilityObject.GetChild(0).Toggle();
+
+            Assert.Equal(!isChecked, checkedListBox.GetItemChecked(0));
+            Assert.True(checkedListBox.IsHandleCreated);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Related Issue: #3421


## Proposed changes

- Switched on the `SupportsUiaProviders` property of `CheckedListBox` class.
- Updated uia properties.
- Added unit tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improving development experience for CheckedListBox control accessibility.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

#### CheckedListBox parent under inspect

![clb fw parent](https://user-images.githubusercontent.com/58004471/127343912-9034832a-6382-48bc-8f9e-2f0d6d0f629a.png)

#### CheckedListBox item under inspect

![clb fw item checked](https://user-images.githubusercontent.com/58004471/127343929-1abaab20-b647-4d70-ba19-6e60ad09309b.png)

#### CheckedListBox control under narrator

![nb cld before](https://user-images.githubusercontent.com/58004471/127343943-1b1fcde7-47c7-4e03-bdbc-9b317757866c.png)


### After

#### CheckedListBox parent under inspect

![new 22](https://user-images.githubusercontent.com/58004471/127657186-a7ffc3da-928e-4772-bee5-ac52b85d5b2a.png)

#### CheckedListBox item under inspect

![new 11](https://user-images.githubusercontent.com/58004471/127657189-3edab19e-15f9-4d63-9c29-b863a45ee76c.png)

## Test methodology

- Manually.
- Unit tests.
- Automation tests.


## Accessibility testing

- Inspect
- Narrator
- Accessibility Insights
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


## Test environment(s) <!-- Remove any that don't apply -->

- .Net SDK version:  6.0.100-rc.1.21377.33

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5276)