### PR TITLE
Support Windows11-style default tooltip behavior (port to 6.0)

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/OsVersion.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/OsVersion.cs
@@ -39,6 +39,13 @@ namespace System.Windows.Forms
             => s_versionInfo.dwMajorVersion >= 10 && s_versionInfo.dwBuildNumber >= 15063;
 
         /// <summary>
+        ///  Is this Windows 11 public preview or later?
+        ///  The underlying API does not read supportedOs from the manifest, it returns the actual version.
+        /// </summary>
+        public static bool IsWindows11_OrGreater
+            => s_versionInfo.dwMajorVersion >= 10 && s_versionInfo.dwBuildNumber >= 22000;
+
+        /// <summary>
         ///  Is Windows 8.1 or later.
         /// </summary>
         public static bool IsWindows8_1OrGreater

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
@@ -35,6 +35,7 @@ namespace System.Windows.Forms.IntegrationTests.Common
         MessageBoxButton,
         ToolStripsButton,
         TrackBarsButton,
-        ScrollBarsButton
+        ScrollBarsButton,
+        ToolTipsButton
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Buttons.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Buttons.Designer.cs
@@ -51,6 +51,7 @@ namespace WinformsControlsTest
         }
 
         #endregion
+
         private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.Designer.cs
@@ -32,34 +32,34 @@ namespace WinformsControlsTest
         /// </summary>
         private void InitializeComponent()
         {
-            this.flowLayoutPanelUITypeEditors = new System.Windows.Forms.FlowLayoutPanel();
-            this.flowLayoutPanelUITypeEditors.SuspendLayout();
+            this.overarchingFlowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
+            this.overarchingFlowLayoutPanel.SuspendLayout();
             this.SuspendLayout();
             // 
-            // flowLayoutPanelUITypeEditors
+            // overarchingFlowLayoutPanel
             // 
-            this.flowLayoutPanelUITypeEditors.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.flowLayoutPanelUITypeEditors.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
-            this.flowLayoutPanelUITypeEditors.Location = new System.Drawing.Point(8, 8);
-            this.flowLayoutPanelUITypeEditors.Name = "flowLayoutPanelUITypeEditors";
-            this.flowLayoutPanelUITypeEditors.TabIndex = 0;
+            this.overarchingFlowLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.overarchingFlowLayoutPanel.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
+            this.overarchingFlowLayoutPanel.Location = new System.Drawing.Point(8, 8);
+            this.overarchingFlowLayoutPanel.Name = "flowLayoutPanelUITypeEditors";
+            this.overarchingFlowLayoutPanel.TabIndex = 0;
             // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(570, 30);
-            this.Controls.Add(this.flowLayoutPanelUITypeEditors);
+            this.Controls.Add(this.overarchingFlowLayoutPanel);
             this.Name = "MainForm";
             this.Padding = new System.Windows.Forms.Padding(8);
             this.Text = "MenuForm";
-            this.flowLayoutPanelUITypeEditors.ResumeLayout(false);
+            this.overarchingFlowLayoutPanel.ResumeLayout(false);
             this.ResumeLayout(false);
         }
 
         #endregion
 
-        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanelUITypeEditors;
+        private System.Windows.Forms.FlowLayoutPanel overarchingFlowLayoutPanel;
     }
 }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -37,7 +37,7 @@ namespace WinformsControlsTest
                 };
                 button.Click += info.Click;
 
-                flowLayoutPanelUITypeEditors.Controls.Add(button);
+                overarchingFlowLayoutPanel.Controls.Add(button);
             }
 
             Text = RuntimeInformation.FrameworkDescription;
@@ -174,6 +174,10 @@ namespace WinformsControlsTest
             {
                 MainFormControlsTabOrder.ScrollBarsButton,
                 new InitInfo("ScrollBars", (obj, e) => new ScrollBars().Show(this))
+            },
+            {
+                MainFormControlsTabOrder.ToolTipsButton,
+                new InitInfo("ToolTips", (obj, e) => new ToolTipTests().Show(this))
             }
         };
 
@@ -182,7 +186,7 @@ namespace WinformsControlsTest
             base.OnShown(e);
 
             UpdateLayout();
-            flowLayoutPanelUITypeEditors.Controls[(int)MainFormControlsTabOrder.ButtonsButton].Focus();
+            overarchingFlowLayoutPanel.Controls[(int)MainFormControlsTabOrder.ButtonsButton].Focus();
         }
 
         private void UpdateLayout()
