### PR TITLE
Fix UIA navigation for TabControl

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+~override System.Windows.Forms.TabControl.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.TabPage.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -808,6 +808,8 @@ namespace System.Windows.Forms
             }
         }
 
+        internal override bool SupportsUiaProviders => true;
+
         /// <summary>
         ///  Returns the number of tabs in the strip
         /// </summary>
@@ -965,6 +967,8 @@ namespace System.Windows.Forms
         {
             BeginUpdateInternal();
         }
+
+        protected override AccessibleObject CreateAccessibilityInstance() => new TabControlAccessibleObject(this);
 
         protected override Control.ControlCollection CreateControlsInstance()
         {
@@ -1278,6 +1282,8 @@ namespace System.Windows.Forms
         {
             NotifyAboutFocusState(SelectedTab, focused: true);
             base.OnGotFocus(e);
+
+            SelectedTab?.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
         }
 
         /// <summary>
@@ -2050,6 +2056,12 @@ namespace System.Windows.Forms
             {
                 OnSelected(new TabControlEventArgs(SelectedTab, SelectedIndex, TabControlAction.Selected));
                 OnSelectedIndexChanged(EventArgs.Empty);
+
+                if (SelectedTab?.ParentInternal is TabControl)
+                {
+                    SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.SelectionItem_ElementSelectedEventId);
+                    SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                }
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1283,7 +1283,10 @@ namespace System.Windows.Forms
             NotifyAboutFocusState(SelectedTab, focused: true);
             base.OnGotFocus(e);
 
-            SelectedTab?.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            if (IsAccessibilityObjectCreated && SelectedTab is not null)
+            {
+                SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            }
         }
 
         /// <summary>
@@ -2057,7 +2060,7 @@ namespace System.Windows.Forms
                 OnSelected(new TabControlEventArgs(SelectedTab, SelectedIndex, TabControlAction.Selected));
                 OnSelectedIndexChanged(EventArgs.Empty);
 
-                if (SelectedTab?.ParentInternal is TabControl)
+                if (IsAccessibilityObjectCreated && SelectedTab?.ParentInternal is TabControl)
                 {
                     SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.SelectionItem_ElementSelectedEventId);
                     SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
@@ -1,0 +1,152 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using Accessibility;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class TabPage
+    {
+        internal class TabAccessibleObject : AccessibleObject
+        {
+            private readonly TabControl _owningTabControl;
+
+            private readonly TabPage _owningTabPage;
+
+            public TabAccessibleObject(TabPage owningTabPage)
+            {
+                _owningTabPage = owningTabPage ?? throw new ArgumentNullException(nameof(owningTabPage));
+                _owningTabControl = owningTabPage.ParentInternal as TabControl
+                                    ?? throw new ArgumentNullException(nameof(owningTabPage.ParentInternal));
+            }
+
+            public override Rectangle Bounds
+            {
+                get
+                {
+                    if (!_owningTabControl.IsHandleCreated)
+                    {
+                        return Rectangle.Empty;
+                    }
+
+                    int index = CurrentIndex;
+
+                    if (index == -1 || (State & AccessibleStates.Invisible) == AccessibleStates.Invisible)
+                    {
+                        return Rectangle.Empty;
+                    }
+
+                    int left = 0;
+                    int top = 0;
+                    int width = 0;
+                    int height = 0;
+
+                    // The "NativeMethods.CHILDID_SELF" constant returns to the id of the trackbar,
+                    // which allows to use the native "accLocation" method to get the "Bounds" property
+                    SystemIAccessibleInternal?.accLocation(out left, out top, out width, out height, GetChildId());
+
+                    return new(left, top, width, height);
+                }
+            }
+
+            public override string? DefaultAction => SystemIAccessibleInternal?.get_accDefaultAction(GetChildId());
+
+            public override string? Name => _owningTabPage.Text;
+
+            public override AccessibleRole Role
+                => SystemIAccessibleInternal?.get_accRole(GetChildId()) is object accRole
+                    ? (AccessibleRole)accRole
+                    : AccessibleRole.None;
+
+            public override AccessibleStates State
+                => SystemIAccessibleInternal?.get_accState(GetChildId()) is object accState
+                    ? (AccessibleStates)accState
+                    : AccessibleStates.None;
+
+            internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot => _owningTabControl.AccessibilityObject;
+
+            internal override bool IsItemSelected => _owningTabControl.SelectedTab == _owningTabPage;
+
+            internal override UiaCore.IRawElementProviderSimple? ItemSelectionContainer => _owningTabControl.AccessibilityObject;
+
+            internal override int[]? RuntimeId
+                => new int[] { RuntimeIDFirstItem, PARAM.ToInt(_owningTabControl.InternalHandle), GetChildId() };
+
+            private int CurrentIndex => _owningTabControl.TabPages.IndexOf(_owningTabPage);
+
+            private IAccessible? SystemIAccessibleInternal
+                => _owningTabControl.AccessibilityObject.GetSystemIAccessibleInternal();
+
+            public override void DoDefaultAction()
+            {
+                if (_owningTabControl.IsHandleCreated && _owningTabControl.Enabled)
+                {
+                    _owningTabControl.SelectedTab = _owningTabPage;
+                }
+            }
+
+            internal override void AddToSelection() => DoDefaultAction();
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                if (!_owningTabControl.IsHandleCreated)
+                {
+                    return null;
+                }
+
+                return direction switch
+                {
+                    UiaCore.NavigateDirection.Parent => _owningTabControl.AccessibilityObject,
+                    UiaCore.NavigateDirection.NextSibling => _owningTabControl.AccessibilityObject.GetChild(GetChildId() + 1),
+                    UiaCore.NavigateDirection.PreviousSibling => _owningTabControl.AccessibilityObject.GetChild(GetChildId() - 1),
+                    _ => null
+                };
+            }
+
+            // +1 is needed because 0 is the Pane id of the selected tab
+            internal override int GetChildId() => CurrentIndex + 1;
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
+                {
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TabItemControlTypeId,
+                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
+                    UiaCore.UIA.AutomationIdPropertyId => _owningTabPage.Name,
+                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
+                    UiaCore.UIA.IsPasswordPropertyId => false,
+                    UiaCore.UIA.HelpTextPropertyId => string.Empty,
+                    UiaCore.UIA.IsEnabledPropertyId => _owningTabControl.Enabled,
+                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,
+                    UiaCore.UIA.NamePropertyId => Name,
+                    UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.SelectionItemPatternId),
+                    UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
+                    UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId
+                        // This is necessary for compatibility with MSAA proxy:
+                        // IsKeyboardFocusable = true regardless the control is enabled/disabled.
+                        => true,
+                    _ => base.GetPropertyValue(propertyID)
+                };
+
+            internal override bool IsPatternSupported(UiaCore.UIA patternId)
+                => patternId switch
+                {
+                    UiaCore.UIA.LegacyIAccessiblePatternId => true,
+                    UiaCore.UIA.InvokePatternId => false,
+                    UiaCore.UIA.SelectionItemPatternId => true,
+                    _ => base.IsPatternSupported(patternId)
+                };
+
+            internal override void RemoveFromSelection()
+            {
+                // Do nothing, C++ implementation returns UIA_E_INVALIDOPERATION 0x80131509
+            }
+
+            internal unsafe override void SelectItem() => DoDefaultAction();
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (OwningTabControl is null || !OwningTabControl.IsHandleCreated)
+                    if (OwningTabControl is null || !OwningTabControl.IsHandleCreated || SystemIAccessibleInternal is null)
                     {
                         return Rectangle.Empty;
                     }
@@ -37,13 +37,9 @@ namespace System.Windows.Forms
                         return Rectangle.Empty;
                     }
 
-                    int left, top, width, height;
-                    left = top = width = height = 0;
-
-                    // The "NativeMethods.CHILDID_SELF" constant returns to the id of the trackbar,
+                    // The "GetChildId" method returns to the id of the TabControl element,
                     // which allows to use the native "accLocation" method to get the "Bounds" property
-                    SystemIAccessibleInternal?.accLocation(out left, out top, out width, out height, GetChildId());
-
+                    SystemIAccessibleInternal.accLocation(out int left, out int top, out int width, out int height, GetChildId());
                     return new(left, top, width, height);
                 }
             }
@@ -142,8 +138,10 @@ namespace System.Windows.Forms
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
                 => patternId switch
                 {
-                    UiaCore.UIA.InvokePatternId => false,
+                    // The "Enabled" property of the TabControl does not affect the behavior of that property,
+                    // so it is always true
                     UiaCore.UIA.SelectionItemPatternId => true,
+                    UiaCore.UIA.InvokePatternId => false,
                     UiaCore.UIA.LegacyIAccessiblePatternId => true,
                     _ => base.IsPatternSupported(patternId)
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
@@ -27,10 +27,8 @@ namespace System.Windows.Forms
                         return Rectangle.Empty;
                     }
 
-                    int left = 0;
-                    int top = 0;
-                    int width = 0;
-                    int height = 0;
+                    int left, top, width, height;
+                    left = top = width = height = 0;
 
                     // The "NativeMethods.CHILDID_SELF" constant returns to the id of the trackbar,
                     // which allows to use the native "accLocation" method to get the "Bounds" property
@@ -95,6 +93,7 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTabPage.Focused,
                     UiaCore.UIA.NamePropertyId => Name,
+                    UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut,
                     UiaCore.UIA.NativeWindowHandlePropertyId => _owningTabPage.InternalHandle,
                     UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
                     UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
