### PR TITLE
Adding `IsAccessibilityObjectCreated` checks to event handlers

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
@@ -251,8 +251,11 @@ namespace System.Windows.Forms
             AccessibilityNotifyClients(AccessibleEvents.NameChange, -1);
 
             // UIA events:
-            AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.NamePropertyId, Name, Name);
-            AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.NamePropertyId, Name, Name);
+                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
+            }
 
             base.OnClick(e);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
@@ -452,8 +452,11 @@ namespace System.Windows.Forms
             AccessibilityNotifyClients(AccessibleEvents.NameChange, -1);
 
             // UIA events:
-            AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.NamePropertyId, Name, Name);
-            AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.NamePropertyId, Name, Name);
+                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
+            }
 
             if (FlatStyle == FlatStyle.System)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
@@ -44,7 +44,7 @@ namespace System.Windows.Forms
                             // Call the focus event for the new selected item accessible object provided by ComboBoxAccessibleObject.
                             // If the owning ComboBox has a custom accessible object,
                             // it should override the logic and implement setting an item focus by itself.
-                            if (before != after && _owner.AccessibilityObject is ComboBoxAccessibleObject comboBoxAccessibleObject)
+                            if (before != after && _owner.IsAccessibilityObjectCreated && _owner.AccessibilityObject is ComboBoxAccessibleObject comboBoxAccessibleObject)
                             {
                                 comboBoxAccessibleObject.SetComboBoxItemFocus();
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -9948,7 +9948,7 @@ namespace System.Windows.Forms
                 UiaCore.UiaReturnRawElementProvider(handle, 0, 0, null);
             }
 
-            if (OsVersion.IsWindows8OrGreater && IsAccessibilityObjectCreated)
+            if (IsAccessibilityObjectCreated && OsVersion.IsWindows8OrGreater)
             {
                 UiaCore.UiaDisconnectProvider(AccessibilityObject);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -50,7 +50,11 @@ namespace System.Windows.Forms
             {
                 AccessibilityNotifyClients(AccessibleEvents.Focus, objectID, childID);
 
-                CurrentCell?.AccessibilityObject.SetFocus();
+                DataGridViewCell currentCell = CurrentCell;
+                if (currentCell is not null && currentCell.IsParentAccessibilityObjectCreated)
+                {
+                    currentCell.AccessibilityObject.SetFocus();
+                }
             }
 
             AccessibilityNotifyClients(AccessibleEvents.Selection, objectID, childID);
@@ -76,10 +80,13 @@ namespace System.Windows.Forms
                 DataGridViewRowEventArgs dgvre = new DataGridViewRowEventArgs(Rows[NewRowIndex]);
                 OnUserAddedRow(dgvre);
 
-                AccessibilityObject.InternalRaiseAutomationNotification(
-                    AutomationNotificationKind.ItemAdded,
-                    AutomationNotificationProcessing.ImportantMostRecent,
-                    string.Format(SR.DataGridView_RowAddedNotification, NewRowIndex));
+                if (IsAccessibilityObjectCreated)
+                {
+                    AccessibilityObject.InternalRaiseAutomationNotification(
+                        AutomationNotificationKind.ItemAdded,
+                        AutomationNotificationProcessing.ImportantMostRecent,
+                        string.Format(SR.DataGridView_RowAddedNotification, NewRowIndex));
+                }
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -492,6 +492,11 @@ namespace System.Windows.Forms
             }
         }
 
+        /// <summary>
+        ///  Indicates whether or not the parent grid view for this element has an accessible object associated with it.
+        /// </summary>
+        internal bool IsParentAccessibilityObjectCreated => DataGridView is not null && DataGridView.IsAccessibilityObjectCreated;
+
         [Browsable(false)]
         public bool IsInEditMode
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.cs
@@ -1039,13 +1039,16 @@ namespace System.Windows.Forms
                     break;
             }
 
