### PR TITLE
Implement IsAncestorSiteInDesignMode.

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
-System.Windows.Forms.Control.IsAncestorSiteInDesignMode(bool checkTopLevelControl) -> bool
+System.Windows.Forms.Control.IsAncestorSiteInDesignMode.get -> bool
 System.Windows.Forms.Form.MdiChildrenMinimizedAnchorBottom.get -> bool
 System.Windows.Forms.Form.MdiChildrenMinimizedAnchorBottom.set -> void

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
+System.Windows.Forms.Control.IsAncestorSiteInDesignMode(bool checkTopLevelControl) -> bool
 System.Windows.Forms.Form.MdiChildrenMinimizedAnchorBottom.get -> bool
 System.Windows.Forms.Form.MdiChildrenMinimizedAnchorBottom.set -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2711,17 +2711,16 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool IsAncestorSiteInDesignMode(bool checkTopLevelControl) =>
-            GetSitedParentSite(this, checkTopLevelControl) is ISite parentSite ? parentSite.DesignMode : false;
+        public bool IsAncestorSiteInDesignMode =>
+            GetSitedParentSite(this) is ISite parentSite ? parentSite.DesignMode : false;
 
-        private ISite GetSitedParentSite(Control control, bool checkTopLevelControl) =>
+        private ISite GetSitedParentSite(Control control) =>
             control is null
                 ? throw new ArgumentNullException(nameof(control))
-                : control.Site is not null ||
-                  control.Parent is null ||
-                  (!checkTopLevelControl && control.Site.DesignMode)
+                : (control.Site is not null && control.Site.DesignMode) ||
+                  control.Parent is null
                     ? control.Site
-                    : GetSitedParentSite(control.Parent, checkTopLevelControl);
+                    : GetSitedParentSite(control.Parent);
 
         // If the control on which GetContainerControl( ) is called is a ContainerControl, then we don't return the parent
         // but return the same control. This is Everett behavior so we cannot change this since this would be a breaking change.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2717,9 +2717,9 @@ namespace System.Windows.Forms
         private ISite GetSitedParentSite(Control control, bool checkTopLevelControl) =>
             control is null
                 ? throw new ArgumentNullException(nameof(control))
-                : control.Site != null ||
+                : control.Site is not null ||
                   control.Parent is null ||
-                  (!checkTopLevelControl && control.Site is not null && control.Site.DesignMode)
+                  (!checkTopLevelControl && control.Site.DesignMode)
                     ? control.Site
                     : GetSitedParentSite(control.Parent, checkTopLevelControl);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2717,7 +2717,9 @@ namespace System.Windows.Forms
         private ISite GetSitedParentSite(Control control, bool checkTopLevelControl) =>
             control is null
                 ? throw new ArgumentNullException(nameof(control))
-                : control.Site != null || control.Parent is null
+                : control.Site != null ||
+                  control.Parent is null ||
+                  (!checkTopLevelControl && control.Site is not null && control.Site.DesignMode)
                     ? control.Site
                     : GetSitedParentSite(control.Parent, checkTopLevelControl);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2704,6 +2704,23 @@ namespace System.Windows.Forms
         /// </summary>
         internal bool IsActiveX => GetExtendedState(ExtendedStates.IsActiveX);
 
+        /// <summary>
+        ///  Indicates if one of the Ancestors of this control is sited
+        ///  and that site in DesignMode. This property is read-only.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public bool IsAncestorSiteInDesignMode(bool checkTopLevelControl) =>
+            GetSitedParentSite(this, checkTopLevelControl) is ISite parentSite ? parentSite.DesignMode : false;
+
+        private ISite GetSitedParentSite(Control control, bool checkTopLevelControl) =>
+            control is null
+                ? throw new ArgumentNullException(nameof(control))
+                : control.Site != null || control.Parent is null
+                    ? control.Site
+                    : GetSitedParentSite(control.Parent, checkTopLevelControl);
+
         // If the control on which GetContainerControl( ) is called is a ContainerControl, then we don't return the parent
         // but return the same control. This is Everett behavior so we cannot change this since this would be a breaking change.
         // Hence we have a new internal property IsContainerControl which returns false for all Everett control, but


### PR DESCRIPTION
Fixes #4146.

[Update]: This is now implemented as originally planned.

Wrote a small Test app for this, which should also serve as a guidance for best practice.
It is currently here: https://github.com/KlausLoeffelmann/IsAncestorSiteInDesignMode/blob/main/README.md

Shows where and how to use correctly `DesignMode` and `IsAncestorSiteInDesignMode` for (derived) Forms, UserControls hosted in Forms and Controls:

![image](https://user-images.githubusercontent.com/9663150/128947375-2ebcd889-449c-4341-8a08-de0438c31ea6.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5375)
