### PR TITLE
Hide keyboard tooltip on form move or resize

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 *REMOVED*override System.Windows.Forms.MonthCalendar.Dispose(bool disposing) -> void
+~override System.Windows.Forms.ContainerControl.OnResize(System.EventArgs e) -> void
 ~override System.Windows.Forms.TabControl.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.TabPage.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.ContainerControl.OnMove(System.EventArgs e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -913,6 +913,12 @@ namespace System.Windows.Forms
             base.OnLayoutResuming(performLayout);
         }
 
+        protected override void OnMove(EventArgs e)
+        {
+            base.OnMove(e);
+            ResetToolTip();
+        }
+
         /// <summary>
         ///  Called when the parent changes. Container controls prefer to have their parents scale
         ///  themselves, but when a parent is first changed, and as a result the font changes as
@@ -924,6 +930,12 @@ namespace System.Windows.Forms
         {
             _state[s_stateParentChanged] = !RequiredScalingEnabled;
             base.OnParentChanged(e);
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            ResetToolTip();
         }
 
         /// <summary>
@@ -1007,6 +1019,14 @@ namespace System.Windows.Forms
             if (_state[s_stateScalingNeededOnLayout])
             {
                 PerformAutoScale(_state[s_stateScalingNeededOnLayout], false);
+            }
+        }
+
+        private void ResetToolTip()
+        {
+            if (GetTopLevel())
+            {
+                KeyboardToolTipStateMachine.Reset();
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.cs
@@ -290,6 +290,8 @@ namespace System.Windows.Forms
             }
         }
 
+        internal static void Reset() => s_instance?.FullFsmReset();
+
         private void StartTracking(IKeyboardToolTip tool, ToolTip toolTip)
         {
             _toolToTip[tool] = toolTip;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5128 


## Proposed changes

- Hide tooltip on container control move and resize

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Keyboard tooltip of Winforms control behavior will be as an expected behavior.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Behavior

### Before

![](https://user-images.githubusercontent.com/26474449/122497998-f271b080-d020-11eb-9dbc-cf10f2899752.gif)

### After

Added hiding on form move and resize

![Animation](https://user-images.githubusercontent.com/58004471/130642183-4e312673-2c12-4330-8d58-fd42c08c935c.gif)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manually

## Test environment(s) <!-- Remove any that don't apply -->

- .Net SDK version 6.0.100-rc.1.21408.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5403)