### PR TITLE
Fixing `ToolStrip` button background rendering in HC theme (port to 6.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -436,10 +436,7 @@ namespace System.Windows.Forms
                     Graphics g = e.Graphics;
                     Rectangle bounds = new Rectangle(Point.Empty, e.Item.Size);
 
-                    if (button.CheckState == CheckState.Checked)
-                    {
-                        g.FillRectangle(SystemBrushes.Highlight, bounds);
-                    }
+                    g.FillRectangle(SystemBrushes.Highlight, bounds);
 
                     if (button.Selected)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSystemRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSystemRenderer.cs
@@ -42,7 +42,8 @@ namespace System.Windows.Forms
             {
                 if (toolStripHighContrastRenderer is null)
                 {
-                    toolStripHighContrastRenderer = new ToolStripHighContrastRenderer(/*renderLikeSystem*/true);
+                    // If system in high contrast mode 'false' flag should be passed to render filled selected button background. This is in consistence with ToolStripProfessionalRenderer.
+                    toolStripHighContrastRenderer = new ToolStripHighContrastRenderer(systemRenderMode: false);
                 }
 
                 return toolStripHighContrastRenderer;
@@ -355,6 +356,14 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
         {
+            // If system in high contrast mode and specific renderer override is defined, use that.
+            // For ToolStripSystemRenderer in High Contrast mode the RendererOverride property will be ToolStripHighContrastRenderer.
+            if (RendererOverride is not null)
+            {
+                base.OnRenderButtonBackground(e);
+                return;
+            }
+
             RenderItemInternal(e);
         }
 
@@ -363,6 +372,14 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
         {
+            // If system in high contrast mode and specific renderer override is defined, use that.
+            // For ToolStripSystemRenderer in High Contrast mode the RendererOverride property will be ToolStripHighContrastRenderer.
+            if (RendererOverride is not null)
+            {
+                base.OnRenderDropDownButtonBackground(e);
+                return;
+            }
+
             RenderItemInternal(e);
         }
 
@@ -499,6 +516,14 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
         {
+            // If system in high contrast mode and specific renderer override is defined, use that.
+            // For ToolStripSystemRenderer in High Contrast mode the RendererOverride property will be ToolStripHighContrastRenderer.
+            if (RendererOverride is not null)
+            {
+                base.OnRenderSplitButtonBackground(e);
+                return;
+            }
+
             ToolStripSplitButton splitButton = e.Item as ToolStripSplitButton;
             Graphics g = e.Graphics;
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.Designer.cs
@@ -39,6 +39,19 @@ namespace WinformsControlsTest
             this.toolStripLabel1 = new System.Windows.Forms.ToolStripLabel();
             this.toolStripProgressBar2 = new System.Windows.Forms.ToolStripProgressBar();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.toolStrip2 = new System.Windows.Forms.ToolStrip();
+            this.toolStrip2_Button1 = new System.Windows.Forms.ToolStripButton();
+            this.toolStrip2_Button2 = new System.Windows.Forms.ToolStripButton();
+            this.toolStrip2_Button3 = new System.Windows.Forms.ToolStripButton();
+            this.toolStrip2_Button4 = new System.Windows.Forms.ToolStripButton();
+            this.toolStrip2_Button5 = new System.Windows.Forms.ToolStripButton();
+            this.toolStrip2_SplitButton1 = new System.Windows.Forms.ToolStripSplitButton();
+            this.toolStrip2_DropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
+            this.toolStrip2_DropDownButton1_ChildButton1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStrip2_DropDownButton1_ChildButton2 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStrip2_SplitButton1_ChildButton1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStrip2_SplitButton1_ChildButton2 = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStrip2.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -53,6 +66,108 @@ namespace WinformsControlsTest
             this.toolStrip1.Size = new System.Drawing.Size(481, 22);
             this.toolStrip1.TabIndex = 0;
             this.toolStrip1.Text = "toolStrip1";
+            // 
+            // toolStrip2
+            // 
+            this.toolStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStrip2_Button1,
+            this.toolStrip2_Button2,
+            this.toolStrip2_Button3,
+            this.toolStrip2_Button4,
+            this.toolStrip2_Button5,
+            this.toolStrip2_SplitButton1,
+            this.toolStrip2_DropDownButton1,});
+            this.toolStrip2.Location = new System.Drawing.Point(0, 22);
+            this.toolStrip2.Name = "toolStrip2";
+            this.toolStrip2.Size = new System.Drawing.Size(481, 22);
+            this.toolStrip2.TabIndex = 1;
+            this.toolStrip2.Text = "toolStrip2";
+            // 
+            // toolStrip2_Button1
+            //
+            this.toolStrip2_Button1.CheckState = System.Windows.Forms.CheckState.Unchecked;
+            this.toolStrip2_Button1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStrip2_Button1.Name = "toolStrip2_Button1_Unchecked";
+            this.toolStrip2_Button1.Size = new System.Drawing.Size(114, 22);
+            this.toolStrip2_Button1.Text = "toolStrip2_Button1_Unchecked";
+            // 
+            // toolStrip2_Button2
+            //
+            this.toolStrip2_Button2.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.toolStrip2_Button1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStrip2_Button2.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStrip2_Button2.Name = "toolStrip2_Button2_Checked";
+            this.toolStrip2_Button2.Size = new System.Drawing.Size(114, 22);
+            this.toolStrip2_Button2.Text = "toolStrip2_Button2_Checked";
+            // 
+            // toolStrip2_Button3
+            //
+            this.toolStrip2_Button3.CheckState = System.Windows.Forms.CheckState.Indeterminate;
+            this.toolStrip2_Button3.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStrip2_Button3.Name = "toolStrip2_Button3_Indeterminate";
+            this.toolStrip2_Button3.Size = new System.Drawing.Size(114, 22);
+            this.toolStrip2_Button3.Text = "toolStrip2_Button3_Indeterminate";
+            // 
+            // toolStrip2_Button4
+            //
+            this.toolStrip2_Button4.CheckOnClick = true;
+            this.toolStrip2_Button4.CheckState = System.Windows.Forms.CheckState.Unchecked;
+            this.toolStrip2_Button4.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStrip2_Button4.Name = "toolStrip2_Button4_Checkable";
+            this.toolStrip2_Button4.Size = new System.Drawing.Size(114, 22);
+            this.toolStrip2_Button4.Text = "toolStrip2_Button4_Checkable";
+            // 
+            // toolStrip2_Button5
+            //
+            this.toolStrip2_Button5.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStrip2_Button5.Name = "toolStrip2_Button5";
+            this.toolStrip2_Button5.Size = new System.Drawing.Size(114, 22);
+            this.toolStrip2_Button5.Text = "toolStrip2_Button5";
+            // 
+            // toolStrip2_SplitButton1_ChildButton1
+            // 
+            this.toolStrip2_SplitButton1_ChildButton1.Name = "toolStrip2_SplitButton1_ChildButton1";
+            this.toolStrip2_SplitButton1_ChildButton1.Size = new System.Drawing.Size(180, 22);
+            this.toolStrip2_SplitButton1_ChildButton1.Text = "toolStrip2_SplitButton1_ChildButton1";
+            // 
+            // toolStrip2_SplitButton1_ChildButton2
+            // 
+            this.toolStrip2_SplitButton1_ChildButton2.Name = "toolStrip2_SplitButton1_ChildButton2";
+            this.toolStrip2_SplitButton1_ChildButton2.Size = new System.Drawing.Size(180, 22);
+            this.toolStrip2_SplitButton1_ChildButton2.Text = "toolStrip2_SplitButton1_ChildButton2";
+            // 
+            // toolStrip2_SplitButton1
+            //
+            this.toolStrip2_SplitButton1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStrip2_SplitButton1_ChildButton1,
+            this.toolStrip2_SplitButton1_ChildButton2});
+            this.toolStrip2_SplitButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.toolStrip2_SplitButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStrip2_SplitButton1.Name = "toolStrip2_SplitButton1";
+            this.toolStrip2_SplitButton1.Size = new System.Drawing.Size(133, 22);
+            this.toolStrip2_SplitButton1.Text = "toolStrip2_SplitButton1";
+            // 
+            // toolStrip2_DropDownButton1_ChildButton1
+            // 
+            this.toolStrip2_DropDownButton1_ChildButton1.Name = "toolStrip2_DropDownButton1_ChildButton1";
+            this.toolStrip2_DropDownButton1_ChildButton1.Size = new System.Drawing.Size(180, 22);
+            this.toolStrip2_DropDownButton1_ChildButton1.Text = "toolStrip2_DropDownButton1_ChildButton1";
+            // 
+            // toolStrip2_DropDownButton1_ChildButton2
+            // 
+            this.toolStrip2_DropDownButton1_ChildButton2.Name = "toolStrip2_DropDownButton1_ChildButton2";
+            this.toolStrip2_DropDownButton1_ChildButton2.Size = new System.Drawing.Size(180, 22);
+            this.toolStrip2_DropDownButton1_ChildButton2.Text = "toolStrip2_DropDownButton1_ChildButton2";
+            // 
+            // toolStrip2_DropDownButton1
+            //
+            this.toolStrip2_DropDownButton1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStrip2_DropDownButton1_ChildButton1,
+            this.toolStrip2_DropDownButton1_ChildButton2});
+            this.toolStrip2_DropDownButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.toolStrip2_DropDownButton1.Name = "toolStrip2_DropDownButton1";
+            this.toolStrip2_DropDownButton1.Size = new System.Drawing.Size(180, 22);
+            this.toolStrip2_DropDownButton1.Text = "toolStrip2_DropDownButton1";
             // 
             // statusStrip1
             // 
