### PR TITLE
Document and annotate IWindowsFormsEditorService

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.DateTimeUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DateTimeEditor.DateTimeUI.cs
@@ -15,8 +15,7 @@ namespace System.ComponentModel.Design
         private class DateTimeUI : Control
         {
             private readonly MonthCalendar _monthCalendar = new DateTimeMonthCalendar();
-            private object _value;
-            private IWindowsFormsEditorService _edSvc;
+            private IWindowsFormsEditorService _editorService;
 
             public DateTimeUI()
             {
@@ -25,18 +24,12 @@ namespace System.ComponentModel.Design
                 _monthCalendar.Resize += MonthCalResize;
             }
 
-            public object Value
-            {
-                get
-                {
-                    return _value;
-                }
-            }
+            public object Value { get; private set; }
 
             public void End()
             {
-                _edSvc = null;
-                _value = null;
+                _editorService = null;
+                Value = null;
             }
 
             private void MonthCalKeyDown(object sender, KeyEventArgs e)
@@ -53,7 +46,7 @@ namespace System.ComponentModel.Design
             {
                 base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
 
-                //Resizing the editor to fit to the SingleMonth size after Dpi changed.
+                // Resizing the editor to fit to the SingleMonth size after Dpi changed.
                 Size = _monthCalendar.SingleMonthSize;
             }
 
@@ -71,8 +64,8 @@ namespace System.ComponentModel.Design
 
             private void OnDateSelected(object sender, DateRangeEventArgs e)
             {
-                _value = _monthCalendar.SelectionStart;
-                _edSvc.CloseDropDown();
+                Value = _monthCalendar.SelectionStart;
+                _editorService.CloseDropDown();
             }
 
             protected override void OnGotFocus(EventArgs e)
@@ -81,15 +74,15 @@ namespace System.ComponentModel.Design
                 _monthCalendar.Focus();
             }
 
-            public void Start(IWindowsFormsEditorService edSvc, object value)
+            public void Start(IWindowsFormsEditorService editorService, object value)
             {
-                _edSvc = edSvc;
-                _value = value;
+                _editorService = editorService;
+                Value = value;
 
-                if (value != null)
+                if (value is not null)
                 {
-                    DateTime dt = (DateTime)value;
-                    _monthCalendar.SetDate((dt.Equals(DateTime.MinValue)) ? DateTime.Today : dt);
+                    DateTime dateTime = (DateTime)value;
+                    _monthCalendar.SetDate((dateTime.Equals(DateTime.MinValue)) ? DateTime.Today : dateTime);
                 }
             }
 

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2000,8 +2000,8 @@ System.Windows.Forms.Design.EventsTab.EventsTab(System.IServiceProvider? sp) -> 
 ~System.Windows.Forms.Design.IUIService.ShowMessage(string message, string caption) -> void
 ~System.Windows.Forms.Design.IUIService.ShowMessage(string message, string caption, System.Windows.Forms.MessageBoxButtons buttons) -> System.Windows.Forms.DialogResult
 ~System.Windows.Forms.Design.IUIService.Styles.get -> System.Collections.IDictionary
-~System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl(System.Windows.Forms.Control control) -> void
-~System.Windows.Forms.Design.IWindowsFormsEditorService.ShowDialog(System.Windows.Forms.Form dialog) -> System.Windows.Forms.DialogResult
+System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl(System.Windows.Forms.Control? control) -> void
+System.Windows.Forms.Design.IWindowsFormsEditorService.ShowDialog(System.Windows.Forms.Form! dialog) -> System.Windows.Forms.DialogResult
 ~System.Windows.Forms.Design.WindowsFormsComponentEditor.EditComponent(object component, System.Windows.Forms.IWin32Window owner) -> bool
 ~System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.DomainItemAccessibleObject(string name, System.Windows.Forms.AccessibleObject parent) -> void
 ~System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.DomainUpDownAccessibleObject(System.Windows.Forms.DomainUpDown owner) -> void

