### PR TITLE
Support Win11 accessibility features in tooltips displayed by keyboard focus 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -8171,6 +8171,12 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual void OnKeyUp(KeyEventArgs e)
         {
+            if (OsVersion.IsWindows11_OrGreater &&
+                (e.KeyCode.HasFlag(Keys.ControlKey) || e.KeyCode == Keys.Escape))
+            {
+                KeyboardToolTipStateMachine.HidePersistentTooltip();
+            }
+
             ((KeyEventHandler)Events[s_keyUpEvent])?.Invoke(this, e);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.SmEvent.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.SmEvent.cs
@@ -12,7 +12,7 @@ namespace System.Windows.Forms
             LeftTool,
             InitialDelayTimerExpired, // internal
             ReshowDelayTimerExpired, // internal
-            AutoPopupDelayTimerExpired, // internal
+            DismissTooltips, // internal
             RefocusWaitDelayExpired // internal
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.SmState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.SmState.cs
@@ -6,7 +6,7 @@ namespace System.Windows.Forms
 {
     internal sealed partial class KeyboardToolTipStateMachine
     {
-        private enum SmState : byte
+        internal enum SmState : byte
         {
             Hidden,
             ReadyForInitShow,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1291,7 +1291,7 @@ namespace System.Windows.Forms
         ///  Windows 11 considers tooltip persistent if AuoPopDelay had never been set or
         ///  was set to infinity.
         /// </summary>
-        internal bool IsPersistent { get; private set; }
+        internal bool IsPersistent { get; set; }
 
         /// <summary>
         ///  Returns true if the AutomaticDelay property should be persisted.
@@ -1530,7 +1530,9 @@ namespace System.Windows.Forms
 
             if (duration < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(duration), string.Format(SR.InvalidLowBoundArgumentEx, nameof(duration), (duration).ToString(CultureInfo.CurrentCulture), 0));
+                throw new ArgumentOutOfRangeException(
+                    nameof(duration),
+                    string.Format(SR.InvalidLowBoundArgumentEx, nameof(duration), (duration).ToString(CultureInfo.CurrentCulture), 0));
             }
 
             Rectangle toolRectangle = tool.GetNativeScreenRectangle();
@@ -1561,7 +1563,11 @@ namespace System.Windows.Forms
 
             SetTrackPosition(pointX, pointY);
             IsActivatedByKeyboard = true;
-            StartTimer(tool.GetOwnerWindow(), duration);
+
+            if (!IsPersistent)
+            {
+                StartTimer(tool.GetOwnerWindow(), duration);
+            }
         }
 
         private bool TryGetBubbleSize(IKeyboardToolTip tool, Rectangle toolRectangle, out Size bubbleSize)

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolTipTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolTipTests.Designer.cs
@@ -65,7 +65,7 @@
             this.automaticDelayButton.Size = new System.Drawing.Size(1031, 183);
             this.automaticDelayButton.TabIndex = 0;
             this.automaticDelayToolTip.SetToolTip(this.automaticDelayButton, "Not persistent");
-            this.automaticDelayButton.Text = "&AutomaticDelay = 30";
+            this.automaticDelayButton.Text = "&AutomaticDelay = 300";
             this.automaticDelayButton.UseVisualStyleBackColor = true;
             // 
             // autoPopDelayButton
@@ -76,7 +76,7 @@
             this.autoPopDelayButton.Size = new System.Drawing.Size(949, 183);
             this.autoPopDelayButton.TabIndex = 1;
             this.autoPopDelayToolTip.SetToolTip(this.autoPopDelayButton, "Not persistent");
-            this.autoPopDelayButton.Text = "Auto&PopDelay = 300";
+            this.autoPopDelayButton.Text = "Auto&PopDelay = 6000";
             this.autoPopDelayButton.UseVisualStyleBackColor = true;
             // 
             // flowLayoutPanel1
@@ -140,11 +140,11 @@
             // 
             // automaticDelayToolTip
             // 
-            this.automaticDelayToolTip.AutomaticDelay = 30;
+            this.automaticDelayToolTip.AutomaticDelay = 300;
             // 
             // autoPopDelayToolTip
             // 
-            this.autoPopDelayToolTip.AutoPopDelay = 300;
+            this.autoPopDelayToolTip.AutoPopDelay = 6000;
             this.autoPopDelayToolTip.InitialDelay = 500;
             this.autoPopDelayToolTip.ReshowDelay = 100;
             // 

--- a/src/System.Windows.Forms/tests/TestUtilities/CommonTestHelperEx.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/CommonTestHelperEx.cs
@@ -121,12 +121,11 @@ namespace System.Windows.Forms.TestUtilities
 
         public static TheoryData<KeyEventArgs> GetKeyEventArgsTheoryData()
         {
-            var data = new TheoryData<KeyEventArgs>
+            return new TheoryData<KeyEventArgs>
             {
-                null,
+                new KeyEventArgs(Keys.None),
                 new KeyEventArgs(Keys.Cancel)
             };
-            return data;
         }
 
         public static TheoryData<KeyPressEventArgs> GetKeyPressEventArgsTheoryData()

--- a/src/System.Windows.Forms/tests/UnitTests/KeyboardTooltipStateMachineTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/KeyboardTooltipStateMachineTests.cs
@@ -12,43 +12,106 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void HookToolTip()
         {
-            using (ToolTip toolTip = new ToolTip())
-            {
-                var mock = new Mock<IKeyboardToolTip>(MockBehavior.Strict);
-                IKeyboardToolTip keyboardToolTip = mock.Object;
+            using ToolTip toolTip = new();
+            var mock = new Mock<IKeyboardToolTip>(MockBehavior.Strict);
+            IKeyboardToolTip keyboardToolTip = mock.Object;
 
-                // Validate we don't get OnHooked if AllowsToolTip is false
-                mock.Setup(m => m.AllowsToolTip()).Returns(false);
-                mock.Setup(m => m.OnHooked(toolTip));
-                KeyboardToolTipStateMachine.Instance.Hook(keyboardToolTip, toolTip);
-                mock.Verify(m => m.AllowsToolTip());
+            // Validate we don't get OnHooked if AllowsToolTip is false
+            mock.Setup(m => m.AllowsToolTip()).Returns(false);
+            mock.Setup(m => m.OnHooked(toolTip));
+            KeyboardToolTipStateMachine.Instance.Hook(keyboardToolTip, toolTip);
+            mock.Verify(m => m.AllowsToolTip());
 
-                mock.Reset();
+            mock.Reset();
 
-                // Now validate we get OnHooked if AllowsToolTip is true
-                mock.Setup(m => m.AllowsToolTip()).Returns(true);
-                mock.Setup(m => m.OnHooked(toolTip));
-                KeyboardToolTipStateMachine.Instance.Hook(keyboardToolTip, toolTip);
-                mock.Verify(m => m.AllowsToolTip());
-                mock.Verify(m => m.OnHooked(toolTip), Times.Once);
+            // Now validate we get OnHooked if AllowsToolTip is true.
+            mock.Setup(m => m.AllowsToolTip()).Returns(true);
+            mock.Setup(m => m.OnHooked(toolTip));
+            KeyboardToolTipStateMachine.Instance.Hook(keyboardToolTip, toolTip);
+            mock.Verify(m => m.AllowsToolTip());
+            mock.Verify(m => m.OnHooked(toolTip), Times.Once);
 
-                mock.Reset();
+            mock.Reset();
 
-                // Validate we don't get OnUnhooked if AllowsToolTip is false
-                mock.Setup(m => m.AllowsToolTip()).Returns(false);
-                mock.Setup(m => m.OnUnhooked(toolTip));
-                KeyboardToolTipStateMachine.Instance.Unhook(keyboardToolTip, toolTip);
-                mock.Verify(m => m.AllowsToolTip());
+            // Validate we don't get OnUnhooked if AllowsToolTip is false.
+            mock.Setup(m => m.AllowsToolTip()).Returns(false);
+            mock.Setup(m => m.OnUnhooked(toolTip));
+            KeyboardToolTipStateMachine.Instance.Unhook(keyboardToolTip, toolTip);
+            mock.Verify(m => m.AllowsToolTip());
 
-                mock.Reset();
+            mock.Reset();
 
-                // Finally validate we get OnUnhooked if AllowsToolTip is true
-                mock.Setup(m => m.AllowsToolTip()).Returns(true);
-                mock.Setup(m => m.OnUnhooked(toolTip));
-                KeyboardToolTipStateMachine.Instance.Unhook(keyboardToolTip, toolTip);
-                mock.Verify(m => m.AllowsToolTip());
-                mock.Verify(m => m.OnUnhooked(toolTip), Times.Once);
-            }
+            // Finally validate we get OnUnhooked if AllowsToolTip is true.
+            mock.Setup(m => m.AllowsToolTip()).Returns(true);
+            mock.Setup(m => m.OnUnhooked(toolTip));
+            KeyboardToolTipStateMachine.Instance.Unhook(keyboardToolTip, toolTip);
+            mock.Verify(m => m.AllowsToolTip());
+            mock.Verify(m => m.OnUnhooked(toolTip), Times.Once);
+        }
+
+        [WinFormsTheory]
+        [InlineData(Keys.ControlKey)]
+        [InlineData(Keys.Escape)]
+        [InlineData(Keys.ControlKey | Keys.ShiftKey | Keys.F10)]
+        public void KeyboardTooltipStateMachine_DismissalKeyUp_NonPersistent_NotDismissed(Keys keys)
+        {
+            using TestControl control = new();
+            using ToolTip toolTip = new();
+
+            control.CreateControl();
+            _ = toolTip.Handle;
+
+            toolTip.SetToolTip(control, "Non-persistent");
+            toolTip.AutoPopDelay = 888;
+
+            // Simulate that the toolTip is shown.
+            KeyboardToolTipStateMachine instance = KeyboardToolTipStateMachine.Instance;
+            instance.TestAccessor().Dynamic._currentTool = control;
+            instance.TestAccessor().Dynamic._currentState = KeyboardToolTipStateMachine.SmState.Shown;
+
+            control.SimulateKeyUp(keys);
+
+            IKeyboardToolTip currentTool = instance.TestAccessor().Dynamic._currentTool;
+            string currentState = instance.TestAccessor().Dynamic._currentState.ToString();
+
+            Assert.Equal(control, currentTool);
+            Assert.Equal("Shown", currentState);
+        }
+
+        [WinFormsTheory]
+        [InlineData(Keys.ControlKey, true)]
+        [InlineData(Keys.Escape, true)]
+        [InlineData(Keys.ControlKey | Keys.ShiftKey | Keys.F10, true)]
+        [InlineData(Keys.ControlKey, false)]
+        [InlineData(Keys.Escape, false)]
+        [InlineData(Keys.ControlKey | Keys.ShiftKey | Keys.F10, false)]
+        public void KeyboardTooltipStateMachine_DismissalKeyUp(Keys keys, bool isPersistent)
+        {
+            using TestControl control = new();
+            using ToolTip toolTip = new();
+
+            control.CreateControl();
+            _ = toolTip.Handle;
+
+            toolTip.SetToolTip(control, "test");
+            toolTip.IsPersistent = isPersistent;
+
+            // Simulate that the toolTip is shown.
+            KeyboardToolTipStateMachine instance = KeyboardToolTipStateMachine.Instance;
+            instance.TestAccessor().Dynamic._currentTool = control;
+            instance.TestAccessor().Dynamic._currentState = KeyboardToolTipStateMachine.SmState.Shown;
+
+            control.SimulateKeyUp(keys);
+
+            IKeyboardToolTip currentTool = instance.TestAccessor().Dynamic._currentTool;
+            string currentState = instance.TestAccessor().Dynamic._currentState.ToString();
+
+            Assert.Equal(isPersistent && OsVersion.IsWindows11_OrGreater ? "Hidden" : "Shown", currentState);
+        }
+
+        private class TestControl : Control
+        {
+            public void SimulateKeyUp(Keys keys) => base.OnKeyUp(new KeyEventArgs(keys));
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/OsVersionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/OsVersionTests.cs
@@ -10,8 +10,8 @@ namespace System.Windows.Forms.Tests
     public class OsVersionTests : IClassFixture<ThreadExceptionFixture>
     {
         private static Interop.NtDll.RTL_OSVERSIONINFOEX s_realVersionInfo;
-        private static FieldInfo s_fiVersionInfo;
-        private static Type s_typeOsVersion;
+        private static readonly FieldInfo s_fiVersionInfo;
+        private static readonly Type s_typeOsVersion;
 
         static OsVersionTests()
         {
@@ -31,7 +31,8 @@ namespace System.Windows.Forms.Tests
         [InlineData(10, 0, 0, false)]
         [InlineData(10, 0, 14393, true)]
         [InlineData(10, 0, 15063, true)]
-        [InlineData(11, 0, 20000, true)] // it is a bit of a leap of faith that we have another OS version and its build number increments in sequence
+        [InlineData(10, 0, 22000, true)]
+        [InlineData(11, 0, 20000, true)] // non-existent version
         public void IsWindows10_1607OrGreater(uint major, uint minor, uint buildNumber, bool expected)
         {
             PerformAssert(major, minor, buildNumber, () => Assert.Equal(expected, OsVersion.IsWindows10_1607OrGreater));
@@ -43,10 +44,25 @@ namespace System.Windows.Forms.Tests
         [InlineData(10, 0, 0, false)]
         [InlineData(10, 0, 14393, false)]
         [InlineData(10, 0, 15063, true)]
-        [InlineData(11, 0, 20000, true)] // it is a bit of a leap of faith that we have another OS version and its build number increments in sequence
+        [InlineData(10, 0, 22000, true)]
+        [InlineData(11, 0, 20000, true)]
         public void IsWindows10_1703OrGreater(uint major, uint minor, uint buildNumber, bool expected)
         {
             PerformAssert(major, minor, buildNumber, () => Assert.Equal(expected, OsVersion.IsWindows10_1703OrGreater));
+        }
+
+        [StaTheory]
+        [InlineData(5, 0, 0, false)]
+        [InlineData(6, 0, 0, false)]
+        [InlineData(10, 0, 0, false)]
+        [InlineData(10, 0, 14393, false)]
+        [InlineData(10, 0, 15063, false)]
+        [InlineData(10, 0, 22000, true)] // Win11 public preview
+        [InlineData(10, 0, 30000, true)] // non-existent version
+        [InlineData(11, 0, 40000, true)] // non-existent version
+        public void IsWindows11_OrGreater(uint major, uint minor, uint buildNumber, bool expected)
+        {
+            PerformAssert(major, minor, buildNumber, () => Assert.Equal(expected, OsVersion.IsWindows11_OrGreater));
         }
 
         [StaTheory]
@@ -56,7 +72,8 @@ namespace System.Windows.Forms.Tests
         [InlineData(10, 0, 0, true)]
         [InlineData(10, 0, 14393, true)]
         [InlineData(10, 0, 15063, true)]
-        [InlineData(11, 0, 20000, true)] // it is a bit of a leap of faith that we have another OS version and its build number increments in sequence
+        [InlineData(10, 0, 22000, true)]
+        [InlineData(11, 0, 20000, true)]
         public void IsWindows8_1OrGreater(uint major, uint minor, uint buildNumber, bool expected)
         {
             PerformAssert(major, minor, buildNumber, () => Assert.Equal(expected, OsVersion.IsWindows8_1OrGreater));

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
@@ -5,8 +5,8 @@
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Drawing;
-using Moq;
 using System.Windows.Forms.TestUtilities;
+using Moq;
 using Xunit;
 using static Interop;
 using static Interop.User32;
@@ -5432,9 +5432,9 @@ namespace System.Windows.Forms.Tests
         {
             foreach (FlatStyle flatStyle in Enum.GetValues(typeof(FlatStyle)))
             {
+                bool expectedIsHandleCreated = flatStyle == FlatStyle.System;
                 foreach (bool enabled in new bool[] { true, false })
                 {
-                    bool expectedIsHandleCreated = flatStyle == FlatStyle.System ? true : false;
                     yield return new object[] { flatStyle, enabled, new KeyEventArgs(Keys.Cancel), false, false };
                     yield return new object[] { flatStyle, enabled, new KeyEventArgs(Keys.Enter), false, false };
                     yield return new object[] { flatStyle, enabled, new KeyEventArgs(Keys.Space), true, expectedIsHandleCreated };
@@ -5699,7 +5699,7 @@ namespace System.Windows.Forms.Tests
             {
                 foreach (bool enabled in new bool[] { true, false })
                 {
-                    yield return new object[] { flatStyle, enabled, null };
+                    yield return new object[] { flatStyle, enabled, new KeyEventArgs(Keys.None) };
                     yield return new object[] { flatStyle, enabled, new KeyEventArgs(Keys.Cancel) };
                     yield return new object[] { flatStyle, enabled, new KeyEventArgs(Keys.Enter) };
                     yield return new object[] { flatStyle, enabled, new KeyEventArgs(Keys.Space) };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitterTests.cs
@@ -1820,7 +1820,7 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> KeyEventArgs_TestData()
         {
-            yield return new object[] { null };
+            yield return new object[] { new KeyEventArgs(Keys.None) };
             yield return new object[] { new KeyEventArgs(Keys.Cancel) };
             yield return new object[] { new KeyEventArgs(Keys.Escape) };
         }


### PR DESCRIPTION
If tooltips do not set `AutoPopDelay` or `AutomaticDelay`, windows 11 assumes that they should be accessible:
1. persistent - not dismissible by a timer but only by a user action
2. dismissible by a keyboard (Ctrl or Esc keys)

Changes:
1. do not start the dismissal timer for tooltips that had not set any dismissal delays
2. Dismiss all "accessible" tooltips when any control receives `Ctrl` or `Esc` key up message

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5424)