### PR TITLE
[release/6.0] Don't run tests in official build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,21 +83,18 @@ stages:
     parameters:
       name: Windows_x64
       targetArchitecture: x64
-      skipTests: $(SkipTests)
 
   # Windows x86
   - template: /eng/pipelines/build.yml
     parameters:
       name: Windows_x86
       targetArchitecture: x86
-      skipTests: $(SkipTests)
 
   # Windows arm64
   - template: /eng/pipelines/build.yml
     parameters:
       name: Windows_arm64
       targetArchitecture: arm64
-      skipTests: $(SkipTests)
 
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -78,33 +78,35 @@ jobs:
         /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\BuildSrc-${{ parameters.targetArchitecture }}.binlog
       displayName: Build
 
-    # Run Unit Tests
-    # Tests are run with /m:1 to work around https://github.com/tonerdo/coverlet/issues/364
-    - script: eng\cibuild.cmd
-        -test
-        -configuration $(_BuildConfig)
-        /p:Platform=${{ parameters.targetArchitecture }}
-        /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-        $(_OfficialBuildIdArgs)
-        $(_InternalRuntimeDownloadArgs)
-        /p:Coverage=$(_Coverage)
-        /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog
-        /m:1
-      displayName: Run Unit Tests
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      # Run Unit Tests
+      # Tests are run with /m:1 to work around https://github.com/tonerdo/coverlet/issues/364
+      - script: eng\cibuild.cmd
+          -test
+          -configuration $(_BuildConfig)
+          /p:Platform=${{ parameters.targetArchitecture }}
+          /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+          $(_OfficialBuildIdArgs)
+          $(_InternalRuntimeDownloadArgs)
+          /p:Coverage=$(_Coverage)
+          /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\Test-${{ parameters.targetArchitecture }}.binlog
+          /m:1
+        displayName: Run Unit Tests
 
-    # Run Integration Tests
-    # Tests are run with /m:1 to avoid parallelism across different assemblies which can lead to
-    # UI race conditions
-    - script: eng\cibuild.cmd
-        -integrationTest
-        -configuration $(_BuildConfig)
-        /p:Platform=${{ parameters.targetArchitecture }}
-        /p:TargetArchitecture=${{ parameters.targetArchitecture }}
-        $(_OfficialBuildIdArgs)
-        $(_InternalRuntimeDownloadArgs)
-        /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\IntegrationTest-${{ parameters.targetArchitecture }}.binlog
-        /m:1
-      displayName: Run Integration Tests
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      # Run Integration Tests
+      # Tests are run with /m:1 to avoid parallelism across different assemblies which can lead to
+      # UI race conditions
+      - script: eng\cibuild.cmd
+          -integrationTest
+          -configuration $(_BuildConfig)
+          /p:Platform=${{ parameters.targetArchitecture }}
+          /p:TargetArchitecture=${{ parameters.targetArchitecture }}
+          $(_OfficialBuildIdArgs)
+          $(_InternalRuntimeDownloadArgs)
+          /bl:$(BUILD.SOURCESDIRECTORY)\artifacts\log\$(_BuildConfig)\IntegrationTest-${{ parameters.targetArchitecture }}.binlog
+          /m:1
+        displayName: Run Integration Tests
 
     # Create Nuget package, sign, and publish
     - script: eng\cibuild.cmd


### PR DESCRIPTION
The tests are reasonably flaky, and frequently need manual reruns. Other repos don't run tests in their official builds for this reason, as well as time. This saves a little under 40% of the build time in passing cases (though these tests are short). Tests are still run in PR and public CI scenarios.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5576)