### PR TITLE
Add NonNullCollection to Primitives

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/NonNullCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/NonNullCollection.cs
@@ -1,0 +1,138 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Windows.Forms
+{
+    /// <summary>
+    ///  Collection that protects against inserting null objects.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal abstract class NonNullCollection<T>
+        : IList<T>, ICollection<T>, IEnumerable<T>, IEnumerable, IList, ICollection, IReadOnlyList<T>, IReadOnlyCollection<T>
+        where T : class
+    {
+        private readonly List<T> _list;
+
+        public NonNullCollection() => _list = new();
+
+        public NonNullCollection(IEnumerable<T> items)
+        {
+            _list = new();
+            AddRange(items);
+        }
+
+        public T this[int index]
+        {
+            get => _list[index];
+            set
+            {
+                _list[index] = value ?? ThrowArgumentNull(nameof(value));
+                ItemAdded(value);
+            }
+        }
+
+        public int Count => _list.Count;
+
+        public bool IsReadOnly => ((ICollection<T>)_list).IsReadOnly;
+
+        public void Add(T item)
+        {
+            _list.Add(item ?? ThrowArgumentNull(nameof(item)));
+            ItemAdded(item);
+        }
+
+        public void Clear() => _list.Clear();
+
+        public bool Contains(T item) => _list.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
+
+        public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
+
+        public int IndexOf(T item) => _list.IndexOf(item);
+
+        public void Insert(int index, T item)
+        {
+            _list.Insert(index, item ?? ThrowArgumentNull(nameof(item)));
+            ItemAdded(item);
+        }
+
+        public bool Remove(T item) => _list.Remove(item);
+
+        public void RemoveAt(int index) => _list.RemoveAt(index);
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_list).GetEnumerator();
+
+        /// <summary>
+        ///  Adds the items in <paramref name="items"/> to the collection.
+        /// </summary>
+        public void AddRange(IEnumerable<T> items)
+        {
+            if (items is null || items.Contains(default))
+            {
+                ThrowArgumentNull(nameof(items));
+            }
+
+            _list.AddRange(items);
+
+            foreach (T item in items)
+            {
+                ItemAdded(item);
+            }
+        }
+
+        int IList.Add(object? value)
+        {
+            int index = ((IList)_list).Add(value ?? ThrowArgumentNull(nameof(value)));
+            ItemAdded((T)value);
+            return index;
+        }
+
+        bool IList.Contains(object? value) => ((IList)_list).Contains(value);
+
+        int IList.IndexOf(object? value) => ((IList)_list).IndexOf(value);
+
+        void IList.Insert(int index, object? value)
+        {
+            ((IList)_list).Insert(index, value ?? ThrowArgumentNull(nameof(value)));
+            ItemAdded((T)value);
+        }
+
+        void IList.Remove(object? value) => ((IList)_list).Remove(value);
+
+        object? IList.this[int index]
+        {
+            get => ((IList)_list)[index];
+            set
+            {
+                ((IList)_list)[index] = value ?? ThrowArgumentNull(nameof(value));
+                ItemAdded((T)value);
+            }
+        }
+
+        void ICollection.CopyTo(Array array, int index) => ((IList)_list).CopyTo(array, index);
+
+        private string DebuggerDisplay => $"Count: {Count}";
+
+        bool IList.IsFixedSize => ((IList)_list).IsFixedSize;
+
+        object ICollection.SyncRoot => ((ICollection)_list).SyncRoot;
+
+        bool ICollection.IsSynchronized => ((ICollection)_list).IsSynchronized;
+
+        /// <summary>
+        ///  Called for each item added to the collection.
+        /// </summary>
+        protected virtual void ItemAdded(T item)
+        {
+        }
+
+        [DoesNotReturn]
+        private static T ThrowArgumentNull(string name) => throw new ArgumentNullException(name);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/NonNullCollectionTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/NonNullCollectionTests.cs
@@ -1,0 +1,175 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class NonNullCollectionTests
+    {
+        [Fact]
+        public void NonNullCollection_Constructor_ThrowsWithNull()
+        {
+            Assert.Throws<ArgumentNullException>("items", () => new TestCollection(null!));
+        }
+
+        [Fact]
+        public void NonNullCollection_Constructor_ThrowsWithNullInCollection()
+        {
+            Assert.Throws<ArgumentNullException>("items", () => new TestCollection(new object[] { null! }));
+        }
+
+        [Fact]
+        public void NonNullCollection_Add_ThrowsWithNull()
+        {
+            TestCollection collection = new();
+            Assert.Throws<ArgumentNullException>("item", () => collection.Add(null!));
+        }
+
+        [Fact]
+        public void NonNullCollection_Add_CallsItemAdded()
+        {
+            TestCollection collection = new();
+            object item = new();
+            collection.Add(item);
+            Assert.Same(item, collection.LastAdded);
+            Assert.Equal(1, collection.AddCount);
+        }
+
+        [Fact]
+        public void NonNullCollection_IListAdd_ThrowsWithNull()
+        {
+            TestCollection collection = new();
+            Assert.Throws<ArgumentNullException>("value", () => ((IList)collection).Add(null));
+        }
+
+        [Fact]
+        public void NonNullCollection_IListAdd_CallsItemAdded()
+        {
+            TestCollection collection = new();
+            object item = new();
+            ((IList)collection).Add(item);
+            Assert.Same(item, collection.LastAdded);
+            Assert.Equal(1, collection.AddCount);
+        }
+
+        [Fact]
+        public void NonNullCollection_Indexer_ThrowsWithNull()
+        {
+            TestCollection collection = new() { new() };
+            Assert.Throws<ArgumentNullException>("value", () => collection[0] = null!);
+        }
+
+        [Fact]
+        public void NonNullCollection_Indexer_CallsItemAdded()
+        {
+            TestCollection collection = new(new object[] { new() });
+            object item = new();
+            collection[0] = item;
+            Assert.Same(item, collection.LastAdded);
+            Assert.Equal(2, collection.AddCount);
+        }
+
+        [Fact]
+        public void NonNullCollection_IListIndexer_ThrowsWithNull()
+        {
+            TestCollection collection = new() { new() };
+            Assert.Throws<ArgumentNullException>("value", () => ((IList)collection)[0] = null);
+        }
+
+        [Fact]
+        public void NonNullCollection_IListIndexer_CallsItemAdded()
+        {
+            TestCollection collection = new(new object[] { new() });
+            object item = new();
+            ((IList)collection)[0] = item;
+            Assert.Same(item, collection.LastAdded);
+            Assert.Equal(2, collection.AddCount);
+        }
+
+        [Fact]
+        public void NonNullCollection_Insert_ThrowsWithNull()
+        {
+            TestCollection collection = new();
+            Assert.Throws<ArgumentNullException>("item", () => collection.Insert(0, null!));
+        }
+
+        [Fact]
+        public void NonNullCollection_Insert_CallsItemAdded()
+        {
+            TestCollection collection = new();
+            object item = new();
+            collection.Insert(0, item);
+            Assert.Same(item, collection.LastAdded);
+            Assert.Equal(1, collection.AddCount);
+        }
+
+        [Fact]
+        public void NonNullCollection_IListInsert_ThrowsWithNull()
+        {
+            TestCollection collection = new();
+            Assert.Throws<ArgumentNullException>("value", () => ((IList)collection).Insert(0, null));
+        }
+
+        [Fact]
+        public void NonNullCollection_IListInsert_CallsItemAdded()
+        {
+            TestCollection collection = new();
+            object item = new();
+            ((IList)collection).Insert(0, item);
+            Assert.Same(item, collection.LastAdded);
+            Assert.Equal(1, collection.AddCount);
+        }
+
+        [Fact]
+        public void NonNullCollection_AddRange_ThrowsWithNull()
+        {
+            TestCollection collection = new();
+            Assert.Throws<ArgumentNullException>("items", () => collection.AddRange(null!));
+        }
+
+        [Fact]
+        public void NonNullCollection_AddRange_ThrowsWithNullInCollection()
+        {
+            TestCollection collection = new();
+            Assert.Throws<ArgumentNullException>("items", () => collection.AddRange(new object[] { null! }));
+        }
+
+        [Fact]
+        public void NonNullCollection_AddRange_CallsItemAdded()
+        {
+            TestCollection collection = new();
+            object item = new();
+            collection.AddRange(new object[] { item });
+            Assert.Same(item, collection.LastAdded);
+            Assert.Equal(1, collection.AddCount);
+
+            collection.AddRange(new object[] { new(), new(), new() });
+            Assert.Equal(4, collection.AddCount);
+        }
+
+        private class TestCollection : NonNullCollection<object>
+        {
+            public object? LastAdded { get; set; }
+
+            public int AddCount { get; set; }
+
+            public TestCollection()
+            {
+            }
+
+            public TestCollection(IEnumerable<object> items) : base(items)
+            {
+            }
+
+            protected override void ItemAdded(object item)
+            {
+                LastAdded = item;
+                AddCount++;
+                base.ItemAdded(item);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GridItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GridItemCollection.cs
@@ -12,7 +12,7 @@ namespace System.Windows.Forms
     public class GridItemCollection : ICollection
     {
 #pragma warning disable IDE1006 // Naming Styles - this is public API
-        public static GridItemCollection Empty = new(null);
+        public static GridItemCollection Empty = new(entries: null);
 #pragma warning restore IDE1006
 
         private protected IReadOnlyList<GridItem> _entries;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GridItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GridItemCollection.cs
@@ -12,12 +12,12 @@ namespace System.Windows.Forms
     public class GridItemCollection : ICollection
     {
 #pragma warning disable IDE1006 // Naming Styles - this is public API
-        public static GridItemCollection Empty = new(Array.Empty<GridItem>());
+        public static GridItemCollection Empty = new(null);
 #pragma warning restore IDE1006
 
-        private protected GridItem[] _entries;
+        private protected IReadOnlyList<GridItem> _entries;
 
-        internal GridItemCollection(GridItem[]? entries)
+        internal GridItemCollection(IReadOnlyList<GridItem>? entries)
         {
             _entries = entries ?? Array.Empty<GridItem>();
         }
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Retrieves the number of member attributes.
         /// </summary>
-        public int Count => _entries.Length;
+        public int Count => _entries.Count;
 
         object ICollection.SyncRoot => this;
 
@@ -40,11 +40,11 @@ namespace System.Windows.Forms
         {
             get
             {
-                foreach (GridItem g in _entries)
+                foreach (GridItem item in _entries)
                 {
-                    if (g.Label == label)
+                    if (item.Label == label)
                     {
-                        return g;
+                        return item;
                     }
                 }
 
@@ -54,9 +54,12 @@ namespace System.Windows.Forms
 
         void ICollection.CopyTo(Array dest, int index)
         {
-            if (_entries.Length > 0)
+            if (_entries.Count > 0)
             {
-                Array.Copy(_entries, 0, dest, index, _entries.Length);
+                for (int i = 0; i < _entries.Count; i++)
+                {
+                    ((IList)dest)[index + i] = _entries[i];
+                }
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -2282,7 +2282,7 @@ namespace System.Windows.Forms
             return @object is ICustomTypeDescriptor descriptor ? descriptor.GetPropertyOwner(pd: null) : @object;
         }
 
-        internal GridEntryCollection GetPropEntries()
+        internal GridEntryCollection GetCurrentEntries()
         {
             if (_currentEntries is null)
             {
@@ -4264,7 +4264,7 @@ namespace System.Windows.Forms
 
                 if (_mainEntry is null)
                 {
-                    _currentEntries = new GridEntryCollection(null, Array.Empty<GridEntry>());
+                    _currentEntries = new GridEntryCollection(disposeItems: false);
                     _gridView.ClearGridEntries();
                     return;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 childGridEntries[i].ParentGridEntry = this;
             }
 
-            ChildCollection = new GridEntryCollection(this, childGridEntries);
+            ChildCollection = new GridEntryCollection(childGridEntries);
 
             lock (s_lock)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -168,7 +168,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected GridEntryCollection ChildCollection
         {
-            get => _children ??= new GridEntryCollection(this, entries: null);
+            get => _children ??= new GridEntryCollection();
             set
             {
                 Debug.Assert(value is null || !Disposed, "Why are we putting new children in after we are disposed?");
@@ -498,7 +498,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     CreateChildren();
                 }
 
-                return Children;
+                return new GridItemCollection(Children);
             }
         }
 
@@ -691,7 +691,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         for (int i = 0; i < _children.Count; i++)
                         {
-                            _children.GetEntry(i).ParentGridEntry = this;
+                            _children[i].ParentGridEntry = this;
                         }
                     }
                 }
@@ -821,7 +821,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 int totalCount = count;
                 for (int i = 0; i < count; i++)
                 {
-                    totalCount += ChildCollection.GetEntry(i).VisibleChildCount;
+                    totalCount += ChildCollection[i].VisibleChildCount;
                 }
 
                 return totalCount;
@@ -878,7 +878,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 for (int i = 0; i < ChildCollection.Count; i++)
                 {
-                    ChildCollection.GetEntry(i).ClearCachedValues();
+                    ChildCollection[i].ClearCachedValues();
                 }
             }
         }
@@ -956,7 +956,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 else
                 {
-                    _children = new GridEntryCollection(this, Array.Empty<GridEntry>());
+                    _children = new GridEntryCollection();
                 }
 
                 return false;
@@ -1005,7 +1005,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 else
                 {
-                    _children = new GridEntryCollection(this, Array.Empty<GridEntry>());
+                    _children = new GridEntryCollection();
                 }
 
                 if (InternalExpanded)
@@ -1022,7 +1022,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
                 else
                 {
-                    _children = new GridEntryCollection(this, childProperties);
+                    _children = new GridEntryCollection(childProperties);
                 }
             }
 
@@ -1160,7 +1160,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// <summary>
         ///  Returns the index of a child GridEntry.
         /// </summary>
-        internal virtual int GetChildIndex(GridEntry entry) => Children.GetEntry(entry);
+        internal int GetChildIndex(GridEntry entry) => Children.IndexOf(entry);
 
         /// <summary>
         ///  Gets the components that own the current value.  This is usually the value of the

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntryCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntryCollection.cs
@@ -2,42 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Diagnostics;
-
 namespace System.Windows.Forms.PropertyGridInternal
 {
-    internal sealed class GridEntryCollection : GridItemCollection
+    internal sealed class GridEntryCollection : NonNullCollection<GridEntry>, IDisposable
     {
-        private readonly GridEntry _owner;
+        private readonly bool _disposeItems;
 
-        public GridEntryCollection(GridEntry owner, GridEntry[] entries) : base(entries)
+        public GridEntryCollection(IEnumerable<GridEntry>? items = null, bool disposeItems = true)
+            : base(items ?? Enumerable.Empty<GridEntry>())
         {
-            _owner = owner;
+            _disposeItems = disposeItems;
         }
-
-        public void AddRange(GridEntry[] value)
-        {
-            if (value is null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            Debug.Assert(_entries is not null, "Entries is initialized in the base class constructor.");
-            var newArray = new GridEntry[_entries.Length + value.Length];
-            _entries.CopyTo(newArray, 0);
-            value.CopyTo(newArray, _entries.Length);
-            _entries = newArray;
-        }
-
-        public void Clear() => _entries = Array.Empty<GridEntry>();
-
-        public void CopyTo(Array dest, int index) => _entries.CopyTo(dest, index);
-
-        internal GridEntry GetEntry(int index) => (GridEntry)_entries[index];
-
-        internal int GetEntry(GridEntry child) => Array.IndexOf(_entries, child);
 
         public void Dispose()
         {
@@ -47,24 +22,15 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && _disposeItems)
             {
-                if (_owner is not null)
+                foreach (GridEntry entry in this)
                 {
-                    for (int i = 0; i < _entries.Length; i++)
-                    {
-                        if (_entries[i] is not null)
-                        {
-                            ((GridEntry)_entries[i]).Dispose();
-                            _entries[i] = null;
-                        }
-                    }
-
-                    _entries = Array.Empty<GridEntry>();
+                    entry.Dispose();
                 }
+
+                Clear();
             }
         }
-
-        ~GridEntryCollection() => Dispose(false);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
@@ -143,7 +143,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (_owningPropertyDescriptorGridEntry.ChildCount > 0)
                 {
-                    return _owningPropertyDescriptorGridEntry.Children.GetEntry(0).AccessibilityObject;
+                    return _owningPropertyDescriptorGridEntry.Children[0].AccessibilityObject;
                 }
 
                 PropertyGridView propertyGridView = GetPropertyGridView();
@@ -182,8 +182,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (_owningPropertyDescriptorGridEntry.ChildCount > 0)
                 {
-                    return _owningPropertyDescriptorGridEntry.Children
-                        .GetEntry(_owningPropertyDescriptorGridEntry.ChildCount - 1).AccessibilityObject;
+                    return _owningPropertyDescriptorGridEntry.Children[_owningPropertyDescriptorGridEntry.ChildCount - 1].AccessibilityObject;
                 }
 
                 PropertyGridView propertyGridView = GetPropertyGridView();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.PropertyGridViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.PropertyGridViewAccessibleObject.cs
@@ -366,7 +366,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 GridEntryCollection properties = ((PropertyGridView)Owner).AccessibilityGetGridEntries();
                 if (properties is not null && index >= 0 && index < properties.Count)
                 {
-                    return properties.GetEntry(index).AccessibilityObject;
+                    return properties[index].AccessibilityObject;
                 }
                 else
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -542,7 +542,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
 
-                GridEntry equivalentEntry = FindEquivalentGridEntry(new GridEntryCollection(null, new GridEntry[] { value }));
+                GridEntry equivalentEntry = FindEquivalentGridEntry(new GridEntryCollection(new[] { value }, disposeItems: false));
 
                 if (equivalentEntry is not null)
                 {
@@ -710,17 +710,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             for (int i = startIndex; i < (startIndex + count); i++)
             {
-                if (entries[i] is not null)
-                {
-                    GridEntry entry = entries.GetEntry(i);
-                    entry.AddOnValueClick(_valueClick);
-                    entry.AddOnLabelClick(_labelClick);
-                    entry.AddOnOutlineClick(_outlineClick);
-                    entry.AddOnOutlineDoubleClick(_outlineClick);
-                    entry.AddOnValueDoubleClick(_valueDoubleClick);
-                    entry.AddOnLabelDoubleClick(_labelDoubleClick);
-                    entry.AddOnRecreateChildren(_recreateChildren);
-                }
+                GridEntry entry = entries[i];
+                entry.AddOnValueClick(_valueClick);
+                entry.AddOnLabelClick(_labelClick);
+                entry.AddOnOutlineClick(_outlineClick);
+                entry.AddOnOutlineDoubleClick(_outlineClick);
+                entry.AddOnValueDoubleClick(_valueDoubleClick);
+                entry.AddOnLabelDoubleClick(_labelDoubleClick);
+                entry.AddOnRecreateChildren(_recreateChildren);
             }
         }
 
@@ -767,17 +764,14 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             for (int i = startIndex; i < (startIndex + count); i++)
             {
-                if (entries[i] is not null)
-                {
-                    GridEntry entry = entries.GetEntry(i);
-                    entry.RemoveOnValueClick(_valueClick);
-                    entry.RemoveOnLabelClick(_labelClick);
-                    entry.RemoveOnOutlineClick(_outlineClick);
-                    entry.RemoveOnOutlineDoubleClick(_outlineClick);
-                    entry.RemoveOnValueDoubleClick(_valueDoubleClick);
-                    entry.RemoveOnLabelDoubleClick(_labelDoubleClick);
-                    entry.RemoveOnRecreateChildren(_recreateChildren);
-                }
+                GridEntry entry = entries[i];
+                entry.RemoveOnValueClick(_valueClick);
+                entry.RemoveOnLabelClick(_labelClick);
+                entry.RemoveOnOutlineClick(_outlineClick);
+                entry.RemoveOnOutlineDoubleClick(_outlineClick);
+                entry.RemoveOnValueDoubleClick(_valueDoubleClick);
+                entry.RemoveOnLabelDoubleClick(_labelDoubleClick);
+                entry.RemoveOnRecreateChildren(_recreateChildren);
             }
         }
 
@@ -1440,11 +1434,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             for (int i = 0; i < _allGridEntries.Count; i++)
             {
-                if (0 == string.Compare(propName, _allGridEntries.GetEntry(i).PropertyLabel, true, CultureInfo.InvariantCulture))
+                if (0 == string.Compare(propName, _allGridEntries[i].PropertyLabel, true, CultureInfo.InvariantCulture))
                 {
                     if (getXY)
                     {
-                        int row = GetRowFromGridEntry(_allGridEntries.GetEntry(i));
+                        int row = GetRowFromGridEntry(_allGridEntries[i]);
 
                         if (row < 0 || row >= _visibleRows)
                         {
@@ -1680,27 +1674,27 @@ namespace System.Windows.Forms.PropertyGridInternal
             EditTextBox.FilterKeyPress(keyChar);
         }
 
-        private GridEntry FindEquivalentGridEntry(GridEntryCollection ipeHier)
+        private GridEntry FindEquivalentGridEntry(GridEntryCollection gridEntries)
         {
-            if (ipeHier is null || ipeHier.Count == 0)
+            if (gridEntries is null || gridEntries.Count == 0)
             {
                 return null;
             }
 
-            GridEntryCollection rgipes = GetAllGridEntries();
+            GridEntryCollection allGridEntries = GetAllGridEntries();
 
-            if (rgipes is null || rgipes.Count == 0)
+            if (allGridEntries is null || allGridEntries.Count == 0)
             {
                 return null;
             }
 
             GridEntry targetEntry = null;
             int row = 0;
-            int count = rgipes.Count;
+            int count = allGridEntries.Count;
 
-            for (int i = 0; i < ipeHier.Count; i++)
+            for (int i = 0; i < gridEntries.Count; i++)
             {
-                if (ipeHier[i] is null)
+                if (gridEntries[i] is null)
                 {
                     continue;
                 }
@@ -1712,7 +1706,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     if (!targetEntry.InternalExpanded)
                     {
                         SetExpand(targetEntry, true);
-                        rgipes = GetAllGridEntries();
+                        allGridEntries = GetAllGridEntries();
                     }
 
                     count = targetEntry.VisibleChildCount;
@@ -1722,11 +1716,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                 targetEntry = null;
 
                 // Now, we will only go as many as were expanded.
-                for (; row < rgipes.Count && ((row - start) <= count); row++)
+                for (; row < allGridEntries.Count && ((row - start) <= count); row++)
                 {
-                    if (ipeHier.GetEntry(i).NonParentEquals(rgipes[row]))
+                    if (gridEntries[i].NonParentEquals(allGridEntries[row]))
                     {
-                        targetEntry = rgipes.GetEntry(row);
+                        targetEntry = allGridEntries[row];
                         row++;
                         break;
                     }
@@ -1792,17 +1786,17 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return _allGridEntries;
             }
 
-            var rgipes = new GridEntry[TotalProperties];
+            var newEntries = new GridEntry[TotalProperties];
             try
             {
-                GetGridEntriesFromOutline(TopLevelGridEntries, 0, 0, rgipes);
+                GetGridEntriesFromOutline(TopLevelGridEntries, 0, 0, newEntries);
             }
             catch (Exception ex)
             {
                 Debug.Fail(ex.ToString());
             }
 
-            _allGridEntries = new GridEntryCollection(null, rgipes);
+            _allGridEntries = new GridEntryCollection(newEntries, disposeItems: false);
             AddGridEntryEvents(_allGridEntries, 0, -1);
             return _allGridEntries;
         }
@@ -1924,22 +1918,22 @@ namespace System.Windows.Forms.PropertyGridInternal
                     depth = gridEntry.PropertyDepth;
                 }
 
-                return new GridEntryCollection(null, entries);
+                return new GridEntryCollection(entries, disposeItems: false);
             }
 
-            return new GridEntryCollection(null, new GridEntry[] { gridEntry });
+            return new GridEntryCollection(new GridEntry[] { gridEntry }, disposeItems: false);
         }
 
         private GridEntry GetGridEntryFromRow(int row) => GetGridEntryFromOffset(row + GetScrollOffset());
 
         private GridEntry GetGridEntryFromOffset(int offset)
         {
-            GridEntryCollection rgipesAll = GetAllGridEntries();
-            if (rgipesAll is not null)
+            GridEntryCollection allGridEntries = GetAllGridEntries();
+            if (allGridEntries is not null)
             {
-                if (offset >= 0 && offset < rgipesAll.Count)
+                if (offset >= 0 && offset < allGridEntries.Count)
                 {
-                    return rgipesAll.GetEntry(offset);
+                    return allGridEntries[offset];
                 }
             }
 
@@ -1964,7 +1958,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     break;
                 }
 
-                GridEntry currentEntry = entries.GetEntry(i);
+                GridEntry currentEntry = entries[i];
                 if (current >= target)
                 {
                     targetEntries[current - target] = currentEntry;
@@ -2042,23 +2036,23 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal int GetRowFromGridEntry(GridEntry gridEntry)
         {
-            GridEntryCollection rgipesAll = GetAllGridEntries();
-            if (gridEntry is null || rgipesAll is null)
+            GridEntryCollection allGridEntries = GetAllGridEntries();
+            if (gridEntry is null || allGridEntries is null)
             {
                 return -1;
             }
 
             int bestMatch = -1;
 
-            for (int i = 0; i < rgipesAll.Count; i++)
+            for (int i = 0; i < allGridEntries.Count; i++)
             {
                 // Try for an exact match. Semantics of equals are a bit loose here.
 
-                if (gridEntry == rgipesAll[i])
+                if (gridEntry == allGridEntries[i])
                 {
                     return i - GetScrollOffset();
                 }
-                else if (bestMatch == -1 && gridEntry.Equals(rgipesAll[i]))
+                else if (bestMatch == -1 && gridEntry.Equals(allGridEntries[i]))
                 {
                     bestMatch = i - GetScrollOffset();
                 }
@@ -2944,7 +2938,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         {
                             if (entry.InternalExpanded)
                             {
-                                SelectGridEntry(entry.Children.GetEntry(0), pageIn: true);
+                                SelectGridEntry(entry.Children[0], pageIn: true);
                             }
                             else
                             {
@@ -2972,7 +2966,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     case Keys.Home:
                     case Keys.End:
                         GridEntryCollection allEntries = GetAllGridEntries();
-                        SelectGridEntry(allEntries.GetEntry(keyCode == Keys.Home ? 0 : allEntries.Count - 1), pageIn: true);
+                        SelectGridEntry(allEntries[keyCode == Keys.Home ? 0 : allEntries.Count - 1], pageIn: true);
                         return;
                     case Keys.Add:
                     case Keys.Oemplus:
@@ -3751,7 +3745,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // Replace the changed items.
                 for (int i = 0; i < childCount; i++)
                 {
-                    entries[parentIndex + i + 1] = children.GetEntry(i);
+                    entries[parentIndex + i + 1] = children[i];
                 }
 
                 // Reset the array, rehook the handlers.
@@ -4132,7 +4126,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 for (int i = 0; i < children.Count; i++)
                 {
-                    RecursivelyExpand(children.GetEntry(i), false, expand, maxExpands);
+                    RecursivelyExpand(children[i], initialize: false, expand, maxExpands);
                 }
             }
 
@@ -4201,7 +4195,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 int oldLength = TotalProperties;
                 object oldObject = TopLevelGridEntries is null
-                    || TopLevelGridEntries.Count == 0 ? null : ((GridEntry)TopLevelGridEntries[0]).GetValueOwner();
+                    || TopLevelGridEntries.Count == 0 ? null : TopLevelGridEntries[0].GetValueOwner();
 
                 // Walk up to the main IPE and refresh it.
                 if (fullRefresh)
@@ -4218,7 +4212,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 UpdateHelpAttributes(_selectedGridEntry, null);
                 _selectedGridEntry = null;
                 SetFlag(FlagIsNewSelection, true);
-                TopLevelGridEntries = OwnerGrid.GetPropEntries();
+                TopLevelGridEntries = OwnerGrid.GetCurrentEntries();
 
                 ClearGridEntryEvents(_allGridEntries, 0, -1);
                 _allGridEntries = null;
@@ -4323,9 +4317,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        internal ArrayList SaveHierarchyState(GridEntryCollection entries) => SaveHierarchyState(entries, null);
-
-        private ArrayList SaveHierarchyState(GridEntryCollection entries, ArrayList expandedItems)
+        internal ArrayList SaveHierarchyState(GridEntryCollection entries, ArrayList expandedItems = null)
         {
             if (entries is null)
             {
@@ -4339,10 +4331,10 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             for (int i = 0; i < entries.Count; i++)
             {
-                if (((GridEntry)entries[i]).InternalExpanded)
+                if (entries[i].InternalExpanded)
                 {
-                    GridEntry entry = entries.GetEntry(i);
-                    expandedItems.Add(GetGridEntryHierarchy(entry.Children.GetEntry(0)));
+                    GridEntry entry = entries[i];
+                    expandedItems.Add(GetGridEntryHierarchy(entry.Children[0]));
                     SaveHierarchyState(entry.Children, expandedItems);
                 }
             }

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiPropertyGridViewTests/PropertyGridViewRowsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiPropertyGridViewTests/PropertyGridViewRowsAccessibleObjectTests.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             int heightSum = 0;
             int entriesBorders = 0;
 
-            GridEntryCollection entries = _propertyGrid.GetPropEntries();
+            GridEntryCollection entries = _propertyGrid.GetCurrentEntries();
             PropertyGridView propertyGridView = (PropertyGridView)_propertyGrid.ActiveControl;
 
             foreach (GridEntry entry in entries)

--- a/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridView.PropertyGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/AccessibleObjects/PropertyGridView.PropertyGridViewAccessibleObjectTests.cs
@@ -52,7 +52,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             using PropertyGrid propertyGrid = new PropertyGrid();
             using ComboBox comboBox = new ComboBox();
             propertyGrid.SelectedObject = comboBox;
-            GridEntry entry = (GridEntry)((GridEntry)propertyGrid.GetPropEntries()[0]).Children[2];
+            GridEntry entry = (GridEntry)((GridEntry)propertyGrid.GetCurrentEntries()[0]).Children[2];
             entry.HasFocus = true;
             entry.Select();
             Assert.Equal(entry, propertyGrid.SelectedGridItem);
@@ -67,7 +67,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             using PropertyGrid propertyGrid = new PropertyGrid();
             using ComboBox comboBox = new ComboBox();
             propertyGrid.SelectedObject = comboBox;
-            GridEntry entry = (GridEntry)((GridEntry)propertyGrid.GetPropEntries()[0]).Children[2];
+            GridEntry entry = (GridEntry)((GridEntry)propertyGrid.GetCurrentEntries()[0]).Children[2];
             entry.HasFocus = true;
             entry.Select();
             Assert.Equal(entry, propertyGrid.SelectedGridItem);
@@ -89,7 +89,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 
             int count = 0;
 
-            foreach (GridEntry category in propertyGrid.GetPropEntries())
+            foreach (GridEntry category in propertyGrid.GetCurrentEntries())
             {
                 count++;
 
@@ -171,7 +171,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 
             int i = 0;
 
-            foreach (GridEntry category in propertyGrid.GetPropEntries())
+            foreach (GridEntry category in propertyGrid.GetCurrentEntries())
             {
                 AccessibleObject categoryAccessibilityObject = category.AccessibilityObject;
                 AccessibleObject categoryItem = (AccessibleObject)accessibleObject.GetItem(i, 1);
@@ -247,7 +247,7 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
             int ROWLABEL = 1;
             int ROWVALUE = 2;
 
-            foreach (GridEntry category in propertyGrid.GetPropEntries())
+            foreach (GridEntry category in propertyGrid.GetCurrentEntries())
             {
                 AccessibleObject categoryAccessibilityObject = category.AccessibilityObject;
                 int row = propertyGridView.GetRowFromGridEntry(category);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObjectTests.cs
@@ -50,7 +50,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             using PropertyGrid control = new();
             using Button button = new();
             control.SelectedObject = button;
-            control.SelectedGridItem = control.GetPropEntries()[1].GridItems[5]; // FlatStyle property
+            control.SelectedGridItem = control.GetCurrentEntries()[1].GridItems[5]; // FlatStyle property
 
             PropertyGridView gridView = control.TestAccessor().GridView;
             DropDownButton dropDownButton = gridView.DropDownButton;
@@ -83,7 +83,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             using PropertyGrid control = new();
             using Button button = new();
             control.SelectedObject = button;
-            control.SelectedGridItem = control.GetPropEntries()[1].GridItems[5]; // FlatStyle property
+            control.SelectedGridItem = control.GetCurrentEntries()[1].GridItems[5]; // FlatStyle property
 
             PropertyGridView gridView = control.TestAccessor().GridView;
             DropDownButton dropDownButton = gridView.DropDownButton;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
@@ -110,7 +110,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
                 {
                     if (_collection is null)
                     {
-                        _collection = new GridEntryCollection(this, Array.Empty<GridEntry>());
+                        _collection = new GridEntryCollection();
                     }
 
                     return _collection;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -2361,10 +2361,10 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void PropertyGrid_SelectedGridItem_SetNull_ThrowsArgumentException()
+        public void PropertyGrid_SelectedGridItem_SetNull_ThrowsArgumentNullException()
         {
             using var control = new PropertyGrid();
-            Assert.Throws<ArgumentException>(null, () => control.SelectedGridItem = null);
+            Assert.Throws<ArgumentNullException>("items", () => control.SelectedGridItem = null);
         }
 
         [WinFormsFact]


### PR DESCRIPTION
Copying NonNullCollection from the designer and use as the base for GridEntryCollection to type the collection and add null safety.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5499)