### PR TITLE
Update templates to use `ApplicationConfiguration.Initialize()`

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
@@ -53,6 +53,10 @@
       "type": "computed",
       "value": "(Framework == \"netcoreapp3.1\")"
     },
+    "UseApplicationBoilerplate": {
+      "type": "computed",
+      "value": "(Framework == \"net5.0\")"
+    },
     "langVersion": {
       "type": "parameter",
       "datatype": "text",
@@ -94,16 +98,29 @@
         {
           "condition": "(UseWindowsDesktopSdk)",
           "exclude": [
-            "Company.WinFormsApplication1.csproj"
+            "Company.WinFormsApplication1.csproj",
+            "Program.cs"
           ],
           "rename": {
-            "Company.WinFormsApplication3x1.csproj": "Company.WinFormsApplication1.csproj"
+            "Company.WinFormsApplication3x1.csproj": "Company.WinFormsApplication1.csproj",
+            "Program.boilerplate.cs": "Program.cs"
           }
         },
         {
-          "condition": "(!UseWindowsDesktopSdk)",
+          "condition": "(!UseWindowsDesktopSdk && UseApplicationBoilerplate)",
           "exclude": [
-            "Company.WinFormsApplication3x1.csproj"
+            "Company.WinFormsApplication3x1.csproj",
+            "Program.cs"
+          ],
+          "rename": {
+            "Program.boilerplate.cs": "Program.cs"
+          }
+        },
+        {
+          "condition": "(!UseWindowsDesktopSdk && !UseApplicationBoilerplate)",
+          "exclude": [
+            "Company.WinFormsApplication3x1.csproj",
+            "Program.boilerplate.cs"
           ]
         }
       ]

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/Program.boilerplate.cs
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/Program.boilerplate.cs
@@ -14,7 +14,9 @@ namespace Company.WinFormsApplication1
         [STAThread]
         static void Main()
         {
-            ApplicationConfiguration.Initialize();
+            Application.SetHighDpiMode(HighDpiMode.SystemAware);
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Form1());
         }
     }


### PR DESCRIPTION
Relates to #5035
Relates to #5071

## Proposed changes

- Update template for .NET 6.0+ apps replacing `Applcation.*` boilerplate with the new `ApplicationConfiguration` generated method introduced in https://github.com/dotnet/designs/blob/main/accepted/2021/winforms/streamline-application-bootstrap.md


## Regression? 

- No, new functionality

## Risk

- Minimal

<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

Manually create various apps and verify the expected content

```
dotnet new -i C:\Development\winforms\pkg\Microsoft.Dotnet.WinForms.ProjectTemplates\content\WinFormsApplication-CSharp
cd .. && md template1 && cd template1 && dotnet new winforms  && code . 
cd .. && md template2 && cd template2 && dotnet new winforms -f net6.0 && code . 
cd .. && md template3 && cd template3 && dotnet new winforms -f net5.0 && code . 
cd .. && md template4 && cd template4 && dotnet new winforms -f netcoreapp3.1 && code . 
```
 

