### PR TITLE
disable loc in main in order to get PRs for release branch.

### DIFF
--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -10,7 +10,7 @@ parameters:
   GithubPat: $(BotAccount-dotnet-bot-repo-PAT)
 
   SourcesDirectory: $(Build.SourcesDirectory)
-  CreatePr: true
+  CreatePr: false
   AutoCompletePr: false
   UseLfLineEndings: true
   UseCheckedInLocProjectJson: false


### PR DESCRIPTION
Disable loc for main in order to get release branch get updated loc strings.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5630)