-            var cellName = AccessibilityObject.Name ?? string.Empty;
-            AccessibilityObject.InternalRaiseAutomationNotification(
-                Automation.AutomationNotificationKind.Other,
-                Automation.AutomationNotificationProcessing.MostRecent,
-                isCheckboxChecked
-                    ? string.Format(SR.DataGridViewCheckBoxCellCheckedStateDescription, cellName)
-                    : string.Format(SR.DataGridViewCheckBoxCellUncheckedStateDescription, cellName));
+            if (IsParentAccessibilityObjectCreated)
+            {
+                var cellName = AccessibilityObject.Name ?? string.Empty;
+                AccessibilityObject.InternalRaiseAutomationNotification(
+                    Automation.AutomationNotificationKind.Other,
+                    Automation.AutomationNotificationProcessing.MostRecent,
+                    isCheckboxChecked
+                        ? string.Format(SR.DataGridViewCheckBoxCellCheckedStateDescription, cellName)
+                        : string.Format(SR.DataGridViewCheckBoxCellUncheckedStateDescription, cellName));
+            }
         }
 
         private void NotifyMSAAClient(int columnIndex, int rowIndex)
@@ -1065,7 +1068,7 @@ namespace System.Windows.Forms
             int childID = visibleColumnIndex + rowHeaderIncrement;  // + 1 because the column header cell is at index 0 in top header row acc obj
                                                                     //     same thing for the row header cell in the data grid view row acc obj
 
-            if (DataGridView.AccessibilityObject is Control.ControlAccessibleObject accessibleObject)
+            if (DataGridView.IsAccessibilityObjectCreated && DataGridView.AccessibilityObject is Control.ControlAccessibleObject accessibleObject)
             {
                 accessibleObject.NotifyClients(AccessibleEvents.StateChange, objectID, childID);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -162,7 +162,8 @@ namespace System.Windows.Forms
         {
             base.OnHandleCreated(e);
 
-            _dataGridView?.SetAccessibleObjectParent(this.AccessibilityObject);
+            // The null-check was added as a fix for a https://github.com/dotnet/winforms/issues/2138
+            _dataGridView?.SetAccessibleObjectParent(AccessibilityObject);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -245,7 +245,10 @@ namespace System.Windows.Forms
         protected override void OnGotFocus(EventArgs e)
         {
             base.OnGotFocus(e);
-            AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            }
         }
 
         protected override void OnMouseWheel(MouseEventArgs e)
@@ -321,7 +324,8 @@ namespace System.Windows.Forms
             base.OnHandleCreated(e);
             if (IsHandleCreated)
             {
-                _dataGridView?.SetAccessibleObjectParent(this.AccessibilityObject);
+                // The null-check was added as a fix for a https://github.com/dotnet/winforms/issues/2138
+                _dataGridView?.SetAccessibleObjectParent(AccessibilityObject);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1271,7 +1271,7 @@ namespace System.Windows.Forms
                 Invalidate();
             }
 
-            if (LiveSetting != AutomationLiveSetting.Off)
+            if (IsAccessibilityObjectCreated && LiveSetting != AutomationLiveSetting.Off)
             {
                 AccessibilityObject.RaiseLiveRegionChanged();
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -1752,7 +1752,7 @@ namespace System.Windows.Forms
 
         protected override void OnGotFocus(EventArgs e)
         {
-            if (IsHandleCreated)
+            if (IsHandleCreated && IsAccessibilityObjectCreated)
             {
                 AccessibleObject item = AccessibilityObject.GetFocused();
 
@@ -1921,7 +1921,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnSelectedIndexChanged(EventArgs e)
         {
-            if (IsHandleCreated)
+            if (IsHandleCreated && IsAccessibilityObjectCreated)
             {
                 if (Focused && FocusedItemIsChanged())
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -2238,9 +2238,9 @@ namespace System.Windows.Forms
                 lvhi.pt.X += si.nPos;
             }
 
-            if (User32.SendMessageW(hwnd, (User32.WM)HDM.HITTEST, 0, ref lvhi) != -1 && lvhi.iItem > -1)
+            if (IsAccessibilityObjectCreated && User32.SendMessageW(hwnd, (User32.WM)HDM.HITTEST, 0, ref lvhi) != -1 && lvhi.iItem > -1)
             {
-                AccessibilityObject?.InternalRaiseAutomationNotification(
+                AccessibilityObject.InternalRaiseAutomationNotification(
                     Automation.AutomationNotificationKind.Other,
                     Automation.AutomationNotificationProcessing.MostRecent,
                     Columns[lvhi.iItem].Text);
@@ -4746,7 +4746,7 @@ namespace System.Windows.Forms
                 NotifyAboutGotFocus(focusedItem);
             }
 
-            if (IsHandleCreated && AccessibilityObject.GetFocus() is AccessibleObject focusedAccessibleObject)
+            if (IsHandleCreated && IsAccessibilityObjectCreated && AccessibilityObject.GetFocus() is AccessibleObject focusedAccessibleObject)
             {
                 focusedAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
             }
@@ -4785,10 +4785,13 @@ namespace System.Windows.Forms
                 return;
             }
 
-            ListViewItem item = e.Item;
-            UiaCore.ToggleState oldValue = item.Checked ? UiaCore.ToggleState.Off : UiaCore.ToggleState.On;
-            UiaCore.ToggleState newValue = item.Checked ? UiaCore.ToggleState.On : UiaCore.ToggleState.Off;
-            item.AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.ToggleToggleStatePropertyId, oldValue, newValue);
+            if (IsAccessibilityObjectCreated)
+            {
+                ListViewItem item = e.Item;
+                UiaCore.ToggleState oldValue = item.Checked ? UiaCore.ToggleState.Off : UiaCore.ToggleState.On;
+                UiaCore.ToggleState newValue = item.Checked ? UiaCore.ToggleState.On : UiaCore.ToggleState.Off;
+                item.AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.ToggleToggleStatePropertyId, oldValue, newValue);
+            }
         }
 
         protected virtual void OnItemDrag(ItemDragEventArgs e)
@@ -4891,7 +4894,10 @@ namespace System.Windows.Forms
             if (firstSelectedItem.Focused && _selectedItem != firstSelectedItem)
             {
                 _selectedItem = firstSelectedItem;
-                firstSelectedItem.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                if (IsAccessibilityObjectCreated)
+                {
+                    firstSelectedItem.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                }
             }
         }
 
@@ -5941,9 +5947,12 @@ namespace System.Windows.Forms
                 }
             }
 
