### PR TITLE
Fixing Entry not found exception for AdjustWindowRectExForDpi(). (#5260)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -3060,7 +3060,7 @@ namespace System.Windows.Forms
         private Size ComputeWindowSize(Size clientSize, int style, int exStyle)
         {
             RECT result = new RECT(0, 0, clientSize.Width, clientSize.Height);
-            AdjustWindowRectEx(ref result, style, false, exStyle);
+            AdjustWindowRectExForControlDpi(ref result, style, false, exStyle);
             return new Size(result.right - result.left, result.bottom - result.top);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
@@ -297,7 +297,7 @@ namespace System.Windows.Forms
             RECT rect = new RECT();
             CreateParams cp = CreateParams;
 
-            AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
+            AdjustWindowRectExForControlDpi(ref rect, cp.Style, false, cp.ExStyle);
 
             Rectangle bounds = Bounds;
             using var rgn1 = new Gdi32.RegionScope(0, 0, bounds.Width, bounds.Height);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms
                     RECT rect = new RECT();
                     CreateParams cp = CreateParams;
 
-                    AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
+                    AdjustWindowRectExForControlDpi(ref rect, cp.Style, false, cp.ExStyle);
 
                     // the coordinates we get back are negative, we need to translate this back to positive.
                     int offsetX = -rect.left; // one to get back to 0,0, another to translate


### PR DESCRIPTION
**Proposed changes**

- We recently fixed an issue to support a high DPI scenario that was using the latest Windows API. however, this API was introduced in Windows 10 (version >1607) and was not serviced/down ported back to Windows7. As a result, running Winforms applications targeting .NET 6.0 on Windows 7 are throwing Entry not found exception for API AdjustWindowRectExForDpi(). This change is checking for the OS at runtime before calling this API.

**Customer Impact**

- Customers running .NET 6.0 Winforms applications on Windows 7 with latest .NET 6.0 preview installed.

**Regression?**

- From recent .NET 6.0 preview (6).

**Risk**

- Minimal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5283)