@@ -108,7 +107,6 @@ namespace System.Windows.Forms
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
                 => patternId switch
                 {
-                    UiaCore.UIA.LegacyIAccessiblePatternId => true,
                     UiaCore.UIA.ValuePatternId => false,
                     _ => base.IsPatternSupported(patternId)
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
@@ -22,18 +22,14 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (!_owningTabPage.IsHandleCreated)
+                    if (!_owningTabPage.IsHandleCreated || GetSystemIAccessibleInternal() is null)
                     {
                         return Rectangle.Empty;
                     }
 
-                    int left, top, width, height;
-                    left = top = width = height = 0;
-
-                    // The "NativeMethods.CHILDID_SELF" constant returns to the id of the trackbar,
+                    // The "NativeMethods.CHILDID_SELF" constant returns to the id of the TabPage,
                     // which allows to use the native "accLocation" method to get the "Bounds" property
-                    GetSystemIAccessibleInternal()?.accLocation(out left, out top, out width, out height, NativeMethods.CHILDID_SELF);
-
+                    GetSystemIAccessibleInternal()!.accLocation(out int left, out int top, out int width, out int height, NativeMethods.CHILDID_SELF);
                     return new(left, top, width, height);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
@@ -1,0 +1,127 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class TabPage
+    {
+        internal class TabPageAccessibleObject : ControlAccessibleObject
+        {
+            private readonly TabPage _owningTabPage;
+
+            public TabPageAccessibleObject(TabPage owningTabPage) : base(owningTabPage)
+            {
+                _owningTabPage = owningTabPage;
+            }
+
+            public override Rectangle Bounds
+            {
+                get
+                {
+                    if (!_owningTabPage.IsHandleCreated)
+                    {
+                        return Rectangle.Empty;
+                    }
+
+                    int left = 0;
+                    int top = 0;
+                    int width = 0;
+                    int height = 0;
+
+                    // The "NativeMethods.CHILDID_SELF" constant returns to the id of the trackbar,
+                    // which allows to use the native "accLocation" method to get the "Bounds" property
+                    GetSystemIAccessibleInternal()?.accLocation(out left, out top, out width, out height, NativeMethods.CHILDID_SELF);
+
+                    return new(left, top, width, height);
+                }
+            }
+
+            public override AccessibleStates State
+                => GetSystemIAccessibleInternal()?.get_accState(GetChildId()) is object accState
+                    ? (AccessibleStates)accState
+                    : AccessibleStates.None;
+
+            internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot => OwningTabControl?.AccessibilityObject;
+
+            private TabControl? OwningTabControl => _owningTabPage.ParentInternal as TabControl;
+
+            public override AccessibleObject? GetChild(int index)
+            {
+                if (!_owningTabPage.IsHandleCreated)
+                {
+                    return null;
+                }
+
+                if (index < 0 || index > _owningTabPage.Controls.Count - 1)
+                {
+                    return null;
+                }
+
+                return _owningTabPage.Controls[index].AccessibilityObject;
+            }
+
+            public override int GetChildCount() => _owningTabPage.IsHandleCreated
+                                                    ? _owningTabPage.Controls.Count
+                                                    : -1;
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                if (!_owningTabPage.IsHandleCreated || OwningTabControl is null)
+                {
+                    return null;
+                }
+
+                return direction switch
+                {
+                    UiaCore.NavigateDirection.Parent => OwningTabControl?.AccessibilityObject,
+                    UiaCore.NavigateDirection.NextSibling => GetNextSibling(),
+                    UiaCore.NavigateDirection.PreviousSibling => null,
+                    _ => base.FragmentNavigate(direction)
+                };
+            }
+
+            internal override int GetChildId() => 0;
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
+                {
+                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
+                    UiaCore.UIA.AutomationIdPropertyId => _owningTabPage.Name,
+                    UiaCore.UIA.IsEnabledPropertyId => _owningTabPage.Enabled,
+                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTabPage.Focused,
+                    UiaCore.UIA.NamePropertyId => Name,
+                    UiaCore.UIA.NativeWindowHandlePropertyId => _owningTabPage.InternalHandle,
+                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
+                    UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId
+                        // This is necessary for compatibility with MSAA proxy:
+                        // IsKeyboardFocusable = true regardless the control is enabled/disabled.
+                        => true,
+                    _ => base.GetPropertyValue(propertyID)
+                };
+
+            internal override bool IsPatternSupported(UiaCore.UIA patternId)
+                => patternId switch
+                {
+                    UiaCore.UIA.LegacyIAccessiblePatternId => true,
+                    UiaCore.UIA.ValuePatternId => false,
+                    _ => base.IsPatternSupported(patternId)
+                };
+
+            private UiaCore.IRawElementProviderFragment? GetNextSibling()
+            {
+                if (OwningTabControl is null || _owningTabPage != OwningTabControl.SelectedTab)
+                {
+                    return null;
+                }
+
+                return OwningTabControl.TabPages.Count > 0 ? OwningTabControl.TabPages[0].TabAccessibilityObject : null;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -31,6 +31,7 @@ namespace System.Windows.Forms
         private List<ToolTip> _associatedToolTips;
         private ToolTip _externalToolTip;
         private readonly ToolTip _internalToolTip = new ToolTip();
+        private TabAccessibleObject _tabAccessibilityObject;
 
         /// <summary>
         ///  Constructs an empty TabPage.
@@ -129,6 +130,9 @@ namespace System.Windows.Forms
                 base.BackColor = value;
             }
         }
+
+        protected override AccessibleObject CreateAccessibilityInstance()
+            => new TabPageAccessibleObject(this);
 
         /// <summary>
         ///  Constructs the new instance of the Controls collection objects.
@@ -373,6 +377,10 @@ namespace System.Windows.Forms
         ///  theming API to render its background because it has large performance cost.
         /// </summary>
         internal override bool RenderTransparencyWithVisualStyles => true;
+
+        internal override bool SupportsUiaProviders => true;
+
+        internal TabAccessibleObject TabAccessibilityObject => _tabAccessibilityObject ??= new TabAccessibleObject(this);
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
@@ -271,6 +271,19 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void TabControlAccessibleObject_HitTest_ReturnsTabControlAccessibleObject_IfTabPagesListIsEmpty()
+        {
+            using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(accessibleObject, accessibleObject.HitTest(10, 33));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
         public void TabControlAccessibleObject_HitTest_ReturnsTabPane()
         {
             using TabControl tabControl = new();
@@ -338,6 +351,19 @@ namespace System.Windows.Forms.Tests
             Assert.False(pages[0].IsHandleCreated);
             Assert.False(pages[1].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_FragmentNavigate_Child_ReturnsNull_IfTabPagesListIsEmpty()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using Xunit;
 using static Interop;
+using static Interop.UiaCore;
+using static System.Windows.Forms.TabControl;
 
 namespace System.Windows.Forms.Tests
 {
@@ -12,7 +15,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void TabControlAccessibilityObject_Ctor_Default()
         {
-            using TabControl tabControl = new TabControl();
+            using TabControl tabControl = new();
             tabControl.CreateControl();
 
             Assert.NotNull(tabControl.AccessibilityObject);
@@ -22,7 +25,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void TabControlAccessibilityObject_ControlType_IsTabControl_IfAccessibleRoleIsDefault()
         {
-            using TabControl tabControl = new TabControl();
+            using TabControl tabControl = new();
             tabControl.CreateControl();
             // AccessibleRole is not set = Default
 
@@ -35,7 +38,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void TabControlAccessibilityObject_Role_IsPageTabList_ByDefault()
         {
-            using TabControl tabControl = new TabControl();
+            using TabControl tabControl = new();
             tabControl.CreateControl();
             // AccessibleRole is not set = Default
 
@@ -64,7 +67,7 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(TabControlAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData))]
         public void TabControlAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole(AccessibleRole role)
         {
-            using TabControl tabControl = new TabControl();
+            using TabControl tabControl = new();
             tabControl.AccessibleRole = role;
 
             object actual = tabControl.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
@@ -72,6 +75,536 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(expected, actual);
             Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public void TabControlAccessibleObject_Bounds_ReturnsExpected(bool createControl, bool boundsIsEmpty)
+        {
+            using TabControl tabControl = new();
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            Assert.Equal(boundsIsEmpty, accessibleObject.Bounds.IsEmpty);
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, true, AccessibleStates.Focusable)]
+        [InlineData(true, false, AccessibleStates.Focusable | AccessibleStates.Unavailable)]
+        [InlineData(false, true, AccessibleStates.None)]
+        [InlineData(false, false, AccessibleStates.None)]
+        public void TabControlAccessibleObject_State_ReturnsExpected(bool createControl, bool enabled, AccessibleStates expectedAccessibleStates)
+        {
+            using TabControl tabControl = new() { Enabled = enabled };
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(expectedAccessibleStates, accessibleObject.State);
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabControlAccessibleObject_IsSelectionRequired_ReturnsTrue(bool createControl)
+        {
+            using TabControl tabControl = new();
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.True(accessibleObject.IsSelectionRequired);
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_GetChildCount_ReturnsMinusOne_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(-1, accessibleObject.GetChildCount());
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_GetChildCount_ReturnsZero_IfTabPagesListIsEmpty()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(0, accessibleObject.GetChildCount());
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_GetChildCount_ReturnsExpected()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(4, accessibleObject.GetChildCount());
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_GetChild_ReturnsNull_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Null(accessibleObject.GetChild(-1));
+            Assert.Null(accessibleObject.GetChild(0));
+            Assert.Null(accessibleObject.GetChild(1));
+            Assert.Null(accessibleObject.GetChild(2));
+            Assert.Null(accessibleObject.GetChild(3));
+            Assert.Null(accessibleObject.GetChild(4));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_GetChild_ReturnsNull_IfTabPagesListIsEmpty()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Null(accessibleObject.GetChild(-1));
+            Assert.Null(accessibleObject.GetChild(0));
+            Assert.Null(accessibleObject.GetChild(1));
+            Assert.Null(accessibleObject.GetChild(2));
+            Assert.Null(accessibleObject.GetChild(3));
+            Assert.Null(accessibleObject.GetChild(4));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_GetChild_ReturnsExpected()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Null(accessibleObject.GetChild(-1));
+            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Equal(tabControl.TabPages[1].TabAccessibilityObject, accessibleObject.GetChild(2));
+            Assert.Null(accessibleObject.GetChild(3));
+            Assert.Null(accessibleObject.GetChild(4));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_GetChild_ReturnsExpectd_AfterUpdatingSelectedTab()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject.GetChild(0));
+
+            tabControl.SelectedIndex = 1;
+
+            Assert.Equal(tabControl.TabPages[1].AccessibilityObject, accessibleObject.GetChild(0));
+
+            tabControl.SelectedIndex = 2;
+
+            Assert.Equal(tabControl.TabPages[2].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_HitTest_ReturnsNull_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Null(accessibleObject.HitTest(10, 33));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_HitTest_ReturnsTabPane()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+            AccessibleObject expectedAccessibleObject = tabControl.SelectedTab.AccessibilityObject;
+            Point point = expectedAccessibleObject.Bounds.Location;
+
+            Assert.Equal(expectedAccessibleObject, accessibleObject.HitTest(point.X, point.Y));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_HitTest_ReturnsFirstItem()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+            AccessibleObject expectedAccessibleObject = tabControl.TabPages[0].TabAccessibilityObject;
+            Point point = expectedAccessibleObject.Bounds.Location;
+
+            Assert.Equal(expectedAccessibleObject, accessibleObject.HitTest(point.X, point.Y));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_HitTest_ReturnsSecondItem()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+            AccessibleObject expectedAccessibleObject = tabControl.TabPages[1].TabAccessibilityObject;
+            Point point = expectedAccessibleObject.Bounds.Location;
+
+            Assert.Equal(expectedAccessibleObject, accessibleObject.HitTest(point.X, point.Y));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_FragmentNavigate_Child_ReturnsNull_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfSingleItem()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(tabControl.SelectedTab.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfThreeItems()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(tabControl.SelectedTab.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(tabControl.TabPages[2].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfSecondTabIsSelected()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            tabControl.SelectedIndex = 1;
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(tabControl.SelectedTab.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(tabControl.TabPages[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(tabControl.TabPages[2].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_FragmentNavigate_FirstChild_ReturnsExpectd_AfterUpdatingSelectedTab()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+
+            tabControl.SelectedIndex = 1;
+
+            Assert.Equal(tabControl.TabPages[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+
+            tabControl.SelectedIndex = 2;
+
+            Assert.Equal(tabControl.TabPages[2].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void TabControlAccessibleObject_GetSelection_ReturnsExpected(int selectedIndex)
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+            tabControl.SelectedIndex = selectedIndex;
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+            IRawElementProviderSimple[] selectedAccessibleObjects = accessibleObject.GetSelection();
+
+            Assert.Equal(1, selectedAccessibleObjects.Length);
+            Assert.Equal(tabControl.TabPages[selectedIndex].TabAccessibilityObject, selectedAccessibleObjects[0]);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void TabControlAccessibleObject_GetSelection_ReturnsEmptyArray_IfHandleIsNotCreated(int selectedIndex)
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.SelectedIndex = selectedIndex;
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+            IRawElementProviderSimple[] selectedAccessibleObjects = accessibleObject.GetSelection();
+
+            Assert.Equal(0, selectedAccessibleObjects.Length);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_GetSelection_ReturnsEmptyArray_IfTabPagesListIsEmpty()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+            IRawElementProviderSimple[] selectedAccessibleObjects = accessibleObject.GetSelection();
+
+            Assert.Equal(0, selectedAccessibleObjects.Length);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_Support_SelectionPattern()
+        {
+            using TabControl tabControl = new TabControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.True(accessibleObject.IsPatternSupported(UIA.SelectionPatternId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_GetPropertyValue_IsSelectionPatternAvailable_ReturnsTrue()
+        {
+            using TabControl tabControl = new TabControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsSelectionPatternAvailablePropertyId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_Support_LegacyIAccessible()
+        {
+            using TabControl tabControl = new TabControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.True(accessibleObject.IsPatternSupported(UIA.LegacyIAccessiblePatternId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_GetPropertyValue_IsLegacyIAccessiblePatternAvailable_ReturnsTrue()
+        {
+            using TabControl tabControl = new TabControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("Test")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TabControlAccessibleObject_Name_ReturnsExpected(string accessibleName)
+        {
+            using TabControl tabControl = new TabControl();
+            tabControl.AccessibleName = accessibleName;
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(accessibleName, accessibleObject.Name);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("Test")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TabControlAccessibleObject_Description_ReturnsExpected(string accessibleDescription)
+        {
+            using TabControl tabControl = new();
+            tabControl.AccessibleDescription = accessibleDescription;
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(accessibleDescription, accessibleObject.Description);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("Test")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TabControlAccessibleObject_AccessibleDefaultActionDescription_ReturnsExpected(string accessibleDefaultActionDescription)
+        {
+            using TabControl tabControl = new();
+            tabControl.AccessibleDefaultActionDescription = accessibleDefaultActionDescription;
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(accessibleDefaultActionDescription, accessibleObject.DefaultAction);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabControlAccessibleObject_RuntimeId_ReturnsExpected(bool createControl)
+        {
+            using TabControl tabControl = new();
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            Assert.NotNull(tabControl.AccessibilityObject.RuntimeId);
+            Assert.Equal(tabControl.InternalHandle, (IntPtr)tabControl.AccessibilityObject.RuntimeId[1]);
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_GetPropertyValue_HasKeyboardFocusPropertyId_ReturnsFalse()
+        {
+            using TabControl tabControl = new TabControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.False((bool)accessibleObject.GetPropertyValue(UIA.HasKeyboardFocusPropertyId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_GetPropertyValue_IsKeyboardFocusablePropertyId_ReturnsTrue()
+        {
+            using TabControl tabControl = new TabControl();
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsKeyboardFocusablePropertyId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabPageAccessibleObject_GetPropertyValue_IsEnabledPropertyId_ReturnsTrue(bool enabled)
+        {
+            using TabControl tabControl = new TabControl() { Enabled = enabled };
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(enabled, (bool)accessibleObject.GetPropertyValue(UIA.IsEnabledPropertyId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabPageAccessibleObject_GetPropertyValue_NativeWindowHandlePropertyId_ReturnsTrue(bool createControl)
+        {
+            using TabControl tabControl = new TabControl();
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(tabControl.InternalHandle, (IntPtr)accessibleObject.GetPropertyValue(UIA.NativeWindowHandlePropertyId));
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
@@ -160,14 +160,15 @@ namespace System.Windows.Forms.Tests
         {
             using TabControl tabControl = new();
             tabControl.CreateControl();
-
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new(), new() });
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             Assert.Equal(4, accessibleObject.GetChildCount());
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(pages[2].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -175,8 +176,8 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_GetChild_ReturnsNull_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
@@ -186,6 +187,8 @@ namespace System.Windows.Forms.Tests
             Assert.Null(accessibleObject.GetChild(2));
             Assert.Null(accessibleObject.GetChild(3));
             Assert.Null(accessibleObject.GetChild(4));
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -210,18 +213,20 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_GetChild_ReturnsExpected()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             Assert.Null(accessibleObject.GetChild(-1));
-            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject.GetChild(0));
-            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject.GetChild(1));
-            Assert.Equal(tabControl.TabPages[1].TabAccessibilityObject, accessibleObject.GetChild(2));
+            Assert.Equal(pages[0].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(pages[0].TabAccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Equal(pages[1].TabAccessibilityObject, accessibleObject.GetChild(2));
             Assert.Null(accessibleObject.GetChild(3));
             Assert.Null(accessibleObject.GetChild(4));
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -229,22 +234,24 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_GetChild_ReturnsExpectd_AfterUpdatingSelectedTab()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new(), new() });
             tabControl.CreateControl();
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
-            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(pages[0].AccessibilityObject, accessibleObject.GetChild(0));
 
             tabControl.SelectedIndex = 1;
 
-            Assert.Equal(tabControl.TabPages[1].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(pages[1].AccessibilityObject, accessibleObject.GetChild(0));
 
             tabControl.SelectedIndex = 2;
 
-            Assert.Equal(tabControl.TabPages[2].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(pages[2].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(pages[2].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -252,12 +259,14 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_HitTest_ReturnsNull_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             Assert.Null(accessibleObject.HitTest(10, 33));
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -265,8 +274,8 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_HitTest_ReturnsTabPane()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
@@ -274,6 +283,8 @@ namespace System.Windows.Forms.Tests
             Point point = expectedAccessibleObject.Bounds.Location;
 
             Assert.Equal(expectedAccessibleObject, accessibleObject.HitTest(point.X, point.Y));
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -281,15 +292,17 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_HitTest_ReturnsFirstItem()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
-            AccessibleObject expectedAccessibleObject = tabControl.TabPages[0].TabAccessibilityObject;
+            AccessibleObject expectedAccessibleObject = pages[0].TabAccessibilityObject;
             Point point = expectedAccessibleObject.Bounds.Location;
 
             Assert.Equal(expectedAccessibleObject, accessibleObject.HitTest(point.X, point.Y));
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -297,15 +310,17 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_HitTest_ReturnsSecondItem()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
-            AccessibleObject expectedAccessibleObject = tabControl.TabPages[1].TabAccessibilityObject;
+            AccessibleObject expectedAccessibleObject = pages[1].TabAccessibilityObject;
             Point point = expectedAccessibleObject.Bounds.Location;
 
             Assert.Equal(expectedAccessibleObject, accessibleObject.HitTest(point.X, point.Y));
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -313,13 +328,15 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_FragmentNavigate_Child_ReturnsNull_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -327,13 +344,15 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfSingleItem()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
             tabControl.CreateControl();
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             Assert.Equal(tabControl.SelectedTab.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
-            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.Equal(pages[0].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(pages[0].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -341,16 +360,18 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfThreeItems()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new(), new() });
             tabControl.CreateControl();
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             Assert.Equal(tabControl.SelectedTab.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
-            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
-            Assert.Equal(tabControl.TabPages[2].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.Equal(pages[0].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(pages[2].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
+            Assert.False(pages[2].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -358,17 +379,19 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfSecondTabIsSelected()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new(), new() });
             tabControl.CreateControl();
 
             tabControl.SelectedIndex = 1;
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             Assert.Equal(tabControl.SelectedTab.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
-            Assert.Equal(tabControl.TabPages[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
-            Assert.Equal(tabControl.TabPages[2].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.Equal(pages[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(pages[2].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.False(pages[2].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -376,22 +399,24 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_FragmentNavigate_FirstChild_ReturnsExpectd_AfterUpdatingSelectedTab()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new(), new() });
             tabControl.CreateControl();
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
-            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(pages[0].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
 
             tabControl.SelectedIndex = 1;
 
-            Assert.Equal(tabControl.TabPages[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(pages[1].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
 
             tabControl.SelectedIndex = 2;
 
-            Assert.Equal(tabControl.TabPages[2].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(pages[2].AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(pages[2].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -402,9 +427,8 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_GetSelection_ReturnsExpected(int selectedIndex)
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new(), new() });
             tabControl.CreateControl();
             tabControl.SelectedIndex = selectedIndex;
 
@@ -412,7 +436,10 @@ namespace System.Windows.Forms.Tests
             IRawElementProviderSimple[] selectedAccessibleObjects = accessibleObject.GetSelection();
 
             Assert.Equal(1, selectedAccessibleObjects.Length);
-            Assert.Equal(tabControl.TabPages[selectedIndex].TabAccessibilityObject, selectedAccessibleObjects[0]);
+            Assert.Equal(pages[selectedIndex].TabAccessibilityObject, selectedAccessibleObjects[0]);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.Equal(selectedIndex == 1, pages[1].IsHandleCreated);
+            Assert.Equal(selectedIndex == 2, pages[2].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -423,15 +450,17 @@ namespace System.Windows.Forms.Tests
         public void TabControlAccessibleObject_GetSelection_ReturnsEmptyArray_IfHandleIsNotCreated(int selectedIndex)
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new(), new() });
             tabControl.SelectedIndex = selectedIndex;
 
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
             IRawElementProviderSimple[] selectedAccessibleObjects = accessibleObject.GetSelection();
 
             Assert.Equal(0, selectedAccessibleObjects.Length);
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
+            Assert.False(pages[2].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -460,7 +489,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void TabPageAccessibleObject_GetPropertyValue_IsSelectionPatternAvailable_ReturnsTrue()
+        public void TabControlAccessibleObject_GetPropertyValue_IsSelectionPatternAvailable_ReturnsTrue()
         {
             using TabControl tabControl = new TabControl();
 
@@ -482,7 +511,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void TabPageAccessibleObject_GetPropertyValue_IsLegacyIAccessiblePatternAvailable_ReturnsTrue()
+        public void TabControlAccessibleObject_GetPropertyValue_IsLegacyIAccessiblePatternAvailable_ReturnsTrue()
         {
             using TabControl tabControl = new TabControl();
 
@@ -555,7 +584,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void TabPageAccessibleObject_GetPropertyValue_HasKeyboardFocusPropertyId_ReturnsFalse()
+        public void TabControlAccessibleObject_GetPropertyValue_HasKeyboardFocusPropertyId_ReturnsFalse()
         {
             using TabControl tabControl = new TabControl();
 
@@ -566,7 +595,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void TabPageAccessibleObject_GetPropertyValue_IsKeyboardFocusablePropertyId_ReturnsTrue()
+        public void TabControlAccessibleObject_GetPropertyValue_IsKeyboardFocusablePropertyId_ReturnsTrue()
         {
             using TabControl tabControl = new TabControl();
 
@@ -579,7 +608,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true)]
         [InlineData(false)]
-        public void TabPageAccessibleObject_GetPropertyValue_IsEnabledPropertyId_ReturnsTrue(bool enabled)
+        public void TabControlAccessibleObject_GetPropertyValue_IsEnabledPropertyId_ReturnsTrue(bool enabled)
         {
             using TabControl tabControl = new TabControl() { Enabled = enabled };
 
@@ -592,7 +621,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true)]
         [InlineData(false)]
-        public void TabPageAccessibleObject_GetPropertyValue_NativeWindowHandlePropertyId_ReturnsTrue(bool createControl)
+        public void TabControlAccessibleObject_GetPropertyValue_NativeWindowHandlePropertyId_ReturnsTrue(bool createControl)
         {
             using TabControl tabControl = new TabControl();
 
@@ -604,6 +633,46 @@ namespace System.Windows.Forms.Tests
             TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             Assert.Equal(tabControl.InternalHandle, (IntPtr)accessibleObject.GetPropertyValue(UIA.NativeWindowHandlePropertyId));
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, "&Name", "Alt+n")]
+        [InlineData(false, "&Name", "Alt+n")]
+        [InlineData(true, "Name", null)]
+        [InlineData(false, "Name", null)]
+        public void TabControlAccessibleObject_KeyboardShortcut_ReturnExpected(bool createControl, string text, string expectedKeyboardShortcut)
+        {
+            using TabControl tabControl = new() { Text = text };
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(expectedKeyboardShortcut, accessibleObject.KeyboardShortcut);
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, "&Name", "Alt+n")]
+        [InlineData(false, "&Name", "Alt+n")]
+        [InlineData(true, "Name", null)]
+        [InlineData(false, "Name", null)]
+        public void TabControlAccessibleObject_GetPropertyValue_AccessKey_ReturnExpected(bool createControl, string text, string expectedKeyboardShortcut)
+        {
+            using TabControl tabControl = new() { Text = text };
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(expectedKeyboardShortcut, accessibleObject.GetPropertyValue(UIA.AccessKeyPropertyId));
             Assert.Equal(createControl, tabControl.IsHandleCreated);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabAccessibleObjectTests.cs
@@ -1,0 +1,878 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop;
+using static Interop.UiaCore;
+using static System.Windows.Forms.TabPage;
+
+namespace System.Windows.Forms.Tests
+{
+    public class TabPage_TabAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsTheory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public void TabAccessibleObject_Bounds_ReturnsExpected(bool createControl, bool boundsIsEmpty)
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.Equal(boundsIsEmpty, accessibleObject.Bounds.IsEmpty);
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("Test", "Test")]
+        public void TabAccessibleObject_Name_ReturnsTabPageText(string text, string expectedText)
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage() { Text = text, Name = "Test" });
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.Equal(expectedText, accessibleObject.Name);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_DefaultAction_ReturnsNull_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new TabControl();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.Null(accessibleObject.DefaultAction);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_DefaultAction_Returns_NotEmptyString_IfHandleIsCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.NotEmpty(accessibleObject.DefaultAction);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.PageTab)]
+        [InlineData(false, AccessibleRole.None)]
+        public void TabAccessibleObject_Role_ReturnsNone_IfHandleIsNotCreated(bool createControl, AccessibleRole expectedAccessibleRole)
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.Equal(expectedAccessibleRole, accessibleObject.Role);
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TabAccessibleObject_State_ReturnsExpected_IfHandleIsCreated(bool tabControlEnabled, bool tabPageEnabled)
+        {
+            using TabControl tabControl = new() { Enabled = tabControlEnabled } ;
+            tabControl.TabPages.Add(new TabPage() { Enabled = tabPageEnabled });
+            tabControl.TabPages.Add(new TabPage() { Enabled = tabPageEnabled });
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(AccessibleStates.Focusable | AccessibleStates.Selectable | AccessibleStates.Selected, accessibleObject1.State);
+            Assert.Equal(AccessibleStates.Focusable | AccessibleStates.Selectable, accessibleObject2.State);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_State_ReturnsNone_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.Equal(AccessibleStates.None, accessibleObject.State);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_FragmentRoot_ReturnsTabControlAccessibleObject()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject.FragmentRoot);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_FragmentNavigate_ReturnsNull_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_FragmentNavigate_Parent_ReturnsTabControlAccessibleObject()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_AfterChaningSelectedTab()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            tabControl.SelectedIndex = 1;
+
+            Assert.Equal(tabControl.TabPages[1].AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_Supports_LegacyIAccessiblePattern()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.True(accessibleObject.IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_GetPropertyValue_IsLegacyIAccessiblePatternAvailable_ReturnsTrue()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_Supports_SelectionItemPattern()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.True(accessibleObject.IsPatternSupported(UiaCore.UIA.SelectionItemPatternId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_GetPropertyValue_IsSelectionItemPatternAvailable_ReturnsTrue()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsSelectionItemPatternAvailablePropertyId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_DoesNotSupport_InvokePattern()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.False(accessibleObject.IsPatternSupported(UiaCore.UIA.InvokePatternId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_GetPropertyValue_IsInvokePatternPatternAvailable_ReturnsTrue()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.False((bool)accessibleObject.GetPropertyValue(UIA.IsInvokePatternAvailablePropertyId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_DoDefaultAction_WorksCorrectly()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(0, tabControl.SelectedIndex);
+
+            accessibleObject.DoDefaultAction();
+
+            Assert.Equal(1, tabControl.SelectedIndex);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_DoDefaultAction_DoesNotAffectTabControl_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(-1, tabControl.SelectedIndex);
+
+            accessibleObject.DoDefaultAction();
+
+            Assert.Equal(-1, tabControl.SelectedIndex);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_DoDefaultAction_DoesNotAffectTabControl_IfTabControlIsDisabled()
+        {
+            using TabControl tabControl = new() { Enabled = false };
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(0, tabControl.SelectedIndex);
+
+            accessibleObject.DoDefaultAction();
+
+            Assert.Equal(0, tabControl.SelectedIndex);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SelectItem_WorksCorrectly()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(0, tabControl.SelectedIndex);
+
+            accessibleObject.SelectItem();
+
+            Assert.Equal(1, tabControl.SelectedIndex);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SelectItem_DoesNotAffectTabControl_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(-1, tabControl.SelectedIndex);
+
+            accessibleObject.SelectItem();
+
+            Assert.Equal(-1, tabControl.SelectedIndex);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SelectItem_DoesNotAffectTabControl_IfTabControlIsDisabled()
+        {
+            using TabControl tabControl = new() { Enabled = false };
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(0, tabControl.SelectedIndex);
+
+            accessibleObject.SelectItem();
+
+            Assert.Equal(0, tabControl.SelectedIndex);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_AddToSelection_WorksCorrectly()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(0, tabControl.SelectedIndex);
+
+            accessibleObject.AddToSelection();
+
+            Assert.Equal(1, tabControl.SelectedIndex);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_AddToSelection__DoesNotAffectTabControl_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(-1, tabControl.SelectedIndex);
+
+            accessibleObject.AddToSelection();
+
+            Assert.Equal(-1, tabControl.SelectedIndex);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_AddToSelection_DoesNotAffectTabControl_IfTabControlIsDisabled()
+        {
+            using TabControl tabControl = new() { Enabled = false };
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.Equal(0, tabControl.SelectedIndex);
+
+            accessibleObject.AddToSelection();
+
+            Assert.Equal(0, tabControl.SelectedIndex);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, 0)]
+        [InlineData(false, -1)]
+        public void TabAccessibleObject_RemoveFromSelection_DoesNotAffectTabControl(bool createControl, int expectedIndex)
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.Equal(expectedIndex, tabControl.SelectedIndex);
+
+            accessibleObject.RemoveFromSelection();
+
+            Assert.Equal(expectedIndex, tabControl.SelectedIndex);
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabAccessibleObject_ItemSelectionContainer_ReturnsTabControlAccessibleObject(bool createControl)
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject.ItemSelectionContainer);
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_ItemIsSelected_ReturnsExpected_IfHandleIsCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.CreateControl();
+
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.True(accessibleObject1.IsItemSelected);
+            Assert.False(accessibleObject2.IsItemSelected);
+
+            tabControl.SelectedIndex = 1;
+
+            Assert.False(accessibleObject1.IsItemSelected);
+            Assert.True(accessibleObject2.IsItemSelected);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_ItemIsSelected_ReturnsFalse_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.False(accessibleObject1.IsItemSelected);
+            Assert.False(accessibleObject2.IsItemSelected);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabAccessibleObject_DoDefaultAction_InvokeRaiseAutomationEvent(bool tabPageEnabled)
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new() { Enabled = tabPageEnabled };
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(tabPage);
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabPage.TabAccessibilityObject.DoDefaultAction();
+
+            Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_DoDefaultAction_DoesNotInvoke_RaiseAutomationEvent_IfTabAlreadySelected()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new();
+            tabControl.TabPages.Add(tabPage);
+            tabControl.TabPages.Add(new TabPage());
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabPage.TabAccessibilityObject.DoDefaultAction();
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabAccessibleObject_DoDefaultAction_DoesNotInvoke_RaiseAutomationEvent_IfTabControlIsDisabled(bool tabPageEnabled)
+        {
+            using TabControl tabControl = new() { Enabled = false };
+            tabControl.CreateControl();
+            using TabPage tabPage = new() { Enabled = tabPageEnabled };
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(tabPage);
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabPage.TabAccessibilityObject.DoDefaultAction();
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SetSelectedTab_InvokeRaiseAutomationEvent()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(tabPage);
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabControl.SelectedTab = tabPage;
+
+            Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SetSelectedTab_DoesNotInvoke_RaiseAutomationEvent_IfTabAlreadySelected()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new();
+            tabControl.TabPages.Add(tabPage);
+            tabControl.TabPages.Add(new TabPage());
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabControl.SelectedTab = tabPage;
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SetSelectedIndex_InvokeRaiseAutomationEvent()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(tabPage);
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabControl.SelectedIndex = 1;
+
+            Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SetSelectedIndex_DoesNotInvoke_RaiseAutomationEvent_IfTabAlreadySelected()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new();
+            tabControl.TabPages.Add(tabPage);
+            tabControl.TabPages.Add(new TabPage());
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabControl.SelectedIndex = 0;
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_OnGotFocus_InvokeTabAccessibleObject_RaiseAutomationEvent()
+        {
+            using SubTabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new();
+            tabControl.TabPages.Add(tabPage);
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabControl.OnGotFocus();
+
+            Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabAccessibleObject_AddToSelection_InvokeRaiseAutomationEvent(bool tabPageEnabled)
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new() { Enabled = tabPageEnabled };
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(tabPage);
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabPage.TabAccessibilityObject.AddToSelection();
+
+            Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_AddToSelection_DoesNotInvoke_RaiseAutomationEvent_IfTabAlreadySelected()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new();
+            tabControl.TabPages.Add(tabPage);
+            tabControl.TabPages.Add(new TabPage());
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabPage.TabAccessibilityObject.AddToSelection();
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabAccessibleObject_AddToSelection_DoesNotInvoke_RaiseAutomationEvent_IfTabControlIsDisabled(bool tabPageEnabled)
+        {
+            using TabControl tabControl = new() { Enabled = false };
+            tabControl.CreateControl();
+            using TabPage tabPage = new() { Enabled = tabPageEnabled };
+            tabControl.TabPages.Add(tabPage);
+            tabControl.TabPages.Add(new TabPage());
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabPage.TabAccessibilityObject.AddToSelection();
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabAccessibleObject_SelectItem_InvokeRaiseAutomationEvent(bool tabPageEnabled)
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new() { Enabled = tabPageEnabled };
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(tabPage);
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabPage.TabAccessibilityObject.SelectItem();
+
+            Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SelectItem_DoesNotInvoke_RaiseAutomationEvent_IfTabAlreadySelected()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            using TabPage tabPage = new();
+            tabControl.TabPages.Add(tabPage);
+            tabControl.TabPages.Add(new TabPage());
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabPage.TabAccessibilityObject.SelectItem();
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabAccessibleObject_SelectItem_DoesNotInvoke_RaiseAutomationEvent_IfTabControlIsDisabled(bool tabPageEnabled)
+        {
+            using TabControl tabControl = new() { Enabled = false };
+            tabControl.CreateControl();
+            using TabPage tabPage = new() { Enabled = tabPageEnabled };
+            tabControl.TabPages.Add(tabPage);
+            tabControl.TabPages.Add(new TabPage());
+            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
+            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabPage.TabAccessibilityObject.SelectItem();
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabAccessibleObject_RuntimeId_ReturnsExpected(bool createControl)
+        {
+            using TabControl tabControl = new();
+
+            if (createControl)
+            {
+                tabControl.CreateControl();
+            }
+
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+
+            Assert.NotNull(accessibleObject1.RuntimeId);
+            Assert.Equal(tabControl.HandleInternal, (IntPtr)accessibleObject1.RuntimeId[1]);
+            Assert.Equal(accessibleObject1.GetChildId(), accessibleObject1.RuntimeId[2]);
+            Assert.NotNull(accessibleObject2.RuntimeId);
+            Assert.Equal(tabControl.HandleInternal, (IntPtr)accessibleObject2.RuntimeId[1]);
+            Assert.Equal(accessibleObject2.GetChildId(), accessibleObject2.RuntimeId[2]);
+            Assert.Equal(createControl, tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, false)]
+        public void TabAccessibleObject_GetPropertyValue_IsEnabledPropertyId_ReturnsExpected(bool tabControlEnabled, bool tabPageEnabled, bool expectedEnabled)
+        {
+            using TabControl tabControl = new() { Enabled = tabControlEnabled };
+            using TabPage tabPage = new() { Enabled = tabPageEnabled };
+            tabControl.TabPages.Add(tabPage);
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabPage.TabAccessibilityObject);
+
+            Assert.Equal(expectedEnabled, (bool)accessibleObject.GetPropertyValue(UIA.IsEnabledPropertyId));
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_GetPropertyValue_IsKeyboardFocusablePropertyId_ReturnsTrue()
+        {
+            using TabControl tabControl = new();
+            using TabPage tabPage = new();
+            tabControl.TabPages.Add(tabPage);
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabPage.TabAccessibilityObject);
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsKeyboardFocusablePropertyId));
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_GetPropertyValue_HasKeyboardFocusPropertyId_ReturnsTrue()
+        {
+            using TabControl tabControl = new();
+            using TabPage tabPage = new();
+            tabControl.TabPages.Add(tabPage);
+
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabPage.TabAccessibilityObject);
+
+            Assert.False((bool)accessibleObject.GetPropertyValue(UIA.HasKeyboardFocusPropertyId));
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        private class SubTabControl : TabControl
+        {
+            internal void OnGotFocus() => base.OnGotFocus(EventArgs.Empty);
+        }
+
+        private class SubTabAccessibleObject : TabAccessibleObject
+        {
+            internal SubTabAccessibleObject(TabPage owningTabPage) : base(owningTabPage)
+            {
+            }
+
+            internal int CallSelectionItemEventCount { get; private set; }
+
+            internal int CallFocusChangedEventCount { get; private set; }
+
+            internal override bool RaiseAutomationEvent(UiaCore.UIA eventId)
+            {
+                switch (eventId)
+                {
+                    case UiaCore.UIA.SelectionItem_ElementSelectedEventId:
+                        CallSelectionItemEventCount++;
+                        break;
+                    case UiaCore.UIA.AutomationFocusChangedEventId:
+                        CallFocusChangedEventCount++;
+                        break;
+                    default:
+                        break;
+                }
+
+                return base.RaiseAutomationEvent(eventId);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabAccessibleObjectTests.cs
@@ -5,6 +5,7 @@
 using Xunit;
 using static Interop;
 using static Interop.UiaCore;
+using static System.Windows.Forms.TabControl;
 using static System.Windows.Forms.TabPage;
 
 namespace System.Windows.Forms.Tests
@@ -17,16 +18,18 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_Bounds_ReturnsExpected(bool createControl, bool boundsIsEmpty)
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
             if (createControl)
             {
                 tabControl.CreateControl();
             }
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.Equal(boundsIsEmpty, accessibleObject.Bounds.IsEmpty);
+            Assert.Equal(createControl, pages[0].IsHandleCreated);
             Assert.Equal(createControl, tabControl.IsHandleCreated);
         }
 
@@ -37,11 +40,13 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_Name_ReturnsTabPageText(string text, string expectedText)
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage() { Text = text, Name = "Test" });
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage() { Text = text, Name = "Test" });
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.Equal(expectedText, accessibleObject.Name);
+            Assert.False(pages[0].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -49,11 +54,13 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_DefaultAction_ReturnsNull_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new TabControl();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.Null(accessibleObject.DefaultAction);
+            Assert.False(pages[0].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -61,12 +68,14 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_DefaultAction_Returns_NotEmptyString_IfHandleIsCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.NotEmpty(accessibleObject.DefaultAction);
+            Assert.True(pages[0].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -76,16 +85,18 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_Role_ReturnsNone_IfHandleIsNotCreated(bool createControl, AccessibleRole expectedAccessibleRole)
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
             if (createControl)
             {
                 tabControl.CreateControl();
             }
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.Equal(expectedAccessibleRole, accessibleObject.Role);
+            Assert.Equal(createControl, pages[0].IsHandleCreated);
             Assert.Equal(createControl, tabControl.IsHandleCreated);
         }
 
@@ -96,16 +107,18 @@ namespace System.Windows.Forms.Tests
         [InlineData(false, false)]
         public void TabAccessibleObject_State_ReturnsExpected_IfHandleIsCreated(bool tabControlEnabled, bool tabPageEnabled)
         {
-            using TabControl tabControl = new() { Enabled = tabControlEnabled } ;
-            tabControl.TabPages.Add(new TabPage() { Enabled = tabPageEnabled });
-            tabControl.TabPages.Add(new TabPage() { Enabled = tabPageEnabled });
+            using TabControl tabControl = new() { Enabled = tabControlEnabled };
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new() { Enabled = tabPageEnabled }, new() { Enabled = tabPageEnabled } } );
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
-            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Equal(AccessibleStates.Focusable | AccessibleStates.Selectable | AccessibleStates.Selected, accessibleObject1.State);
             Assert.Equal(AccessibleStates.Focusable | AccessibleStates.Selectable, accessibleObject2.State);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -113,11 +126,13 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_State_ReturnsNone_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.Equal(AccessibleStates.None, accessibleObject.State);
+            Assert.False(pages[0].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -125,11 +140,13 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_FragmentRoot_ReturnsTabControlAccessibleObject()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.Equal(tabControl.AccessibilityObject, accessibleObject.FragmentRoot);
+            Assert.False(pages[0].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -137,11 +154,11 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_FragmentNavigate_ReturnsNull_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
 
-            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
-            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.Parent));
             Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
@@ -154,6 +171,8 @@ namespace System.Windows.Forms.Tests
             Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
             Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -161,12 +180,14 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_FragmentNavigate_Parent_ReturnsTabControlAccessibleObject()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.Equal(tabControl.AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.True(pages[0].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -174,18 +195,20 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
-            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
-            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(pages[0].AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
             Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -193,24 +216,26 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_AfterChaningSelectedTab()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
-            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
-            Assert.Equal(tabControl.TabPages[0].AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(pages[0].AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
             Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
             tabControl.SelectedIndex = 1;
 
-            Assert.Equal(tabControl.TabPages[1].AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(pages[1].AccessibilityObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
             Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -218,11 +243,13 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_Supports_LegacyIAccessiblePattern()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.True(accessibleObject.IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId));
+            Assert.False(pages[0].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -230,11 +257,13 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_GetPropertyValue_IsLegacyIAccessiblePatternAvailable_ReturnsTrue()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+            Assert.False(pages[0].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -242,11 +271,13 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_Supports_SelectionItemPattern()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.True(accessibleObject.IsPatternSupported(UiaCore.UIA.SelectionItemPatternId));
+            Assert.False(pages[0].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -254,11 +285,13 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_GetPropertyValue_IsSelectionItemPatternAvailable_ReturnsTrue()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsSelectionItemPatternAvailablePropertyId));
+            Assert.False(pages[0].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -266,11 +299,13 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_DoesNotSupport_InvokePattern()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.False(accessibleObject.IsPatternSupported(UiaCore.UIA.InvokePatternId));
+            Assert.False(pages[0].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -278,11 +313,13 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_GetPropertyValue_IsInvokePatternPatternAvailable_ReturnsTrue()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.False((bool)accessibleObject.GetPropertyValue(UIA.IsInvokePatternAvailablePropertyId));
+            Assert.False(pages[0].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -290,17 +327,19 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_DoDefaultAction_WorksCorrectly()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Equal(0, tabControl.SelectedIndex);
 
             accessibleObject.DoDefaultAction();
 
             Assert.Equal(1, tabControl.SelectedIndex);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -308,16 +347,18 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_DoDefaultAction_DoesNotAffectTabControl_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Equal(-1, tabControl.SelectedIndex);
 
             accessibleObject.DoDefaultAction();
 
             Assert.Equal(-1, tabControl.SelectedIndex);
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -325,17 +366,19 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_DoDefaultAction_DoesNotAffectTabControl_IfTabControlIsDisabled()
         {
             using TabControl tabControl = new() { Enabled = false };
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Equal(0, tabControl.SelectedIndex);
 
             accessibleObject.DoDefaultAction();
 
             Assert.Equal(0, tabControl.SelectedIndex);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -343,17 +386,19 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_SelectItem_WorksCorrectly()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Equal(0, tabControl.SelectedIndex);
 
             accessibleObject.SelectItem();
 
             Assert.Equal(1, tabControl.SelectedIndex);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -361,16 +406,18 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_SelectItem_DoesNotAffectTabControl_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Equal(-1, tabControl.SelectedIndex);
 
             accessibleObject.SelectItem();
 
             Assert.Equal(-1, tabControl.SelectedIndex);
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -378,17 +425,19 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_SelectItem_DoesNotAffectTabControl_IfTabControlIsDisabled()
         {
             using TabControl tabControl = new() { Enabled = false };
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Equal(0, tabControl.SelectedIndex);
 
             accessibleObject.SelectItem();
 
             Assert.Equal(0, tabControl.SelectedIndex);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -396,17 +445,19 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_AddToSelection_WorksCorrectly()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Equal(0, tabControl.SelectedIndex);
 
             accessibleObject.AddToSelection();
 
             Assert.Equal(1, tabControl.SelectedIndex);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -414,16 +465,18 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_AddToSelection__DoesNotAffectTabControl_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Equal(-1, tabControl.SelectedIndex);
 
             accessibleObject.AddToSelection();
 
             Assert.Equal(-1, tabControl.SelectedIndex);
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -431,17 +484,19 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_AddToSelection_DoesNotAffectTabControl_IfTabControlIsDisabled()
         {
             using TabControl tabControl = new() { Enabled = false };
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.Equal(0, tabControl.SelectedIndex);
 
             accessibleObject.AddToSelection();
 
             Assert.Equal(0, tabControl.SelectedIndex);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -451,21 +506,23 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_RemoveFromSelection_DoesNotAffectTabControl(bool createControl, int expectedIndex)
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
 
             if (createControl)
             {
                 tabControl.CreateControl();
             }
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.Equal(expectedIndex, tabControl.SelectedIndex);
 
             accessibleObject.RemoveFromSelection();
 
             Assert.Equal(expectedIndex, tabControl.SelectedIndex);
+            Assert.Equal(createControl, pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.Equal(createControl, tabControl.IsHandleCreated);
         }
 
@@ -475,17 +532,19 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_ItemSelectionContainer_ReturnsTabControlAccessibleObject(bool createControl)
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
 
             if (createControl)
             {
                 tabControl.CreateControl();
             }
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.Equal(tabControl.AccessibilityObject, accessibleObject.ItemSelectionContainer);
+            Assert.Equal(createControl, pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.Equal(createControl, tabControl.IsHandleCreated);
         }
 
@@ -493,12 +552,12 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_ItemIsSelected_ReturnsExpected_IfHandleIsCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
             tabControl.CreateControl();
 
-            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
-            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.True(accessibleObject1.IsItemSelected);
             Assert.False(accessibleObject2.IsItemSelected);
@@ -507,6 +566,8 @@ namespace System.Windows.Forms.Tests
 
             Assert.False(accessibleObject1.IsItemSelected);
             Assert.True(accessibleObject2.IsItemSelected);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
             Assert.True(tabControl.IsHandleCreated);
         }
 
@@ -514,14 +575,16 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_ItemIsSelected_ReturnsFalse_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new() });
 
-            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
-            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.False(accessibleObject1.IsItemSelected);
             Assert.False(accessibleObject2.IsItemSelected);
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
             Assert.False(tabControl.IsHandleCreated);
         }
 
@@ -531,34 +594,64 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_DoDefaultAction_InvokeRaiseAutomationEvent(bool tabPageEnabled)
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new() { Enabled = tabPageEnabled };
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(tabPage);
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() { Enabled = tabPageEnabled } } );
 
-            tabPage.TabAccessibilityObject.DoDefaultAction();
+            SubTabAccessibleObject tabAccessibleObject = new(pages[1]);
+            pages[1].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            pages[1].TabAccessibilityObject.DoDefaultAction();
 
             Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabAccessibleObject_DoDefaultAction_DoesNotInvoke_RaiseAutomationEvent_IfTabAlreadySelected()
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new();
-            tabControl.TabPages.Add(tabPage);
-            tabControl.TabPages.Add(new TabPage());
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() });
 
-            tabPage.TabAccessibilityObject.DoDefaultAction();
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            pages[0].TabAccessibilityObject.DoDefaultAction();
 
             Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_DoDefaultAction_DoesNotInvoke_RaiseAutomationEvent_IfAccessibleObjectIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
+            tabControl.CreateControl();
+            pages.AddRange(new TabPage[] { new(), new() });
+
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            pages[0].TabAccessibilityObject.DoDefaultAction();
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -567,100 +660,188 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_DoDefaultAction_DoesNotInvoke_RaiseAutomationEvent_IfTabControlIsDisabled(bool tabPageEnabled)
         {
             using TabControl tabControl = new() { Enabled = false };
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new() { Enabled = tabPageEnabled };
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(tabPage);
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() { Enabled = tabPageEnabled } });
 
-            tabPage.TabAccessibilityObject.DoDefaultAction();
+            SubTabAccessibleObject tabAccessibleObject = new(pages[1]);
+            pages[1].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            pages[1].TabAccessibilityObject.DoDefaultAction();
 
             Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabAccessibleObject_SetSelectedTab_InvokeRaiseAutomationEvent()
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(tabPage);
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() });
 
-            tabControl.SelectedTab = tabPage;
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            SubTabAccessibleObject tabAccessibleObject = new(pages[1]);
+            pages[1].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabControl.SelectedTab = pages[1];
 
             Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SetSelectedTab_DoesNotInvoke_RaiseAutomationEvent_IfAccessibleObjectIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
+            tabControl.CreateControl();
+            pages.AddRange(new TabPage[] { new(), new() });
+
+            SubTabAccessibleObject tabAccessibleObject = new(pages[1]);
+            pages[1].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabControl.SelectedTab = pages[1];
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabAccessibleObject_SetSelectedTab_DoesNotInvoke_RaiseAutomationEvent_IfTabAlreadySelected()
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new();
-            tabControl.TabPages.Add(tabPage);
-            tabControl.TabPages.Add(new TabPage());
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() });
 
-            tabControl.SelectedTab = tabPage;
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            tabControl.SelectedTab = pages[0];
 
             Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabAccessibleObject_SetSelectedIndex_InvokeRaiseAutomationEvent()
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(tabPage);
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() });
+
+            SubTabAccessibleObject tabAccessibleObject = new(pages[1]);
+            pages[1].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             tabControl.SelectedIndex = 1;
 
             Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SetSelectedIndex_DoesNotInvoke_RaiseAutomationEvent_IfAccessibleObjectIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
+            tabControl.CreateControl();
+            pages.AddRange(new TabPage[] { new(), new() });
+
+            SubTabAccessibleObject tabAccessibleObject = new(pages[1]);
+            pages[1].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabControl.SelectedIndex = 1;
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabAccessibleObject_SetSelectedIndex_DoesNotInvoke_RaiseAutomationEvent_IfTabAlreadySelected()
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new();
-            tabControl.TabPages.Add(tabPage);
-            tabControl.TabPages.Add(new TabPage());
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() });
+
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             tabControl.SelectedIndex = 0;
 
             Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabAccessibleObject_OnGotFocus_InvokeTabAccessibleObject_RaiseAutomationEvent()
         {
             using SubTabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new();
-            tabControl.TabPages.Add(tabPage);
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() });
+
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             tabControl.OnGotFocus();
 
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_OnGotFocus_DoesNotInvoke_RaiseAutomationEvent_IfControlTabAccessibleObjectIsNotCreated()
+        {
+            using SubTabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
+            tabControl.CreateControl();
+            pages.AddRange(new TabPage[] { new(), new() });
+
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            tabControl.OnGotFocus();
+
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -669,34 +850,62 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_AddToSelection_InvokeRaiseAutomationEvent(bool tabPageEnabled)
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new() { Enabled = tabPageEnabled };
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(tabPage);
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() { Enabled = tabPageEnabled } });
 
-            tabPage.TabAccessibilityObject.AddToSelection();
+            SubTabAccessibleObject tabAccessibleObject = new(pages[1]);
+            pages[1].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            pages[1].TabAccessibilityObject.AddToSelection();
 
             Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_AddToSelection_DoesNotInvoke_RaiseAutomationEvent_IfAccessibleObjectIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
+            tabControl.CreateControl();
+            pages.AddRange(new TabPage[] { new(), new() });
+
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            pages[0].TabAccessibilityObject.AddToSelection();
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabAccessibleObject_AddToSelection_DoesNotInvoke_RaiseAutomationEvent_IfTabAlreadySelected()
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new();
-            tabControl.TabPages.Add(tabPage);
-            tabControl.TabPages.Add(new TabPage());
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() });
 
-            tabPage.TabAccessibilityObject.AddToSelection();
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            pages[0].TabAccessibilityObject.AddToSelection();
 
             Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -705,17 +914,22 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_AddToSelection_DoesNotInvoke_RaiseAutomationEvent_IfTabControlIsDisabled(bool tabPageEnabled)
         {
             using TabControl tabControl = new() { Enabled = false };
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new() { Enabled = tabPageEnabled };
-            tabControl.TabPages.Add(tabPage);
-            tabControl.TabPages.Add(new TabPage());
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new() { Enabled = tabPageEnabled }, new() });
 
-            tabPage.TabAccessibilityObject.AddToSelection();
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            pages[0].TabAccessibilityObject.AddToSelection();
 
             Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -724,34 +938,64 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_SelectItem_InvokeRaiseAutomationEvent(bool tabPageEnabled)
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new() { Enabled = tabPageEnabled };
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(tabPage);
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() { Enabled = tabPageEnabled } });
 
-            tabPage.TabAccessibilityObject.SelectItem();
+            SubTabAccessibleObject tabAccessibleObject = new(pages[1]);
+            pages[1].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            pages[1].TabAccessibilityObject.SelectItem();
 
             Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabAccessibleObject_SelectItem_DoesNotInvoke_RaiseAutomationEvent_IfAccessibleObjectIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
+            tabControl.CreateControl();
+            pages.AddRange(new TabPage[] { new(), new() });
+
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            pages[0].TabAccessibilityObject.SelectItem();
+
+            Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
+            Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabAccessibleObject_SelectItem_DoesNotInvoke_RaiseAutomationEvent_IfTabAlreadySelected()
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new();
-            tabControl.TabPages.Add(tabPage);
-            tabControl.TabPages.Add(new TabPage());
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() });
 
-            tabPage.TabAccessibilityObject.SelectItem();
+            SubTabAccessibleObject tabAccessibleObject = new(pages[0]);
+            pages[0].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            pages[0].TabAccessibilityObject.SelectItem();
 
             Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -760,17 +1004,22 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_SelectItem_DoesNotInvoke_RaiseAutomationEvent_IfTabControlIsDisabled(bool tabPageEnabled)
         {
             using TabControl tabControl = new() { Enabled = false };
+            TabPageCollection pages = tabControl.TabPages;
             tabControl.CreateControl();
-            using TabPage tabPage = new() { Enabled = tabPageEnabled };
-            tabControl.TabPages.Add(tabPage);
-            tabControl.TabPages.Add(new TabPage());
-            SubTabAccessibleObject tabAccessibleObject = new(tabPage);
-            tabPage.TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+            pages.AddRange(new TabPage[] { new(), new() { Enabled = tabPageEnabled } });
 
-            tabPage.TabAccessibilityObject.SelectItem();
+            SubTabAccessibleObject tabAccessibleObject = new(pages[1]);
+            pages[1].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
+
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            pages[1].TabAccessibilityObject.SelectItem();
 
             Assert.Equal(0, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(0, tabAccessibleObject.CallFocusChangedEventCount);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -779,16 +1028,16 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_RuntimeId_ReturnsExpected(bool createControl)
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
 
             if (createControl)
             {
                 tabControl.CreateControl();
             }
 
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
-            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[0].TabAccessibilityObject);
-            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(tabControl.TabPages[1].TabAccessibilityObject);
+            pages.AddRange(new TabPage[] { new TabPage(), new TabPage() });
+            TabAccessibleObject accessibleObject1 = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
+            TabAccessibleObject accessibleObject2 = Assert.IsType<TabAccessibleObject>(pages[1].TabAccessibilityObject);
 
             Assert.NotNull(accessibleObject1.RuntimeId);
             Assert.Equal(tabControl.HandleInternal, (IntPtr)accessibleObject1.RuntimeId[1]);
@@ -796,6 +1045,8 @@ namespace System.Windows.Forms.Tests
             Assert.NotNull(accessibleObject2.RuntimeId);
             Assert.Equal(tabControl.HandleInternal, (IntPtr)accessibleObject2.RuntimeId[1]);
             Assert.Equal(accessibleObject2.GetChildId(), accessibleObject2.RuntimeId[2]);
+            Assert.Equal(createControl, pages[0].IsHandleCreated);
+            Assert.Equal(createControl, pages[1].IsHandleCreated);
             Assert.Equal(createControl, tabControl.IsHandleCreated);
         }
 
@@ -807,39 +1058,45 @@ namespace System.Windows.Forms.Tests
         public void TabAccessibleObject_GetPropertyValue_IsEnabledPropertyId_ReturnsExpected(bool tabControlEnabled, bool tabPageEnabled, bool expectedEnabled)
         {
             using TabControl tabControl = new() { Enabled = tabControlEnabled };
-            using TabPage tabPage = new() { Enabled = tabPageEnabled };
-            tabControl.TabPages.Add(tabPage);
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage() { Enabled = tabPageEnabled });
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabPage.TabAccessibilityObject);
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.Equal(expectedEnabled, (bool)accessibleObject.GetPropertyValue(UIA.IsEnabledPropertyId));
-            Assert.False(tabPage.IsHandleCreated);
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabAccessibleObject_GetPropertyValue_IsKeyboardFocusablePropertyId_ReturnsTrue()
         {
             using TabControl tabControl = new();
-            using TabPage tabPage = new();
-            tabControl.TabPages.Add(tabPage);
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabPage.TabAccessibilityObject);
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsKeyboardFocusablePropertyId));
-            Assert.False(tabPage.IsHandleCreated);
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabAccessibleObject_GetPropertyValue_HasKeyboardFocusPropertyId_ReturnsTrue()
         {
             using TabControl tabControl = new();
-            using TabPage tabPage = new();
-            tabControl.TabPages.Add(tabPage);
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(tabPage.TabAccessibilityObject);
+            Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+            TabAccessibleObject accessibleObject = Assert.IsType<TabAccessibleObject>(pages[0].TabAccessibilityObject);
 
             Assert.False((bool)accessibleObject.GetPropertyValue(UIA.HasKeyboardFocusPropertyId));
-            Assert.False(tabPage.IsHandleCreated);
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(tabControl.IsHandleCreated);
         }
 
         private class SubTabControl : TabControl

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
@@ -3,7 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using static Interop;
+using static Interop.UiaCore;
+using static System.Windows.Forms.TabPage;
 
 namespace System.Windows.Forms.Tests
 {
@@ -12,7 +13,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void TabPageAccessibilityObject_Ctor_Default()
         {
-            using TabPage tabPage = new TabPage();
+            using TabPage tabPage = new();
             tabPage.CreateControl();
 
             Assert.NotNull(tabPage.AccessibilityObject);
@@ -22,27 +23,30 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void TabPageAccessibilityObject_ControlType_IsPane_IfAccessibleRoleIsDefault()
         {
-            using TabPage tabPage = new TabPage();
+            using TabPage tabPage = new();
             tabPage.CreateControl();
             // AccessibleRole is not set = Default
 
-            object actual = tabPage.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
+            object actual = tabPage.AccessibilityObject.GetPropertyValue(UIA.ControlTypePropertyId);
 
-            Assert.Equal(UiaCore.UIA.PaneControlTypeId, actual);
+            Assert.Equal(UIA.PaneControlTypeId, actual);
             Assert.True(tabPage.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void TabPageAccessibilityObject_Role_IsClient_ByDefault()
+        [WinFormsTheory]
+        [InlineData(true, AccessibleRole.Client)]
+        [InlineData(false, AccessibleRole.None)]
+        public void TabPageAccessibilityObject_Role_ReturnsExpected(bool createControl, AccessibleRole expectedAccessibleRole)
         {
-            using TabPage tabPage = new TabPage();
-            tabPage.CreateControl();
-            // AccessibleRole is not set = Default
+            using TabPage tabPage = new();
 
-            AccessibleRole actual = tabPage.AccessibilityObject.Role;
+            if (createControl)
+            {
+                tabPage.CreateControl();
+            }
 
-            Assert.Equal(AccessibleRole.Client, actual);
-            Assert.True(tabPage.IsHandleCreated);
+            Assert.Equal(expectedAccessibleRole, tabPage.AccessibilityObject.Role);
+            Assert.Equal(createControl, tabPage.IsHandleCreated);
         }
 
         public static IEnumerable<object[]> TabPageAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData()
@@ -64,14 +68,365 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(TabPageAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData))]
         public void TabPageAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole(AccessibleRole role)
         {
-            using TabPage tabPage = new TabPage();
+            using TabPage tabPage = new();
             tabPage.AccessibleRole = role;
 
-            object actual = tabPage.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
-            UiaCore.UIA expected = AccessibleRoleControlTypeMap.GetControlType(role);
+            object actual = tabPage.AccessibilityObject.GetPropertyValue(UIA.ControlTypePropertyId);
+            UIA expected = AccessibleRoleControlTypeMap.GetControlType(role);
 
             Assert.Equal(expected, actual);
             Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public void TabPageAccessibleObject_Bounds_ReturnsExpected(bool createControl, bool boundsIsEmpty)
+        {
+            using TabPage tabPage = new();
+
+            if (createControl)
+            {
+                tabPage.CreateControl();
+            }
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.Equal(boundsIsEmpty, accessibleObject.Bounds.IsEmpty);
+            Assert.Equal(createControl, tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("Accessible Name", "Text", "Accessible Name")]
+        [InlineData("", "Text", "")]
+        [InlineData(null, "Text", "Text")]
+        [InlineData(null, null, null)]
+        public void TabPageAccessibleObject_Name_ReturnsExpected(string accessibleName, string tabPageText, string expectedName)
+        {
+            using TabPage tabPage = new()
+            {
+                AccessibleName = accessibleName,
+                Text = tabPageText,
+                Name = "Name",
+            };
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.Equal(expectedName, accessibleObject.Name);
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("Test")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TabPageAccessibleObject_Description_ReturnsExpected(string accessibleDescription)
+        {
+            using TabPage tabPage = new();
+            tabPage.AccessibleDescription = accessibleDescription;
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.Equal(accessibleDescription, accessibleObject.Description);
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabPageAccessibleObject_RuntimeId_ReturnsExpected(bool createControl)
+        {
+            using TabPage tabPage = new();
+
+            if (createControl)
+            {
+                tabPage.CreateControl();
+            }
+
+            Assert.NotNull(tabPage.AccessibilityObject.RuntimeId);
+            Assert.Equal(tabPage.HandleInternal, (IntPtr)tabPage.AccessibilityObject.RuntimeId[1]);
+            Assert.Equal(createControl, tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("Test")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TabPageAccessibleObject_AccessibleDefaultActionDescription_ReturnsExpected(string accessibleDefaultActionDescription)
+        {
+            using TabPage tabPage = new();
+            tabPage.AccessibleDefaultActionDescription = accessibleDefaultActionDescription;
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.Equal(accessibleDefaultActionDescription, accessibleObject.DefaultAction);
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, true, AccessibleStates.Focusable)]
+        [InlineData(true, false, AccessibleStates.Focusable | AccessibleStates.Unavailable)]
+        [InlineData(false, true, AccessibleStates.None)]
+        [InlineData(false, false, AccessibleStates.None)]
+        public void TabPageAccessibleObject_State_ReturnExpected(bool createControl, bool enabled, AccessibleStates expectedAccessibleStates)
+        {
+            using TabPage tabPage = new() { Enabled = enabled };
+
+            if (createControl)
+            {
+                tabPage.CreateControl();
+            }
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.Equal(expectedAccessibleStates, accessibleObject.State);
+            Assert.Equal(createControl, tabPage.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_FragmentNaviage_ReturnsNull_IfTabPageHasNotTabControl()
+        {
+            using TabPage tabPage = new();
+            tabPage.CreateControl();
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_FragmentNaviage_ReturnsNull_IfHandleIsNotCreated()
+        {
+            using TabControl tabControl = new();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[0].AccessibilityObject);
+
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.False(tabControl.TabPages[0].IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_FragmentNaviage_ReturnsExpected_IfSingleItem()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            tabControl.TabPages.Add(new TabPage());
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[0].AccessibilityObject);
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(tabControl.TabPages[0].IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_FragmentNaviage_ReturnsExpected_IfThreeItem()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[0].AccessibilityObject);
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.True(tabControl.TabPages[0].IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_FragmentNaviage_ReturnsExpected_AfterChaningSelectedTab()
+        {
+            using TabControl tabControl = new();
+            tabControl.CreateControl();
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+            tabControl.TabPages.Add(new TabPage());
+
+            TabPageAccessibleObject accessibleObject1 = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[0].AccessibilityObject);
+            TabPageAccessibleObject accessibleObject2 = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[1].AccessibilityObject);
+            TabPageAccessibleObject accessibleObject3 = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[2].AccessibilityObject);
+
+            // First tab is selected
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject3.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.LastChild));
+
+            // Second tab is selected
+            tabControl.SelectedIndex = 1;
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject3.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.LastChild));
+
+            // Third tab is selected
+            tabControl.SelectedIndex = 2;
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(tabControl.AccessibilityObject, accessibleObject3.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject3.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.True(tabControl.TabPages[0].IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_Supports_LegacyIAccessiblePattern()
+        {
+            using TabPage tabPage = new();
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.True(accessibleObject.IsPatternSupported(UIA.LegacyIAccessiblePatternId));
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_DoesNotSupports_ValuePattern()
+        {
+            using TabPage tabPage = new();
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.False(accessibleObject.IsPatternSupported(UIA.ValuePatternId));
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_GetPropertyValue_IsLegacyIAccessiblePatternAvailable_ReturnsTrue()
+        {
+            using TabPage tabPage = new();
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_GetPropertyValue_IsValuePatternAvailable_ReturnsFalse()
+        {
+            using TabPage tabPage = new();
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.False((bool)accessibleObject.GetPropertyValue(UIA.IsValuePatternAvailablePropertyId));
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_GetPropertyValue_HasKeyboardFocusPropertyId_ReturnsFalse()
+        {
+            using TabPage tabPage = new();
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.False((bool)accessibleObject.GetPropertyValue(UIA.HasKeyboardFocusPropertyId));
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_GetPropertyValue_IsKeyboardFocusablePropertyId_ReturnsTrue()
+        {
+            using TabPage tabPage = new();
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UIA.IsKeyboardFocusablePropertyId));
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, false)]
+        public void TabPageAccessibleObject_GetPropertyValue_IsEnabledPropertyId_ReturnsExpected(bool tabControlEnabled, bool tabPageEnabled, bool expectedEnabled)
+        {
+            using TabControl tabControl = new() { Enabled = tabControlEnabled };
+            using TabPage tabPage = new() { Enabled = tabPageEnabled };
+            tabControl.TabPages.Add(tabPage);
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.Equal(expectedEnabled, (bool)accessibleObject.GetPropertyValue(UIA.IsEnabledPropertyId));
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabPageAccessibleObject_GetPropertyValue_NativeWindowHandlePropertyId_ReturnsTrue(bool createControl)
+        {
+            using TabPage tabPage = new();
+
+            if (createControl)
+            {
+                tabPage.CreateControl();
+            }
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.Equal(tabPage.InternalHandle, (IntPtr)accessibleObject.GetPropertyValue(UIA.NativeWindowHandlePropertyId));
+            Assert.Equal(createControl, tabPage.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using static Interop.UiaCore;
+using static System.Windows.Forms.TabControl;
 using static System.Windows.Forms.TabPage;
 
 namespace System.Windows.Forms.Tests
@@ -203,16 +204,18 @@ namespace System.Windows.Forms.Tests
         public void TabPageAccessibleObject_FragmentNaviage_ReturnsNull_IfHandleIsNotCreated()
         {
             using TabControl tabControl = new();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[0].AccessibilityObject);
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(pages[0].AccessibilityObject);
 
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.Parent));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
-            Assert.False(tabControl.TabPages[0].IsHandleCreated);
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -220,35 +223,39 @@ namespace System.Windows.Forms.Tests
         {
             using TabControl tabControl = new();
             tabControl.CreateControl();
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage());
 
-            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[0].AccessibilityObject);
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(pages[0].AccessibilityObject);
 
             Assert.Equal(tabControl.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.Parent));
-            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(pages[0].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
-            Assert.True(tabControl.TabPages[0].IsHandleCreated);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void TabPageAccessibleObject_FragmentNaviage_ReturnsExpected_IfThreeItem()
         {
             using TabControl tabControl = new();
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new(), new() });
             tabControl.CreateControl();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
 
-            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[0].AccessibilityObject);
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(pages[0].AccessibilityObject);
 
             Assert.Equal(tabControl.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.Parent));
-            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(pages[0].TabAccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
             Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
-            Assert.True(tabControl.TabPages[0].IsHandleCreated);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.False(pages[1].IsHandleCreated);
+            Assert.False(pages[2].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -256,17 +263,16 @@ namespace System.Windows.Forms.Tests
         {
             using TabControl tabControl = new();
             tabControl.CreateControl();
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
-            tabControl.TabPages.Add(new TabPage());
+            TabPageCollection pages = tabControl.TabPages;
+            pages.AddRange(new TabPage[] { new(), new(), new() });
 
-            TabPageAccessibleObject accessibleObject1 = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[0].AccessibilityObject);
-            TabPageAccessibleObject accessibleObject2 = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[1].AccessibilityObject);
-            TabPageAccessibleObject accessibleObject3 = Assert.IsType<TabPageAccessibleObject>(tabControl.TabPages[2].AccessibilityObject);
+            TabPageAccessibleObject accessibleObject1 = Assert.IsType<TabPageAccessibleObject>(pages[0].AccessibilityObject);
+            TabPageAccessibleObject accessibleObject2 = Assert.IsType<TabPageAccessibleObject>(pages[1].AccessibilityObject);
+            TabPageAccessibleObject accessibleObject3 = Assert.IsType<TabPageAccessibleObject>(pages[2].AccessibilityObject);
 
             // First tab is selected
             Assert.Equal(tabControl.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.Parent));
-            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(pages[0].TabAccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.NextSibling));
             Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.FirstChild));
             Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.LastChild));
@@ -293,7 +299,7 @@ namespace System.Windows.Forms.Tests
             Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.LastChild));
 
             Assert.Equal(tabControl.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.Parent));
-            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(pages[0].TabAccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.NextSibling));
             Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.FirstChild));
             Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.LastChild));
@@ -320,12 +326,15 @@ namespace System.Windows.Forms.Tests
             Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.LastChild));
 
             Assert.Equal(tabControl.AccessibilityObject, accessibleObject3.FragmentNavigate(NavigateDirection.Parent));
-            Assert.Equal(tabControl.TabPages[0].TabAccessibilityObject, accessibleObject3.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(pages[0].TabAccessibilityObject, accessibleObject3.FragmentNavigate(NavigateDirection.NextSibling));
             Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.PreviousSibling));
             Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.FirstChild));
             Assert.Null(accessibleObject3.FragmentNavigate(NavigateDirection.LastChild));
 
-            Assert.True(tabControl.TabPages[0].IsHandleCreated);
+            Assert.True(pages[0].IsHandleCreated);
+            Assert.True(pages[1].IsHandleCreated);
+            Assert.True(pages[2].IsHandleCreated);
+            Assert.True(tabControl.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -402,13 +411,14 @@ namespace System.Windows.Forms.Tests
         public void TabPageAccessibleObject_GetPropertyValue_IsEnabledPropertyId_ReturnsExpected(bool tabControlEnabled, bool tabPageEnabled, bool expectedEnabled)
         {
             using TabControl tabControl = new() { Enabled = tabControlEnabled };
-            using TabPage tabPage = new() { Enabled = tabPageEnabled };
-            tabControl.TabPages.Add(tabPage);
+            TabPageCollection pages = tabControl.TabPages;
+            pages.Add(new TabPage() { Enabled = tabPageEnabled });
 
-            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(pages[0].AccessibilityObject);
 
             Assert.Equal(expectedEnabled, (bool)accessibleObject.GetPropertyValue(UIA.IsEnabledPropertyId));
-            Assert.False(tabPage.IsHandleCreated);
+            Assert.False(pages[0].IsHandleCreated);
+            Assert.False(tabControl.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -426,6 +436,46 @@ namespace System.Windows.Forms.Tests
             TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
 
             Assert.Equal(tabPage.InternalHandle, (IntPtr)accessibleObject.GetPropertyValue(UIA.NativeWindowHandlePropertyId));
+            Assert.Equal(createControl, tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, "&Name", "Alt+n")]
+        [InlineData(false, "&Name", "Alt+n")]
+        [InlineData(true, "Name", null)]
+        [InlineData(false, "Name", null)]
+        public void TabPageAccessibleObject_KeyboardShortcut_ReturnExpected(bool createControl, string text, string expectedKeyboardShortcut)
+        {
+            using TabPage tabPage = new() { Text = text };
+
+            if (createControl)
+            {
+                tabPage.CreateControl();
+            }
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.Equal(expectedKeyboardShortcut, accessibleObject.KeyboardShortcut);
+            Assert.Equal(createControl, tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, "&Name", "Alt+n")]
+        [InlineData(false, "&Name", "Alt+n")]
+        [InlineData(true, "Name", null)]
+        [InlineData(false, "Name", null)]
+        public void TabPageAccessibleObject_GetPropertyValue_AccessKey_ReturnExpected(bool createControl, string text, string expectedKeyboardShortcut)
+        {
+            using TabPage tabPage = new() { Text = text };
+
+            if (createControl)
+            {
+                tabPage.CreateControl();
+            }
+
+            TabPageAccessibleObject accessibleObject = Assert.IsType<TabPageAccessibleObject>(tabPage.AccessibilityObject);
+
+            Assert.Equal(expectedKeyboardShortcut, accessibleObject.GetPropertyValue(UIA.AccessKeyPropertyId));
             Assert.Equal(createControl, tabPage.IsHandleCreated);
         }
     }


### PR DESCRIPTION
Fixes #3058

Related issue: #3421 

## Proposed changes
- The issue is reproduced because the old logic sometimes returned incorrect results for "NextSibling" and "PreviousSibling", which led to incorrect shortcuts behavior. To fix the issue, UIA support was added in which we return the correct results 
- Updated "SupportsUiaProviders" flag.
- Added and implemented accessible objects for the TabControl and TabPage
- Added unit tests.
- Fixed issue with Narrator

## Customer Impact
**Before fix:**
 Shortcuts in some cases did not work for TabControl

**After fix:**
![3058-expected](https://user-images.githubusercontent.com/23376742/127846214-36087c48-caf9-456e-9002-cf9f6b88901f.gif)


## Regression? 

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator
- Accessibility Insights
- Inspect


## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.100-preview.3.21202.5

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5380)