### PR TITLE
Normalize more property grid names

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -2712,15 +2712,11 @@ namespace System.Windows.Forms
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         EventDescriptorCollection ICustomTypeDescriptor.GetEvents()
-        {
-            return TypeDescriptor.GetEvents(this, true);
-        }
+            => TypeDescriptor.GetEvents(this, noCustomTypeDesc: true);
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[] attributes)
-        {
-            return TypeDescriptor.GetEvents(this, attributes, true);
-        }
+            => TypeDescriptor.GetEvents(this, attributes, noCustomTypeDesc: true);
 
         private void OnIdle(object sender, EventArgs e)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/EventsTab.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/EventsTab.cs
@@ -91,11 +91,14 @@ namespace System.Windows.Forms.Design
             return null;
         }
 
-        /// <inheritdoc />
         public override PropertyDescriptorCollection GetProperties(object component, Attribute[]? attributes)
             => GetProperties(context: null, component, attributes);
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
+        /// <devdoc>
+        ///  The <see cref="EventsTab"/> uses <see cref="IEventBindingService.GetEventProperties(EventDescriptorCollection)"/>
+        ///  to get <paramref name="component"/> property descriptors from <see cref="TypeDescriptor.GetEvents(object)"/>.
+        /// </devdoc>
         public override PropertyDescriptorCollection GetProperties(
             ITypeDescriptorContext? context,
             object component,
@@ -106,6 +109,8 @@ namespace System.Windows.Forms.Design
                 return new(null);
             }
 
+            // By passing `noCustomTypeDesc: false` we allow the component itself to participate in getting events
+            // (if `component` implements `ICustomTypeDescriptor`).
             var componentEventProperties = eventBindingService.GetEventProperties(
                TypeDescriptor.GetEvents(component, attributes, noCustomTypeDesc: false));
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GridItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GridItem.cs
@@ -36,7 +36,7 @@ namespace System.Windows.Forms
         public abstract GridItemCollection GridItems { get; }
 
         /// <summary>
-        ///  Retrieves type of this <see cref="GridItem"/>.
+        ///  Retrieves the type of this <see cref="GridItem"/>.
         /// </summary>
         public abstract GridItemType GridItemType { get; }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GridItemType.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GridItemType.cs
