### PR TITLE
cleanup in MonthCalendar

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
+*REMOVED*override System.Windows.Forms.MonthCalendar.Dispose(bool disposing) -> void
 ~override System.Windows.Forms.TabControl.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.TabPage.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Calendar.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Calendar.Designer.cs
@@ -55,7 +55,16 @@ namespace WinformsControlsTest
             this.monthCalendar1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
             | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.monthCalendar1.AnnuallyBoldedDates = new System.DateTime[] {
+        new System.DateTime(2021, 8, 1, 0, 0, 0, 0),
+        new System.DateTime(2021, 8, 2, 0, 0, 0, 0)};
+            this.monthCalendar1.BoldedDates = new System.DateTime[] {
+        new System.DateTime(2021, 7, 3, 0, 0, 0, 0),
+        new System.DateTime(2021, 7, 4, 0, 0, 0, 0)};
             this.monthCalendar1.Location = new System.Drawing.Point(18, 80);
+            this.monthCalendar1.MonthlyBoldedDates = new System.DateTime[] {
+        new System.DateTime(2021, 9, 5, 0, 0, 0, 0),
+        new System.DateTime(2021, 9, 6, 0, 0, 0, 0)};
             this.monthCalendar1.Name = "monthCalendar1";
             this.monthCalendar1.TabIndex = 0;
             // 


### PR DESCRIPTION
Initially this ws based on @JeremyKuhne suggestion made in https://github.com/dotnet/winforms/pull/5201#issuecomment-885210059
> I wouldn't mess with the collections without a clear, measured win. This class originally was using `ArrayList`. `List<DateTime>` is significantly more performant, so we're already way better. Generally speaking the class is way more performant than it used to be as the interop has been cleaned up. The comment in the code should probably be removed.
> 
> There are other things that could be done here if you want to make an improvement:
> 
> * Setting `BoldedDates` should use `AddRange`.
> * WmDateBold could be significantly faster.
>   
>   * There is no need to create a wrapper DateBoldEventArgs class.
>   * BoldDates could also write directly into the buffer being used (don't allocate arrays you don't need).
>   * The buffer has no need to use Marshal.
>     
>     * Can use a pinning `GCHandle` kept in the class with a normal `int[]` array.
>     * Better yet, allocate a pinned array up front using [`GC.AllocateArray`](https://docs.microsoft.com/en-us/dotnet/api/system.gc.allocatearray?view=net-5.0) and just use `fixed` to get the address.


However, it is not needed to allocate the buffer in winforms becasue it is already allocated in the comctls calendar control code before this notification is called.
https://docs.microsoft.com/en-us/cpp/mfc/setting-the-day-state-of-a-month-calendar-control?view=msvc-160

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5561)