### PR TITLE
Remove boxing from idle loop

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ComponentManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ComponentManager.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -361,11 +360,8 @@ namespace System.Windows.Forms
 
                             if (OleComponents is not null)
                             {
-                                IEnumerator enumerator = OleComponents.Values.GetEnumerator();
-
-                                while (enumerator.MoveNext())
+                                foreach (ComponentHashtableEntry idleEntry in OleComponents.Values)
                                 {
-                                    ComponentHashtableEntry idleEntry = (ComponentHashtableEntry)enumerator.Current;
                                     continueIdle |= idleEntry.component.FDoIdle(msoidlef.All).IsTrue();
                                 }
                             }


### PR DESCRIPTION
Casting to `IEnumerator` is creating an unnecessary box of the enumerator. Just call `foreach` to avoid this and the unnecessary extra lines of code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5545)