### PR TITLE
Change ToolTipBuffer to use pinned managed memory

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -5753,9 +5753,6 @@ namespace System.Windows.Forms
                 }
             }
 
-            // Dispose unmanaged resources.
-            _toolTipBuffer.Dispose();
-
             base.Dispose(disposing);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1059,9 +1059,6 @@ namespace System.Windows.Forms
                 }
             }
 
-            // Dispose unmanaged resources.
-            _toolTipBuffer.Dispose();
-
             base.Dispose(disposing);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -1664,7 +1664,6 @@ namespace System.Windows.Forms
 
             // Dispose unmanaged resources.
             UnhookNodes();
-            _toolTipBuffer.Dispose();
             KeyboardToolTip.Dispose();
 
             base.Dispose(disposing);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipBufferTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipBufferTests.cs
@@ -12,14 +12,14 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ToolTipBuffer_Buffer_GetEmpty_ReturnsZero()
         {
-            using var buffer = new ToolTipBuffer();
+            var buffer = new ToolTipBuffer();
             Assert.Equal(IntPtr.Zero, buffer.Buffer);
         }
 
         [WinFormsFact]
         public void ToolTipBuffer_SetText_NoBuffer_Success()
         {
-            using var buffer = new ToolTipBuffer();
+            var buffer = new ToolTipBuffer();
             IntPtr memory1 = buffer.Buffer;
             Assert.Null(Marshal.PtrToStringUni(memory1));
 
@@ -34,7 +34,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("")]
         public void ToolTipBuffer_SetText_EmptyNoBuffer_Success(string empty)
         {
-            using var buffer = new ToolTipBuffer();
+            var buffer = new ToolTipBuffer();
             IntPtr memory1 = buffer.Buffer;
             Assert.Null(Marshal.PtrToStringUni(memory1));
 
@@ -49,7 +49,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("abcdef")]
         public void ToolTipBuffer_SetTextLonger_Success(string longer)
         {
-            using var buffer = new ToolTipBuffer();
+            var buffer = new ToolTipBuffer();
             buffer.SetText("text");
             IntPtr memory1 = buffer.Buffer;
             Assert.Equal("text", Marshal.PtrToStringUni(buffer.Buffer));
@@ -69,7 +69,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("abc", "abc")]
         public void ToolTipBuffer_SetTextShorter_Success(string shorter, string expected)
         {
-            using var buffer = new ToolTipBuffer();
+            var buffer = new ToolTipBuffer();
             buffer.SetText("text");
             IntPtr memory1 = buffer.Buffer;
             Assert.Equal("text", Marshal.PtrToStringUni(buffer.Buffer));
@@ -86,7 +86,7 @@ namespace System.Windows.Forms.Tests
         [InlineData("abcd")]
         public void ToolTipBuffer_SetTextSameLength_Success(string sameLength)
         {
-            using var buffer = new ToolTipBuffer();
+            var buffer = new ToolTipBuffer();
             buffer.SetText("text");
             IntPtr memory1 = buffer.Buffer;
             Assert.Equal("text", Marshal.PtrToStringUni(buffer.Buffer));
@@ -96,31 +96,6 @@ namespace System.Windows.Forms.Tests
             IntPtr memory2 = buffer.Buffer;
             Assert.Equal(memory1, memory2);
             Assert.Equal(sameLength, Marshal.PtrToStringUni(memory2));
-        }
-
-        [WinFormsFact]
-        public void ToolTipBuffer_DisposeNoBuffer_Success()
-        {
-            using var buffer = new ToolTipBuffer();
-            buffer.Dispose();
-            Assert.Equal(IntPtr.Zero, buffer.Buffer);
-
-            // Call again.
-            buffer.Dispose();
-            Assert.Equal(IntPtr.Zero, buffer.Buffer);
-        }
-
-        [WinFormsFact]
-        public void ToolTipBuffer_DisposeWithBuffer_Success()
-        {
-            using var buffer = new ToolTipBuffer();
-            buffer.SetText("text");
-            buffer.Dispose();
-            Assert.Equal(IntPtr.Zero, buffer.Buffer);
-
-            // Call again.
-            buffer.Dispose();
-            Assert.Equal(IntPtr.Zero, buffer.Buffer);
         }
     }
 }


### PR DESCRIPTION
Using the newer functionality that allows allocating pinned arrays which makes management simpler and reduces the risk of memory leaks.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5562)