@@ -102,9 +217,10 @@ namespace WinformsControlsTest
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(481, 123);
+            this.ClientSize = new System.Drawing.Size(881, 123);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.statusStrip1);
+            this.Controls.Add(this.toolStrip2);
             this.Controls.Add(this.toolStrip1);
             this.Name = "ToolStripTests";
             this.Text = "ToolStripTests";
@@ -112,6 +228,8 @@ namespace WinformsControlsTest
             this.toolStrip1.PerformLayout();
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
+            this.toolStrip2.ResumeLayout(false);
+            this.toolStrip2.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -126,5 +244,17 @@ namespace WinformsControlsTest
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
         private System.Windows.Forms.ToolStripProgressBar toolStripProgressBar2;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.ToolStrip toolStrip2;
+        private System.Windows.Forms.ToolStripButton toolStrip2_Button1;
+        private System.Windows.Forms.ToolStripButton toolStrip2_Button2;
+        private System.Windows.Forms.ToolStripButton toolStrip2_Button3;
+        private System.Windows.Forms.ToolStripButton toolStrip2_Button4;
+        private System.Windows.Forms.ToolStripButton toolStrip2_Button5;
+        private System.Windows.Forms.ToolStripSplitButton toolStrip2_SplitButton1;
+        private System.Windows.Forms.ToolStripDropDownButton toolStrip2_DropDownButton1;
+        private System.Windows.Forms.ToolStripMenuItem toolStrip2_DropDownButton1_ChildButton1;
+        private System.Windows.Forms.ToolStripMenuItem toolStrip2_DropDownButton1_ChildButton2;
+        private System.Windows.Forms.ToolStripMenuItem toolStrip2_SplitButton1_ChildButton1;
+        private System.Windows.Forms.ToolStripMenuItem toolStrip2_SplitButton1_ChildButton2;
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolStripTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using System.Windows.Forms;
 
 namespace WinformsControlsTest