--- a/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditor.cs
@@ -23,27 +23,27 @@ namespace System.Drawing.Design
             Hashtable intrinsicEditors = new Hashtable
             {
                 // System.ComponentModel type Editors
-                [typeof(DateTime)] = "System.ComponentModel.Design.DateTimeEditor, " + AssemblyRef.SystemDesign,
-                [typeof(Array)] = "System.ComponentModel.Design.ArrayEditor, " + AssemblyRef.SystemDesign,
-                [typeof(IList)] = "System.ComponentModel.Design.CollectionEditor, " + AssemblyRef.SystemDesign,
-                [typeof(ICollection)] = "System.ComponentModel.Design.CollectionEditor, " + AssemblyRef.SystemDesign,
-                [typeof(byte[])] = "System.ComponentModel.Design.BinaryEditor, " + AssemblyRef.SystemDesign,
-                [typeof(Stream)] = "System.ComponentModel.Design.BinaryEditor, " + AssemblyRef.SystemDesign,
+                [typeof(DateTime)] = $"System.ComponentModel.Design.DateTimeEditor, {AssemblyRef.SystemDesign}",
+                [typeof(Array)] = $"System.ComponentModel.Design.ArrayEditor, {AssemblyRef.SystemDesign}",
+                [typeof(IList)] = $"System.ComponentModel.Design.CollectionEditor, {AssemblyRef.SystemDesign}",
+                [typeof(ICollection)] = $"System.ComponentModel.Design.CollectionEditor, {AssemblyRef.SystemDesign}",
+                [typeof(byte[])] = $"System.ComponentModel.Design.BinaryEditor, {AssemblyRef.SystemDesign}",
+                [typeof(Stream)] = $"System.ComponentModel.Design.BinaryEditor, {AssemblyRef.SystemDesign}",
 
                 // System.Windows.Forms type Editors
-                [typeof(string[])] = "System.Windows.Forms.Design.StringArrayEditor, " + AssemblyRef.SystemDesign,
-                [typeof(Collection<string>)] = "System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign,
-                [typeof(StringCollection)] = "System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign,
+                [typeof(string[])] = $"System.Windows.Forms.Design.StringArrayEditor, {AssemblyRef.SystemDesign}",
+                [typeof(Collection<string>)] = $"System.Windows.Forms.Design.StringCollectionEditor, {AssemblyRef.SystemDesign}",
+                [typeof(StringCollection)] = $"System.Windows.Forms.Design.StringCollectionEditor, {AssemblyRef.SystemDesign}",
 
                 // System.Drawing.Design type Editors
-                [typeof(Bitmap)] = "System.Drawing.Design.BitmapEditor, " + AssemblyRef.SystemDrawingDesign,
-                [typeof(Color)] = "System.Drawing.Design.ColorEditor, " + AssemblyRef.SystemDrawingDesign,
-                [typeof(ContentAlignment)] = "System.Drawing.Design.ContentAlignmentEditor, " + AssemblyRef.SystemDrawingDesign,
-                [typeof(Font)] = "System.Drawing.Design.FontEditor, " + AssemblyRef.SystemDrawingDesign,
-                // no way to add Font.Name and associate it with FontNameEditor
-                [typeof(Icon)] = "System.Drawing.Design.IconEditor, " + AssemblyRef.SystemDrawingDesign,
-                [typeof(Image)] = "System.Drawing.Design.ImageEditor, " + AssemblyRef.SystemDrawingDesign,
-                [typeof(Metafile)] = "System.Drawing.Design.MetafileEditor, " + AssemblyRef.SystemDrawingDesign,
+                [typeof(Bitmap)] = $"System.Drawing.Design.BitmapEditor, {AssemblyRef.SystemDrawingDesign}",
+                [typeof(Color)] = $"System.Drawing.Design.ColorEditor, {AssemblyRef.SystemDrawingDesign}",
+                [typeof(ContentAlignment)] = $"System.Drawing.Design.ContentAlignmentEditor, {AssemblyRef.SystemDrawingDesign}",
+                [typeof(Font)] = $"System.Drawing.Design.FontEditor, {AssemblyRef.SystemDrawingDesign}",
+                // No way to add Font.Name and associate it with FontNameEditor.
+                [typeof(Icon)] = $"System.Drawing.Design.IconEditor, {AssemblyRef.SystemDrawingDesign}",
+                [typeof(Image)] = $"System.Drawing.Design.ImageEditor, {AssemblyRef.SystemDrawingDesign}",
+                [typeof(Metafile)] = $"System.Drawing.Design.MetafileEditor, {AssemblyRef.SystemDrawingDesign}",
             };
 
             // Add our intrinsic editors to TypeDescriptor.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/IWindowsFormsEditorService.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/IWindowsFormsEditorService.cs
