### PR TITLE
Fix getting value for "ControlAccessibleObject.AccessKey" property

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -506,7 +506,7 @@ namespace System.Windows.Forms
                         case UiaCore.UIA.IsPasswordPropertyId:
                             return false;
                         case UiaCore.UIA.AccessKeyPropertyId:
-                            return string.Empty;
+                            return KeyboardShortcut;
                         case UiaCore.UIA.HelpTextPropertyId:
                             return Help ?? string.Empty;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObject.cs
@@ -93,7 +93,6 @@ namespace System.Windows.Forms
                         UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                         UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                         UiaCore.UIA.HasKeyboardFocusPropertyId => _owningLinkLabel.FocusLink == _owningLink,
-                        UiaCore.UIA.AccessKeyPropertyId => _linkLabelAccessibleObject.KeyboardShortcut,
                         UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
                         UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                         UiaCore.UIA.LegacyIAccessiblePatternId => IsPatternSupported(propertyID),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.LinkLabelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.LinkLabelAccessibleObject.cs
@@ -62,7 +62,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsEnabledPropertyId => _owningLinkLabel.Enabled,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => false,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
-                    UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -157,8 +157,6 @@ namespace System.Windows.Forms
             // and adjust its children bounds with respect to propertygrid bounds. Autoscale mode should not scale them again.
             _doNotScaleChildren = true;
 
-            SetStyle(ControlStyles.UseTextForAccessibility, false);
-
             // Static variables are problem in a child level mixed mode scenario. Changing static variables causes compatibility issues.
             // So, recalculate static variables every time property grid initialized.
             if (DpiHelper.IsPerMonitorV2Awareness)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabControlAccessibleObject.cs
@@ -141,7 +141,6 @@ namespace System.Windows.Forms
                     UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UIA.HasKeyboardFocusPropertyId => _owningTabControl.Focused,
                     UIA.NamePropertyId => Name,
-                    UIA.AccessKeyPropertyId => KeyboardShortcut,
                     UIA.NativeWindowHandlePropertyId => _owningTabControl.InternalHandle,
                     UIA.IsSelectionPatternAvailablePropertyId => IsPatternSupported(UIA.SelectionPatternId),
                     UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UIA.LegacyIAccessiblePatternId),

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -3392,7 +3392,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(ControlStyles.EnableNotifyMessage, false)]
         [InlineData(ControlStyles.DoubleBuffer, false)]
         [InlineData(ControlStyles.OptimizedDoubleBuffer, false)]
-        [InlineData(ControlStyles.UseTextForAccessibility, false)]
+        [InlineData(ControlStyles.UseTextForAccessibility, true)]
         [InlineData((ControlStyles)0, true)]
         [InlineData((ControlStyles)int.MaxValue, false)]
         [InlineData((ControlStyles)(-1), false)]


### PR DESCRIPTION
Fixes #5702 

## Proposed changes
- The logic for getting the `AccessKey` property has been moved to the base `ControlAccessibleObject` class.
- Removed the logic to set the `ControlStyles.UseTextForAccessibility` flag to `False` for a `PropertyGrid`, as this changes the behavior of the `AccessKey` property in the `PropertyGrid`, making it different from .NET Framework 4.7.2.
![image](https://user-images.githubusercontent.com/23376742/132230697-4176dbe4-5976-4b1d-8859-cf6070e81280.png)

- Added unit test.

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/132231790-35acd728-3ef5-49f8-be74-545b1f01f091.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/132231268-02ffc764-6aad-437a-a568-cd1b08a46471.png)

## Regression? 
- Yes (regression after tasks listed in the #3421 )

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manually 
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core 6.0.100-rc.1.21430.12