### PR TITLE
Seal PropertyGridView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -1315,7 +1315,7 @@ namespace System.Windows.Forms
             /// </summary>
             internal bool PreTranslateMessage(ref User32.MSG msg)
             {
-                if (ProcessFilters(ref msg, out bool modified))
+                if (ProcessFilters(ref msg, out _))
                 {
                     return true;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ExtendedStates.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ExtendedStates.cs
@@ -47,10 +47,22 @@ namespace System.Windows.Forms
             /// </summary>
             ClearLayoutArgs = 0x00000040,
 
+            /// <summary>
+            ///  Used to flag that <see cref="IsInputKey(Keys)"/> returned true in <see cref="PreProcessMessage(ref Message)" />
+            ///  so that <see cref="PreProcessControlMessageInternal(Control, ref Message)"/> doesn't call it again.
+            /// </summary>
             InputKey = 0x00000080,
 
+            /// <summary>
+            ///  Used to flag that <see cref="IsInputChar(char)"/> returned true in <see cref="PreProcessMessage(ref Message)" />
+            ///  so that <see cref="PreProcessControlMessageInternal(Control, ref Message)"/> doesn't call it again.
+            /// </summary>
             InputChar = 0x00000100,
 
+            /// <summary>
+            ///  Used by <see cref="PreProcessControlMessageInternal(Control, ref Message)"/> to avoid calling
+            ///  <see cref="ProcessUICues(ref Message)"/> multiple times.
+            /// </summary>
             UiCues = 0x00000200,
 
             IsActiveX = 0x00000400,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PreProcessControlState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PreProcessControlState.cs
@@ -7,18 +7,17 @@ namespace System.Windows.Forms
     public enum PreProcessControlState
     {
         /// <summary>
-        ///  Indicates the message has been processed, and no further processing
-        ///  is necessary
+        ///  Indicates the message has been processed, and no further processing is necessary.
         /// </summary>
         MessageProcessed = 0x00,
 
         /// <summary>
-        ///  Indicates the control wants the message and processing should continue
+        ///  Indicates the control wants the message and processing should continue.
         /// </summary>
         MessageNeeded = 0x01,
 
         /// <summary>
-        ///  Indicates the control doesn't care about the message
+        ///  Indicates the control doesn't care about the message.
         /// </summary>
         MessageNotNeeded = 0x02
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -218,7 +218,7 @@ namespace System.Windows.Forms
                 SetToolStripRenderer();
 
                 // Always add the property tab here.
-                AddRefTab(DefaultTabType, null, PropertyTabScope.Static, setupToolbar: true);
+                AddTab(DefaultTabType, PropertyTabScope.Static);
 
                 _docComment = new(this);
                 _docComment.SuspendLayout();
@@ -877,9 +877,9 @@ namespace System.Windows.Forms
                     }
                     catch (ArgumentException)
                     {
-                        // When no row is selected, SelectedGridItem returns grid entry for root
+                        // When no row is selected, SelectedGridItem returns the grid entry for the root
                         // object. But this is not a selectable item. So don't worry if setting SelectedGridItem
-                        // cause an argument exception when trying to re-select the root object. Just leave the
+                        // causes an argument exception when trying to re-select the root object. Just leave the
                         // the grid with no selected row.
                     }
                 }
@@ -892,9 +892,8 @@ namespace System.Windows.Forms
         public PropertyTabCollection PropertyTabs => new(this);
 
         /// <summary>
-        ///  Sets a single object into the grid to be browsed.  If multiple
-        ///  objects are being browsed, this property will return the first
-        ///  one in the list.  If no objects are selected, null is returned.
+        ///  Sets a single object into the grid to be browsed. If multiple objects are being browsed, this property
+        ///  will return the first one in the list. If no objects are selected, null is returned.
         /// </summary>
         [DefaultValue(null)]
         [SRDescription(nameof(SR.PropertyGridSelectedObjectDesc))]
@@ -1461,10 +1460,10 @@ namespace System.Windows.Forms
 
         internal void AddTab(Type tabType, PropertyTabScope scope)
         {
-            AddRefTab(tabType, component: null, scope, setupToolbar: true);
+            AddTab(tabType, @object: null, scope, setupToolbar: true);
         }
 
-        internal void AddRefTab(Type tabType, object component, PropertyTabScope type, bool setupToolbar)
+        internal void AddTab(Type tabType, object @object, PropertyTabScope type, bool setupToolbar)
         {
             PropertyTab tab = null;
             int tabIndex = -1;
@@ -1493,7 +1492,7 @@ namespace System.Windows.Forms
                 // The tabs need service providers. The one we hold onto is not good enough,
                 // so try to get the one off of the component's site.
                 IDesignerHost host = null;
-                if (component is IComponent component1 && component1.Site is ISite site)
+                if (@object is IComponent component && component.Site is ISite site)
                 {
                     host = site.GetService<IDesignerHost>();
                 }
@@ -1559,7 +1558,7 @@ namespace System.Windows.Forms
                 Debug.Assert(_viewTabs is not null, "Tab array destroyed!");
             }
 
-            if (tab is not null && component is not null)
+            if (tab is not null && @object is not null)
             {
                 try
                 {
@@ -1572,7 +1571,7 @@ namespace System.Windows.Forms
                         Array.Copy(tabComponents, newComponents, oldArraySize);
                     }
 
-                    newComponents[oldArraySize] = component;
+                    newComponents[oldArraySize] = @object;
                     tab.Components = newComponents;
                 }
                 catch (Exception e)
@@ -2470,7 +2469,7 @@ namespace System.Windows.Forms
             {
                 if (attribute.TabScopes[i] == PropertyTabScope.Document)
                 {
-                    AddRefTab(attribute.TabClasses[i], e.Component, PropertyTabScope.Document, true);
+                    AddTab(attribute.TabClasses[i], e.Component, PropertyTabScope.Document, true);
                 }
             }
         }
@@ -2537,7 +2536,7 @@ namespace System.Windows.Forms
                     else
                     {
                         // Otherwise, just dump the selection.
-                        _gridView.ClearProps();
+                        _gridView.ClearGridEntries();
                         _currentObjects = newObjects;
                         SetFlag(Flags.FullRefreshAfterBatch, true);
                     }
@@ -2901,7 +2900,7 @@ namespace System.Windows.Forms
         protected void OnNotifyPropertyValueUIItemsChanged(object sender, EventArgs e)
         {
             _gridView.LabelPaintMargin = 0;
-            _gridView.Invalidate(true);
+            _gridView.Invalidate(invalidateChildren: true);
         }
 
 #pragma warning disable CA1725 // Parameter name shipped as 'pevent'
@@ -3452,7 +3451,7 @@ namespace System.Windows.Forms
                     {
                         for (int j = 0; j < _currentObjects.Length; j++)
                         {
-                            AddRefTab(tabTypes[i], _currentObjects[j], PropertyTabScope.Component, false);
+                            AddTab(tabTypes[i], _currentObjects[j], PropertyTabScope.Component, false);
                         }
                     }
                 }
@@ -3472,7 +3471,7 @@ namespace System.Windows.Forms
                         {
                             if (attribute.TabScopes[j] == PropertyTabScope.Document)
                             {
-                                AddRefTab(attribute.TabClasses[j], component, PropertyTabScope.Document, false);
+                                AddTab(attribute.TabClasses[j], component, PropertyTabScope.Document, false);
                             }
                         }
                     }
