### PR TITLE
Clean up MapWindowPoints and more PropertyGrid

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.MouseHook.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.MouseHook.cs
@@ -175,7 +175,7 @@ namespace System.Windows.Forms.Design.Behavior
                             {
                                 _processingMessage = true;
                                 var pt = new Point(x, y);
-                                User32.MapWindowPoints(IntPtr.Zero, adornerWindow.Handle, ref pt, 1);
+                                adornerWindow.PointToClient(pt);
                                 Message m = Message.Create(hWnd, msg, (IntPtr)0, PARAM.FromLowHigh(pt.Y, pt.X));
 
                                 // No one knows why we get an extra click here from VS. As a workaround, we check the TimeStamp and discard it.

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.cs
@@ -215,15 +215,15 @@ namespace System.Windows.Forms.Design.Behavior
             {
                 ProcessingDrag = true;
 
-                // determine if this is a local drag, if it is, do normal processing otherwise, force a
+                // Determine if this is a local drag, if it is, do normal processing otherwise, force a
                 // PropagateHitTest.  We need to force this because the OLE D&D service suspends mouse messages
                 // when the drag is not local so the mouse hook never sees them.
                 if (!IsLocalDrag(e))
                 {
                     _behaviorService._validDragArgs = e;
-                    User32.GetCursorPos(out Point pt);
-                    User32.MapWindowPoints(IntPtr.Zero, Handle, ref pt, 1);
-                    _behaviorService.PropagateHitTest(pt);
+                    User32.GetCursorPos(out Point point);
+                    point = PointToClient(point);
+                    _behaviorService.PropagateHitTest(point);
                 }
 
                 _behaviorService.OnDragEnter(null, e);
@@ -257,9 +257,9 @@ namespace System.Windows.Forms.Design.Behavior
                 if (!IsLocalDrag(e))
                 {
                     _behaviorService._validDragArgs = e;
-                    User32.GetCursorPos(out Point pt);
-                    User32.MapWindowPoints(IntPtr.Zero, Handle, ref pt, 1);
-                    _behaviorService.PropagateHitTest(pt);
+                    User32.GetCursorPos(out Point point);
+                    point = PointToClient(point);
+                    _behaviorService.PropagateHitTest(point);
                 }
 
                 _behaviorService.OnDragOver(e);
@@ -332,8 +332,9 @@ namespace System.Windows.Forms.Design.Behavior
                         Point pt = new Point(
                             (short)PARAM.LOWORD(m.LParam),
                             (short)PARAM.HIWORD(m.LParam));
+
                         var pt1 = new Point();
-                        User32.MapWindowPoints(IntPtr.Zero, Handle, ref pt1, 1);
+                        pt1 = PointToClient(pt1);
                         pt.Offset(pt1.X, pt1.Y);
 
                         if (_behaviorService.PropagateHitTest(pt) && !ProcessingDrag)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -281,20 +281,12 @@ namespace System.Windows.Forms.Design.Behavior
         /// <summary>
         ///  Translates a point in the AdornerWindow to screen coords.
         /// </summary>
-        public Point AdornerWindowPointToScreen(Point p)
-        {
-            User32.MapWindowPoints(_adornerWindow.Handle, IntPtr.Zero, ref p, 1);
-            return p;
-        }
+        public Point AdornerWindowPointToScreen(Point p) => _adornerWindow.PointToScreen(p);
 
         /// <summary>
         ///  Gets the location (upper-left corner) of the AdornerWindow in screen coords.
         /// </summary>
-        public Point AdornerWindowToScreen()
-        {
-            Point origin = new Point(0, 0);
-            return AdornerWindowPointToScreen(origin);
-        }
+        public Point AdornerWindowToScreen() => AdornerWindowPointToScreen(new Point(0, 0));
 
         /// <summary>
         ///  Returns the location of a Control translated to AdornerWindow coords.
@@ -307,7 +299,7 @@ namespace System.Windows.Forms.Design.Behavior
             }
 
             var pt = new Point(c.Left, c.Top);
-            User32.MapWindowPoints(c.Parent.Handle, _adornerWindow.Handle, ref pt, 1);
+            User32.MapWindowPoint(c.Parent, _adornerWindow, ref pt);
             if (c.Parent.IsMirrored)
             {
                 pt.X -= c.Width;
@@ -321,7 +313,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public Point MapAdornerWindowPoint(IntPtr handle, Point pt)
         {
-            User32.MapWindowPoints(handle, _adornerWindow.Handle, ref pt, 1);
+            User32.MapWindowPoint(handle, _adornerWindow, ref pt);
             return pt;
         }
 
@@ -506,11 +498,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// <summary>
         ///  Translates a screen coord into a coord relative to the BehaviorService's AdornerWindow.
         /// </summary>
-        public Point ScreenToAdornerWindow(Point p)
-        {
-            User32.MapWindowPoints(IntPtr.Zero, _adornerWindow.Handle, ref p, 1);
-            return p;
-        }
+        public Point ScreenToAdornerWindow(Point p) => _adornerWindow.PointToClient(p);
 
         internal void OnLoseCapture()
         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -1684,7 +1684,7 @@ namespace System.Windows.Forms.Design
                         // Get a hit test on any glyphs that we are managing this way - we know where to route appropriate  messages
                         Point pt = new Point((short)PARAM.LOWORD(m.LParam), (short)PARAM.HIWORD(m.LParam));
                         var pt1 = new Point();
-                        User32.MapWindowPoints(IntPtr.Zero, Handle, ref pt1, 1);
+                        pt1 = PointToClient(pt1);
                         pt.Offset(pt1.X, pt1.Y);
                         glyphManager.GetHitTest(pt);
                     }
@@ -2641,7 +2641,7 @@ namespace System.Windows.Forms.Design
                             // Make sure tha we send our glyphs hit test messages over the TrayControls too
                             Point pt = new Point((short)PARAM.LOWORD(m.LParam), (short)PARAM.HIWORD(m.LParam));
                             var pt1 = new Point();
-                            User32.MapWindowPoints(IntPtr.Zero, Handle, ref pt1, 1);
+                            pt1 = PointToClient(pt1);
                             pt.Offset(pt1.X, pt1.Y);
                             pt.Offset(Location.X, Location.Y);//offset the loc of the traycontrol -so now we're in comptray coords
                             _tray.glyphManager.GetHitTest(pt);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -320,7 +320,7 @@ namespace System.Windows.Forms.Design
         internal Point GetOffsetToClientArea()
         {
             var nativeOffset = new Point();
-            User32.MapWindowPoints(Control.Handle, Control.Parent.Handle, ref nativeOffset, 1);
+            User32.MapWindowPoint(Control, Control.Parent, ref nativeOffset);
             Point offset = Control.Location;
 
             // If the 2 controls do not have the same orientation, then force one to make sure we calculate the correct offset
@@ -1814,12 +1814,13 @@ namespace System.Windows.Forms.Design
 
             if (m.Msg >= (int)User32.WM.MOUSEFIRST && m.Msg <= (int)User32.WM.MOUSELAST)
             {
-                var pt = new Point
+                Point pt = new()
                 {
                     X = PARAM.SignedLOWORD(m.LParam),
                     Y = PARAM.SignedHIWORD(m.LParam)
                 };
-                User32.MapWindowPoints(m.HWnd, IntPtr.Zero, ref pt, 1);
+
+                User32.MapWindowPoints(m.HWnd, IntPtr.Zero, &pt, 1);
                 x = pt.X;
                 y = pt.Y;
             }
@@ -2139,9 +2140,9 @@ namespace System.Windows.Forms.Design
                         {
                             // Re-map the clip rect we pass to the paint event args to our child coordinates.
                             Point point = default;
-                            User32.MapWindowPoints(m.HWnd, Control.Handle, ref point, 1);
+                            User32.MapWindowPoint(m.HWnd, Control, ref point);
                             graphics.TranslateTransform(-point.X, -point.Y);
-                            User32.MapWindowPoints(m.HWnd, Control.Handle, ref clip, 2);
+                            User32.MapWindowPoints(m.HWnd, Control.Handle, ref clip);
                         }
 
                         Rectangle paintRect = clip;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
@@ -70,23 +70,22 @@ namespace System.Windows.Forms.Design
         /// <summary>
         ///  We override GetHitTest to make the header in report view UI-active.
         /// </summary>
-        protected override bool GetHitTest(Point point)
+        protected unsafe override bool GetHitTest(Point point)
         {
-            ListView lv = (ListView)Component;
-            if (lv.View == View.Details)
+            ListView listView = (ListView)Component;
+            if (listView.View == View.Details)
             {
-                Point lvPoint = Control.PointToClient(point);
-                IntPtr hwndList = lv.Handle;
-                IntPtr hwndHit = User32.ChildWindowFromPointEx(hwndList, lvPoint, User32.CWP.SKIPINVISIBLE);
+                Point listViewPoint = Control.PointToClient(point);
+                IntPtr hwndHit = User32.ChildWindowFromPointEx(listView, listViewPoint, User32.CWP.SKIPINVISIBLE);
 
-                if (hwndHit != IntPtr.Zero && hwndHit != hwndList)
+                if (hwndHit != IntPtr.Zero && hwndHit != listView.Handle)
                 {
-                    IntPtr hwndHdr = User32.SendMessageW(hwndList, (User32.WM)ComCtl32.LVM.GETHEADER);
-                    if (hwndHit == hwndHdr)
+                    IntPtr headerHwnd = User32.SendMessageW(listView, (User32.WM)ComCtl32.LVM.GETHEADER);
+                    if (hwndHit == headerHwnd)
                     {
-                        User32.MapWindowPoints(IntPtr.Zero, hwndHdr, ref point, 1);
+                        User32.MapWindowPoints(IntPtr.Zero, headerHwnd, &point, 1);
                         _hdrhit.pt = point;
-                        User32.SendMessageW(hwndHdr, (User32.WM)ComCtl32.HDM.HITTEST, IntPtr.Zero, ref _hdrhit);
+                        User32.SendMessageW(headerHwnd, (User32.WM)ComCtl32.HDM.HITTEST, IntPtr.Zero, ref _hdrhit);
                         if (_hdrhit.flags == ComCtl32.HHT.ONDIVIDER)
                             return true;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -2043,16 +2043,11 @@ namespace System.Windows.Forms.Design
             if (_statusCommandUI != null && !offset.IsEmpty)
             {
                 Point location = new(baseVar.X, baseVar.Y);
-                User32.MapWindowPoints(IntPtr.Zero, Control.Handle, ref location, 1);
-                if (_statusCommandUI != null)
-                {
-                    _statusCommandUI.SetStatusInformation(new Rectangle(location.X, location.Y, offset.Width, offset.Height));
-                }
+                location = Control.PointToClient(location);
+                _statusCommandUI?.SetStatusInformation(new Rectangle(location.X, location.Y, offset.Width, offset.Height));
             }
 
-            // Quit now if we don't have an offset rect.  This indicates that
-            // the user didn't move the mouse.
-            //
+            // Quit now if we don't have an offset rect.  This indicates that the user didn't move the mouse.
             if (offset.IsEmpty && !cancel)
             {
                 // BUT, if we have a selected tool, create it here
@@ -2274,11 +2269,8 @@ namespace System.Windows.Forms.Design
             if (_statusCommandUI != null)
             {
                 Point offset = new(_mouseDragOffset.X, _mouseDragOffset.Y);
-                User32.MapWindowPoints(IntPtr.Zero, Control.Handle, ref offset, 1);
-                if (_statusCommandUI != null)
-                {
-                    _statusCommandUI.SetStatusInformation(new Rectangle(offset.X, offset.Y, _mouseDragOffset.Width, _mouseDragOffset.Height));
-                }
+                offset = Control.PointToClient(offset);
+                _statusCommandUI?.SetStatusInformation(new Rectangle(offset.X, offset.Y, _mouseDragOffset.Width, _mouseDragOffset.Height));
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
@@ -97,20 +97,12 @@ namespace System.Windows.Forms.Design
         /// <summary>
         ///  Translates a point in the AdornerWindow to screen coords.
         /// </summary>
-        public Point AdornerWindowPointToScreen(Point p)
-        {
-            User32.MapWindowPoints(_toolStripAdornerWindow.Handle, IntPtr.Zero, ref p, 1);
-            return p;
-        }
+        public Point AdornerWindowPointToScreen(Point p) => _toolStripAdornerWindow.PointToScreen(p);
 
         /// <summary>
         ///  Gets the location (upper-left corner) of the AdornerWindow in screen coords.
         /// </summary>
-        public Point AdornerWindowToScreen()
-        {
-            Point origin = new Point(0, 0);
-            return AdornerWindowPointToScreen(origin);
-        }
+        public Point AdornerWindowToScreen() => AdornerWindowPointToScreen(new Point(0, 0));
 
         /// <summary>
         ///  Returns the location of a Control translated to AdornerWidnow coords.
@@ -123,7 +115,7 @@ namespace System.Windows.Forms.Design
             }
 
             var pt = new Point(c.Left, c.Top);
-            User32.MapWindowPoints(c.Parent.Handle, _toolStripAdornerWindow.Handle, ref pt, 1);
+            User32.MapWindowPoint(c.Parent, _toolStripAdornerWindow, ref pt);
             return pt;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -1831,7 +1831,7 @@ namespace System.Windows.Forms.Design
             bool dropAtHead = false;
             ToolStrip parentToolStrip = ToolStrip;
             var offset = new Point(de.X, de.Y);
-            User32.MapWindowPoints(IntPtr.Zero, parentToolStrip.Handle, ref offset, 1);
+            offset = parentToolStrip.PointToClient(offset);
             if (ToolStrip.Orientation == Orientation.Horizontal)
             {
                 if (ToolStrip.RightToLeft == RightToLeft.Yes)

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MapWindowPoints.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MapWindowPoints.cs
@@ -10,60 +10,71 @@ internal static partial class Interop
     internal static partial class User32
     {
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern int MapWindowPoints(IntPtr hWndFrom, IntPtr hWndTo, ref Point lpPoints, uint cPoints);
+        public unsafe static extern int MapWindowPoints(IntPtr hWndFrom, IntPtr hWndTo, Point* lpPoints, uint cPoints);
 
-        public static int MapWindowPoints(HandleRef hWndFrom, IntPtr hWndTo, ref Point lpPoints, uint cPoints)
+        public unsafe static int MapWindowPoint(IHandle hWndFrom, IHandle hWndTo, ref Point lpPoints)
         {
-            int result = MapWindowPoints(hWndFrom.Handle, hWndTo, ref lpPoints, cPoints);
-            GC.KeepAlive(hWndFrom.Wrapper);
-            return result;
+            fixed (Point* p = &lpPoints)
+            {
+                int result = MapWindowPoints(
+                    hWndFrom?.Handle ?? IntPtr.Zero,
+                    hWndTo?.Handle ?? IntPtr.Zero,
+                    p,
+                    1);
+
+                GC.KeepAlive(hWndFrom);
+                GC.KeepAlive(hWndTo);
+                return result;
+            }
         }
 
-        public static int MapWindowPoints(IntPtr hWndFrom, HandleRef hWndTo, ref Point lpPoints, uint cPoints)
+        public unsafe static int MapWindowPoint(IHandle hWndFrom, IntPtr hWndTo, ref Point lpPoints)
         {
-            int result = MapWindowPoints(hWndFrom, hWndTo.Handle, ref lpPoints, cPoints);
-            GC.KeepAlive(hWndTo.Wrapper);
-            return result;
+            fixed (Point* p = &lpPoints)
+            {
+                int result = MapWindowPoints(hWndFrom.Handle, hWndTo, p, 1);
+                GC.KeepAlive(hWndFrom);
+                return result;
+            }
         }
 
-        public static int MapWindowPoints(HandleRef hWndFrom, HandleRef hWndTo, ref Point lpPoints, uint cPoints)
+        public unsafe static int MapWindowPoint(IntPtr hWndFrom, IHandle hWndTo, ref Point lpPoints)
         {
-            int result = MapWindowPoints(hWndFrom.Handle, hWndTo.Handle, ref lpPoints, cPoints);
-            GC.KeepAlive(hWndFrom.Wrapper);
-            GC.KeepAlive(hWndTo.Wrapper);
-            return result;
+            fixed (Point* p = &lpPoints)
+            {
+                int result = MapWindowPoints(hWndFrom, hWndTo.Handle, p, 1);
+                GC.KeepAlive(hWndTo);
+                return result;
+            }
         }
 
-        public static int MapWindowPoints(IntPtr hWndFrom, IHandle hWndTo, ref Point lpPoints, uint cPoints)
+        public unsafe static int MapWindowPoints(IntPtr hWndFrom, IntPtr hWndTo, ref RECT lpPoints)
         {
-            int result = MapWindowPoints(hWndFrom, hWndTo.Handle, ref lpPoints, cPoints);
-            GC.KeepAlive(hWndTo);
-            return result;
+            fixed (RECT* r = &lpPoints)
+            {
+                int result = MapWindowPoints(hWndFrom, hWndTo, (Point*)r, 2);
+                return result;
+            }
         }
 
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern int MapWindowPoints(IntPtr hWndFrom, IntPtr hWndTo, ref RECT lpPoints, uint cPoints);
-
-        public static int MapWindowPoints(HandleRef hWndFrom, IntPtr hWndTo, ref RECT lpPoints, uint cPoints)
+        public unsafe static int MapWindowPoints(IHandle hWndFrom, IntPtr hWndTo, ref RECT lpPoints)
         {
-            int result = MapWindowPoints(hWndFrom.Handle, hWndTo, ref lpPoints, cPoints);
-            GC.KeepAlive(hWndFrom.Wrapper);
-            return result;
+            fixed (RECT* r = &lpPoints)
+            {
+                int result = MapWindowPoints(hWndFrom.Handle, hWndTo, (Point*)r, 2);
+                GC.KeepAlive(hWndFrom);
+                return result;
+            }
         }
 
-        public static int MapWindowPoints(IntPtr hWndFrom, HandleRef hWndTo, ref RECT lpPoints, uint cPoints)
+        public unsafe static int MapWindowPoints(IntPtr hWndFrom, IHandle hWndTo, ref RECT lpPoints)
         {
-            int result = MapWindowPoints(hWndFrom, hWndTo.Handle, ref lpPoints, cPoints);
-            GC.KeepAlive(hWndTo.Wrapper);
-            return result;
-        }
-
-        public static int MapWindowPoints(HandleRef hWndFrom, HandleRef hWndTo, ref RECT lpPoints, uint cPoints)
-        {
-            int result = MapWindowPoints(hWndFrom.Handle, hWndTo.Handle, ref lpPoints, cPoints);
-            GC.KeepAlive(hWndFrom.Wrapper);
-            GC.KeepAlive(hWndTo.Wrapper);
-            return result;
+            fixed (RECT* r = &lpPoints)
+            {
+                int result = MapWindowPoints(hWndFrom, hWndTo.Handle, (Point*)r, 2);
+                GC.KeepAlive(hWndTo);
+                return result;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -360,8 +360,8 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Returns the value of the specified <paramref name="propertyID"/> from the element.
         /// </summary>
-        /// <param name="propertyID">Identifier indicating the property to return</param>
-        /// <returns>Returns the requested value if supported or null if it is not.</returns>
+        /// <param name="propertyID">Identifier indicating the property to return.</param>
+        /// <returns>The requested value if supported or null if it is not.</returns>
         internal virtual object? GetPropertyValue(UiaCore.UIA propertyID) =>
             propertyID switch
             {
@@ -428,7 +428,7 @@ namespace System.Windows.Forms
         ///  Returns the element in the specified <paramref name="direction"/>.
         /// </summary>
         /// <param name="direction">Indicates the direction in which to navigate.</param>
-        /// <returns>Returns the element in the specified direction if it exists.</returns>
+        /// <returns>The element in the specified direction if it exists.</returns>
         internal virtual UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction) => null;
 
         internal virtual UiaCore.IRawElementProviderSimple[]? GetEmbeddedFragmentRoots() => null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -47,7 +47,10 @@ namespace System.Windows.Forms
                     RECT itemRect = new();
 
                     int result = unchecked((int)(long)User32.SendMessageW(
-                        listHandle, (User32.WM)User32.LB.GETITEMRECT, (IntPtr)currentIndex, ref itemRect));
+                        listHandle,
+                        (User32.WM)User32.LB.GETITEMRECT,
+                        (IntPtr)currentIndex,
+                        ref itemRect));
 
                     if (result == User32.LB_ERR)
                     {
@@ -55,7 +58,7 @@ namespace System.Windows.Forms
                     }
 
                     // Translate the item rect to screen coordinates
-                    User32.MapWindowPoints(listHandle, IntPtr.Zero, ref itemRect, 2);
+                    User32.MapWindowPoints(listHandle, IntPtr.Zero, ref itemRect);
                     return itemRect;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
@@ -277,7 +277,7 @@ namespace System.Windows.Forms
 
             public override Point PointToScreen(Point pt)
             {
-                User32.MapWindowPoints(_owningChildEdit.Handle, IntPtr.Zero, ref pt, 1);
+                User32.MapWindowPoint(_owningChildEdit, IntPtr.Zero, ref pt);
                 return pt;
             }
 
@@ -320,7 +320,7 @@ namespace System.Windows.Forms
 
                 // Convert screen to client coordinates.
                 // (Essentially ScreenToClient but MapWindowPoints accounts for window mirroring using WS_EX_LAYOUTRTL.)
-                if (MapWindowPoints(default, _owningChildEdit, ref clientLocation, 1) == 0)
+                if (MapWindowPoint(IntPtr.Zero, _owningChildEdit, ref clientLocation) == 0)
                 {
                     return new UiaTextRange(new InternalAccessibleObject(_owningComboBox.ChildEditAccessibleObject), this, 0, 0);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -326,7 +326,7 @@ namespace System.Windows.Forms
                                     X = PARAM.LOWORD(lpmsg->lParam),
                                     Y = PARAM.HIWORD(lpmsg->lParam)
                                 };
-                                User32.MapWindowPoints(hwndMap, new HandleRef(_control, _control.Handle), ref pt, 1);
+                                User32.MapWindowPoint(hwndMap, _control, ref pt);
 
                                 // check to see if this message should really go to a child
                                 //  control, and if so, map the point into that child's window
@@ -334,7 +334,7 @@ namespace System.Windows.Forms
                                 Control realTarget = target.GetChildAtPoint(pt);
                                 if (realTarget is not null && realTarget != target)
                                 {
-                                    User32.MapWindowPoints(new HandleRef(target, target.Handle), new HandleRef(realTarget, realTarget.Handle), ref pt, 1);
+                                    pt = WindowsFormsUtils.TranslatePoint(pt, target, realTarget);
                                     target = realTarget;
                                 }
 
@@ -2139,7 +2139,7 @@ namespace System.Windows.Forms
                         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, $"Old Intersect: {(Rectangle)rcIntersect}");
                         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, $"New Control Bounds: {posRect}");
 
-                        User32.MapWindowPoints(hWndParent, new HandleRef(_control, _control.Handle), ref rcIntersect, 2);
+                        User32.MapWindowPoints(hWndParent, _control, ref rcIntersect);
 
                         Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, $"New Intersect: {(Rectangle)rcIntersect}");
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -8994,7 +8994,7 @@ namespace System.Windows.Forms
         /// </summary>
         public Point PointToClient(Point p)
         {
-            User32.MapWindowPoints(IntPtr.Zero, new HandleRef(this, Handle), ref p, 1);
+            User32.MapWindowPoint(IntPtr.Zero, this, ref p);
             return p;
         }
 
@@ -9003,7 +9003,7 @@ namespace System.Windows.Forms
         /// </summary>
         public Point PointToScreen(Point p)
         {
-            User32.MapWindowPoints(new HandleRef(this, Handle), IntPtr.Zero, ref p, 1);
+            User32.MapWindowPoint(this, IntPtr.Zero, ref p);
             return p;
         }
 
@@ -9867,7 +9867,7 @@ namespace System.Windows.Forms
         public Rectangle RectangleToClient(Rectangle r)
         {
             RECT rect = r;
-            User32.MapWindowPoints(IntPtr.Zero, new HandleRef(this, Handle), ref rect, 2);
+            User32.MapWindowPoints(IntPtr.Zero, this, ref rect);
             return Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
         }
 
@@ -9877,7 +9877,7 @@ namespace System.Windows.Forms
         public Rectangle RectangleToScreen(Rectangle r)
         {
             RECT rect = r;
-            User32.MapWindowPoints(new HandleRef(this, Handle), IntPtr.Zero, ref rect, 2);
+            User32.MapWindowPoints(this, IntPtr.Zero, ref rect);
             return Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
         }
 
@@ -11392,8 +11392,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Updates the bounds of the control based on the handle the control is
-        ///  bound to.
+        ///  Updates the bounds of the control based on the handle the control is bound to.
         /// </summary>
         // Internal for ScrollableControl
         [EditorBrowsable(EditorBrowsableState.Advanced)]
@@ -11406,11 +11405,16 @@ namespace System.Windows.Forms
             User32.GetWindowRect(new HandleRef(_window, InternalHandle), ref rect);
             if (!GetTopLevel())
             {
-                User32.MapWindowPoints(IntPtr.Zero, User32.GetParent(new HandleRef(_window, InternalHandle)), ref rect, 2);
+                User32.MapWindowPoints(IntPtr.Zero, User32.GetParent(new HandleRef(_window, InternalHandle)), ref rect);
             }
 
-            UpdateBounds(rect.left, rect.top, rect.right - rect.left,
-                         rect.bottom - rect.top, clientWidth, clientHeight);
+            UpdateBounds(
+                rect.left,
+                rect.top,
+                rect.right - rect.left,
+                rect.bottom - rect.top,
+                clientWidth,
+                clientHeight);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
@@ -7,7 +7,6 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Drawing;
-using System.Runtime.InteropServices;
 using System.Windows.Forms.Layout;
 using static Interop;
 
@@ -607,7 +606,7 @@ namespace System.Windows.Forms
                             gripLocation = new Point(SizeGripBounds.Right, SizeGripBounds.Bottom);
                         }
 
-                        User32.MapWindowPoints(new HandleRef(this, Handle), rootHwnd, ref gripLocation, 1);
+                        User32.MapWindowPoint(this, rootHwnd, ref gripLocation);
 
                         int deltaBottomEdge = Math.Abs(rootHwndClientArea.bottom - gripLocation.Y);
                         int deltaRightEdge = Math.Abs(rootHwndClientArea.right - gripLocation.X);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -77,7 +77,7 @@ namespace System.Windows.Forms
 
                 // Convert screen to client coordinates.
                 // (Essentially ScreenToClient but MapWindowPoints accounts for window mirroring using WS_EX_LAYOUTRTL.)
-                if (MapWindowPoints(default, _owningTextBoxBase, ref clientLocation, 1) == 0)
+                if (MapWindowPoint(IntPtr.Zero, _owningTextBoxBase, ref clientLocation) == 0)
                 {
                     return new UiaTextRange(new InternalAccessibleObject(_owningTextBoxBase.AccessibilityObject), this, 0, 0);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.ModalMenuFilter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.ModalMenuFilter.cs
@@ -354,7 +354,7 @@ namespace System.Windows.Forms
                     if (activeToolStrip is not null)
                     {
                         var pt = new Point(x, y);
-                        User32.MapWindowPoints(new HandleRef(activeToolStrip, hwndMouseMessageIsFrom), new HandleRef(activeToolStrip, activeToolStrip.Handle), ref pt, 1);
+                        User32.MapWindowPoint(hwndMouseMessageIsFrom, activeToolStrip, ref pt);
                         if (!activeToolStrip.ClientRectangle.Contains(pt.X, pt.Y))
                         {
                             if (activeToolStrip is ToolStripDropDown activeToolStripDropDown)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.cs
@@ -893,7 +893,7 @@ namespace System.Windows.Forms
                 // Same control as PointToClient or PointToScreen, just
                 // with two specific controls in mind.
                 var point = new Point(e.X, e.Y);
-                User32.MapWindowPoints(new HandleRef(child, child.Handle), new HandleRef(this, Handle), ref point, 1);
+                point = WindowsFormsUtils.TranslatePoint(point, child, this);
                 return new MouseEventArgs(e.Button, e.Clicks, point.X, point.Y, e.Delta);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WinFormsUtils.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Text;
 using static Interop;
 
@@ -273,14 +272,16 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Translates a point from one control's coordinate system to the other
-        ///  same as:
-        ///  controlTo.PointToClient(controlFrom.PointToScreen(point))
-        ///  but slightly more performant.
+        ///  Translates a point from one control's coordinate system to the other.
         /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Same as controlTo.PointToClient(controlFrom.PointToScreen(point)), but more slightly more performant.
+        ///  </para>
+        /// </remarks>
         public static Point TranslatePoint(Point point, Control fromControl, Control toControl)
         {
-            User32.MapWindowPoints(new HandleRef(fromControl, fromControl.Handle), new HandleRef(toControl, toControl.Handle), ref point, 1);
+            User32.MapWindowPoint(fromControl, toControl, ref point);
             return point;
         }
 


### PR DESCRIPTION
`MapWindowPoints` was not efficient as it had two separate P/Invokes and the pinning was happening in the generated interop layer. Additionally we weren't leveraging the `IHandle ` optimization. Lastly it was risky as we were specifying the count all over the place. Cleaned this up as we were using this in `PropertyGrid`.

Add more comments to `CommandsPane` and a bit more cleanup to `PropertyGrid`.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5539)