@@ -16,6 +17,11 @@ namespace WinformsControlsTest
             toolStrip1.Items.Add(new ToolStripControlHost(new HScrollBar() { Value = 30 })); // HScrollBar doesn't support UIA
             statusStrip1.Items.Add(new ToolStripControlHost(new RadioButton() { Text = "RadioButton" })); // RadioButton supports UIA
             statusStrip1.Items.Add(new ToolStripControlHost(new HScrollBar() { Value = 30 })); // HScrollBar doesn't support UIA
+
+            toolStrip2_Button4.Image = Image.FromFile("Images\\SmallA.bmp");
+            toolStrip2_Button4.DisplayStyle = ToolStripItemDisplayStyle.ImageAndText;
+            toolStrip2_Button5.Image = Image.FromFile("Images\\SmallABlue.bmp");
+            toolStrip2_Button5.DisplayStyle = ToolStripItemDisplayStyle.Image;
         }
     }
 }


### PR DESCRIPTION
Fixes #5502

## Proposed changes

- `false` flag is being passed while creating `ToolStripHighContrastRenderer` instance at `ToolStripSystemRenderer`, so after this flag is inverted at `ToolStripHighContrastRenderer`'s constructor, the `FillWhenSelected` flag will be `true` (`ToolStripProfessionalRenderer` already has the same logic) 
- If there's a special overridden renderer for High Contrast theme, then base class should call that renderer's method for rendering backgrounds of `ToolStripButton`, `ToolStripDropDownButton`, `ToolStripSplitButton` (`ToolStripProfessionalRenderer` already has the same logic)  
- Ported from PR #5614
 
## Customer Impact

**Before fix**

![image](https://user-images.githubusercontent.com/87859299/131334951-ae4081c5-fa28-44bf-a52f-476c562dd44d.png)

**After fix**
![image](https://user-images.githubusercontent.com/87859299/131335345-6306989e-a65b-4b59-b35b-9c695c19714b.png)
![image](https://user-images.githubusercontent.com/87859299/131335358-3f958c63-37c1-4f5d-8642-c6432a8d0f25.png)
![image](https://user-images.githubusercontent.com/87859299/131335363-f20dc935-bc8d-4f1c-b6fb-3c07e7850f7d.png)

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit tests
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect
- Accessibility Insights

## Test environment(s) <!-- Remove any that don't apply -->
Microsoft Windows [Version 10.0.19043.1165]
.NET SDK 6.0.100-rc.1.21416.15

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5671)