### PR TITLE
Turn on single-file analyzer and fix problems

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,6 +16,11 @@
     <CoverletOutput>$(TargetDir)coverage\$(MSBuildProjectName).coverage</CoverletOutput>
   </PropertyGroup>
 
+  <!-- Turn on single-file publishing analysis for everything except the test projects -->
+  <PropertyGroup Condition="'$(IsTestProject)' != 'true'">
+    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' ">
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
     <Platform Condition="'$(Platform)' == 'AnyCPU' or '$(Platform)' == 'Any CPU'">$(TargetArchitecture)</Platform>
@@ -52,7 +57,7 @@
 
   <ItemGroup>
     <!-- Set TargetingPackVersion -->
-    <FrameworkReference Update="Microsoft.NETCore.App" 
+    <FrameworkReference Update="Microsoft.NETCore.App"
       Condition=" '$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)'!='' And $(TargetFramework.StartsWith('net6.')) ">
     <TargetingPackVersion>$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)</TargetingPackVersion>
     </FrameworkReference>

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ToolboxItem.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Windows.Forms;
@@ -556,6 +557,7 @@ namespace System.Drawing.Design
         ///  locate the type.  If reference is true, the given assembly name will be added
         ///  to the designer host's set of references.
         /// </summary>
+        [UnconditionalSuppressMessage("SingleFile", "IL3002", Justification = "Single-file case is handled")]
         protected virtual Type GetType(IDesignerHost host, AssemblyName assemblyName, string typeName, bool reference)
         {
             ITypeResolutionService ts = null;

--- a/src/System.Windows.Forms/src/System/Resources/AssemblyNamesTypeResolutionService.cs
+++ b/src/System.Windows.Forms/src/System/Resources/AssemblyNamesTypeResolutionService.cs
@@ -6,6 +6,7 @@
 
 using System.Collections;
 using System.ComponentModel.Design;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace System.Resources
@@ -29,6 +30,7 @@ namespace System.Resources
             return GetAssembly(name, true);
         }
 
+        [UnconditionalSuppressMessage("SingleFile", "IL3002", Justification = "Handles single file case")]
         public Assembly GetAssembly(AssemblyName name, bool throwOnError)
         {
             Assembly result = null;
@@ -76,6 +78,7 @@ namespace System.Resources
             return result;
         }
 
