### PR TITLE
Add templatestrings.json files to LocProject.json

### DIFF
--- a/eng/Localize/LocProject.json
+++ b/eng/Localize/LocProject.json
@@ -3,6 +3,36 @@
                      {
                          "LocItems":  [
                                           {
+                                              "SourceFile":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsApplication-CSharp\\.template.config\\localize\\templatestrings.json",
+                                              "CopyOption":  "LangIDOnName",
+                                              "OutputPath":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsApplication-CSharp\\.template.config\\localize\\"
+                                          },
+                                          {
+                                              "SourceFile":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsApplication-VisualBasic\\.template.config\\localize\\templatestrings.json",
+                                              "CopyOption":  "LangIDOnName",
+                                              "OutputPath":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsApplication-VisualBasic\\.template.config\\localize\\"
+                                          },
+                                          {
+                                              "SourceFile":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsControlLibrary-CSharp\\.template.config\\localize\\templatestrings.json",
+                                              "CopyOption":  "LangIDOnName",
+                                              "OutputPath":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsControlLibrary-CSharp\\.template.config\\localize\\"
+                                          },
+                                          {
+                                              "SourceFile":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsControlLibrary-VisualBasic\\.template.config\\localize\\templatestrings.json",
+                                              "CopyOption":  "LangIDOnName",
+                                              "OutputPath":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsControlLibrary-VisualBasic\\.template.config\\localize\\"
+                                          },
+                                          {
+                                              "SourceFile":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsLibrary-CSharp\\.template.config\\localize\\templatestrings.json",
+                                              "CopyOption":  "LangIDOnName",
+                                              "OutputPath":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsLibrary-CSharp\\.template.config\\localize\\"
+                                          },
+                                          {
+                                              "SourceFile":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsLibrary-VisualBasic\\.template.config\\localize\\templatestrings.json",
+                                              "CopyOption":  "LangIDOnName",
+                                              "OutputPath":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsLibrary-VisualBasic\\.template.config\\localize\\"
+                                          },
+                                          {
                                               "SourceFile":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsApplication-CSharp\\.template.config\\en\\strings.json",
                                               "CopyOption":  "LangIDOnPath",
                                               "OutputPath":  ".\\pkg\\Microsoft.Dotnet.WinForms.ProjectTemplates\\content\\WinFormsApplication-CSharp\\.template.config\\"


### PR DESCRIPTION
It looks like #5429 broke an internal localization build step.

![image](https://user-images.githubusercontent.com/54385/129772775-f00aeee9-01ab-46f9-a155-fdd0f5fedf8b.png)

The output complains:

> Existing LocProject.json differs from generated LocProject.json. Download LocProject-generated.json and compare them.

This updates the checked in LocProject.json to match what was generated.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5440)