-            Point screenPoint = PointToScreen(point);
-            AccessibleObject accessibilityObject = AccessibilityObject.HitTest(screenPoint.X, screenPoint.Y);
-            accessibilityObject?.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            if (IsAccessibilityObjectCreated)
+            {
+                Point screenPoint = PointToScreen(point);
+                AccessibleObject accessibilityObject = AccessibilityObject.HitTest(screenPoint.X, screenPoint.Y);
+                accessibilityObject?.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            }
         }
 
         private unsafe bool WmNotify(ref Message m)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -356,7 +356,10 @@ namespace System.Windows.Forms
                 {
                     listView.SetItemState(Index, value ? LVIS.FOCUSED : 0, LVIS.FOCUSED);
 
-                    AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                    if (listView.IsAccessibilityObjectCreated)
+                    {
+                        AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                    }
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1488,7 +1488,10 @@ namespace System.Windows.Forms
         {
             base.OnGotFocus(e);
 
-            ((MonthCalendarAccessibleObject)AccessibilityObject).FocusedCell?.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            if (IsAccessibilityObjectCreated)
+            {
+                ((MonthCalendarAccessibleObject)AccessibilityObject).FocusedCell?.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+            }
         }
 
         /// <summary>
@@ -2177,8 +2180,11 @@ namespace System.Windows.Forms
                 UpdateDisplayRange();
             }
 
