### PR TITLE
Fix the behavior of the Narrator rectangle for TabControl

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -2062,7 +2062,7 @@ namespace System.Windows.Forms
                 if (IsAccessibilityObjectCreated && SelectedTab?.ParentInternal is TabControl)
                 {
                     SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.SelectionItem_ElementSelectedEventId);
-                    SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                    BeginInvoke((MethodInvoker)(() => SelectedTab.TabAccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId)));
                 }
             }
             else

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabAccessibleObjectTests.cs
@@ -604,6 +604,7 @@ namespace System.Windows.Forms.Tests
             Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             pages[1].TabAccessibilityObject.DoDefaultAction();
+            Application.DoEvents();
 
             Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
@@ -692,6 +693,7 @@ namespace System.Windows.Forms.Tests
             pages[1].TestAccessor().Dynamic._tabAccessibilityObject = tabAccessibleObject;
 
             tabControl.SelectedTab = pages[1];
+            Application.DoEvents();
 
             Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
@@ -756,6 +758,7 @@ namespace System.Windows.Forms.Tests
             Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             tabControl.SelectedIndex = 1;
+            Application.DoEvents();
 
             Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
@@ -860,6 +863,7 @@ namespace System.Windows.Forms.Tests
             Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             pages[1].TabAccessibilityObject.AddToSelection();
+            Application.DoEvents();
 
             Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);
@@ -948,6 +952,7 @@ namespace System.Windows.Forms.Tests
             Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
 
             pages[1].TabAccessibilityObject.SelectItem();
+            Application.DoEvents();
 
             Assert.Equal(1, tabAccessibleObject.CallSelectionItemEventCount);
             Assert.Equal(1, tabAccessibleObject.CallFocusChangedEventCount);


### PR DESCRIPTION
Fixes #5571


## Proposed changes
- The issue is reproduced because the `TabControl` generates an event that switches the focus of the accessibility tool to the `TabControl` after switching between `TabPages`.
- Added `BeginInvoke` method, which allows to send the event about the focusing to the `TabPage` after the focus has switched to `TabControl`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![Issue-5571-beforefix](https://user-images.githubusercontent.com/23376742/131139056-f07f2b46-920f-4fd0-b5b4-e1871c2835bf.gif)

**After fix:**
![Issue-5571-afterfix](https://user-images.githubusercontent.com/23376742/131139087-b07ef2cc-acf1-4da7-88d9-c1cc998f4aa1.gif)


## Regression? 

- Yes (from #3058 )

## Risk
- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->
- CTI team 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator
- Inspector
- Accessibility Insights

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- NET Core SDK 6.0.100-rc.1.21416.15

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5574)