### PR TITLE
Reduce flackiness of the integration tests

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/WinformsControlsTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/WinformsControlsTest.cs
@@ -163,6 +163,7 @@ namespace System.Windows.Forms.IntegrationTests
             TestHelpers.SendAltKeyToProcess(process, 'b', switchToMainWindow: false);
             TestHelpers.SendAltKeyToProcess(process, 'o', switchToMainWindow: false);
 
+            System.Threading.Thread.Sleep(2_000);
             Assert.False(process.HasExited);
 
             process.Kill();

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/WinformsControlsTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/WinformsControlsTest.cs
@@ -163,7 +163,7 @@ namespace System.Windows.Forms.IntegrationTests
             TestHelpers.SendAltKeyToProcess(process, 'b', switchToMainWindow: false);
             TestHelpers.SendAltKeyToProcess(process, 'o', switchToMainWindow: false);
 
-            System.Threading.Thread.Sleep(2_000);
+            Process.WaitForExit(2_000);
             Assert.False(process.HasExited);
 
             process.Kill();

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/WinformsControlsTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests/WinformsControlsTest.cs
@@ -163,7 +163,7 @@ namespace System.Windows.Forms.IntegrationTests
             TestHelpers.SendAltKeyToProcess(process, 'b', switchToMainWindow: false);
             TestHelpers.SendAltKeyToProcess(process, 'o', switchToMainWindow: false);
 
-            Process.WaitForExit(2_000);
+            process.WaitForExit(2_000);
             Assert.False(process.HasExited);
 
             process.Kill();


### PR DESCRIPTION
This number reduce count of times the test succeed when it should fail.
I assume this is because of WER doing it's job and process do not exit in time.

When I set 1 sec, each second time test succeed
When I set 1,5 sec, each forth time test succeed
When I set 2 sec seems to be enough.

I suspect that I should add this kind of delay to other similar places.

Related #5319


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5351)