### PR TITLE
Update CMake that supports VS 2022

### DIFF
--- a/global.json
+++ b/global.json
@@ -21,7 +21,7 @@
     "Microsoft.NET.Sdk.IL": "7.0.0-alpha.1.21418.2"
   },
   "native-tools": {
-    "cmake": "3.17.3",
+    "cmake": "3.21.0",
     "dotnet-api-docs_net5.0": "0.0.0.3"
   }
 }

--- a/src/System.Windows.Forms/tests/InteropTests/NativeTests/CMakeLists.txt
+++ b/src/System.Windows.Forms/tests/InteropTests/NativeTests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8.12)
 project (NativeTests)
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Update CMake version that support VS2022 generators.

VS 2022 Preview 3 or above needed ( VS toolset version 143 and above required)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5465)