### PR TITLE
Fixing freezing ListView in virtual mode when Accessibility Tool is active

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -128,12 +128,10 @@ namespace System.Windows.Forms
                     return -1;
                 }
 
-                for (int i = 0; i < _owningListView.Items.Count; i++)
+                if (child is ListViewItem.ListViewItemBaseAccessibleObject itemAccessibleObject)
                 {
-                    if (_owningListView.Items[i].AccessibilityObject == child)
-                    {
-                        return i;
-                    }
+                    int index = itemAccessibleObject.CurrentIndex;
+                    return index < _owningListView.Items.Count ? index : -1;
                 }
 
                 return -1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -48,8 +48,8 @@ namespace System.Windows.Forms
                         _owningItem.Bounds.Width,
                         _owningItem.Bounds.Height);
 
-            private protected int CurrentIndex
-                => _owningListView.Items.IndexOf(_owningItem);
+            internal int CurrentIndex
+                => _owningItem.Index;
 
             internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
                 => _owningListView.AccessibilityObject;


### PR DESCRIPTION
Fixes #5033


## Proposed changes
- The issue is reproduced because each time we get the Accessibility object, we calculate the current index of the ListViewItemAccessibleObject and the index to get the next / previous ListViewItem. Both operations use a loop that checks all the ListViewItem in order to find the one we want. Unfortunately, when we have 1 million ListViewItem, this approach becomes too laborious.
- Fixed the logic for getting indices, now we use the element's index instead of calculating it every time 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![5033-before fix](https://user-images.githubusercontent.com/23376742/126325292-f4edfec7-9e52-4511-808f-4009cde33fdf.gif)

**After fix:**
![5033-after fix](https://user-images.githubusercontent.com/23376742/126325296-cf3f21e0-51ce-4ef4-94df-dbb62a55ec29.gif)

## Regression? 
- Yes

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manually 
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator
- Inspect
- Accessibility Insights
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.0-preview.7.21352.2


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5289)