### PR TITLE
Fixing ToolStripButton high contrast issue

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSystemRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSystemRenderer.cs
@@ -624,6 +624,14 @@ namespace System.Windows.Forms
                 VisualStyleRenderer vsRenderer = VisualStyleRenderer;
                 vsRenderer.SetParameters(toolBarElement.ClassName, toolBarElement.Part, (int)state);
                 vsRenderer.DrawBackground(g, new Rectangle(Point.Empty, item.Size));
+
+                if (!SystemInformation.HighContrast &&
+                    (state == ToolBarState.Hot || state == ToolBarState.Pressed || state == ToolBarState.Checked))
+                {
+                    var bounds = item.ClientBounds;
+                    bounds.Height -= 1;
+                    ControlPaint.DrawBorderSimple(g, bounds, SystemColors.Highlight);
+                }
             }
             else
             {


### PR DESCRIPTION
Fixes #5503


## Proposed changes
- The issue is reproduced because the `vsRenderer.DrawBackground` method draws the background with the wrong contrast. In addition to this method, logic has been added to draw a solid border with acceptable contrast when the button is focused, pressed or checked

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:** 
![image](https://user-images.githubusercontent.com/23376742/131351641-133d3e24-2973-4b63-9084-14c6327bcf50.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/131351667-89c1df40-d125-47fa-acc5-8feb9b5123de.png)
![image](https://user-images.githubusercontent.com/23376742/131351684-1a9fc6e5-2d09-410d-93ea-20d816df7f46.png)


## Regression? 

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->

- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Accessibility Insights
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 6.0.100-rc.1.21416.15

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5618)