### PR TITLE
Checking if DataGridView handle is created for ToolTip (port to 6.0-rc1)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.ToolTip.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Forms
 
             public void Activate(bool activate)
             {
-                if (_dataGridView.DesignMode)
+                if (_dataGridView.DesignMode || !_dataGridView.IsHandleCreated)
                 {
                     return;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridView.DataGridViewTooltipTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridView.DataGridViewTooltipTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Data;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class DataGridView_DataGridViewToolTipTests
+    {
+        [WinFormsFact]
+        public void DataGridViewToolTip_Get_Not_ThrowsException()
+        {
+            DataTable dataTable = new();
+            dataTable.Columns.Add(columnName: "name");
+            dataTable.Rows.Add(values: "name1");
+
+            // create DataGridView with DataSource set to dataTable
+            DataGridView dataGridView = new();
+            dataGridView.ShowCellToolTips = true;
+            dataGridView.DataSource = dataTable;
+
+            // create form and add dataGridView
+            Form dialog = new();
+            dialog.Controls.Add(dataGridView);
+
+            // these two steps can also be done manually after the dialog is shown
+            dialog.Shown += (sender, args) =>
+            {
+                // 1. move mouse cursor over any cell of the first row
+                Cursor.Position = dataGridView.PointToScreen(dataGridView.GetCellDisplayRectangle(columnIndex: 0, rowIndex: 0, cutOverflow: false).Location);
+
+                // 2. close the dialog after a short delay
+                Task.Delay(millisecondsDelay: 100).ContinueWith((t) => dialog.Close(), TaskScheduler.FromCurrentSynchronizationContext());
+            };
+
+            dialog.ShowDialog();
+
+            bool exceptionThrown = false;
+
+            try
+            {
+                dataTable.AcceptChanges();
+            }
+            catch
+            {
+                exceptionThrown = true;
+            }
+
+            Assert.False(exceptionThrown, "Accepting changes on DataTable has thrown an InvalidOperationException because handle of the DataGridView used in Tooltip isn't created");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5496

## Proposed changes

- `InvalidOperationException` was thrown at the `Hide` method of the `ToolTip` class while creating a new instance of `ToolInfoWrapper` class. That was happening because `ToolTip` instance (class member named `_window`) has a created handle, and `ToolTip`'s `DataGridView` (method parameter named `win`) has not. Added a check if `DataGridView` handle is created while `DataGridViewToolTip` is being activated with its `DataGridView` (`Activate` method is used both for showing and hiding `DataGridViewToolTip`), so no hiding or showing `DataGridViewToolTip` for `DataGridView` without a handle would be attempted at the first place.
- Ported from PR #5533

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

**Before the fix**
![badIssue](https://user-images.githubusercontent.com/87859299/130793435-d5320a29-2d74-48dc-9da1-78960d66e218.gif)

**After the fix**
![goodIssue](https://user-images.githubusercontent.com/87859299/130793460-f50b2ac8-edea-4c16-972e-f98f259d5834.gif)

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit tests
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
Microsoft Windows [Version 10.0.19043.1165]
.NET SDK 6.0.100-rc.1.21416.15

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5607)