### PR TITLE
Disable loc builds from release branch for 6.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,7 +100,7 @@ stages:
       skipTests: $(SkipTests)
 
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and( and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))), eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
   - stage: OneLocBuild
     displayName: Publish localizable content to OneLocBuild
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,7 +100,7 @@ stages:
       skipTests: $(SkipTests)
 
 
-- ${{ if and( and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'))), eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+- ${{ if and( and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')), eq(variables['Build.SourceBranch'], 'refs/heads/main')) }}:
   - stage: OneLocBuild
     displayName: Publish localizable content to OneLocBuild
     jobs:


### PR DESCRIPTION
Change in templates, to disable Loc PRs, is being overridden by Arcade. This is the right place to disable Loc build/ PRs on a branch.

Based my conversation with loc team, Loc tools can target only one branch at a time and branch owners need to notify loc team if there is a change in the branch for which loc need to be run. Ideally, we would always be running loc on `main `branches and snapping from there. In some specific cases, like templates, we would need to run localization for the changes/fixes we serviced to `release `branch.

For this to work, and because of limitations in loc tools, Only one branch need to be actively triggering loc build at any point in time. Changing branch needs work from loc team and has an SLA of 1-2 weeks. In our case, the best course of action is to wait until `release `branch is locked for major changes and raise one final request against release branch.

PRs we have been seeing in this repo are being triggered against changes in `release `and `main `branches but or creating PRs against one branch ( that is `main`). Hence, sync issues and build failures. To prevent this, I am disabling Loc on all branches except for `main`. We will raise ticket against loc when we are ready to update loc on `release `branches.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5653)