@@ -6,9 +6,34 @@ namespace System.Windows.Forms
 {
     public enum GridItemType
     {
+        /// <summary>
+        ///  The <see cref="GridItem"/> corresponds to a property.
+        /// </summary>
         Property,
+
+        /// <summary>
+        ///  The <see cref="GridItem"/> is a category name.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Typical categories include "Behavior", "Layout", "Data", and "Appearance".
+        ///  </para>
+        /// </remarks>
         Category,
+
+        /// <summary>
+        ///  The <see cref="GridItem"/> is an element of an array.
+        /// </summary>
         ArrayValue,
+
+        /// <summary>
+        ///  The <see cref="GridItem"/> is the root in the grid hierarchy.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   This item represents the selection in the <see cref="PropertyGrid"/>.
+        ///  </para>
+        /// </remarks>
         Root
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         protected override GridEntryAccessibleObject GetAccessibilityObject() => new CategoryGridEntryAccessibleObject(this);
 
-        protected override Color GetBackgroundColor() => GridEntryHost.GetLineColor();
+        protected override Color GetBackgroundColor() => OwnerGridView.GetLineColor();
 
         protected override Color LabelTextColor => OwnerGrid.CategoryForeColor;
 
@@ -114,7 +114,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             get
             {
-                PropertyGridView gridHost = GridEntryHost;
+                PropertyGridView gridHost = OwnerGridView;
 
                 // Give an extra pixel for breathing room.
                 // Calling base.PropertyDepth to avoid the -1 in the override.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.Flags.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.Flags.cs
@@ -33,6 +33,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             ReadOnlyEditable        = 0x00000080,
             RenderReadOnly          = 0x00000100,
             Immutable               = 0x00000200,
+
+            /// <summary>
+            ///  Used to distribute read-only behavior to child properties when the root <see cref="GridEntry"/> is
+            ///  read-only or one of the objects in the root <see cref="GridEntry"/> (with multiple select) is read-only.
+            /// </summary>
             ForceReadOnly           = 0x00000400,
             RenderPassword          = 0x00001000,
             Disposed                = 0x00002000,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -62,7 +62,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             public override string? Name => _owningGridEntry?.PropertyLabel;
 
-            public override AccessibleObject? Parent => _owningGridEntry?.GridEntryHost?.AccessibilityObject;
+            public override AccessibleObject? Parent => _owningGridEntry?.OwnerGridView?.AccessibilityObject;
 
             public override AccessibleRole Role => AccessibleRole.Cell;
 
@@ -181,7 +181,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 get
                 {
-                    if (_owningGridEntry.GridEntryHost is null || !_owningGridEntry.GridEntryHost.IsHandleCreated)
+                    if (_owningGridEntry.OwnerGridView is null || !_owningGridEntry.OwnerGridView.IsHandleCreated)
                     {
                         return base.RuntimeId;
                     }
@@ -197,7 +197,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                         _runtimeId = new int[3];
                         _runtimeId[0] = 0x2a;
-                        _runtimeId[1] = (int)(long)_owningGridEntry.GridEntryHost.InternalHandle;
+                        _runtimeId[1] = (int)(long)_owningGridEntry.OwnerGridView.InternalHandle;
                         _runtimeId[2] = GetHashCode();
                     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -1245,7 +1245,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 PropertyDescriptor defaultProperty = null;
                 if (ownerTab is not null)
                 {
-                    // Get properties from the 
                     properties = ownerTab.GetProperties(this, value, attributes);
                     defaultProperty = ownerTab.GetDefaultProperty(value);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ImmutablePropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ImmutablePropertyDescriptorGridEntry.cs
@@ -49,7 +49,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 for (int i = 0; i < properties.Count; i++)
                 {
-                    if (_propertyInfo.Name is not null && _propertyInfo.Name.Equals(properties[i].Name))
+                    if (PropertyDescriptor.Name is not null && PropertyDescriptor.Name.Equals(properties[i].Name))
                     {
                         values[properties[i].Name] = value;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
@@ -36,21 +36,15 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (!_forceReadOnlyChecked)
                 {
-                    bool anyReadOnly = false;
                     foreach (object obj in (Array)_value)
                     {
-                        var readOnlyAttr = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(obj)[typeof(ReadOnlyAttribute)];
-                        if ((readOnlyAttr is not null && !readOnlyAttr.IsDefaultAttribute())
+                        var readOnlyAttribute = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(obj)[typeof(ReadOnlyAttribute)];
+                        if ((readOnlyAttribute is not null && !readOnlyAttribute.IsDefaultAttribute())
                             || TypeDescriptor.GetAttributes(obj).Contains(InheritanceAttribute.InheritedReadOnly))
                         {
-                            anyReadOnly = true;
+                            SetForceReadOnlyFlag();
                             break;
                         }
-                    }
-
-                    if (anyReadOnly)
-                    {
-                        SetForceReadOnlyFlag();
                     }
 
                     _forceReadOnlyChecked = true;
@@ -68,7 +62,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 ChildCollection.Clear();
 
-                MultiPropertyDescriptorGridEntry[] mergedProps = PropertyMerger.GetMergedProperties(rgobjs, this, _propertySort, CurrentTab);
+                MultiPropertyDescriptorGridEntry[] mergedProps = PropertyMerger.GetMergedProperties(rgobjs, this, _propertySort, OwnerTab);
 
                 Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose && mergedProps is null, "PropertyGridView: MergedProps returned null!");
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.ExceptionConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.ExceptionConverter.cs
@@ -16,13 +16,6 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         private class ExceptionConverter : TypeConverter
         {
-            /// <summary>
-            ///  Converts the given object to another type.  The most common types to convert
-            ///  are to and from a string object.  The default implementation will make a call
-            ///  to ToString on the object if the object is valid and if the destination
-            ///  type is string.  If this cannot convert to the destination type, this will
-            ///  throw a NotSupportedException.
-            /// </summary>
             public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
             {
                 if (destinationType == typeof(string))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/SingleSelectRootGridEntry.cs
@@ -23,27 +23,27 @@ namespace System.Windows.Forms.PropertyGridInternal
         private GridEntry _defaultEntry;
         private IDesignerHost _host;
         private IServiceProvider _baseProvider;
-        private PropertyTab _tab;
-        private PropertyGridView _gridEntryHost;
+        private PropertyTab _ownerTab;
+        private PropertyGridView _ownerGridView;
         private AttributeCollection _browsableAttributes;
         private IComponentChangeService _changeService;
         protected bool _forceReadOnlyChecked;
 
         internal SingleSelectRootGridEntry(
-            PropertyGridView gridEntryHost,
+            PropertyGridView ownerGridView,
             object value,
             GridEntry parent,
             IServiceProvider baseProvider,
             IDesignerHost host,
-            PropertyTab tab,
+            PropertyTab ownerTab,
             PropertySort sortType)
-            : base(gridEntryHost.OwnerGrid, parent)
+            : base(ownerGridView.OwnerGrid, parent)
         {
             Debug.Assert(value is not null, "Can't browse a null object!");
             _host = host;
-            _gridEntryHost = gridEntryHost;
+            _ownerGridView = ownerGridView;
             _baseProvider = baseProvider;
-            _tab = tab;
+            _ownerTab = ownerTab;
             _value = value;
             _valueClassName = TypeDescriptor.GetClassName(_value);
 
@@ -114,19 +114,15 @@ namespace System.Windows.Forms.PropertyGridInternal
         protected override IComponentChangeService ComponentChangeService
             => _changeService ?? this.GetService<IComponentChangeService>();
 
-        public override PropertyTab CurrentTab
-        {
-            get => _tab;
-            set => _tab = value;
-        }
+        public override PropertyTab OwnerTab => _ownerTab;
 
-        internal override GridEntry DefaultChild
+        internal sealed override GridEntry DefaultChild
         {
             get => _defaultEntry;
             set => _defaultEntry = value;
         }
 
-        internal override IDesignerHost DesignerHost
+        internal sealed override IDesignerHost DesignerHost
         {
             get => _host;
             set => _host = value;
@@ -148,14 +144,14 @@ namespace System.Windows.Forms.PropertyGridInternal
                     _forceReadOnlyChecked = true;
                 }
 
-                return base.ForceReadOnly || (GridEntryHost is not null && !GridEntryHost.Enabled);
+                return base.ForceReadOnly || (OwnerGridView is not null && !OwnerGridView.Enabled);
             }
         }
 
-        internal override PropertyGridView GridEntryHost
+        internal override PropertyGridView OwnerGridView
         {
-            get => _gridEntryHost;
-            set => _gridEntryHost = value;
+            get => _ownerGridView;
+            set => _ownerGridView = value;
         }
 
         public override GridItemType GridItemType => GridItemType.Root;
@@ -213,8 +209,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 _host = null;
                 _baseProvider = null;
-                _tab = null;
-                _gridEntryHost = null;
+                _ownerTab = null;
+                _ownerGridView = null;
                 _changeService = null;
             }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
@@ -92,15 +92,15 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
                 _propertyGridView = propertyGridView;
             }
 
-            internal override PropertyGridView GridEntryHost => _propertyGridView;
+            internal override PropertyGridView OwnerGridView => _propertyGridView;
         }
 
         private class TestPropertyDescriptorGridEntry : PropertyDescriptorGridEntry
         {
             private GridEntryCollection _collection;
 
-            public TestPropertyDescriptorGridEntry(PropertyGrid ownerGrid, GridEntry peParent, bool hide)
-                : base(ownerGrid, peParent, hide)
+            public TestPropertyDescriptorGridEntry(PropertyGrid ownerGrid, GridEntry parent, bool hide)
+                : base(ownerGrid, parent, hide)
             {
             }
 


### PR DESCRIPTION
Change names to "owner" for consistency (instead of "host", "current", etc.).

Other miscellaneous cleanup.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5721)