### PR TITLE
Fixing focus rectangle width for controls with vertical scrollbar

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowRect.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -23,6 +25,12 @@ internal static partial class Interop
             BOOL result = GetWindowRect(hWnd.Handle, ref rect);
             GC.KeepAlive(hWnd);
             return result;
+        }
+
+        public static Rectangle GetWindowRect(IHandle hWnd)
+        {
+            Unsafe.SkipInit(out RECT rectangle);
+            return User32.GetWindowRect(hWnd, ref rectangle).IsTrue() ? rectangle : default;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using System.Runtime.InteropServices;
 using static System.Windows.Forms.ComboBox.ObjectCollection;
 using static Interop;
@@ -25,6 +26,8 @@ namespace System.Windows.Forms
                 _owningComboBox = owningComboBox;
                 _childListControlhandle = childListControlhandle;
             }
+
+            internal override Rectangle BoundingRectangle => User32.GetWindowRect(_owningComboBox.GetListNativeWindow());
 
             /// <summary>
             ///  Return the child object at the given screen coordinates.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -253,7 +253,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                Rectangle listBounds = _owningComboBox.ChildListAccessibleObject.BoundingRectangle;
+                Rectangle listBounds = _owningComboBox.ChildListAccessibleObject.Bounds;
                 if (listBounds.IntersectsWith(Bounds))
                 {
                     // Do nothing because the item is already visible

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -19,6 +19,10 @@ namespace System.Windows.Forms
                 _owningListView = owningListView;
             }
 
+            internal override Rectangle BoundingRectangle => _owningListView.IsHandleCreated
+                ? User32.GetWindowRect(_owningListView)
+                : Rectangle.Empty;
+
             internal override bool CanSelectMultiple
                 => _owningListView.IsHandleCreated;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProviderTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using Xunit;
 using static Interop;
 
@@ -79,6 +80,45 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(expectedItem, nextItem);
             Assert.True(comboBox.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ChildListAccessibleObject_BoundingRectangle_ReturnsCorrectWidth_IfComboBoxIsScrollable_TestData()
+        {
+            foreach (ComboBoxStyle comboBoxStyle in Enum.GetValues(typeof(ComboBoxStyle)))
+            {
+                yield return new object[] { comboBoxStyle };
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ChildListAccessibleObject_BoundingRectangle_ReturnsCorrectWidth_IfComboBoxIsScrollable_TestData))]
+        public void ChildListAccessibleObject_BoundingRectangle_ReturnsCorrectWidth_IfComboBoxIsScrollable(ComboBoxStyle comboBoxStyle)
+        {
+            const int expectedWidth = 100;
+
+            using ComboBox comboBox = new()
+            {
+                DropDownStyle = comboBoxStyle,
+                IntegralHeight = false
+            };
+            comboBox.Items.AddRange(Enumerable.Range(0, 11).Cast<object>().ToArray());
+            comboBox.CreateControl();
+
+            if (comboBoxStyle == ComboBoxStyle.Simple)
+            {
+                comboBox.Size = new Size(expectedWidth, 150);
+            }
+            else
+            {
+                comboBox.Size = new Size(expectedWidth, comboBox.Size.Height);
+                comboBox.DropDownHeight = 120;
+                comboBox.DroppedDown = true;
+            }
+
+            UiaCore.IRawElementProviderFragment childListUiaProvider = comboBox.ChildListAccessibleObject;
+            UiaCore.UiaRect actual = childListUiaProvider.BoundingRectangle;
+
+            Assert.Equal(expectedWidth, actual.width);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
@@ -1734,6 +1734,24 @@ namespace System.Windows.Forms.Tests
 
             return listView;
         }
+
+        [WinFormsFact]
+        public void ListViewAccessibleObject_BoundingRectangle_ReturnsCorrectWidth_IfListViewIsScrollable()
+        {
+            const int expectedWidth = 100;
+
+            using ListView listView = new()
+            {
+                Size = new Size(expectedWidth, 150)
+            };
+            listView.Items.AddRange(Enumerable.Range(0, 11).Select(i => new ListViewItem()).ToArray());
+            listView.CreateControl();
+
+            UiaCore.IRawElementProviderFragment uiaProvider = listView.AccessibilityObject;
+            UiaCore.UiaRect actual = uiaProvider.BoundingRectangle;
+
+            Assert.Equal(expectedWidth, actual.width);
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #4404. Currently BoundingRectangle for ComboBox and ListView doesn't take into account a vertical scrollbar if it's present. This problem is not present in .NET Framework 4.7.2 because UIA providers for these controls was added later and we need to fix this issue to keep the old behavior. When UIA provider is not present for the control UIAutomationCore uses GetWindowRect as a fallback. So, one of the possible solutions is to use GetWindowRect in the BoundingRectangle implementation. Another solution is to return an empty rectangle from the BoundingRectangle, that will trigger the fallback code in the UIAutomationCore. Using GetWindowRect directly should be the best solution since we won't rely on the internals of UIAutomationCore.

## Proposed changes

- Added `BoundingRectangle` implementation that uses `GetWindowRect` for `ComboBoxChildListUiaProvider` and `ListViewAccessibleObject`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Accessibility tools are properly highlighting lists that have vertical scrollbars with a rectangle

## Regression? 

- Yes (from .NET Framework 4.7.2)

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Without the fix the focus rectangle doesn't include the vertical scrollbar.
![focus rectangle before](https://user-images.githubusercontent.com/5282741/130835929-9483e96e-4c64-473c-816e-712a382a6131.png)

### After

With the fix the focus rectangle includes the vertical scrollbar.
![focus rectangle after](https://user-images.githubusercontent.com/5282741/130836823-7abd7c1b-7b49-4714-94e9-64dfdfa9f7bb.png)


## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Manual testing
- CTI

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19043.1165]
- .NET 7.0.0-alpha.1.21422.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5534)