@@ -3972,16 +3971,16 @@ namespace System.Windows.Forms
             else
             {
                 // Clear all the items from the toolStrip and image list after the first two.
-                int count = buttonList.Count;
+                int items = buttonList.Count;
 
-                for (i = count - 1; i >= 2; i--)
+                for (i = items - 1; i >= 2; i--)
                 {
                     buttonList.RemoveAt(i);
                 }
 
-                count = _imageList[NormalButtonSize].Images.Count;
+                items = _imageList[NormalButtonSize].Images.Count;
 
-                for (i = count - 1; i >= 2; i--)
+                for (i = items - 1; i >= 2; i--)
                 {
                     RemoveImage(i);
                 }
@@ -4266,7 +4265,7 @@ namespace System.Windows.Forms
                 if (_mainEntry is null)
                 {
                     _currentEntries = new GridEntryCollection(null, Array.Empty<GridEntry>());
-                    _gridView.ClearProps();
+                    _gridView.ClearGridEntries();
                     return;
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -3971,16 +3971,16 @@ namespace System.Windows.Forms
             else
             {
                 // Clear all the items from the toolStrip and image list after the first two.
-                int items = buttonList.Count;
+                int count = buttonList.Count;
 
-                for (i = items - 1; i >= 2; i--)
+                for (i = count - 1; i >= 2; i--)
                 {
                     buttonList.RemoveAt(i);
                 }
 
-                items = _imageList[NormalButtonSize].Images.Count;
+                count = _imageList[NormalButtonSize].Images.Count;
 
-                for (i = items - 1; i >= 2; i--)
+                for (i = count - 1; i >= 2; i--)
                 {
                     RemoveImage(i);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObject.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (direction == UiaCore.NavigateDirection.NextSibling)
                 {
-                    return _owningPropertyGridView.Edit.AccessibilityObject;
+                    return _owningPropertyGridView.EditTextBox.AccessibilityObject;
                 }
 
                 return base.FragmentNavigate(direction);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
@@ -8,14 +8,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 {
     internal partial class PropertyGridView
     {
-        private partial class GridViewEdit
+        private partial class GridViewTextBox
         {
-            protected class GridViewEditAccessibleObject : ControlAccessibleObject
+            private class GridViewTextBoxAccessibleObject : ControlAccessibleObject
             {
                 private readonly PropertyGridView _owningPropertyGridView;
                 private readonly TextBoxBaseUiaTextProvider _textProvider;
 
-                public GridViewEditAccessibleObject(GridViewEdit owner) : base(owner)
+                public GridViewTextBoxAccessibleObject(GridViewTextBox owner) : base(owner)
                 {
                     _owningPropertyGridView = owner.PropertyGridView;
                     _textProvider = new TextBoxBaseUiaTextProvider(owner);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -783,7 +783,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public void ClearGridEntries()
         {
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:ClearClearGridEntries");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:ClearGridEntries");
 
             if (!HasEntries)
             {
@@ -902,7 +902,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             try
             {
                 // We do this because the Focus call above doesn't always stick, so
-                // we make the Edit think that it doesn't have focus. This prevents
+                // we make the EditTextBox think that it doesn't have focus. This prevents
                 // ActiveControl code on the container control from moving focus elsewhere
                 // when the dropdown closes.
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -18,13 +18,13 @@ using static Interop;
 
 namespace System.Windows.Forms.PropertyGridInternal
 {
-    internal partial class PropertyGridView :
+    internal sealed partial class PropertyGridView :
         Control,
         IWin32Window,
         IWindowsFormsEditorService,
         IServiceProvider
     {
-        protected static Point InvalidPoint { get; } = new(int.MinValue, int.MinValue);
+        private static Point InvalidPoint { get; } = new(int.MinValue, int.MinValue);
 
         private static readonly TraceSwitch s_gridViewDebugPaint = new("GridViewDebugPaint", "PropertyGridView: Debug property painting");
 
@@ -56,7 +56,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         private const int Offset2Pixels = 2;
         private int _offset2Units = Offset2Pixels;
 
-        protected static Point InvalidPosition { get; } = new(int.MinValue, int.MinValue);
+        private static Point InvalidPosition { get; } = new(int.MinValue, int.MinValue);
 
         private Font _boldFont;
         private Color _grayTextColor;
@@ -80,7 +80,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         private int _tipInfo = -1;
 
         // Editors & controls
-        private GridViewEdit _edit;
+        private GridViewTextBox _editTextBox;
         private DropDownButton _dropDownButton;
         private DropDownButton _dialogButton;
         private GridViewListBox _listBox;
@@ -178,24 +178,8 @@ namespace System.Windows.Forms.PropertyGridInternal
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public bool CanCopy
-        {
-            get
-            {
-                if (_selectedGridEntry is null)
-                {
-                    return false;
-                }
-
-                if (!Edit.Focused)
-                {
-                    string val = _selectedGridEntry.GetPropertyTextValue();
-
-                    return val is not null && val.Length > 0;
-                }
-
-                return true;
-            }
-        }
+            => _selectedGridEntry is not null
+                && (EditTextBox.Focused || !string.IsNullOrEmpty(_selectedGridEntry.GetPropertyTextValue()));
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
@@ -211,12 +195,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (!Edit.Visible || !Edit.Focused)
+                if (!EditTextBox.Visible || !EditTextBox.Focused)
                 {
                     return false;
                 }
 
-                return User32.SendMessageW(Edit, (User32.WM)User32.EM.CANUNDO) != IntPtr.Zero;
+                return User32.SendMessageW(EditTextBox, (User32.WM)User32.EM.CANUNDO) != IntPtr.Zero;
             }
         }
 
@@ -303,15 +287,18 @@ namespace System.Windows.Forms.PropertyGridInternal
             return bitmap;
         }
 
-        private GridViewEdit Edit
+        /// <summary>
+        ///  The common text box for editing values.
+        /// </summary>
+        private GridViewTextBox EditTextBox
         {
             get
             {
-                if (_edit is null)
+                if (_editTextBox is null)
                 {
                     OwnerGrid.CheckInCreate();
 
-                    _edit = new(this)
+                    _editTextBox = new(this)
                     {
                         BorderStyle = BorderStyle.None,
                         AutoSize = false,
@@ -321,25 +308,25 @@ namespace System.Windows.Forms.PropertyGridInternal
                         ForeColor = ForeColor
                     };
 
-                    _edit.KeyDown += OnEditKeyDown;
-                    _edit.KeyPress += OnEditKeyPress;
-                    _edit.GotFocus += OnEditGotFocus;
-                    _edit.LostFocus += OnEditLostFocus;
-                    _edit.MouseDown += OnEditMouseDown;
-                    _edit.TextChanged += OnEditChange;
+                    _editTextBox.KeyDown += OnEditKeyDown;
+                    _editTextBox.KeyPress += OnEditKeyPress;
+                    _editTextBox.GotFocus += OnEditGotFocus;
+                    _editTextBox.LostFocus += OnEditLostFocus;
+                    _editTextBox.MouseDown += OnEditMouseDown;
+                    _editTextBox.TextChanged += OnEditChange;
 
-                    _edit.TabIndex = 1;
-                    CommonEditorSetup(_edit);
+                    _editTextBox.TabIndex = 1;
+                    CommonEditorSetup(_editTextBox);
                 }
 
-                return _edit;
+                return _editTextBox;
             }
         }
 
         /// <summary>
         ///  Represents the Editor's control accessible object.
         /// </summary>
-        internal AccessibleObject EditAccessibleObject => Edit.AccessibilityObject;
+        internal AccessibleObject EditAccessibleObject => EditTextBox.AccessibilityObject;
 
         internal GridViewListBox DropDownListBox
         {
@@ -377,9 +364,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                if (_edit is not null && _edit.IsHandleCreated)
+                if (_editTextBox is not null && _editTextBox.IsHandleCreated)
                 {
-                    int exStyle = unchecked((int)(long)User32.GetWindowLong(_edit, User32.GWL.EXSTYLE));
+                    int exStyle = unchecked((int)(long)User32.GetWindowLong(_editTextBox, User32.GWL.EXSTYLE));
                     return (exStyle & (int)User32.WS_EX.RTLREADING) != 0;
                 }
                 else
@@ -443,7 +430,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private bool HasEntries => TopLevelGridEntries is not null && TopLevelGridEntries.Count > 0;
 
-        protected int InternalLabelWidth
+        private int InternalLabelWidth
         {
             get
             {
@@ -466,21 +453,21 @@ namespace System.Windows.Forms.PropertyGridInternal
             set => _requiredLabelPaintMargin = (short)Math.Max(Math.Max(value, _requiredLabelPaintMargin), GdiPlusSpace);
         }
 
-        protected bool NeedsCommit
+        private bool NeedsCommit
         {
             get
             {
                 string text;
 
-                if (_edit is null || !Edit.Visible)
+                if (_editTextBox is null || !EditTextBox.Visible)
                 {
                     return false;
                 }
 
-                text = Edit.Text;
+                text = EditTextBox.Text;
 
-                if (((text is null || text.Length == 0) && (_originalTextValue is null || _originalTextValue.Length == 0))
-                    || (text is not null && _originalTextValue is not null && text.Equals(_originalTextValue)))
+                if ((string.IsNullOrEmpty(text) && string.IsNullOrEmpty(_originalTextValue))
+                    || text.Equals(_originalTextValue))
                 {
                     return false;
                 }
@@ -491,7 +478,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public PropertyGrid OwnerGrid { get; private set; }
 
-        protected int RowHeight
+        private int RowHeight
         {
             get
             {
@@ -632,7 +619,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     OwnerGrid.CheckInCreate();
 
-                    _toolTip = new GridToolTip(new Control[] { this, Edit })
+                    _toolTip = new GridToolTip(new Control[] { this, EditTextBox })
                     {
                         ToolTip = string.Empty,
                         Font = Font
@@ -737,11 +724,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        protected virtual void AdjustOrigin(Graphics g, Point newOrigin, ref Rectangle r)
+        private void AdjustOrigin(Graphics g, Point newOrigin, ref Rectangle r)
         {
             Debug.WriteLineIf(
                 s_gridViewDebugPaint.TraceVerbose,
-                $"Adjusting paint origin to ({newOrigin.X.ToString(CultureInfo.InvariantCulture)},{newOrigin.Y.ToString(CultureInfo.InvariantCulture)})");
+                $"Adjusting paint origin to ({newOrigin.X},{newOrigin.Y})");
 
             g.ResetTransform();
             g.TranslateTransform(newOrigin.X, newOrigin.Y);
@@ -794,9 +781,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        public void ClearProps()
+        public void ClearGridEntries()
         {
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:ClearProps");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:ClearClearGridEntries");
 
             if (!HasEntries)
             {
@@ -839,7 +826,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     OnListClick(null, null);
                 }
 
-                Edit.Filter = false;
+                EditTextBox.Filter = false;
 
                 // Disable the ddh so it won't steal the focus back
                 _dropDownHolder.SetComponent(null, resizable: false);
@@ -857,9 +844,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         DropDownButton.Focus();
                     }
-                    else if (Edit.Visible)
+                    else if (EditTextBox.Visible)
                     {
-                        Edit.Focus();
+                        EditTextBox.Focus();
                     }
                     else
                     {
@@ -891,9 +878,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        private void CommonEditorHide() => CommonEditorHide(always: false);
-
-        private void CommonEditorHide(bool always)
+        private void CommonEditorHide(bool always = false)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:CommonEditorHide");
 
@@ -904,43 +889,44 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             CloseDropDown();
 
-            bool gotfocus = false;
+            bool gotFocus = false;
 
-            if (Edit.Focused || DialogButton.Focused || DropDownButton.Focused)
+            if (EditTextBox.Focused || DialogButton.Focused || DropDownButton.Focused)
             {
                 if (IsHandleCreated && Visible && Enabled)
                 {
-                    gotfocus = IntPtr.Zero != User32.SetFocus(new HandleRef(this, Handle));
+                    gotFocus = User32.SetFocus(new HandleRef(this, Handle)) != IntPtr.Zero;
                 }
             }
 
             try
             {
                 // We do this because the Focus call above doesn't always stick, so
-                // we make the Edit think that it doesn't have focus.  this prevents
-                // ActiveControl code on the containercontrol from moving focus elsewhere
+                // we make the Edit think that it doesn't have focus. This prevents
+                // ActiveControl code on the container control from moving focus elsewhere
                 // when the dropdown closes.
-                Edit.DontFocus = true;
-                if (Edit.Focused && !gotfocus)
+
+                EditTextBox.HideFocusState = true;
+                if (EditTextBox.Focused && !gotFocus)
                 {
-                    gotfocus = Focus();
+                    gotFocus = Focus();
                 }
 
-                Edit.Visible = false;
+                EditTextBox.Visible = false;
 
-                Edit.SelectionStart = 0;
-                Edit.SelectionLength = 0;
+                EditTextBox.SelectionStart = 0;
+                EditTextBox.SelectionLength = 0;
 
-                if (DialogButton.Focused && !gotfocus)
+                if (DialogButton.Focused && !gotFocus)
                 {
-                    gotfocus = Focus();
+                    gotFocus = Focus();
                 }
 
                 DialogButton.Visible = false;
 
-                if (DropDownButton.Focused && !gotfocus)
+                if (DropDownButton.Focused && !gotFocus)
                 {
-                    gotfocus = Focus();
+                    gotFocus = Focus();
                 }
 
                 DropDownButton.Visible = false;
@@ -948,18 +934,18 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             finally
             {
-                Edit.DontFocus = false;
+                EditTextBox.HideFocusState = false;
             }
         }
 
-        protected virtual void CommonEditorSetup(Control control)
+        private void CommonEditorSetup(Control control)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:CommonEditorSetup");
             control.Visible = false;
             Controls.Add(control);
         }
 
-        protected virtual void CommonEditorUse(Control control, Rectangle targetRectangle)
+        private void CommonEditorUse(Control control, Rectangle targetRectangle)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:CommonEditorUse");
             Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Showing common editors");
@@ -1058,7 +1044,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return bitmap;
         }
 
-        protected virtual void CreateUI() => UpdateUIBasedOnFont(layoutRequired: false);
+        private void CreateUI() => UpdateUIBasedOnFont(layoutRequired: false);
 
         protected override void Dispose(bool disposing)
         {
@@ -1087,8 +1073,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 _helpService = null;
 
-                _edit?.Dispose();
-                _edit = null;
+                _editTextBox?.Dispose();
+                _editTextBox = null;
 
                 _boldFont?.Dispose();
                 _boldFont = null;
@@ -1110,9 +1096,9 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             if (CanCopy)
             {
-                if (Edit.Focused)
+                if (EditTextBox.Focused)
                 {
-                    Edit.Copy();
+                    EditTextBox.Copy();
                 }
                 else if (_selectedGridEntry is not null)
                 {
@@ -1126,23 +1112,23 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (CanCut)
             {
                 DoCopyCommand();
-                if (Edit.Visible)
+                if (EditTextBox.Visible)
                 {
-                    Edit.Cut();
+                    EditTextBox.Cut();
                 }
             }
         }
 
         public void DoPasteCommand()
         {
-            if (!CanPaste || !Edit.Visible)
+            if (!CanPaste || !EditTextBox.Visible)
             {
                 return;
             }
 
-            if (Edit.Focused)
+            if (EditTextBox.Focused)
             {
-                Edit.Paste();
+                EditTextBox.Paste();
             }
             else
             {
@@ -1152,8 +1138,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                     string data = (string)dataObj.GetData(typeof(string));
                     if (data is not null)
                     {
-                        Edit.Focus();
-                        Edit.Text = data;
+                        EditTextBox.Focus();
+                        EditTextBox.Text = data;
                         SetCommitError(ErrorState.None, capture: true);
                     }
                 }
@@ -1162,9 +1148,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public void DoUndoCommand()
         {
-            if (CanUndo && Edit.Visible)
+            if (CanUndo && EditTextBox.Visible)
             {
-                User32.SendMessageW(Edit, User32.WM.UNDO);
+                User32.SendMessageW(EditTextBox, User32.WM.UNDO);
             }
         }
 
@@ -1188,7 +1174,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return length > _location.X + InternalLabelWidth;
         }
 
-        protected void DrawLabel(Graphics g, int row, Rectangle rect, bool selected, bool longLabelrequest, Rectangle clipRect)
+        private void DrawLabel(Graphics g, int row, Rectangle rect, bool selected, bool longLabelrequest, Rectangle clipRect)
         {
             GridEntry gridEntry = GetGridEntryFromRow(row);
 
@@ -1237,7 +1223,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        protected virtual void DrawValueEntry(Graphics g, int row, Rectangle clipRect)
+        private void DrawValueEntry(Graphics g, int row, Rectangle clipRect)
         {
             GridEntry gridEntry = GetGridEntryFromRow(row);
             if (gridEntry is null)
@@ -1292,9 +1278,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             // If we are in an errorState, just put the focus back on the Edit.
-            if (_errorState != ErrorState.None && Edit.Visible)
+            if (_errorState != ErrorState.None && EditTextBox.Visible)
             {
-                Edit.Focus();
+                EditTextBox.Focus();
                 return;
             }
 
@@ -1313,10 +1299,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                     DialogButton.Focus();
                 }
             }
-            else if (Edit.Visible)
+            else if (EditTextBox.Visible)
             {
-                Edit.Focus();
-                SelectEdit();
+                EditTextBox.Focus();
+                EditTextBox.SelectAll();
             }
 
             return;
@@ -1384,10 +1370,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            if (Edit.Visible)
+            if (EditTextBox.Visible)
             {
-                Edit.Focus();
-                SelectEdit();
+                EditTextBox.Focus();
+                EditTextBox.SelectAll();
                 return;
             }
         }
@@ -1429,21 +1415,21 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private bool GetFlag(short flag) => (_flags & flag) != 0;
 
-        public virtual Color GetLineColor() => OwnerGrid.LineColor;
+        public Color GetLineColor() => OwnerGrid.LineColor;
 
-        public virtual Color GetSelectedItemWithFocusForeColor() => OwnerGrid.SelectedItemWithFocusForeColor;
+        public Color GetSelectedItemWithFocusForeColor() => OwnerGrid.SelectedItemWithFocusForeColor;
 
-        public virtual Color GetSelectedItemWithFocusBackColor() => OwnerGrid.SelectedItemWithFocusBackColor;
+        public Color GetSelectedItemWithFocusBackColor() => OwnerGrid.SelectedItemWithFocusBackColor;
 
-        public virtual IntPtr GetHostHandle() => Handle;
+        public IntPtr GetHostHandle() => Handle;
 
-        public virtual int GetLabelWidth() => InternalLabelWidth;
+        public int GetLabelWidth() => InternalLabelWidth;
 
         internal bool IsExplorerTreeSupported => OwnerGrid.CanShowVisualStyleGlyphs && VisualStyleRenderer.IsSupported;
 
-        public virtual int GetOutlineIconSize() => IsExplorerTreeSupported ? _outlineSizeExplorerTreeStyle : _outlineSize;
+        public int GetOutlineIconSize() => IsExplorerTreeSupported ? _outlineSizeExplorerTreeStyle : _outlineSize;
 
-        public virtual int GetGridEntryHeight() => RowHeight;
+        public int GetGridEntryHeight() => RowHeight;
 
         internal int GetPropertyLocation(string propName, bool getXY, bool rowValue)
         {
@@ -1495,17 +1481,17 @@ namespace System.Windows.Forms.PropertyGridInternal
             return null;
         }
 
-        public virtual int GetSplitterWidth() => 1;
+        public int GetSplitterWidth() => 1;
 
-        public virtual int GetTotalWidth() => GetLabelWidth() + GetSplitterWidth() + GetValueWidth();
+        public int GetTotalWidth() => GetLabelWidth() + GetSplitterWidth() + GetValueWidth();
 
-        public virtual int GetValuePaintIndent() => _paintIndent;
+        public int GetValuePaintIndent() => _paintIndent;
 
-        public virtual int GetValuePaintWidth() => _paintWidth;
+        public int GetValuePaintWidth() => _paintWidth;
 
-        public virtual int GetValueStringIndent() => EditIndent;
+        public int GetValueStringIndent() => EditIndent;
 
-        public virtual int GetValueWidth() => (int)(InternalLabelWidth * (_labelRatio - 1));
+        public int GetValueWidth() => (int)(InternalLabelWidth * (_labelRatio - 1));
 
         /// <summary>
         ///  Displays the provided control in a drop down.  When possible, the
@@ -1515,48 +1501,48 @@ namespace System.Windows.Forms.PropertyGridInternal
         ///  nicely.  If the user performs an action that would cause the drop down
         ///  to prematurely disappear the control will be hidden.
         /// </summary>
-        public void DropDownControl(Control ctl)
+        public void DropDownControl(Control control)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:DropDownControl");
-            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"DropDownControl(ctl = {ctl.GetType().Name})");
+            Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, $"DropDownControl(ctl = {control.GetType().Name})");
 
             _dropDownHolder ??= new(this);
             _dropDownHolder.Visible = false;
-            _dropDownHolder.SetComponent(ctl, GetFlag(FlagResizableDropDown));
+            _dropDownHolder.SetComponent(control, GetFlag(FlagResizableDropDown));
 
             Rectangle rect = GetRectangle(_selectedRow, RowValue);
             Size size = _dropDownHolder.Size;
-            Point loc = PointToScreen(new Point(0, 0));
-            Rectangle rectScreen = Screen.FromControl(Edit).WorkingArea;
+            Point location = PointToScreen(new Point(0, 0));
+            Rectangle rectScreen = Screen.FromControl(EditTextBox).WorkingArea;
             size.Width = Math.Max(rect.Width + 1, size.Width);
 
-            loc.X = Math.Min(
+            location.X = Math.Min(
                 rectScreen.X + rectScreen.Width - size.Width,
-                Math.Max(rectScreen.X, loc.X + rect.X + rect.Width - size.Width));
+                Math.Max(rectScreen.X, location.X + rect.X + rect.Width - size.Width));
 
-            loc.Y += rect.Y;
-            if (rectScreen.Y + rectScreen.Height < (size.Height + loc.Y + Edit.Height))
+            location.Y += rect.Y;
+            if (rectScreen.Y + rectScreen.Height < (size.Height + location.Y + EditTextBox.Height))
             {
-                loc.Y -= size.Height;
+                location.Y -= size.Height;
                 _dropDownHolder.ResizeUp = true;
             }
             else
             {
-                loc.Y += rect.Height + 1;
+                location.Y += rect.Height + 1;
                 _dropDownHolder.ResizeUp = false;
             }
 
-            // Control is a top level window. Standard way of set parent on the control is prohibited for top-level controls.
+            // Control is a top level window. Standard way of setting parent on the control is prohibited for top-level controls.
             // It is unknown why this control was created as a top-level control. Windows does not recommend this way of setting parent.
             // We are not touching this for this release. We may revisit it in next release.
 
             User32.SetWindowLong(_dropDownHolder, User32.GWL.HWNDPARENT, new HandleRef(this, Handle));
-            _dropDownHolder.SetBounds(loc.X, loc.Y, size.Width, size.Height);
+            _dropDownHolder.SetBounds(location.X, location.Y, size.Width, size.Height);
             User32.ShowWindow(_dropDownHolder, User32.SW.SHOWNA);
-            Edit.Filter = true;
+            EditTextBox.Filter = true;
             _dropDownHolder.Visible = true;
             _dropDownHolder.FocusComponent();
-            SelectEdit();
+            EditTextBox.SelectAll();
 
             var gridEntry = GetGridEntryFromRow(_selectedRow);
             if (gridEntry is not null)
@@ -1585,16 +1571,16 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        public virtual void DropDownDone() => CloseDropDown();
+        public void DropDownDone() => CloseDropDown();
 
-        public virtual void DropDownUpdate()
+        public void DropDownUpdate()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "DropDownHolder:DropDownUpdate");
             if (_dropDownHolder is not null && _dropDownHolder.GetUsed())
             {
                 int row = _selectedRow;
                 GridEntry gridEntry = GetGridEntryFromRow(row);
-                Edit.Text = gridEntry.GetPropertyTextValue();
+                EditTextBox.Text = gridEntry.GetPropertyTextValue();
             }
         }
 
@@ -1636,9 +1622,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                     if (text is not null && text.Length > 0 && string.Compare(text.Substring(0, 1), letter, true, CultureInfo.InvariantCulture) == 0)
                     {
                         CommitValue(valueCur);
-                        if (Edit.Focused)
+                        if (EditTextBox.Focused)
                         {
-                            SelectEdit();
+                            EditTextBox.SelectAll();
                         }
 
                         return true;
@@ -1649,9 +1635,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             return false;
         }
 
-        public virtual bool WillFilterKeyPress(char charPressed)
+        public bool WillFilterKeyPress(char charPressed)
         {
-            if (!Edit.Visible)
+            if (!EditTextBox.Visible)
             {
                 return false;
             }
@@ -1691,7 +1677,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:FilterKeyPress()");
 
-            Edit.FilterKeyPress(keyChar);
+            EditTextBox.FilterKeyPress(keyChar);
         }
 
         private GridEntry FindEquivalentGridEntry(GridEntryCollection ipeHier)
@@ -1756,7 +1742,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return targetEntry;
         }
 
-        protected virtual Point FindPosition(int x, int y)
+        private Point FindPosition(int x, int y)
         {
             if (RowHeight == -1)
             {
@@ -1780,10 +1766,10 @@ namespace System.Windows.Forms.PropertyGridInternal
             return pt;
         }
 
-        public virtual void Flush()
+        public void Flush()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView::Flush()");
-            if (Commit() && Edit.Focused)
+            if (Commit() && EditTextBox.Focused)
             {
                 Focus();
             }
@@ -1885,7 +1871,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return -1;
         }
 
-        public virtual int GetDefaultOutlineIndent()
+        public int GetDefaultOutlineIndent()
         {
             return OutlineIndent;
         }
@@ -1904,7 +1890,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return _helpService;
         }
 
-        public virtual int GetScrollOffset()
+        public int GetScrollOffset()
         {
             if (_scrollBar is null)
             {
@@ -2086,16 +2072,16 @@ namespace System.Windows.Forms.PropertyGridInternal
             return -1 - GetScrollOffset();
         }
 
-        public virtual bool GetInPropertySet() => GetFlag(FlagInPropertySet);
+        public bool GetInPropertySet() => GetFlag(FlagInPropertySet);
 
-        protected virtual bool GetScrollbarHidden() => _scrollBar is null || !ScrollBar.Visible;
+        private bool GetScrollbarHidden() => _scrollBar is null || !ScrollBar.Visible;
 
         /// <summary>
         ///  Returns a string containing test info about a given GridEntry. Requires an offset into the top-level
         ///  entry collection (ie. nested entries are not accessible). Or specify -1 to get info for the current
         ///  selected entry (which can be any entry, top-level or nested).
         /// </summary>
-        public virtual string GetTestingInfo(int entry)
+        public string GetTestingInfo(int entry)
         {
             GridEntry gridEntry = (entry < 0) ? GetGridEntryFromRow(_selectedRow) : GetGridEntryFromOffset(entry);
 
@@ -2174,7 +2160,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return false;
 
                 case Keys.Return:
-                    if (Edit.Focused)
+                    if (EditTextBox.Focused)
                     {
                         return false;
                     }
@@ -2327,7 +2313,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (!Commit())
                 {
-                    Edit.Focus();
+                    EditTextBox.Focus();
                     return;
                 }
             }
@@ -2386,9 +2372,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (!DropDownListBox.InSetSelectedIndex())
             {
                 GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
-                Edit.Text = gridEntry.GetPropertyTextValue(DropDownListBox.SelectedItem);
-                Edit.Focus();
-                SelectEdit();
+                EditTextBox.Text = gridEntry.GetPropertyTextValue(DropDownListBox.SelectedItem);
+                EditTextBox.Focus();
+                EditTextBox.SelectAll();
             }
 
             SetFlag(FlagDropDownCommit, true);
@@ -2531,12 +2517,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         private void OnEditChange(object sender, EventArgs e)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnEditChange");
-            SetCommitError(ErrorState.None, Edit.Focused);
+            SetCommitError(ErrorState.None, EditTextBox.Focused);
 
             ToolTip.ToolTip = string.Empty;
             ToolTip.Visible = false;
 
-            if (!Edit.InSetText())
+            if (!EditTextBox.InSetText)
             {
                 GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
                 if (gridEntry is not null && gridEntry.IsImmediatelyEditable)
@@ -2550,7 +2536,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnEditGotFocus");
 
-            if (!Edit.Visible)
+            if (!EditTextBox.Visible)
             {
                 Focus();
                 return;
@@ -2561,9 +2547,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 case ErrorState.MessageBoxUp:
                     return;
                 case ErrorState.Thrown:
-                    if (Edit.Visible)
+                    if (EditTextBox.Visible)
                     {
-                        Edit.HookMouseDown = true;
+                        EditTextBox.HookMouseDown = true;
                     }
 
                     break;
@@ -2581,9 +2567,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "adding gridEntry focus");
                 _selectedGridEntry.HasFocus = true;
                 InvalidateRow(_selectedRow);
-                (Edit.AccessibilityObject as ControlAccessibleObject).NotifyClients(AccessibleEvents.Focus);
+                (EditTextBox.AccessibilityObject as ControlAccessibleObject).NotifyClients(AccessibleEvents.Focus);
 
-                Edit.AccessibilityObject.SetFocus();
+                EditTextBox.AccessibilityObject.SetFocus();
             }
             else
             {
@@ -2643,7 +2629,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 CommitValue(entry, valueNew, closeDropDown);
-                SelectEdit();
+                EditTextBox?.SelectAll();
                 return true;
             }
 
@@ -2698,7 +2684,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnEditLostFocus");
 
             // Believe it or not this can actually happen.
-            if (Edit.Focused || (_errorState == ErrorState.MessageBoxUp) || (_errorState == ErrorState.Thrown) || GetInPropertySet())
+            if (EditTextBox.Focused || (_errorState == ErrorState.MessageBoxUp) || (_errorState == ErrorState.Thrown) || GetInPropertySet())
             {
                 return;
             }
@@ -2729,7 +2715,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // If the focus isn't going to a child of the view
             if (!Commit())
             {
-                Edit.Focus();
+                EditTextBox.Focus();
                 return;
             }
 
@@ -2749,7 +2735,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (e.Clicks % 2 == 0)
             {
                 DoubleClickRow(_selectedRow, toggleExpand: false, RowValue);
-                Edit.SelectAll();
+                EditTextBox.SelectAll();
             }
 
             if (_rowSelectTime == 0)
@@ -2764,14 +2750,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (delta < SystemInformation.DoubleClickTime)
             {
-                Point screenPoint = Edit.PointToScreen(new(e.X, e.Y));
+                Point screenPoint = EditTextBox.PointToScreen(new(e.X, e.Y));
 
                 if (Math.Abs(screenPoint.X - _rowSelectPos.X) < SystemInformation.DoubleClickSize.Width &&
                     Math.Abs(screenPoint.Y - _rowSelectPos.Y) < SystemInformation.DoubleClickSize.Height)
                 {
                     DoubleClickRow(_selectedRow, toggleExpand: false, RowValue);
-                    User32.SendMessageW(Edit, User32.WM.LBUTTONUP, IntPtr.Zero, PARAM.FromLowHigh(e.X, e.Y));
-                    Edit.SelectAll();
+                    User32.SendMessageW(EditTextBox, User32.WM.LBUTTONUP, IntPtr.Zero, PARAM.FromLowHigh(e.X, e.Y));
+                    EditTextBox.SelectAll();
                 }
 
                 _rowSelectPos = Point.Empty;
@@ -2810,7 +2796,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             SetFlag(FlagDropDownCommit, false);
 
-            if (sender != Edit || !Edit.Focused)
+            if (sender != EditTextBox || !EditTextBox.Focused)
             {
                 if (sender != this)
                 {
@@ -2824,7 +2810,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // If we aren't in an error state, just quit.
             if (_errorState == ErrorState.None)
             {
-                Edit.Text = _originalTextValue;
+                EditTextBox.Text = _originalTextValue;
                 Focus();
                 return true;
             }
@@ -2832,7 +2818,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (NeedsCommit)
             {
                 bool success = false;
-                Edit.Text = _originalTextValue;
+                EditTextBox.Text = _originalTextValue;
                 bool needReset = true;
 
                 if (_selectedGridEntry is not null)
@@ -2859,8 +2845,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (!success)
                 {
-                    Edit.Focus();
-                    SelectEdit();
+                    EditTextBox.Focus();
+                    EditTextBox.SelectAll();
                     return true;
                 }
             }
@@ -3102,10 +3088,10 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         break;
                     case Keys.A:
-                        if (controlPressed && !altPressed && !shiftPressed && Edit.Visible)
+                        if (controlPressed && !altPressed && !shiftPressed && EditTextBox.Visible)
                         {
-                            Edit.Focus();
-                            Edit.SelectAll();
+                            EditTextBox.Focus();
+                            EditTextBox.SelectAll();
                         }
 
                         break;
@@ -3258,7 +3244,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         TipRow = rowMoveCurrent;
                         TipColumn = point.X;
                     }
-                    else if (!onLabel && gridItem.ValueToolTipLocation != InvalidPoint && !Edit.Focused)
+                    else if (!onLabel && gridItem.ValueToolTipLocation != InvalidPoint && !EditTextBox.Focused)
                     {
                         if (!NeedsCommit)
                         {
@@ -3331,7 +3317,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             // Should this only work if the Edit has focus?
             // We use the mouse wheel to change the values in the dropdown if it's an enumerable value.
-            if (_selectedGridEntry is not null && _selectedGridEntry.Enumerable && Edit.Focused && _selectedGridEntry.IsValueEditable)
+            if (_selectedGridEntry is not null && _selectedGridEntry.Enumerable && EditTextBox.Focused && _selectedGridEntry.IsValueEditable)
             {
                 int index = GetCurrentValueIndex(_selectedGridEntry);
                 if (index != -1)
@@ -3354,7 +3340,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     CommitValue(values[index]);
                     SelectGridEntry(_selectedGridEntry, pageIn: true);
-                    Edit.Focus();
+                    EditTextBox.Focus();
                     return;
                 }
             }
@@ -3539,7 +3525,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             DrawLabel(g, i, rect, i == _selectedRow, false, clipRect);
                             if (i == _selectedRow)
                             {
-                                Edit.Invalidate();
+                                EditTextBox.Invalidate();
                             }
                         }
                         catch
@@ -3640,7 +3626,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             _lastClickedEntry = (GridEntry)sender;
             bool setSelectTime = sender != _selectedGridEntry;
             SelectGridEntry(_lastClickedEntry, pageIn: true);
-            Edit.Focus();
+            EditTextBox.Focus();
 
             if (_lastMouseDown != InvalidPosition)
             {
@@ -3648,9 +3634,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 _rowSelectTime = 0;
 
                 Point editPoint = PointToScreen(_lastMouseDown);
-                editPoint = Edit.PointToClient(editPoint);
-                User32.SendMessageW(Edit, User32.WM.LBUTTONDOWN, IntPtr.Zero, PARAM.FromLowHigh(editPoint.X, editPoint.Y));
-                User32.SendMessageW(Edit, User32.WM.LBUTTONUP, IntPtr.Zero, PARAM.FromLowHigh(editPoint.X, editPoint.Y));
+                editPoint = EditTextBox.PointToClient(editPoint);
+                User32.SendMessageW(EditTextBox, User32.WM.LBUTTONDOWN, IntPtr.Zero, PARAM.FromLowHigh(editPoint.X, editPoint.Y));
+                User32.SendMessageW(EditTextBox, User32.WM.LBUTTONUP, IntPtr.Zero, PARAM.FromLowHigh(editPoint.X, editPoint.Y));
             }
 
             if (setSelectTime)
@@ -3711,7 +3697,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             base.OnVisibleChanged(e);
         }
 
-        protected virtual void OnRecreateChildren(object s, GridEntryRecreateChildrenEventArgs e)
+        private void OnRecreateChildren(object s, GridEntryRecreateChildrenEventArgs e)
         {
             var parent = (GridEntry)s;
 
@@ -3872,7 +3858,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        public virtual void PopupDialog(int row)
+        public void PopupDialog(int row)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:PopupDialog");
             GridEntry gridEntry = GetGridEntryFromRow(row);
@@ -3958,7 +3944,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 try
                 {
                     SetFlag(FlagInPropertySet, true);
-                    Edit.DisableMouseHook = true;
+                    EditTextBox.DisableMouseHook = true;
 
                     try
                     {
@@ -3973,7 +3959,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 finally
                 {
                     SetFlag(FlagInPropertySet, false);
-                    Edit.DisableMouseHook = false;
+                    EditTextBox.DisableMouseHook = false;
                 }
 
                 Refresh();
@@ -4064,7 +4050,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         {
                             // One of our editors has focus.
 
-                            if (Edit.Focused)
+                            if (EditTextBox.Focused)
                             {
                                 if (forward)
                                 {
@@ -4087,9 +4073,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                             }
                             else if (DialogButton.Focused || DropDownButton.Focused)
                             {
-                                if (!forward && Edit.Visible)
+                                if (!forward && EditTextBox.Visible)
                                 {
-                                    Edit.Focus();
+                                    EditTextBox.Focus();
                                     return true;
                                 }
                             }
@@ -4120,7 +4106,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return base.ProcessDialogKey(keyData);
         }
 
-        protected virtual void RecalculateProperties()
+        private void RecalculateProperties()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:RecalculateProps");
             int props = CountPropsFromOutline(TopLevelGridEntries);
@@ -4309,7 +4295,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        public virtual void Reset()
+        public void Reset()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Reset");
             GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
@@ -4322,7 +4308,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             SelectRow(_selectedRow);
         }
 
-        protected virtual void ResetOrigin(Graphics g) => g.ResetTransform();
+        private void ResetOrigin(Graphics g) => g.ResetTransform();
 
         internal void RestoreHierarchyState(ArrayList expandedItems)
         {
@@ -4374,11 +4360,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return false;
             }
 
-            bool editVisible = Edit.Visible;
+            bool editVisible = EditTextBox.Visible;
             bool dropDownButtonVisible = DropDownButton.Visible;
             bool editButtonVisible = DialogButton.Visible;
 
-            Edit.Visible = false;
+            EditTextBox.Visible = false;
             DialogButton.Visible = false;
             DropDownButton.Visible = false;
 
@@ -4389,7 +4375,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 int currentRow = GetRowFromGridEntry(currentEntry);
                 if (currentRow >= 0 && currentRow < _visibleRows - 1)
                 {
-                    Edit.Visible = editVisible;
+                    EditTextBox.Visible = editVisible;
                     DialogButton.Visible = editButtonVisible;
                     DropDownButton.Visible = dropDownButtonVisible;
                     SelectGridEntry(currentEntry, pageIn: true);
@@ -4407,8 +4393,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             Invalidate();
             return true;
         }
-
-        private void SelectEdit() => Edit?.SelectAll();
 
         internal void SelectGridEntry(GridEntry entry, bool pageIn)
         {
@@ -4573,40 +4557,40 @@ namespace System.Windows.Forms.PropertyGridInternal
                 rect.Width -= EditIndent + 1;
             }
 
-            if ((GetFlag(FlagIsNewSelection) || !Edit.Focused) && s is not null && !s.Equals(Edit.Text))
+            if ((GetFlag(FlagIsNewSelection) || !EditTextBox.Focused) && s is not null && !s.Equals(EditTextBox.Text))
             {
-                Edit.Text = s;
+                EditTextBox.Text = s;
                 _originalTextValue = s;
-                Edit.SelectionStart = 0;
-                Edit.SelectionLength = 0;
+                EditTextBox.SelectionStart = 0;
+                EditTextBox.SelectionLength = 0;
             }
 
-            Edit.AccessibleName = gridEntry.Label;
+            EditTextBox.AccessibleName = gridEntry.Label;
 
             if (gridEntry.ShouldSerializePropertyValue())
             {
-                Edit.Font = GetBoldFont();
+                EditTextBox.Font = GetBoldFont();
             }
             else
             {
-                Edit.Font = Font;
+                EditTextBox.Font = Font;
             }
 
             if (GetFlag(FlagIsSplitterMove) || !gridEntry.HasValue || !FocusInside)
             {
-                Edit.Visible = false;
+                EditTextBox.Visible = false;
             }
             else
             {
                 rect.Offset(1, 1);
                 rect.Height -= 1;
                 rect.Width -= 1;
-                CommonEditorUse(Edit, rect);
+                CommonEditorUse(EditTextBox, rect);
                 bool drawReadOnly = gridEntry.ShouldRenderReadOnly;
-                Edit.ForeColor = drawReadOnly ? GrayTextColor : ForeColor;
-                Edit.BackColor = BackColor;
-                Edit.ReadOnly = drawReadOnly || !gridEntry.IsTextEditable;
-                Edit.UseSystemPasswordChar = gridEntry.ShouldRenderPassword;
+                EditTextBox.ForeColor = drawReadOnly ? GrayTextColor : ForeColor;
+                EditTextBox.BackColor = BackColor;
+                EditTextBox.ReadOnly = drawReadOnly || !gridEntry.IsTextEditable;
+                EditTextBox.UseSystemPasswordChar = gridEntry.ShouldRenderPassword;
             }
 
             GridEntry oldSelectedGridEntry = _selectedGridEntry;
@@ -4645,7 +4629,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        public virtual void SetConstants()
+        public void SetConstants()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:SetConstants");
             Size size = GetOurSize();
@@ -4729,7 +4713,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 CancelSplitterMove();
             }
 
-            Edit.HookMouseDown = capture;
+            EditTextBox.HookMouseDown = capture;
         }
 
         internal void SetExpand(GridEntry entry, bool value)
@@ -4743,7 +4727,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             int currentRow = _selectedRow;
 
             // If the currently selected row is below us, we need to commit now or the offsets will be wrong.
-            if (_selectedRow != -1 && row < _selectedRow && Edit.Visible)
+            if (_selectedRow != -1 && row < _selectedRow && EditTextBox.Visible)
             {
                 // This will cause the commit.
                 Focus();
@@ -4808,7 +4792,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        public virtual void SetScrollOffset(int offset)
+        public void SetScrollOffset(int offset)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"PropertyGridView:SetScrollOffset({offset})");
             int newPosition = Math.Max(0, Math.Min(TotalProperties - _visibleRows + 1, offset));
@@ -4821,9 +4805,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        internal virtual bool _Commit() => Commit();
-
-        private bool Commit()
+        internal bool Commit()
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:Commit()");
 
@@ -4857,14 +4839,14 @@ namespace System.Windows.Forms.PropertyGridInternal
             bool success = false;
             try
             {
-                success = CommitText(Edit.Text);
+                success = CommitText(EditTextBox.Text);
             }
             finally
             {
                 if (!success)
                 {
-                    Edit.Focus();
-                    SelectEdit();
+                    EditTextBox.Focus();
+                    EditTextBox.SelectAll();
                 }
                 else
                 {
@@ -4898,7 +4880,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"PropertyGridView:CommitValue({value?.ToString() ?? "null"})");
 
             int propCount = entry.ChildCount;
-            bool capture = Edit.HookMouseDown;
+            bool capture = EditTextBox.HookMouseDown;
             object originalValue = null;
 
             try
@@ -4929,13 +4911,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     try
                     {
-                        Edit.DisableMouseHook = true;
+                        EditTextBox.DisableMouseHook = true;
                         entry.PropertyValue = value;
                     }
                     finally
                     {
-                        Edit.DisableMouseHook = false;
-                        Edit.HookMouseDown = capture;
+                        EditTextBox.DisableMouseHook = false;
+                        EditTextBox.HookMouseDown = capture;
                     }
                 }
                 catch (Exception ex)
@@ -4953,11 +4935,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             SetCommitError(ErrorState.None);
 
             string text = entry.GetPropertyTextValue();
-            if (!string.Equals(text, Edit.Text))
+            if (!string.Equals(text, EditTextBox.Text))
             {
-                Edit.Text = text;
-                Edit.SelectionStart = 0;
-                Edit.SelectionLength = 0;
+                EditTextBox.Text = text;
+                EditTextBox.SelectionStart = 0;
+                EditTextBox.SelectionLength = 0;
             }
 
             _originalTextValue = text;
@@ -4974,15 +4956,15 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (entry.Disposed)
             {
-                bool editfocused = _edit is not null && _edit.Focused;
+                bool editfocused = _editTextBox is not null && _editTextBox.Focused;
 
                 // Reselect the row to find the replacement.
                 SelectGridEntry(entry, pageIn: true);
                 entry = _selectedGridEntry;
 
-                if (editfocused && _edit is not null)
+                if (editfocused && _editTextBox is not null)
                 {
-                    _edit.Focus();
+                    _editTextBox.Focus();
                 }
             }
 
@@ -5044,10 +5026,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     DropDownButton.Focus();
                 }
-                else if (Edit.Visible)
+                else if (EditTextBox.Visible)
                 {
-                    Edit.SelectAll();
-                    Edit.Focus();
+                    EditTextBox.SelectAll();
+                    EditTextBox.Focus();
                 }
             }
         }
@@ -5157,8 +5139,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"PropertyGridView:ShowFormatExceptionMessage(prop={propertyName})");
 
             // We have to uninstall our hook so the user can push the button!
-            bool hooked = Edit.HookMouseDown;
-            Edit.DisableMouseHook = true;
+            bool hooked = EditTextBox.HookMouseDown;
+            EditTextBox.DisableMouseHook = true;
             SetCommitError(ErrorState.MessageBoxUp, false);
 
             // Before invoking the error dialog, flush all mouse messages in the message queue.
@@ -5210,7 +5192,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 revert = DialogResult.Cancel == ShowDialog(ErrorDialog);
             }
 
-            Edit.DisableMouseHook = false;
+            EditTextBox.DisableMouseHook = false;
 
             if (hooked)
             {
@@ -5221,7 +5203,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (revert)
             {
-                OnEscape(Edit);
+                OnEscape(EditTextBox);
             }
         }
 
@@ -5232,8 +5214,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, $"PropertyGridView:ShowInvalidMessage(prop={propertyName})");
 
             // We have to uninstall our hook so the user can push the button.
-            bool hooked = Edit.HookMouseDown;
-            Edit.DisableMouseHook = true;
+            bool hooked = EditTextBox.HookMouseDown;
+            EditTextBox.DisableMouseHook = true;
             SetCommitError(ErrorState.MessageBoxUp, capture: false);
 
             // Before invoking the error dialog, flush all mouse messages in the message queue.
@@ -5282,7 +5264,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 revert = DialogResult.Cancel == ShowDialog(ErrorDialog);
             }
 
-            Edit.DisableMouseHook = false;
+            EditTextBox.DisableMouseHook = false;
 
             if (hooked)
             {
@@ -5293,7 +5275,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (revert)
             {
-                OnEscape(Edit);
+                OnEscape(EditTextBox);
             }
         }
 
@@ -5307,10 +5289,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return;
             }
 
-            if (Edit.Visible)
+            if (EditTextBox.Visible)
             {
-                Edit.Focus();
-                SelectEdit();
+                EditTextBox.Focus();
+                EditTextBox.SelectAll();
             }
             else if (_dropDownHolder is not null && _dropDownHolder.Visible)
             {
@@ -5462,12 +5444,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (Focused)
                 {
                     // We want a tab if the grid has focus and we have a button or an Edit.
-                    if (DropDownButton.Visible || DialogButton.Visible || Edit.Visible)
+                    if (DropDownButton.Visible || DialogButton.Visible || EditTextBox.Visible)
                     {
                         return true;
                     }
                 }
-                else if (Edit.Focused && (DropDownButton.Visible || DialogButton.Visible))
+                else if (EditTextBox.Focused && (DropDownButton.Visible || DialogButton.Visible))
                 {
                     // If the Edit has focus, and we have a button, we want the tab as well.
                     return true;
@@ -5477,7 +5459,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else
             {
-                if (Edit.Focused || DropDownButton.Focused || DialogButton.Focused)
+                if (EditTextBox.Focused || DropDownButton.Focused || DialogButton.Focused)
                 {
                     return true;
                 }
@@ -5561,24 +5543,24 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // If we get focus in the error state, make sure we push it back to the
                 // Edit or bad bad things can happen with our state.
                 case (int)User32.WM.SETFOCUS:
-                    if (!GetInPropertySet() && Edit.Visible && (_errorState != ErrorState.None || !Commit()))
+                    if (!GetInPropertySet() && EditTextBox.Visible && (_errorState != ErrorState.None || !Commit()))
                     {
                         base.WndProc(ref m);
-                        Edit.Focus();
+                        EditTextBox.Focus();
                         return;
                     }
 
                     break;
 
                 case (int)User32.WM.IME_STARTCOMPOSITION:
-                    Edit.Focus();
-                    Edit.Clear();
-                    User32.PostMessageW(Edit, User32.WM.IME_STARTCOMPOSITION);
+                    EditTextBox.Focus();
+                    EditTextBox.Clear();
+                    User32.PostMessageW(EditTextBox, User32.WM.IME_STARTCOMPOSITION);
                     return;
 
                 case (int)User32.WM.IME_COMPOSITION:
-                    Edit.Focus();
-                    User32.PostMessageW(Edit, User32.WM.IME_COMPOSITION, m.WParam, m.LParam);
+                    EditTextBox.Focus();
+                    User32.PostMessageW(EditTextBox, User32.WM.IME_COMPOSITION, m.WParam, m.LParam);
                     return;
 
                 case (int)User32.WM.GETDLGCODE:
@@ -5591,7 +5573,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         {
                             // If we're going backwards, we don't want the tab.
                             // Otherwise we only want it if we have an edit.
-                            if (_edit.Visible)
+                            if (_editTextBox.Visible)
                             {
                                 flags |= (int)User32.DLGC.WANTTAB;
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1878,8 +1878,8 @@ namespace System.Windows.Forms
         /// </summary>
         public void SelectAll()
         {
-            int textLen = TextLength;
-            SelectInternal(0, textLen, textLen);
+            int textLength = TextLength;
+            SelectInternal(0, textLength, textLength);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
@@ -14,15 +14,18 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         public void PropertyDescriptorGridEntryAccessibleObject_Navigates_to_DropDownControlHolder()
         {
             using PropertyGrid propertyGrid = new();
-            using TestPropertyGridView testPropertyGridView = new(null, propertyGrid);
+            using PropertyGridView propertyGridView = new(serviceProvider: null, propertyGrid);
+
+            TestPropertyGridViewAccessibleObject accessibleObject = new(propertyGridView, parentPropertyGrid: null);
+            propertyGridView.Properties.SetObject(propertyGrid.TestAccessor().Dynamic.s_accessibilityProperty, accessibleObject);
 
             TestPropertyDescriptorGridEntry gridEntry = new(propertyGrid, null, false);
-            testPropertyGridView.TestAccessor().Dynamic._selectedGridEntry = gridEntry;
+            propertyGridView.TestAccessor().Dynamic._selectedGridEntry = gridEntry;
 
-            TestDropDownHolder dropDownHolder = new(testPropertyGridView);
+            TestDropDownHolder dropDownHolder = new(propertyGridView);
             dropDownHolder.SetState(0x00000002, true); // Control class States.Visible flag
-            testPropertyGridView.TestAccessor().Dynamic._dropDownHolder = dropDownHolder;
-            gridEntry.TestAccessor().Dynamic._parent = new TestGridEntry(propertyGrid, null, testPropertyGridView);
+            propertyGridView.TestAccessor().Dynamic._dropDownHolder = dropDownHolder;
+            gridEntry.TestAccessor().Dynamic._parent = new TestGridEntry(propertyGrid, null, propertyGridView);
 
             UiaCore.IRawElementProviderFragment firstChild = gridEntry.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
             Assert.NotNull(firstChild);
@@ -115,28 +118,6 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             }
 
             internal override bool Enumerable => false;
-        }
-
-        private class TestPropertyGridView : PropertyGridView
-        {
-            private Control _parent;
-
-            public TestPropertyGridView(IServiceProvider serviceProvider, PropertyGrid propertyGrid)
-                : base(serviceProvider, propertyGrid)
-            {
-                _parent = propertyGrid;
-            }
-
-            protected override AccessibleObject CreateAccessibilityInstance()
-            {
-                return new TestPropertyGridViewAccessibleObject(this, null);
-            }
-
-            internal override Control ParentInternal
-            {
-                get => _parent;
-                set => _parent = value;
-            }
         }
 
         private class TestPropertyGridViewAccessibleObject : PropertyGridView.PropertyGridViewAccessibleObject

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObjectTests.cs
@@ -36,7 +36,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             UiaCore.IRawElementProviderFragment editFieldAccessibleObject = selectedGridEntryAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
             Assert.NotNull(editFieldAccessibleObject);
 
-            Assert.Equal("GridViewEditAccessibleObject", editFieldAccessibleObject.GetType().Name);
+            Assert.Equal("GridViewTextBoxAccessibleObject", editFieldAccessibleObject.GetType().Name);
         }
 
         [WinFormsFact]
@@ -55,7 +55,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             propertyGridView.TestAccessor().Dynamic._selectedGridEntry = gridEntry;
 
             UiaCore.IRawElementProviderFragment editFieldAccessibleObject = gridEntry.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
-            Assert.Equal("GridViewEditAccessibleObject", editFieldAccessibleObject.GetType().Name);
+            Assert.Equal("GridViewTextBoxAccessibleObject", editFieldAccessibleObject.GetType().Name);
 
             // The case with drop down holder:
             using TestDropDownHolder dropDownHolder = new TestDropDownHolder(propertyGridView);
@@ -93,10 +93,10 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
             PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
-            Type gridViewEditType = typeof(PropertyGridView).GetNestedType("GridViewEdit", BindingFlags.NonPublic);
+            Type gridViewEditType = typeof(PropertyGridView).GetNestedType("GridViewTextBox", BindingFlags.NonPublic);
             Assert.NotNull(gridViewEditType);
             TextBox gridViewEdit = (TextBox)Activator.CreateInstance(gridViewEditType, gridView);
-            Type accessibleObjectType = gridViewEditType.GetNestedType("GridViewEditAccessibleObject", BindingFlags.NonPublic);
+            Type accessibleObjectType = gridViewEditType.GetNestedType("GridViewTextBoxAccessibleObject", BindingFlags.NonPublic);
             Assert.NotNull(accessibleObjectType);
             ControlAccessibleObject accessibleObject = (ControlAccessibleObject)Activator.CreateInstance(accessibleObjectType, gridViewEdit);
             Assert.Equal(gridViewEdit, accessibleObject.Owner);
@@ -107,10 +107,10 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
             PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
-            Type gridViewEditType = typeof(PropertyGridView).GetNestedType("GridViewEdit", BindingFlags.NonPublic);
+            Type gridViewEditType = typeof(PropertyGridView).GetNestedType("GridViewTextBox", BindingFlags.NonPublic);
             Assert.NotNull(gridViewEditType);
             TextBox gridViewEdit = (TextBox)Activator.CreateInstance(gridViewEditType, gridView);
-            Type accessibleObjectType = gridViewEditType.GetNestedType("GridViewEditAccessibleObject", BindingFlags.NonPublic);
+            Type accessibleObjectType = gridViewEditType.GetNestedType("GridViewTextBoxAccessibleObject", BindingFlags.NonPublic);
             Assert.NotNull(accessibleObjectType);
             Assert.Throws<TargetInvocationException>(() => Activator.CreateInstance(accessibleObjectType, (TextBox)null));
         }
@@ -145,6 +145,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             using PropertyGrid propertyGrid = new PropertyGrid();
             PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
             AccessibleObject accessibleObject = gridView.EditAccessibleObject;
+
             // AccessibleRole is not set = Default
 
             object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
@@ -160,11 +161,12 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
             PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
+
             // AccessibleRole is not set = Default
 
             if (createControl)
             {
-                gridView.TestAccessor().Dynamic.Edit.CreateControl(true); // "true" means ignoring Visible value
+                gridView.TestAccessor().Dynamic.EditTextBox.CreateControl(true); // "true" means ignoring Visible value
             }
 
             AccessibleRole actual = gridView.EditAccessibleObject.Role;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObjectTests.cs
@@ -10,10 +10,10 @@ using static Interop;
 
 namespace System.Windows.Forms.PropertyGridInternal.Tests
 {
-    public class PropertyGridView_GridViewEdit_GridViewEditAccessibleObjectTests
+    public class PropertyGridView_GridViewTextBox_GridViewTextBoxAccessibleObjectTests
     {
         [WinFormsFact]
-        public void GridViewEditAccessibleObject_created_for_string_property()
+        public void GridViewTextBoxAccessibleObject_created_for_string_property()
         {
             TestEntityWithTextField testEntity = new TestEntityWithTextField
             {
@@ -40,7 +40,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         }
 
         [WinFormsFact]
-        public void GridViewEditAccessibleObject_FragmentNavigate_navigates_correctly()
+        public void GridViewTextBoxAccessibleObject_FragmentNavigate_navigates_correctly()
         {
             using PropertyGrid propertyGrid = new PropertyGrid
             {
@@ -89,28 +89,28 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         }
 
         [WinFormsFact]
-        public void GridViewEditAccessibleObject_ctor_default()
+        public void GridViewTextBoxAccessibleObject_ctor_default()
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
             PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
-            Type gridViewEditType = typeof(PropertyGridView).GetNestedType("GridViewTextBox", BindingFlags.NonPublic);
-            Assert.NotNull(gridViewEditType);
-            TextBox gridViewEdit = (TextBox)Activator.CreateInstance(gridViewEditType, gridView);
-            Type accessibleObjectType = gridViewEditType.GetNestedType("GridViewTextBoxAccessibleObject", BindingFlags.NonPublic);
+            Type gridViewTextBoxType = typeof(PropertyGridView).GetNestedType("GridViewTextBox", BindingFlags.NonPublic);
+            Assert.NotNull(gridViewTextBoxType);
+            TextBox gridViewTextBox = (TextBox)Activator.CreateInstance(gridViewTextBoxType, gridView);
+            Type accessibleObjectType = gridViewTextBoxType.GetNestedType("GridViewTextBoxAccessibleObject", BindingFlags.NonPublic);
             Assert.NotNull(accessibleObjectType);
-            ControlAccessibleObject accessibleObject = (ControlAccessibleObject)Activator.CreateInstance(accessibleObjectType, gridViewEdit);
-            Assert.Equal(gridViewEdit, accessibleObject.Owner);
+            ControlAccessibleObject accessibleObject = (ControlAccessibleObject)Activator.CreateInstance(accessibleObjectType, gridViewTextBox);
+            Assert.Equal(gridViewTextBox, accessibleObject.Owner);
         }
 
         [WinFormsFact]
-        public void GridViewEditAccessibleObject_ctor_ThrowsException_IfOwnerIsNull()
+        public void GridViewTextBoxAccessibleObject_ctor_ThrowsException_IfOwnerIsNull()
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
             PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
-            Type gridViewEditType = typeof(PropertyGridView).GetNestedType("GridViewTextBox", BindingFlags.NonPublic);
-            Assert.NotNull(gridViewEditType);
-            TextBox gridViewEdit = (TextBox)Activator.CreateInstance(gridViewEditType, gridView);
-            Type accessibleObjectType = gridViewEditType.GetNestedType("GridViewTextBoxAccessibleObject", BindingFlags.NonPublic);
+            Type gridViewTextBoxType = typeof(PropertyGridView).GetNestedType("GridViewTextBox", BindingFlags.NonPublic);
+            Assert.NotNull(gridViewTextBoxType);
+            TextBox gridViewTextBox = (TextBox)Activator.CreateInstance(gridViewTextBoxType, gridView);
+            Type accessibleObjectType = gridViewTextBoxType.GetNestedType("GridViewTextBoxAccessibleObject", BindingFlags.NonPublic);
             Assert.NotNull(accessibleObjectType);
             Assert.Throws<TargetInvocationException>(() => Activator.CreateInstance(accessibleObjectType, (TextBox)null));
         }
@@ -119,7 +119,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         [InlineData((int)UiaCore.UIA.IsTextPatternAvailablePropertyId)]
         [InlineData((int)UiaCore.UIA.IsTextPattern2AvailablePropertyId)]
         [InlineData((int)UiaCore.UIA.IsValuePatternAvailablePropertyId)]
-        public void GridViewEditAccessibleObject_GetPropertyValue_PatternsSuported(int propertyID)
+        public void GridViewTextBoxAccessibleObject_GetPropertyValue_PatternsSuported(int propertyID)
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
             PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
@@ -131,7 +131,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         [InlineData((int)UiaCore.UIA.ValuePatternId)]
         [InlineData((int)UiaCore.UIA.TextPatternId)]
         [InlineData((int)UiaCore.UIA.TextPattern2Id)]
-        public void GridViewEditAccessibleObject_IsPatternSupported_PatternsSuported(int patternId)
+        public void GridViewTextBoxAccessibleObject_IsPatternSupported_PatternsSuported(int patternId)
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
             PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
@@ -140,7 +140,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         }
 
         [WinFormsFact]
-        public void GridViewEditAccessibleObject_ControlType_IsEdit_IfAccessibleRoleIsDefault()
+        public void GridViewTextBoxAccessibleObject_ControlType_IsEdit_IfAccessibleRoleIsDefault()
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
             PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
@@ -157,7 +157,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         [WinFormsTheory]
         [InlineData(true, AccessibleRole.Text)]
         [InlineData(false, AccessibleRole.None)]
-        public void GridViewEditAccessibleObject_Role_IsExpected_ByDefault(bool createControl, AccessibleRole expectedRole)
+        public void GridViewTextBoxAccessibleObject_Role_IsExpected_ByDefault(bool createControl, AccessibleRole expectedRole)
         {
             using PropertyGrid propertyGrid = new PropertyGrid();
             PropertyGridView gridView = propertyGrid.TestAccessor().GridView;


### PR DESCRIPTION
PropertyGridView had been gaining virtuals for testing and this wasn't necessary. Sealing the class for perf and maintainability.

Rename GridViewEdit to GridViewTextBox to match typical naming. Also change "Edit" to "EditTextBox" to follow.

Other related code cleanup, including better documentation for Control message preprocessing.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5484)