### PR TITLE
Fixing the issue with getting a ListBox.ItemAccessibleObject.Role

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -19,14 +19,12 @@ namespace System.Windows.Forms
             private readonly ItemArray.Entry _itemEntry;
             private readonly ListBoxAccessibleObject _owningAccessibleObject;
             private readonly ListBox _owningListBox;
-            private readonly IAccessible? _systemIAccessible;
 
             public ListBoxItemAccessibleObject(ListBox owningListBox, ItemArray.Entry itemEntry, ListBoxAccessibleObject owningAccessibleObject)
             {
                 _owningListBox = owningListBox ?? throw new ArgumentNullException(nameof(owningListBox));
                 _itemEntry = itemEntry ?? throw new ArgumentNullException(nameof(itemEntry));
                 _owningAccessibleObject = owningAccessibleObject ?? throw new ArgumentNullException(nameof(owningAccessibleObject));
-                _systemIAccessible = owningAccessibleObject.GetSystemIAccessibleInternal();
             }
 
             private int CurrentIndex
@@ -105,13 +103,13 @@ namespace System.Windows.Forms
             ///  Gets the <see cref="ListBox"/> item default action.
             /// </summary>
             public override string? DefaultAction
-                => _systemIAccessible?.accDefaultAction[GetChildId()];
+                => SystemIAccessible?.accDefaultAction[GetChildId()];
 
             /// <summary>
             ///  Gets the help text.
             /// </summary>
             public override string? Help
-                => _systemIAccessible?.accHelp[GetChildId()];
+                => SystemIAccessible?.accHelp[GetChildId()];
 
             /// <summary>
             ///  Gets or sets the item accessible name.
@@ -132,7 +130,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    var accRole = _systemIAccessible?.get_accRole(GetChildId());
+                    var accRole = SystemIAccessible?.get_accRole(GetChildId());
                     return accRole is not null
                         ? (AccessibleRole)accRole
                         : AccessibleRole.None;
@@ -153,7 +151,7 @@ namespace System.Windows.Forms
                         return state |= AccessibleStates.Selected | AccessibleStates.Focused;
                     }
 
-                    var systemIAccessibleState = _systemIAccessible?.get_accState(GetChildId());
+                    var systemIAccessibleState = SystemIAccessible?.get_accState(GetChildId());
                     if (systemIAccessibleState is not null)
                     {
                         return state |= (AccessibleStates)systemIAccessibleState;
@@ -162,6 +160,8 @@ namespace System.Windows.Forms
                     return state;
                 }
             }
+
+            private IAccessible? SystemIAccessible => _owningAccessibleObject.GetSystemIAccessibleInternal();
 
             internal override void AddToSelection()
             {
@@ -332,7 +332,7 @@ namespace System.Windows.Forms
             {
                 try
                 {
-                    _systemIAccessible?.accSelect((int)flags, GetChildId());
+                    SystemIAccessible?.accSelect((int)flags, GetChildId());
                 }
                 catch (ArgumentException)
                 {


### PR DESCRIPTION
Fixes #5397


## Proposed changes
- The problem is reproduced because we are caching and then using an obsolete `SystemIAccessibleInternal`. As a result, it can only return data about itself, but not about its descendants. 
- Changed the logic for getting a `SystemIAccessibleInternal`. Now we always get it from the `ListBoxAccessibleObject`, and not store it cached.

**Notes:**
Issue also is reproduced for the .NET Core 5.0

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
This issue does not lead to exceptions in my custom application (although i see an exception in the test `WinformsControlsTest` application), but blocks the receipt of the following properties:

- DefaultAction
- Help
- Role
- State (if option is not selected)

![image](https://user-images.githubusercontent.com/23376742/129039289-454ac058-ef98-43eb-9a98-3ec17c61d35a.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/129038636-257b3717-8d16-4265-ae32-583e7da9fdab.png)

## Regression? 
- Yes ( .NET Core 5.0)

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team 
## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK: 6.0.100-rc.1.21379.2


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5416)