### PR TITLE
Fixing freezing ListView in virtual mode when Accessibility Tool is active (port to 5.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -151,6 +151,12 @@ namespace System.Windows.Forms
                     return -1;
                 }
 
+                if (child is ListViewItem.ListViewItemAccessibleObject itemAccessibleObject)
+                {
+                    int index = itemAccessibleObject.CurrentIndex;
+                    return index < _owningListView.Items.Count ? index : -1;
+                }
+
                 int childCount = GetChildCount();
                 for (int i = 0; i < childCount; i++)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObject.cs
@@ -40,8 +40,8 @@ namespace System.Windows.Forms
                         _owningItem.Bounds.Width,
                         _owningItem.Bounds.Height);
 
-            private int CurrentIndex
-                => _owningListView.Items.IndexOf(_owningItem);
+            internal int CurrentIndex
+                => _owningItem.Index;
 
             internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
                 => _owningListView.AccessibilityObject;


### PR DESCRIPTION
Fixes #5033


## Proposed changes
- The issue is reproduced because each time we get the Accessibility object, we calculate the current index of the ListViewItemAccessibleObject and the index to get the next / previous ListViewItem. Both operations use a loop that checks all the ListViewItem in order to find the one we want. Unfortunately, when we have 1 million ListViewItem, this approach becomes too laborious.
- Fixed the logic for getting indices, now we use the element's index instead of calculating it every time (ported from #5289)
<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![5033-before fix](https://user-images.githubusercontent.com/23376742/126325292-f4edfec7-9e52-4511-808f-4009cde33fdf.gif)

**After fix:**
![5033-after fix](https://user-images.githubusercontent.com/23376742/126325296-cf3f21e0-51ce-4ef4-94df-dbb62a55ec29.gif)

## Regression? 
- Yes

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manually 
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator
- Inspect
- Accessibility Insights
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.0-preview.7.21352.2

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5333)