@@ -2,27 +2,61 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
+using System.Drawing.Design;
+using System.Windows.Forms.PropertyGridInternal;
 
 namespace System.Windows.Forms.Design
 {
     /// <summary>
-    ///  Provides an interface to display Win Forms dialog boxes and controls.
+    ///  Provides an interface for a <see cref="UITypeEditor"/> to display Windows Forms or to display a control in a
+    ///  drop-down area from a <see cref="PropertyGrid"/> control in design mode.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The default <see cref="IWindowsFormsEditorService"/> is provided to <see cref="UITypeEditor"/>s through
+    ///   the service provider given to the <see cref="UITypeEditor.EditValue(IServiceProvider, object)"/> and
+    ///   <see cref="UITypeEditor.EditValue(System.ComponentModel.ITypeDescriptorContext, IServiceProvider, object)"/>
+    ///   methods.
+    ///  </para>
+    /// </remarks>
+    /// <devdoc>
+    ///  <see cref="PropertyGridView"/> implements this interface and it provides it via the
+    ///  <see cref="PropertyGrid.PropertyGridServiceProvider"/> in the <see cref="SingleSelectRootGridEntry.GetService(Type)"/>
+    ///  override.
+    ///
+    ///  <see cref="PropertyGridView.PopupEditor(int)"/> calls <see cref="GridEntry.EditPropertyValue(PropertyGridView)"/>
+    ///  which invokes <see cref="UITypeEditor"/>'s EditValue methods.
+    /// </devdoc>
     public interface IWindowsFormsEditorService
     {
         /// <summary>
-        ///  Closes a previously opened drop down list
+        ///  Closes a previously opened drop down list.
         /// </summary>
         void CloseDropDown();
 
         /// <summary>
-        ///  Displays the specified control in a drop down list
+        ///  Modally displays the specified control in a drop down area below a value field of the
+        ///  <see cref="PropertyGrid"/> that provides this service.
         /// </summary>
-        void DropDownControl(Control control);
+        /// <remarks>
+        ///  <para>
+        ///   The EditValue methods of a <see cref="UITypeEditor"/> can call this method to display a specified control
+        ///   in a drop down area over the <see cref="PropertyGrid"/> hosting the editor which uses this service.
+        ///  </para>
+        ///  <para>
+        ///   When possible, the dimensions of the control will be maintained. If this is not possible due to the screen
+        ///   layout, the control may be resized. To ensure that the control resizes neatly, you should implement docking
+        ///   and anchoring, and possibly any resize event-handler update code. If the user performs an action that
+        ///   causes the drop down to close, the control will be hidden and disposed by garbage collection if there is
+        ///   no other stored reference to the control.
+        ///  </para>
+        /// </remarks>
+        void DropDownControl(Control? control);
 
         /// <summary>
-        ///  Shows the specified dialog box.
+        ///  Shows the specified <see cref="Form"/> as a dialog and returns its result. You should always use this
+        ///  method rather than showing the dialog directly, as this will properly position the dialog and provide
+        ///  it a dialog owner.
         /// </summary>
         DialogResult ShowDialog(Form dialog);
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.PropertyGridServiceProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.PropertyGridServiceProvider.cs
@@ -2,10 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Windows.Forms.PropertyGridInternal;
+
 namespace System.Windows.Forms
 {
     public partial class PropertyGrid
     {
+        /// <summary>
+        ///  Service provider that searches the <see cref="ActiveDesigner"/>, then the <see cref="PropertyGridView"/>,
+        ///  then finally the <see cref="Site"/> for requested services.
+        /// </summary>
         private class PropertyGridServiceProvider : IServiceProvider
         {
             private readonly PropertyGrid _ownerPropertyGrid;
@@ -17,24 +23,10 @@ namespace System.Windows.Forms
 
             public object? GetService(Type serviceType)
             {
-                object? s = null;
-
-                if (_ownerPropertyGrid.ActiveDesigner is not null)
-                {
-                    s = _ownerPropertyGrid.ActiveDesigner.GetService(serviceType);
-                }
-
-                if (s is null)
-                {
-                    s = _ownerPropertyGrid._gridView.GetService(serviceType);
-                }
-
-                if (s is null && _ownerPropertyGrid.Site is not null)
-                {
-                    s = _ownerPropertyGrid.Site.GetService(serviceType);
-                }
-
-                return s;
+                object? service = _ownerPropertyGrid.ActiveDesigner?.GetService(serviceType);
+                service ??= _ownerPropertyGrid._gridView.GetService(serviceType);
+                service ??= _ownerPropertyGrid.Site?.GetService(serviceType);
+                return service;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.Flags.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.Flags.cs
@@ -2,33 +2,46 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing.Design;
+
 namespace System.Windows.Forms.PropertyGridInternal
 {
     internal abstract partial class GridEntry
     {
-        // Type flags
         [Flags]
         public enum Flags
         {
-            TextEditable        = 0x00000001,
-            Enumerable          = 0x00000002,
-            CustomPaint         = 0x00000004,
-            ImmediatelyEditable = 0x00000008,
-            CustomEditable      = 0x00000010,
-            DropdownEditable    = 0x00000020,
-            LabelBold           = 0x00000040,
-            ReadOnlyEditable    = 0x00000080,
-            RenderReadOnly      = 0x00000100,
-            Immutable           = 0x00000200,
-            ForceReadOnly       = 0x00000400,
-            RenderPassword      = 0x00001000,
-            Disposed            = 0x00002000,
-            Expand              = 0x00010000,
-            Expandable          = 0x00020000,
-            ExpandableFailed    = 0x00080000,
-            NoCustomPaint       = 0x00100000,
-            Categories          = 0x00200000,
-            Checked             = unchecked((int)0x80000000)
+            TextEditable            = 0x00000001,
+
+            /// <summary>
+            ///  The <see cref="TypeConverter"/> supports standard values.
+            /// </summary>
+            StandardValuesSupported = 0x00000002,
+            CustomPaint             = 0x00000004,
+            ImmediatelyEditable     = 0x00000008,
+
+            /// <summary>
+            ///  The current <see cref="UITypeEditor.GetEditStyle()"/> is <see cref="UITypeEditorEditStyle.Modal"/>.
+            /// </summary>
+            ModalEditable           = 0x00000010,
+
+            /// <summary>
+            ///  The current <see cref="UITypeEditor.GetEditStyle()"/> is <see cref="UITypeEditorEditStyle.DropDown"/>.
+            /// </summary>
+            DropDownEditable        = 0x00000020,
+            LabelBold               = 0x00000040,
+            ReadOnlyEditable        = 0x00000080,
+            RenderReadOnly          = 0x00000100,
+            Immutable               = 0x00000200,
+            ForceReadOnly           = 0x00000400,
+            RenderPassword          = 0x00001000,
+            Disposed                = 0x00002000,
+            Expand                  = 0x00010000,
+            Expandable              = 0x00020000,
+            ExpandableFailed        = 0x00080000,
+            NoCustomPaint           = 0x00100000,
+            Categories              = 0x00200000,
+            Checked                 = unchecked((int)0x80000000)
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -213,8 +213,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <summary>
-        ///  Returns the default child GridEntry of this item.  Usually the default property
-        ///  of the target object.
+        ///  Returns the default child GridEntry of this item.  Usually the default property of the target object.
         /// </summary>
         internal virtual GridEntry DefaultChild
         {
@@ -236,7 +235,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal bool Disposed => GetFlagSet(Flags.Disposed);
 
-        internal virtual bool Enumerable => (EntryFlags & Flags.Enumerable) != 0;
+        /// <summary>
+        ///  Returns true if there is a standard set of values that can be selected from.
+        ///  <see cref="GetPropertyValueList"/> should return said values when this is true.
+        /// </summary>
+        internal virtual bool Enumerable => (EntryFlags & Flags.StandardValuesSupported) != 0;
 
         public override bool Expandable
         {
@@ -346,7 +349,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (converter.GetStandardValuesSupported(this))
                 {
-                    _flags |= Flags.Enumerable;
+                    _flags |= Flags.StandardValuesSupported;
                 }
 
                 if (!forceReadOnly && converter.CanConvertFrom(this, typeof(string)) &&
@@ -398,7 +401,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         switch (uiEditor.GetEditStyle(this))
                         {
                             case UITypeEditorEditStyle.Modal:
-                                _flags |= Flags.CustomEditable;
+                                _flags |= Flags.ModalEditable;
                                 if (!isImmutable && !PropertyType.IsValueType)
                                 {
                                     _flags |= Flags.ReadOnlyEditable;
@@ -406,7 +409,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                                 break;
                             case UITypeEditorEditStyle.DropDown:
-                                _flags |= Flags.DropdownEditable;
+                                _flags |= Flags.DropDownEditable;
                                 break;
                         }
                     }
@@ -590,7 +593,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public virtual bool IsValueEditable
             => !ForceReadOnly
-            && 0 != (EntryFlags & (Flags.DropdownEditable | Flags.TextEditable | Flags.CustomEditable | Flags.Enumerable));
+            && 0 != (EntryFlags & (Flags.DropDownEditable | Flags.TextEditable | Flags.ModalEditable | Flags.StandardValuesSupported));
 
         public bool IsImmediatelyEditable => (EntryFlags & Flags.ImmediatelyEditable) != 0;
 
@@ -636,10 +639,16 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal virtual string LabelToolTipText => PropertyLabel;
 
-        public virtual bool NeedsDropDownButton => (EntryFlags & Flags.DropdownEditable) != 0;
+        /// <summary>
+        ///  The entry needs a drop down button to invoke it's editor.
+        /// </summary>
+        public virtual bool NeedsDropDownButton => (EntryFlags & Flags.DropDownEditable) != 0;
 
-        public virtual bool NeedsCustomEditorButton
-            => (EntryFlags & Flags.CustomEditable) != 0
+        /// <summary>
+        ///  The entry needs a modal editor button ("...") to invoke it's editor.
+        /// </summary>
+        public virtual bool NeedsModalEditorButton
+            => (EntryFlags & Flags.ModalEditable) != 0
                 && (IsValueEditable || (EntryFlags & Flags.ReadOnlyEditable) != 0);
 
         public PropertyGrid OwnerGrid { get; }
@@ -1501,7 +1510,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <summary>
-        ///  Returns the text values of this property.
+        ///  Returns the standard text values of this property.
         /// </summary>
         public virtual object[] GetPropertyValueList()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
@@ -130,7 +130,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (row != -1)
                 {
-                    propertyGridView.PopupDialog(row);
+                    propertyGridView.PopupEditor(row);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -283,7 +283,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 _readOnlyVerified = true;
 
-                return base.ShouldRenderReadOnly && !_isSerializeContentsProperty && !base.NeedsCustomEditorButton;
+                return base.ShouldRenderReadOnly && !_isSerializeContentsProperty && !base.NeedsModalEditorButton;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.Flags.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.Flags.cs
@@ -17,7 +17,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             DropDownClosing         = 0x0020,
             DropDownCommit          = 0x0040,
             NeedUpdateUIBasedOnFont = 0x0080,
-            BtnLaunchedEditor       = 0x0100,
+
+            /// <summary>
+            ///  The editor is currently launched via the drop-down button.
+            /// </summary>
+            ButtonLaunchedEditor    = 0x0100,
             NoDefault               = 0x0200,
             ResizableDropDown       = 0x0400
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -9,6 +9,7 @@ using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.Drawing;
+using System.Drawing.Design;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.Design;
@@ -191,6 +192,15 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
+        /// <summary>
+        ///  Shared drop-down button used to open the drop down editor (if applicable) for the currently selected row.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   The visisbility of this button is primarily driven through associated <see cref="UITypeEditor"/>s for
+        ///   the selected row's <see cref="GridEntry"/>.
+        ///  </para>
+        /// </remarks>
         internal DropDownButton DropDownButton
         {
             get
@@ -223,6 +233,15 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
+        /// <summary>
+        ///  Shared "..." button used to launch editor dialogs for the selected row if applicable.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   The visisbility of this button is primarily driven through associated <see cref="UITypeEditor"/>s for
+        ///   the selected row's <see cref="GridEntry"/>.
+        ///  </para>
+        /// </remarks>
         private Button DialogButton
         {
             get
@@ -252,26 +271,6 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 return _dialogButton;
             }
-        }
-
-        private static Bitmap GetBitmapFromIcon(string iconName, int iconWidth, int iconHeight)
-        {
-            Size desiredSize = new(iconWidth, iconHeight);
-            Icon icon = new(new Icon(typeof(PropertyGrid), iconName), desiredSize);
-            var bitmap = icon.ToBitmap();
-            icon.Dispose();
-
-            if (bitmap.Size.Width != iconWidth || bitmap.Size.Height != iconHeight)
-            {
-                Bitmap scaledBitmap = DpiHelper.CreateResizedBitmap(bitmap, desiredSize);
-                if (scaledBitmap is not null)
-                {
-                    bitmap.Dispose();
-                    bitmap = scaledBitmap;
-                }
-            }
-
-            return bitmap;
         }
 
         /// <summary>
@@ -545,8 +544,8 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <summary>
-        ///  Returns or sets the IServiceProvider the PropertyGridView will use to obtain
-        ///  services.  This may be null.
+        ///  Returns or sets the <see cref="IServiceProvider"/> the <see cref="PropertyGridView"/> will use to obtain
+        ///  services. This may be null.
         /// </summary>
         public IServiceProvider ServiceProvider
         {
@@ -784,10 +783,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             _tipInfo = -1;
         }
 
-        /// <summary>
-        ///  Closes a previously opened drop down.  This should be called by the
-        ///  drop down when the user does something that should close it.
-        /// </summary>
+        /// <inheritdoc />
         public void CloseDropDown() => CloseDropDownInternal(resetFocus: true);
 
         private void CloseDropDownInternal(bool resetFocus)
@@ -1025,6 +1021,26 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
 
             return bitmap;
+
+            static Bitmap GetBitmapFromIcon(string iconName, int iconWidth, int iconHeight)
+            {
+                Size desiredSize = new(iconWidth, iconHeight);
+                Icon icon = new(new Icon(typeof(PropertyGrid), iconName), desiredSize);
+                var bitmap = icon.ToBitmap();
+                icon.Dispose();
+
+                if (bitmap.Size.Width != iconWidth || bitmap.Size.Height != iconHeight)
+                {
+                    Bitmap scaledBitmap = DpiHelper.CreateResizedBitmap(bitmap, desiredSize);
+                    if (scaledBitmap is not null)
+                    {
+                        bitmap.Dispose();
+                        bitmap = scaledBitmap;
+                    }
+                }
+
+                return bitmap;
+            }
         }
 
         private void CreateUI() => UpdateUIBasedOnFont(layoutRequired: false);
@@ -1252,6 +1268,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
+        /// <summary>
+        ///  Handle selection and/or editor invocation when F4 is pressed. If the current row has a modal dialog ("...")
+        ///  <paramref name="popupModalDialog"/> will cause it to be invoked. If not set to true, the ("...") button
+        ///  will just be focused. Drop-down editors will always be launched.
+        /// </summary>
         private void F4Selection(bool popupModalDialog)
         {
             GridEntry gridEntry = GetGridEntryFromRow(_selectedRow);
@@ -1269,13 +1290,13 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (DropDownButton.Visible)
             {
-                PopupDialog(_selectedRow);
+                PopupEditor(_selectedRow);
             }
             else if (DialogButton.Visible)
             {
                 if (popupModalDialog)
                 {
-                    PopupDialog(_selectedRow);
+                    PopupEditor(_selectedRow);
                 }
                 else
                 {
@@ -1284,6 +1305,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
             else if (EditTextBox.Visible)
             {
+                // No edit buttons, just focus and select the text value.
                 EditTextBox.Focus();
                 EditTextBox.SelectAll();
             }
@@ -1474,17 +1496,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public int GetValueWidth() => (int)(InternalLabelWidth * (_labelRatio - 1));
 
-        /// <summary>
-        ///  Modally displays the provided control in a drop down.
-        /// </summary>
-        /// <remarks>
-        ///  <para>
-        ///   When possible, the current dimensions of the control will be respected. If this is not possible for the
-        ///   current screen layout the control may be resized, so it should be implemented using appropriate docking
-        ///   and anchoring so it will resize nicely. If the user performs an action that would cause the drop down to
-        ///   prematurely disappear the control will be hidden.
-        ///  </para>
-        /// </remarks>
+        /// <inheritdoc/>
         public void DropDownControl(Control control)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:DropDownControl");
@@ -1853,24 +1865,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return -1;
         }
 
-        public int GetDefaultOutlineIndent()
-        {
-            return OutlineIndent;
-        }
-
-        private IHelpService GetHelpService()
-        {
-            if (_helpService is null && ServiceProvider.TryGetService(out _topHelpService!))
-            {
-                IHelpService localHelpService = _topHelpService.CreateLocalContext(HelpContextType.ToolWindowSelection);
-                if (localHelpService is not null)
-                {
-                    _helpService = localHelpService;
-                }
-            }
-
-            return _helpService;
-        }
+        public int GetDefaultOutlineIndent() => OutlineIndent;
 
         public int GetScrollOffset()
         {
@@ -2248,11 +2243,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         /// <summary>
-        ///  Shared click handler for the dialog and drop-down button.
+        ///  Shared click handler for the dialog and drop-down button. Commits any pending edits in the
+        ///  shared text box before launching the relevant editor for the currently selected row.
         /// </summary>
         private void OnButtonClick(object sender, EventArgs e)
         {
-            if (_flags.HasFlag(Flags.BtnLaunchedEditor))
+            if (_flags.HasFlag(Flags.ButtonLaunchedEditor))
             {
                 return;
             }
@@ -2267,12 +2263,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             try
             {
                 CommitEditTextBox();
-                SetFlag(Flags.BtnLaunchedEditor, true);
-                PopupDialog(_selectedRow);
+                SetFlag(Flags.ButtonLaunchedEditor, true);
+                PopupEditor(_selectedRow);
             }
             finally
             {
-                SetFlag(Flags.BtnLaunchedEditor, false);
+                SetFlag(Flags.ButtonLaunchedEditor, false);
             }
         }
 
@@ -2755,26 +2751,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        private bool OnF4(Control sender)
-        {
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnF4");
-            if (ModifierKeys != 0)
-            {
-                return false;
-            }
-
-            if (sender == this || sender == OwnerGrid)
-            {
-                F4Selection(true);
-            }
-            else
-            {
-                UnfocusSelection();
-            }
-
-            return true;
-        }
-
         private bool OnEscape(Control sender)
         {
             Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnEscape");
@@ -2877,7 +2853,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // Alt-Arrow support.
             if (keyCode == Keys.Down && altPressed && DropDownButton.Visible)
             {
-                F4Selection(false);
+                F4Selection(popupModalDialog: false);
                 return;
             }
 
@@ -3847,9 +3823,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        public void PopupDialog(int row)
+        /// <summary>
+        ///  Displays the appropriate editor for the given <paramref name="row"/>.
+        /// </summary>
+        public void PopupEditor(int row)
         {
-            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:PopupDialog");
+            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:PopupEditor");
             GridEntry gridEntry = GetGridEntryFromRow(row);
             if (gridEntry is null)
             {
@@ -3864,10 +3843,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             bool needsDropDownButton = gridEntry.NeedsDropDownButton;
             bool enumerable = gridEntry.Enumerable;
-            bool needsCustomEditorButton = gridEntry.NeedsCustomEditorButton;
+            bool needsCustomEditorButton = gridEntry.NeedsModalEditorButton;
 
             if (enumerable && !needsDropDownButton)
             {
+                // Just a simple selection of possible values, fill our common listbox with the values and show it.
+
                 DropDownListBox.Items.Clear();
                 _ = gridEntry.PropertyValue;
                 object[] rgItems = gridEntry.GetPropertyValueList();
@@ -3927,36 +3908,42 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 Refresh();
+                return;
             }
-            else if (needsCustomEditorButton || needsDropDownButton)
+
+            if (!needsCustomEditorButton && !needsDropDownButton)
             {
+                return;
+            }
+
+            // The current grid entry supports editing, invoke the editor.
+
+            try
+            {
+                InPropertySet = true;
+                EditTextBox.DisableMouseHook = true;
+
                 try
                 {
-                    InPropertySet = true;
-                    EditTextBox.DisableMouseHook = true;
-
-                    try
-                    {
-                        SetFlag(Flags.ResizableDropDown, gridEntry.UITypeEditor.IsDropDownResizable);
-                        gridEntry.EditPropertyValue(this);
-                    }
-                    finally
-                    {
-                        SetFlag(Flags.ResizableDropDown, false);
-                    }
+                    SetFlag(Flags.ResizableDropDown, gridEntry.UITypeEditor.IsDropDownResizable);
+                    gridEntry.EditPropertyValue(this);
                 }
                 finally
                 {
-                    InPropertySet = false;
-                    EditTextBox.DisableMouseHook = false;
+                    SetFlag(Flags.ResizableDropDown, false);
                 }
+            }
+            finally
+            {
+                InPropertySet = false;
+                EditTextBox.DisableMouseHook = false;
+            }
 
-                Refresh();
+            Refresh();
 
-                if (FocusInside)
-                {
-                    SelectGridEntry(gridEntry, pageIn: false);
-                }
+            if (FocusInside)
+            {
+                SelectGridEntry(gridEntry, pageIn: false);
             }
         }
 
@@ -3996,7 +3983,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                     case Keys.F4:
                         if (FocusInside)
                         {
-                            return OnF4(this);
+                            Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "PropertyGridView:OnF4");
+                            if (ModifierKeys != 0)
+                            {
+                                return false;
+                            }
+
+                            F4Selection(popupModalDialog: true);
+                            return true;
                         }
 
                         break;
@@ -4349,7 +4343,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             bool editVisible = EditTextBox.Visible;
             bool dropDownButtonVisible = DropDownButton.Visible;
-            bool editButtonVisible = DialogButton.Visible;
+            bool dialogButtonVisible = DialogButton.Visible;
 
             EditTextBox.Visible = false;
             DialogButton.Visible = false;
@@ -4363,7 +4357,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 if (currentRow >= 0 && currentRow < _visibleRows - 1)
                 {
                     EditTextBox.Visible = editVisible;
-                    DialogButton.Visible = editButtonVisible;
+                    DialogButton.Visible = dialogButtonVisible;
                     DropDownButton.Visible = dropDownButtonVisible;
                     SelectGridEntry(currentEntry, pageIn: true);
                 }
@@ -4508,7 +4502,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             // What components are we using?
             bool needsDropDownButton = gridEntry.NeedsDropDownButton | gridEntry.Enumerable;
-            bool needsCustomEditorButton = gridEntry.NeedsCustomEditorButton;
+            bool needsCustomEditorButton = gridEntry.NeedsModalEditorButton;
             bool customPaint = gridEntry.IsCustomPaint;
 
             rect.X += 1;
@@ -5073,13 +5067,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             return scrollBarChanged;
         }
 
-        /// <summary>
-        ///  Shows the given dialog, and returns its dialog result.  You should always
-        ///  use this method rather than showing the dialog directly, as this will
-        ///  properly position the dialog and provide it a dialog owner.
-        /// </summary>
+        /// <inheritdoc />
         public DialogResult ShowDialog(Form dialog)
         {
+            ArgumentNullException.ThrowIfNull(dialog);
+
             // Try to shift down if sitting right on top of existing owner.
             if (dialog.StartPosition == FormStartPosition.CenterScreen)
             {
@@ -5304,8 +5296,12 @@ namespace System.Windows.Forms.PropertyGridInternal
         private void UpdateHelpAttributes(GridEntry oldEntry, GridEntry newEntry)
         {
             // Update the help context with the current property.
-            IHelpService helpService = GetHelpService();
-            if (helpService is null || oldEntry == newEntry)
+            if (_helpService is null && ServiceProvider.TryGetService(out _topHelpService!))
+            {
+                _helpService = _topHelpService.CreateLocalContext(HelpContextType.ToolWindowSelection);
+            }
+
+            if (_helpService is null || oldEntry == newEntry)
             {
                 return;
             }
@@ -5315,7 +5311,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 while (temp is not null)
                 {
-                    helpService.RemoveContextAttribute("Keyword", temp.HelpKeyword);
+                    _helpService.RemoveContextAttribute("Keyword", temp.HelpKeyword);
                     temp = temp.ParentGridEntry;
                 }
             }
@@ -5324,7 +5320,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 temp = newEntry;
 
-                UpdateHelpAttributes(helpService, temp, true);
+                UpdateHelpAttributes(_helpService, temp, true);
             }
         }
 


### PR DESCRIPTION
Document more around the editor experience in the PropertyGrid. Docs additions include public docs for public API (with further clarifications).

Some name changes and collapsing of single caller methods. Name changes are intended to align more with public API documentation.
