### PR TITLE
Add test for opening folder browser dialog

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/TestHelpers.cs
@@ -307,6 +307,18 @@ namespace System.Windows.Forms.IntegrationTests.Common
         }
 
         /// <summary>
+        ///  Presses Alt plus choosen letter on the given process if it can be made the foreground process
+        /// </summary>
+        /// <param name="process">The process to send the Alt and key to</param>
+        /// <param name="letter">Letter in addition to Alt to send to process.</param>
+        /// <returns>Whether or not the Up key was pressed on the process</returns>
+        /// <seealso cref="SendKeysToProcess(Process, string, bool)"/>
+        public static bool SendAltKeyToProcess(Process process, char letter, bool switchToMainWindow = true)
+        {
+            return SendKeysToProcess(process, "%{" + letter + "}", switchToMainWindow);
+        }
+
+        /// <summary>
         ///  Presses Tab any number of times on the given process if it can be made the foreground process
         /// </summary>
         /// <param name="process">The process to send the Tab key(s) to</param>

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/WinformsControlsTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/WinformsControlsTest.cs
@@ -153,6 +153,25 @@ namespace System.Windows.Forms.IntegrationTests
         }
 
         [Fact]
+        public void WinformsControlsTest_OpenFolderBrowserDialogTest()
+        {
+            Process process = TestHelpers.StartProcess(_exePath);
+            TestHelpers.SendTabKeysToProcess(process, MainFormControlsTabOrder.DialogsButton);
+            TestHelpers.SendEnterKeyToProcess(process);
+            TestHelpers.SendEnterKeyToProcess(process, switchToMainWindow: false);
+
+            TestHelpers.SendAltKeyToProcess(process, 'b', switchToMainWindow: false);
+            TestHelpers.SendAltKeyToProcess(process, 'o', switchToMainWindow: false);
+
+            Assert.False(process.HasExited);
+
+            process.Kill();
+            process.WaitForExit();
+
+            Assert.True(process.HasExited);
+        }
+
+        [Fact]
         public void DataBindings_remove_should_unsubscribe_INotifyPropertyChanged_PropertyChanged_event()
         {
             var mainObject = new Mocks.MainObject();

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.Designer.cs
@@ -64,7 +64,7 @@ namespace WinformsControlsTest
             this.btnOpenFileDialog.Name = "btnOpenFileDialog";
             this.btnOpenFileDialog.Size = new System.Drawing.Size(163, 23);
             this.btnOpenFileDialog.TabIndex = 1;
-            this.btnOpenFileDialog.Text = "Open file dialog";
+            this.btnOpenFileDialog.Text = "Open &file dialog";
             this.btnOpenFileDialog.UseVisualStyleBackColor = true;
             this.btnOpenFileDialog.Click += new System.EventHandler(this.btnOpenFileDialog_Click);
             // 
@@ -74,7 +74,7 @@ namespace WinformsControlsTest
             this.btnThreadExceptionDialog.Name = "btnThreadExceptionDialog";
             this.btnThreadExceptionDialog.Size = new System.Drawing.Size(163, 23);
             this.btnThreadExceptionDialog.TabIndex = 2;
-            this.btnThreadExceptionDialog.Text = "Thread exception dialog";
+            this.btnThreadExceptionDialog.Text = "&Thread exception dialog";
             this.btnThreadExceptionDialog.UseVisualStyleBackColor = true;
             this.btnThreadExceptionDialog.Click += new System.EventHandler(this.btnThreadExceptionDialog_Click);
             // 
@@ -84,7 +84,7 @@ namespace WinformsControlsTest
             this.btnPrintDialog.Name = "btnPrintDialog";
             this.btnPrintDialog.Size = new System.Drawing.Size(163, 23);
             this.btnPrintDialog.TabIndex = 3;
-            this.btnPrintDialog.Text = "Print dialog";
+            this.btnPrintDialog.Text = "&Print dialog";
             this.btnPrintDialog.UseVisualStyleBackColor = true;
             this.btnPrintDialog.Click += new System.EventHandler(this.btnPrintDialog_Click);
             // 
@@ -94,7 +94,7 @@ namespace WinformsControlsTest
             this.btnFolderBrowserDialog.Name = "btnFolderBrowserDialog";
             this.btnFolderBrowserDialog.Size = new System.Drawing.Size(163, 23);
             this.btnFolderBrowserDialog.TabIndex = 4;
-            this.btnFolderBrowserDialog.Text = "Folder browser dialog";
+            this.btnFolderBrowserDialog.Text = "Folder &browser dialog";
             this.btnFolderBrowserDialog.UseVisualStyleBackColor = true;
             this.btnFolderBrowserDialog.Click += new System.EventHandler(this.btnFolderBrowserDialog_Click);
             // 
@@ -104,7 +104,7 @@ namespace WinformsControlsTest
             this.btnSaveFileDialog.Name = "btnSaveFileDialog";
             this.btnSaveFileDialog.Size = new System.Drawing.Size(163, 23);
             this.btnSaveFileDialog.TabIndex = 5;
-            this.btnSaveFileDialog.Text = "Save file dialog";
+            this.btnSaveFileDialog.Text = "&Save file dialog";
             this.btnSaveFileDialog.UseVisualStyleBackColor = true;
             this.btnSaveFileDialog.Click += new System.EventHandler(this.btnSaveFileDialog_Click);
             // 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.cs
@@ -23,10 +23,10 @@ namespace WinformsControlsTest
             TypeDescriptor.AddProvider(new AssociatedMetadataTypeTypeDescriptionProvider(saveFileDialog1.GetType(), typeof(ExposedClientGuidMetadata)), saveFileDialog1);
             TypeDescriptor.AddProvider(new AssociatedMetadataTypeTypeDescriptionProvider(folderBrowserDialog1.GetType(), typeof(ExposedClientGuidMetadata)), folderBrowserDialog1);
 
-            _btnOpen = new("Open dialog")
+            _btnOpen = new("&Open dialog")
             {
                 Image = (System.Drawing.Bitmap?)(resources.GetObject("OpenDialog")),
-                Enabled = false
+                Enabled = false,
             };
 
             _btnOpen.Click += (s, e) =>


### PR DESCRIPTION
In order to make writing tests morepleasant I add shortcuts for operations inside form
That allow me express tests better then just counting tabs and pressing enter.

This currently catches one of issues in #5319

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5344)