+        [UnconditionalSuppressMessage("SingleFile", "IL3002", Justification = "Returns null if in a single file")]
         public string GetPathOfAssembly(AssemblyName name)
         {
             return name.CodeBase;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -6,6 +6,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Globalization;
 using System.Reflection;
@@ -54,9 +55,6 @@ namespace System.Windows.Forms
         /// </summary>
         private static readonly object s_eventApplicationExit = new object();
         private static readonly object s_eventThreadExit = new object();
-
-        // Constant string used in Application.Restart()
-        private const string IEEXEC = "ieexec.exe";
 
         // Defines a new callback delegate type
         [EditorBrowsable(EditorBrowsableState.Advanced)]
@@ -819,6 +817,7 @@ namespace System.Windows.Forms
         ///  Enables visual styles for all subsequent <see cref="Run()"/> and <see cref="Control.CreateHandle"/> calls.
         ///  Uses the default theming manifest file shipped with the redist.
         /// </summary>
+        [UnconditionalSuppressMessage("SingleFile", "IL3002", Justification = "Single-file case is handled")]
         public static void EnableVisualStyles()
         {
             // Pull manifest from our resources
@@ -951,6 +950,7 @@ namespace System.Windows.Forms
         ///  Retrieves the FileVersionInfo associated with the main module for
         ///  the application.
         /// </summary>
+        [UnconditionalSuppressMessage("SingleFile", "IL3002", Justification = "Single-file case is handled")]
         private static FileVersionInfo GetAppFileVersionInfo()
         {
             lock (s_internalSyncObject)
@@ -958,7 +958,7 @@ namespace System.Windows.Forms
                 if (s_appFileVersion is null)
                 {
                     Type t = GetAppMainType();
-                    if (t is not null)
+                    if (t is not null && t.Assembly.Location.Length > 0)
                     {
                         s_appFileVersion = FileVersionInfo.GetVersionInfo(t.Module.FullyQualifiedName);
                     }
@@ -1140,21 +1140,6 @@ namespace System.Windows.Forms
 
             Process process = Process.GetCurrentProcess();
             Debug.Assert(process is not null);
-            if (string.Equals(process.MainModule.ModuleName, IEEXEC, StringComparison.OrdinalIgnoreCase))
-            {
-                string clrPath = Path.GetDirectoryName(typeof(object).Module.FullyQualifiedName);
-
-                if (string.Equals(clrPath + "\\" + IEEXEC, process.MainModule.FileName, StringComparison.OrdinalIgnoreCase))
-                {
-                    // HRef exe case
-                    hrefExeCase = true;
-                    Exit();
-                    if (AppDomain.CurrentDomain.GetData("APP_LAUNCH_URL") is string launchUrl)
-                    {
-                        Process.Start(process.MainModule.FileName, launchUrl);
-                    }
-                }
-            }
 
             if (!hrefExeCase)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlVersionInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlVersionInfo.cs
@@ -178,7 +178,6 @@ namespace System.Windows.Forms
                 return _versionInfo;
             }
 
-            //[UnconditionalSuppressMessage("SingleFile", "IL3000")]
             private bool OwnerIsInMemoryAssembly => _owner.GetType().Assembly.Location.Length == 0;
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlVersionInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlVersionInfo.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace System.Windows.Forms
@@ -25,6 +26,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  The company name associated with the component.
             /// </summary>
+            [UnconditionalSuppressMessage("SingleFile", "IL3002", Justification = "Single-file case is handled")]
             internal string CompanyName
             {
                 get
@@ -37,7 +39,7 @@ namespace System.Windows.Forms
                             _companyName = ((AssemblyCompanyAttribute)attrs[0]).Company;
                         }
 
-                        if (_companyName is null || _companyName.Length == 0)
+                        if ((_companyName is null || _companyName.Length == 0) && !OwnerIsInMemoryAssembly)
                         {
                             _companyName = GetFileVersionInfo().CompanyName;
                             if (_companyName is not null)
@@ -74,6 +76,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  The product name associated with this component.
             /// </summary>
+            [UnconditionalSuppressMessage("SingleFile", "IL3002", Justification = "Single-file case is handled")]
             internal string ProductName
             {
                 get
@@ -86,7 +89,7 @@ namespace System.Windows.Forms
                             _productName = ((AssemblyProductAttribute)attrs[0]).Product;
                         }
 
-                        if (_productName is null || _productName.Length == 0)
+                        if ((_productName is null || _productName.Length == 0) && !OwnerIsInMemoryAssembly)
                         {
                             _productName = GetFileVersionInfo().ProductName;
                             if (_productName is not null)
@@ -123,6 +126,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  The product version associated with this component.
             /// </summary>
+            [UnconditionalSuppressMessage("SingleFile", "IL3002", Justification = "Single-file case is handled")]
             internal string ProductVersion
             {
                 get
@@ -137,7 +141,7 @@ namespace System.Windows.Forms
                         }
 
                         // win32 version info
-                        if (_productVersion is null || _productVersion.Length == 0)
+                        if ((_productVersion is null || _productVersion.Length == 0) && !OwnerIsInMemoryAssembly)
                         {
                             _productVersion = GetFileVersionInfo().ProductVersion;
                             if (_productVersion is not null)
@@ -161,6 +165,7 @@ namespace System.Windows.Forms
             ///  Retrieves the FileVersionInfo associated with the main module for
             ///  the component.
             /// </summary>
+            [RequiresAssemblyFiles("Throws if _owner is an in-memory assembly. Check " + nameof(OwnerIsInMemoryAssembly) + " first")]
             private FileVersionInfo GetFileVersionInfo()
             {
                 if (_versionInfo is null)
@@ -172,6 +177,9 @@ namespace System.Windows.Forms
 
                 return _versionInfo;
             }
+
+            //[UnconditionalSuppressMessage("SingleFile", "IL3000")]
+            private bool OwnerIsInMemoryAssembly => _owner.GetType().Assembly.Location.Length == 0;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlVersionInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlVersionInfo.cs
@@ -165,7 +165,7 @@ namespace System.Windows.Forms
             ///  Retrieves the FileVersionInfo associated with the main module for
             ///  the component.
             /// </summary>
-            [RequiresAssemblyFiles("Throws if _owner is an in-memory assembly. Check " + nameof(OwnerIsInMemoryAssembly) + " first")]
+            [RequiresAssemblyFiles("Throws if " + nameof(_owner) + " is an in-memory assembly. Check " + nameof(OwnerIsInMemoryAssembly) + " first")]
             private FileVersionInfo GetFileVersionInfo()
             {
                 if (_versionInfo is null)


### PR DESCRIPTION
Should fully fix https://github.com/dotnet/runtime/issues/44488


## Proposed changes

This change turns on the single-file analyzer in the winforms repo, fixes the few real problems that were encountered, and suppresses warnings when issues are addressed.

## Customer Impact

Full support for single-file publishing in WinForms, with some confidence that all issues are addressed.

## Regression? 

- No

## Risk

Very low.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5426)