-            MonthCalendarAccessibleObject calendarAccessibleObject = (MonthCalendarAccessibleObject)AccessibilityObject;
-            calendarAccessibleObject.RaiseAutomationEventForChild(UiaCore.UIA.AutomationFocusChangedEventId);
+            if (IsAccessibilityObjectCreated)
+            {
+                MonthCalendarAccessibleObject calendarAccessibleObject = (MonthCalendarAccessibleObject)AccessibilityObject;
+                calendarAccessibleObject.RaiseAutomationEventForChild(UiaCore.UIA.AutomationFocusChangedEventId);
+            }
 
             OnDateChanged(new DateRangeEventArgs(start, end));
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -2979,7 +2979,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (dropDown && !_gridView.DropDownVisible)
+            if (IsAccessibilityObjectCreated && dropDown && !_gridView.DropDownVisible)
             {
                 AccessibilityObject.RaiseAutomationNotification(
                     Automation.AutomationNotificationKind.ActionCompleted,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -327,8 +327,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // Notify accessibility clients of expanded state change. StateChange requires NameChange as well.
                 // Accessible clients won't see this unless both events are raised.
 
-                // Root item is hidden and should not raise events.
-                if (GridItemType != GridItemType.Root)
+                // Root item is hidden and should not raise events
+                if (OwnerGridView.IsAccessibilityObjectCreated && GridItemType != GridItemType.Root)
                 {
                     int id = OwnerGridView.AccessibilityGetGridEntryChildID(this);
                     if (id >= 0)
@@ -463,7 +463,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     _hasFocus = value;
 
                     // Notify accessibility applications that keyboard focus has changed.
-                    if (value == true)
+                    if (OwnerGridView.IsAccessibilityObjectCreated && value == true)
                     {
                         int id = OwnerGridView.AccessibilityGetGridEntryChildID(this);
                         if (id >= 0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
@@ -135,7 +135,10 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 base.OnGotFocus(e);
 
-                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                if (IsAccessibilityObjectCreated)
+                {
+                    AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                }
             }
 
             protected override void OnKeyDown(KeyEventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -812,7 +812,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (_selectedRow != -1)
                 {
                     GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
-                    if (gridEntry is not null)
+                    if (gridEntry is not null && IsAccessibilityObjectCreated)
                     {
                         gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
                         gridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
@@ -1503,7 +1503,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             EditTextBox.SelectAll();
 
             var gridEntry = GetGridEntryFromRow(_selectedRow);
-            if (gridEntry is not null)
+            if (gridEntry is not null && IsAccessibilityObjectCreated)
             {
                 gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
                 gridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
@@ -2230,7 +2230,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void OnDropDownButtonGotFocus(object sender, EventArgs e)
         {
-            if (sender is DropDownButton dropDownButton)
+            if (sender is DropDownButton dropDownButton && dropDownButton.IsAccessibilityObjectCreated)
             {
                 dropDownButton.AccessibilityObject.SetFocus();
             }
@@ -2491,9 +2491,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "adding gridEntry focus");
                 _selectedGridEntry.HasFocus = true;
                 InvalidateRow(_selectedRow);
-                (EditTextBox.AccessibilityObject as ControlAccessibleObject).NotifyClients(AccessibleEvents.Focus);
 
-                EditTextBox.AccessibilityObject.SetFocus();
+                if (EditTextBox.IsAccessibilityObjectCreated)
+                {
+                    (EditTextBox.AccessibilityObject as ControlAccessibleObject).NotifyClients(AccessibleEvents.Focus);
+                    EditTextBox.AccessibilityObject.SetFocus();
+                }
             }
             else
             {
@@ -4658,12 +4661,15 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             entry.InternalExpanded = value;
 
-            var oldExpandedState = value ? UiaCore.ExpandCollapseState.Collapsed : UiaCore.ExpandCollapseState.Expanded;
-            var newExpandedState = value ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
-            _selectedGridEntry?.AccessibilityObject?.RaiseAutomationPropertyChangedEvent(
-                UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
-                oldExpandedState,
-                newExpandedState);
+            if (_selectedGridEntry is not null && IsAccessibilityObjectCreated)
+            {
+                var oldExpandedState = value ? UiaCore.ExpandCollapseState.Collapsed : UiaCore.ExpandCollapseState.Expanded;
+                var newExpandedState = value ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
+                _selectedGridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
+                    UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
+                    oldExpandedState,
+                    newExpandedState);
+            }
 
             RecalculateProperties();
             GridEntry selectedEntry = _selectedGridEntry;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
@@ -401,8 +401,11 @@ namespace System.Windows.Forms
             AccessibilityNotifyClients(AccessibleEvents.NameChange, -1);
 
             // UIA events:
-            AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.NamePropertyId, Name, Name);
-            AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.NamePropertyId, Name, Name);
+                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
+            }
 
             ((EventHandler)Events[EVENT_CHECKEDCHANGED])?.Invoke(this, e);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -2500,10 +2500,13 @@ namespace System.Windows.Forms
         {
             base.OnGotFocus(e);
 
-            AccessibilityObject.RaiseAutomationNotification(
-                Automation.AutomationNotificationKind.Other,
-                Automation.AutomationNotificationProcessing.MostRecent,
-                Text);
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationNotification(
+                        Automation.AutomationNotificationKind.Other,
+                        Automation.AutomationNotificationProcessing.MostRecent,
+                        Text);
+            }
         }
 
         protected override void OnHandleCreated(EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -644,9 +644,9 @@ namespace System.Windows.Forms
         {
             base.OnKeyUp(e);
 
-            if (IsHandleCreated && ContainsNavigationKeyCode(e.KeyCode))
+            if (IsHandleCreated && IsAccessibilityObjectCreated && ContainsNavigationKeyCode(e.KeyCode))
             {
-                AccessibilityObject?.RaiseAutomationEvent(UiaCore.UIA.Text_TextSelectionChangedEventId);
+                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextSelectionChangedEventId);
             }
         }
 
@@ -672,7 +672,7 @@ namespace System.Windows.Forms
         {
             base.OnMouseDown(e);
 
-            if (IsHandleCreated)
+            if (IsHandleCreated && IsAccessibilityObjectCreated)
             {
                 // As there is no corresponding windows notification
                 // about text selection changed for TextBox assuming

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1830,7 +1830,10 @@ namespace System.Windows.Forms
 
                 SendMessageW(this, (WM)EM.SETSEL, s, e);
 
-                AccessibilityObject?.RaiseAutomationEvent(UiaCore.UIA.Text_TextSelectionChangedEventId);
+                if (IsAccessibilityObjectCreated)
+                {
+                    AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextSelectionChangedEventId);
+                }
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -3070,7 +3070,7 @@ namespace System.Windows.Forms
 
                 KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(this);
 
-                if (AccessibilityObject is ToolStripItemAccessibleObject accessibleObject)
+                if (IsParentAccessibilityObjectCreated && AccessibilityObject is ToolStripItemAccessibleObject accessibleObject)
                 {
                     accessibleObject.RaiseFocusChanged();
                 }
@@ -3534,6 +3534,11 @@ namespace System.Windows.Forms
         internal virtual void OnKeyboardToolTipUnhook(ToolTip toolTip)
         {
         }
+
+        /// <summary>
+        ///  Indicates whether or not the parent of this item has an accessible object associated with it.
+        /// </summary>
+        internal bool IsParentAccessibilityObjectCreated => ParentInternal is not null && ParentInternal.IsAccessibilityObjectCreated;
 
         internal virtual bool IsBeingTabbedTo() => ToolStrip.AreCommonNavigationalKeysDown();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.cs
@@ -193,7 +193,7 @@ namespace System.Windows.Forms
         protected override void OnTextChanged(EventArgs e)
         {
             base.OnTextChanged(e);
-            if (LiveSetting != AutomationLiveSetting.Off)
+            if (IsParentAccessibilityObjectCreated && LiveSetting != AutomationLiveSetting.Off)
             {
                 AccessibilityObject.RaiseLiveRegionChanged();
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -637,7 +637,12 @@ namespace System.Windows.Forms
         /// </summary>
         private void AnnounceText(Control tool, string text)
         {
-            tool?.AccessibilityObject?.RaiseAutomationNotification(
+            if (tool is null || !tool.IsAccessibilityObjectCreated)
+            {
+                return;
+            }
+
+            tool.AccessibilityObject.RaiseAutomationNotification(
                 Automation.AutomationNotificationKind.ActionCompleted,
                 Automation.AutomationNotificationProcessing.All,
                 $"{ToolTipTitle} {text}");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -916,9 +916,11 @@ namespace System.Windows.Forms
         /// </summary>
         protected virtual void OnValueChanged(EventArgs e)
         {
-            // UIA events:
-            AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.ValueValuePropertyId, Name, Name);
-            AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.ValueValuePropertyId, Name, Name);
+                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
+            }
 
             ((EventHandler)Events[s_valueChangedEvent])?.Invoke(this, e);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownEdit.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownEdit.cs
@@ -29,8 +29,7 @@ namespace System.Windows.Forms
                 get => base.Text;
                 set
                 {
-                    bool valueChanged = (value != base.Text);
-                    if (valueChanged)
+                    if (IsAccessibilityObjectCreated && value != base.Text)
                     {
                         AccessibilityObject.RaiseAutomationNotification(Automation.AutomationNotificationKind.ActionCompleted,
                             Automation.AutomationNotificationProcessing.CurrentThenMostRecent, SR.UpDownEditLocalizedControlTypeName);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -4831,6 +4831,9 @@ namespace System.Windows.Forms.Tests
         {
             using DataGridView dataGridView = new DataGridView();
             dataGridView.CreateControl();
+
+            Assert.True(dataGridView.AccessibilityObject is Control.ControlAccessibleObject);
+
             using DataGridViewTextBoxColumn column1 = new DataGridViewTextBoxColumn();
             dataGridView.Columns.Add(column1);
             dataGridView.Rows.Add();
@@ -6535,6 +6538,9 @@ namespace System.Windows.Forms.Tests
             cell.MockAccessibleObject = mockAccessibleObject.Object;
             cell.Value = false;
             dataGridView.CurrentCell = cell;
+
+            // Enforce accessible object creation
+            _ = dataGridView.AccessibilityObject;
 
             // Checkbox is checked
             dataGridView.BeginEdit(false);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewComboBoxEditingControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewComboBoxEditingControlAccessibleObjectTests.cs
@@ -113,6 +113,9 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewComboBoxEditingControlAccessibleObject_FragmentNavigate_ParentIsCell()
         {
             using DataGridView control = new();
+
+            Assert.True(control.AccessibilityObject is Control.ControlAccessibleObject);
+
             control.Columns.Add(new DataGridViewComboBoxColumn());
             control.Rows.Add();
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObjectTests.cs
@@ -137,6 +137,9 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewTextBoxEditingControlAccessibleObject_FragmentNavigate_ParentIsCell()
         {
             using DataGridView control = new();
+
+            Assert.True(control.AccessibilityObject is Control.ControlAccessibleObject);
+
             control.Columns.Add(new DataGridViewTextBoxColumn());
             control.Rows.Add();
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -4338,6 +4338,9 @@ namespace System.Windows.Forms.Tests
             SubListViewItemAccessibleObject customAccessibleObject = new SubListViewItemAccessibleObject(testItem);
             testItem.CustomAccessibleObject = customAccessibleObject;
 
+            // Enforce accessible object creation
+            _ = listView.AccessibilityObject;
+
             listView.Items[0].Focused = focused;
             listView.Items[0].Selected = selected;
 


### PR DESCRIPTION
This prevents creation of `AccessibilityObject`s when they're not needed.

## Proposed changes

- Add `IsAccessibilityObjectCreated` checks before accessing `AccessibilityObject` in different event handlers

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5436)