@@ -191,51 +195,55 @@ namespace WinformsControlsTest
             Debug.WriteLine($"MessageBoxFont: {SystemFonts.MessageBoxFont}", nameof(MainForm));
             Debug.WriteLine($"Default font: {Control.DefaultFont}", nameof(MainForm));
 
-            // 1. Auto-size all buttons
-            flowLayoutPanelUITypeEditors.SuspendLayout();
-            foreach (Control c in flowLayoutPanelUITypeEditors.Controls)
+            List<Button> buttons = new List<Button>();
+            foreach (Control control in overarchingFlowLayoutPanel.Controls)
             {
-                if (c is Button button)
+                if (control is Button button)
                 {
-                    button.AutoSize = true;
+                    buttons.Add(button);
+                }
+                else
+                {
+                    Debug.WriteLine($"Why did we get a {control.GetType().Name} instead a {nameof(Button)} on {nameof(MainForm)}?");
                 }
             }
 
-            flowLayoutPanelUITypeEditors.ResumeLayout(true);
+            // 1. Auto-size all buttons
+            overarchingFlowLayoutPanel.SuspendLayout();
+            foreach (Button button in buttons)
+            {
+                button.AutoSize = true;
+            }
+
+            overarchingFlowLayoutPanel.ResumeLayout(true);
 
             // 2. Find the biggest button
             Size biggestButton = default;
-            foreach (Control c in flowLayoutPanelUITypeEditors.Controls)
+            foreach (Button button in buttons)
             {
-                if (c is Button button)
+                if (button.Width > biggestButton.Width)
                 {
-                    if (button.Width > biggestButton.Width)
-                    {
-                        biggestButton = button.Size;
-                    }
+                    biggestButton = button.Size;
                 }
             }
 
             Debug.WriteLine($"Biggest button size: {biggestButton}", nameof(MainForm));
 
             // 3. Size all buttons to the biggest button
-            flowLayoutPanelUITypeEditors.SuspendLayout();
-            foreach (Control c in flowLayoutPanelUITypeEditors.Controls)
+            overarchingFlowLayoutPanel.SuspendLayout();
+            foreach (Button button in buttons)
             {
-                if (c is Button button)
-                {
-                    button.AutoSize = false;
-                    button.Size = biggestButton;
-                }
+                button.AutoSize = false;
+                button.Size = biggestButton;
             }
 
-            flowLayoutPanelUITypeEditors.ResumeLayout(true);
+            overarchingFlowLayoutPanel.ResumeLayout(true);
 
             // 4. Calculate the new form size showing all buttons in two vertical columns
-            int padding = flowLayoutPanelUITypeEditors.Controls[0].Margin.All;
+            int padding = overarchingFlowLayoutPanel.Controls[0].Margin.All;
             ClientSize = new Size(
                 (biggestButton.Width + padding * 2) * 2 + padding * 2,
-                (int)(flowLayoutPanelUITypeEditors.Controls.Count / 2 * (biggestButton.Height + padding * 2) + padding * 2)
+                (int)((overarchingFlowLayoutPanel.Controls.Count + 1) / 2 * (biggestButton.Height + padding * 2) + padding * 2)
                 );
             MinimumSize = Size;
             Debug.WriteLine($"Minimum form size: {MinimumSize}", nameof(MainForm));

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolTipTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolTipTests.Designer.cs
@@ -1,0 +1,189 @@
+﻿namespace WinformsControlsTest
+{
+    partial class ToolTipTests
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.delaysNotSetButton = new System.Windows.Forms.Button();
+            this.automaticDelayButton = new System.Windows.Forms.Button();
+            this.autoPopDelayButton = new System.Windows.Forms.Button();
+            this.delaysNotSetToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.defaultAutomaticDelayButton = new System.Windows.Forms.Button();
+            this.defaultAutoPopDelayButton = new System.Windows.Forms.Button();
+            this.initialDelayButton = new System.Windows.Forms.Button();
+            this.automaticDelayToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.autoPopDelayToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.defaultAutoPopDelayToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.defaultAutomaticDelayToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.initialDelayToolTip = new System.Windows.Forms.ToolTip(this.components);
+            this.autoEllipsisButton = new System.Windows.Forms.Button();
+            this.flowLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // delaysNoSetButton
+            // 
+            this.delaysNotSetButton.AutoSize = true;
+            this.delaysNotSetButton.Location = new System.Drawing.Point(8, 411);
+            this.delaysNotSetButton.Name = "delaysNoSetButton";
+            this.delaysNotSetButton.Size = new System.Drawing.Size(876, 183);
+            this.delaysNotSetButton.TabIndex = 2;
+            this.delaysNotSetToolTip.SetToolTip(this.delaysNotSetButton, "Persistent");
+            this.delaysNotSetButton.Text = "Delays &not set";
+            this.delaysNotSetButton.UseVisualStyleBackColor = true;
+            // 
+            // automaticDelayButton
+            // 
+            this.automaticDelayButton.AutoSize = true;
+            this.automaticDelayButton.Location = new System.Drawing.Point(8, 9);
+            this.automaticDelayButton.Name = "automaticDelayButton";
+            this.automaticDelayButton.Size = new System.Drawing.Size(1031, 183);
+            this.automaticDelayButton.TabIndex = 0;
+            this.automaticDelayToolTip.SetToolTip(this.automaticDelayButton, "Not persistent");
+            this.automaticDelayButton.Text = "&AutomaticDelay = 30";
+            this.automaticDelayButton.UseVisualStyleBackColor = true;
+            // 
+            // autoPopDelayButton
+            // 
+            this.autoPopDelayButton.AutoSize = true;
+            this.autoPopDelayButton.Location = new System.Drawing.Point(8, 210);
+            this.autoPopDelayButton.Name = "autoPopDelayButton";
+            this.autoPopDelayButton.Size = new System.Drawing.Size(949, 183);
+            this.autoPopDelayButton.TabIndex = 1;
+            this.autoPopDelayToolTip.SetToolTip(this.autoPopDelayButton, "Not persistent");
+            this.autoPopDelayButton.Text = "Auto&PopDelay = 300";
+            this.autoPopDelayButton.UseVisualStyleBackColor = true;
+            // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Controls.Add(this.automaticDelayButton);
+            this.flowLayoutPanel1.Controls.Add(this.autoPopDelayButton);
+            this.flowLayoutPanel1.Controls.Add(this.delaysNotSetButton);
+            this.flowLayoutPanel1.Controls.Add(this.defaultAutomaticDelayButton);
+            this.flowLayoutPanel1.Controls.Add(this.defaultAutoPopDelayButton);
+            this.flowLayoutPanel1.Controls.Add(this.initialDelayButton);
+            this.flowLayoutPanel1.Controls.Add(this.autoEllipsisButton);
+            this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(1417, 1577);
+            this.flowLayoutPanel1.TabIndex = 0;
+            // 
+            // defaultAutomaticDelayButton
+            // 
+            this.defaultAutomaticDelayButton.AutoSize = true;
+            this.defaultAutomaticDelayButton.Location = new System.Drawing.Point(8, 612);
+            this.defaultAutomaticDelayButton.Name = "defaultAutomaticDelayButton";
+            this.defaultAutomaticDelayButton.Size = new System.Drawing.Size(915, 183);
+            this.defaultAutomaticDelayButton.TabIndex = 3;
+            this.defaultAutomaticDelayToolTip.SetToolTip(this.defaultAutomaticDelayButton, "Persistent");
+            this.defaultAutomaticDelayButton.Text = "AutomaticDelay = 500";
+            this.defaultAutomaticDelayButton.UseVisualStyleBackColor = true;
+            // 
+            // defaultAutoPopDelayButton
+            // 
+            this.defaultAutoPopDelayButton.AutoSize = true;
+            this.defaultAutoPopDelayButton.Location = new System.Drawing.Point(8, 813);
+            this.defaultAutoPopDelayButton.Name = "defaultAutoPopDelayButton";
+            this.defaultAutoPopDelayButton.Size = new System.Drawing.Size(904, 183);
+            this.defaultAutoPopDelayButton.TabIndex = 4;
+            this.defaultAutoPopDelayToolTip.SetToolTip(this.defaultAutoPopDelayButton, "Persistent");
+            this.defaultAutoPopDelayButton.Text = "AutoPopDelay = 5000";
+            this.defaultAutoPopDelayButton.UseVisualStyleBackColor = true;
+            // 
+            // initialDelayButton
+            // 
+            this.initialDelayButton.AutoSize = true;
+            this.initialDelayButton.Location = new System.Drawing.Point(8, 1014);
+            this.initialDelayButton.Name = "initialDelayButton";
+            this.initialDelayButton.Size = new System.Drawing.Size(876, 183);
+            this.initialDelayButton.TabIndex = 5;
+            this.initialDelayToolTip.SetToolTip(this.initialDelayButton, "Persistent");
+            this.initialDelayButton.Text = "I&nitial delay = 10";
+            this.initialDelayButton.UseVisualStyleBackColor = true;
+            // 
+            // autoEllipsisButton
+            // 
+            this.autoEllipsisButton.AutoEllipsis = true;
+            this.autoEllipsisButton.AutoSize = false;
+            this.autoEllipsisButton.Location = new System.Drawing.Point(8, 1215);
+            this.autoEllipsisButton.Name = "autoEllipsisButton";
+            this.autoEllipsisButton.Size = new System.Drawing.Size(876, 183);
+            this.autoEllipsisButton.TabIndex = 6;
+            this.autoEllipsisButton.Text = "Auto&Ellipsis = true; 1234567890";
+            this.autoEllipsisButton.UseVisualStyleBackColor = true;
+            // 
+            // automaticDelayToolTip
+            // 
+            this.automaticDelayToolTip.AutomaticDelay = 30;
+            // 
+            // autoPopDelayToolTip
+            // 
+            this.autoPopDelayToolTip.AutoPopDelay = 300;
+            this.autoPopDelayToolTip.InitialDelay = 500;
+            this.autoPopDelayToolTip.ReshowDelay = 100;
+            // 
+            // initialDelayToolTip
+            // 
+            this.initialDelayToolTip.AutoPopDelay = 5000;
+            this.initialDelayToolTip.InitialDelay = 10;
+            this.initialDelayToolTip.ReshowDelay = 100;
+            // 
+            // ToolTipTests
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(17F, 41F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(1417, 1577);
+            this.Controls.Add(this.flowLayoutPanel1);
+            this.Name = "ToolTipTests";
+            this.Text = "ToolTips";
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button delaysNotSetButton;
+        private System.Windows.Forms.Button automaticDelayButton;
+        private System.Windows.Forms.Button autoPopDelayButton;
+        private System.Windows.Forms.Button autoEllipsisButton;
+        private System.Windows.Forms.Button defaultAutomaticDelayButton;
+        private System.Windows.Forms.Button defaultAutoPopDelayButton;
+        private System.Windows.Forms.Button initialDelayButton;
+        private System.Windows.Forms.ToolTip automaticDelayToolTip;
+        private System.Windows.Forms.ToolTip autoPopDelayToolTip;
+        private System.Windows.Forms.ToolTip defaultAutomaticDelayToolTip;
+        private System.Windows.Forms.ToolTip defaultAutoPopDelayToolTip;
+        private System.Windows.Forms.ToolTip delaysNotSetToolTip;
+        private System.Windows.Forms.ToolTip initialDelayToolTip;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+    }
+}
+

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolTipTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolTipTests.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    public partial class ToolTipTests : Form
+    {
+        public ToolTipTests()
+        {
+            InitializeComponent();
+
+            defaultAutomaticDelayToolTip.AutomaticDelay = 500;
+            defaultAutoPopDelayToolTip.AutoPopDelay = 5000;
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolTipTests.resx
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ToolTipTests.resx
@@ -1,0 +1,78 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="delaysNotSetToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>350, 17</value>
+  </metadata>
+  <metadata name="automaticDelayToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>714, 17</value>
+  </metadata>
+  <metadata name="autoPopDelayToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1110, 17</value>
+  </metadata>
+  <metadata name="defaultAutoPopDelayToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1485, 17</value>
+  </metadata>
+  <metadata name="defaultAutomaticDelayToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 82</value>
+  </metadata>
+  <metadata name="initialDelayToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>


### PR DESCRIPTION
If AutoPopDelay is never set to a non-default, then this tooltip follows the comctl-defined default behavior on win11. (#5422)

* common control tooltip is not dismissed automatically, only by user actions.
* tooltip can be dismissed by CONTROL or ESCAPE keys
* tooltip stays open when mouse hovers over it.

## Proposed changes

cherry-pick  commit from main - https://github.com/dotnet/winforms/pull/5422/commits/11c9ba1f7b63e34607dd7267a550fd504228853b

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

On Win11 it will be possible to create tooltips that comply with WCAG2.1

## Regression? 

- No

## Risk

- an expected breaking change in the default behavior, but this change is consistent with the comclt tooltips

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

manual testing of tooltips with different sets of delays, and manual testing of designer generating code-behind.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5686)