### PR TITLE
Adding exception when user tries to add group to ListView in virtual mode (port to 6.0)

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6779,4 +6779,7 @@ Stack trace where the illegal operation occurred was:
   <data name="ProfessionalColorsStatusStripBorderDescr" xml:space="preserve">
     <value>Border color to use on the top edge of the StatusStrip.</value>
   </data>
+  <data name="ListViewCannotAddGroupsToVirtualListView" xml:space="preserve">
+    <value>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -6291,6 +6291,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Upozorňuje uživatele virtuálních ovládacích prvků ListView, že by si měli připravit mezipaměť.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">Nelze získat přístup ke kolekci zaškrtnutých položek, pokud je zobrazení ListView ve virtuálním režimu.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -6291,6 +6291,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Benachrichtigt die Benutzer virtueller ListView-Steuerelemente, dass sie den Cache vorbereiten müssen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">Auf die Sammlung aktivierter Steuerelemente kann nicht zugegriffen werden, wenn sich die ListView im virtuellen Modus befindet.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -6291,6 +6291,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Notifica a los usuarios de controles ListView virtuales que deberían preparar su caché.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">No se puede tener acceso a la colección de elementos activados cuando ListView está en modo virtual.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -6291,6 +6291,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Informe les utilisateurs de contrôles ListView virtuels qu'ils doivent préparer leur cache.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">Impossible d'accéder à la collection des éléments activés lorsque le ListView est en mode virtuel.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -6291,6 +6291,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Notifica agli utenti dei controlli ListView virtuali di preparare la cache.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">Impossibile accedere alla raccolta degli elementi selezionati quando ListView è in modalità virtuale.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -6291,6 +6291,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">仮想 ListView コントロールのユーザーにキャッシュを用意する必要があることを通知します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">ListView が仮想モードにされているときは、チェックされた項目コレクションにアクセスできません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -6291,6 +6291,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">가상 ListView 컨트롤의 사용자에게 캐시를 준비해야 함을 알립니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">ListView가 가상 모드에 있으면 선택한 항목 컬렉션에 액세스할 수 없습니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -6291,6 +6291,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Powiadamia użytkowników formantów ListView, że powinni przygotować pamięć podręczną.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">Nie można uzyskać dostępu do kolekcji zaznaczonych elementów, gdy element ListView jest w trybie wirtualnym.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -6291,6 +6291,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">Notifica os usuários de controles ListView virtuais de que devem preparar o cache.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">Não é possível acessar a coleção de itens marcados quando ListView está no modo virtual.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -6292,6 +6292,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Оповещает пользователей виртуальных элементов управления ListView о том, что они должны подготовить кэш.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">Если ListView находится в виртуальном режиме, доступ к коллекции элементов с установленным флажком невозможен.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -6291,6 +6291,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Sanal ListView denetimlerinin kullanıcılarına önbelleklerini hazırlamaları gerektiğini bildirir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">ListView sanal moddayken işaretlenmiş öğeler koleksiyonuna erişilemiyor.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -6291,6 +6291,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">通知虚拟 ListView 控件的用户他们应该准备缓存。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">当 ListView 处于虚拟模式时，无法访问选中的项集合。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -6291,6 +6291,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">通知虛擬 ListView 控制項的使用者應該準備快取區。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewCannotAddGroupsToVirtualListView">
+        <source>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</source>
+        <target state="new">You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewCantAccessCheckedItemsCollectionWhenInVirtualMode">
         <source>Cannot access the checked items collection when the ListView is in virtual mode.</source>
         <target state="translated">當 ListView 處於虛擬模式時，無法存取已核取的項目集合。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollection.cs
@@ -42,10 +42,7 @@ namespace System.Windows.Forms
             get => (ListViewGroup)List[index];
             set
             {
-                if (value is null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value, nameof(value));
 
                 if (List.Contains(value))
                 {
@@ -79,10 +76,7 @@ namespace System.Windows.Forms
             }
             set
             {
-                if (value is null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
+                ArgumentNullException.ThrowIfNull(value, nameof(value));
 
                 if (_list is null)
                 {
@@ -121,10 +115,8 @@ namespace System.Windows.Forms
 
         public int Add(ListViewGroup group)
         {
-            if (group is null)
-            {
-                throw new ArgumentNullException(nameof(group));
-            }
+            ArgumentNullException.ThrowIfNull(group, nameof(group));
+            ThrowInvalidOperationExceptionIfVirtualMode();
 
             if (Contains(group))
             {
@@ -162,10 +154,8 @@ namespace System.Windows.Forms
 
         public void AddRange(ListViewGroup[] groups)
         {
-            if (groups is null)
-            {
-                throw new ArgumentNullException(nameof(groups));
-            }
+            ArgumentNullException.ThrowIfNull(groups, nameof(groups));
+            ThrowInvalidOperationExceptionIfVirtualMode();
 
             for (int i = 0; i < groups.Length; i++)
             {
@@ -175,10 +165,8 @@ namespace System.Windows.Forms
 
         public void AddRange(ListViewGroupCollection groups)
         {
-            if (groups is null)
-            {
-                throw new ArgumentNullException(nameof(groups));
-            }
+            ArgumentNullException.ThrowIfNull(groups, nameof(groups));
+            ThrowInvalidOperationExceptionIfVirtualMode();
 
             for (int i = 0; i < groups.Count; i++)
             {
@@ -251,10 +239,8 @@ namespace System.Windows.Forms
 
         public void Insert(int index, ListViewGroup group)
         {
-            if (group is null)
-            {
-                throw new ArgumentNullException(nameof(group));
-            }
+            ArgumentNullException.ThrowIfNull(group, nameof(group));
+            ThrowInvalidOperationExceptionIfVirtualMode();
 
             if (Contains(group))
             {
@@ -312,5 +298,13 @@ namespace System.Windows.Forms
         }
 
         public void RemoveAt(int index) => Remove(this[index]);
+
+        private void ThrowInvalidOperationExceptionIfVirtualMode()
+        {
+            if (_listView.VirtualMode)
+            {
+                throw new InvalidOperationException(SR.ListViewCannotAddGroupsToVirtualListView);
+            }
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -68,13 +68,6 @@ namespace WinformsControlsTest
             listView2.SelectedIndexChanged += listView2_SelectedIndexChanged;
             listView2.Click += listView2_Click;
 
-            ListViewGroup listViewGroup1 = new("ListViewGroup", HorizontalAlignment.Left)
-            {
-                Header = "ListViewGroup",
-                Name = "listViewGroup1"
-            };
-            listView2.Groups.AddRange(new ListViewGroup[] { listViewGroup1 });
-
             // Create three items and three sets of subitems for each item.
             ListViewItem item1 = new("item1", 0)
             {
@@ -136,10 +129,6 @@ namespace WinformsControlsTest
             // Add the ListView to the control collection.
             Controls.Add(listView2);
             listView2.Dock = DockStyle.Bottom;
-
-            // Change a ListViewGroup's header.
-            listView2.Groups[0].HeaderAlignment = HorizontalAlignment.Center;
-            listView2.Groups[0].Header = "NewText";
         }
 
         private void AddCollapsibleGroupToListView()

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MultipleControls.cs
@@ -42,13 +42,6 @@ namespace WinformsControlsTest
                 VirtualListSize = 3,
             };
 
-            ListViewGroup listViewGroup1 = new("ListViewGroup", HorizontalAlignment.Left)
-            {
-                Header = "ListViewGroup",
-                Name = "listViewGroup1"
-            };
-            listView2.Groups.AddRange(new ListViewGroup[] { listViewGroup1 });
-
             // Create three items and three sets of subitems for each item.
             ListViewItem item1 = new("item1", 0)
             {
@@ -110,10 +103,6 @@ namespace WinformsControlsTest
             // Add the ListView to the control collection.
             Controls.Add(listView2);
             listView2.Dock = DockStyle.Bottom;
-
-            // Change a ListViewGroup's header.
-            listView2.Groups[0].HeaderAlignment = HorizontalAlignment.Center;
-            listView2.Groups[0].Header = "NewText";
         }
 
         private void Test3_Load(object sender, EventArgs e)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
@@ -267,10 +267,16 @@ namespace System.Windows.Forms.Tests
 
             listView.Columns.Add(new ColumnHeader());
 
-            ListViewGroup listViewGroup = new("Test Group");
-            listView.Groups.Add(listViewGroup);
-            ListViewItem listViewItem1 = new("Test item 1", listViewGroup);
-            ListViewItem listViewItem2 = new("Test item 2", group: createDefaultGroup ? null : listViewGroup);
+            ListViewItem listViewItem1 = new("Test item 1");
+            ListViewItem listViewItem2 = new("Test item 2");
+
+            if (!virtualMode)
+            {
+                ListViewGroup listViewGroup = new("Test Group");
+                listView.Groups.Add(listViewGroup);
+                listViewItem1.Group = listViewGroup;
+                listViewItem2.Group = createDefaultGroup ? null : listViewGroup;
+            }
 
             if (virtualMode)
             {
@@ -342,8 +348,11 @@ namespace System.Windows.Forms.Tests
 
             listView.Columns.Add(new ColumnHeader());
 
-            ListViewGroup listViewGroup = new("Test Group");
-            listView.Groups.Add(listViewGroup);
+            if (!virtualMode)
+            {
+                ListViewGroup listViewGroup = new("Test Group");
+                listView.Groups.Add(listViewGroup);
+            }
 
             if (virtualMode)
             {
@@ -385,7 +394,7 @@ namespace System.Windows.Forms.Tests
             ListViewItem listViewItem2 = new("Test item 2");
             ListViewItem listViewItem3 = new("Test item 3");
 
-            if (createGroup)
+            if (!virtualMode && createGroup)
             {
                 listView.Groups.Add(new ListViewGroup("Test Group"));
                 listViewItem2.Group = listView.Groups[0];
@@ -442,7 +451,7 @@ namespace System.Windows.Forms.Tests
 
             listView.Columns.Add(new ColumnHeader());
 
-            if (createGroup)
+            if (!virtualMode && createGroup)
             {
                 listView.Groups.Add(new ListViewGroup("Test Group"));
             }
@@ -508,7 +517,7 @@ namespace System.Windows.Forms.Tests
             ListViewItem listViewItem2 = new("Test item 2");
             ListViewItem listViewItem3 = new("Test item 3");
 
-            if (createGroup)
+            if (!virtualMode && createGroup)
             {
                 listView.Groups.Add(new ListViewGroup("Test Group"));
                 listViewItem2.Group = listView.Groups[0];
@@ -579,7 +588,7 @@ namespace System.Windows.Forms.Tests
             ListViewItem listViewItem2 = new("Test item 2");
             ListViewItem listViewItem3 = new("Test item 3");
 
-            if (createGroup)
+            if (!virtualMode && createGroup)
             {
                 listView.Groups.Add(new ListViewGroup("Test Group"));
                 listViewItem2.Group = listView.Groups[0];
@@ -634,7 +643,7 @@ namespace System.Windows.Forms.Tests
             ListViewItem listViewItem2 = new("Test item 2");
             ListViewItem listViewItem3 = new("Test item 3");
 
-            if (createGroup)
+            if (!virtualMode && createGroup)
             {
                 listView.Groups.Add(new ListViewGroup("Test Group 1"));
                 listView.Groups.Add(new ListViewGroup("Test Group 2"));
@@ -714,7 +723,7 @@ namespace System.Windows.Forms.Tests
             ListViewItem listViewItem2 = new("Test item 2");
             ListViewItem listViewItem3 = new("Test item 3");
 
-            if (createGroup)
+            if (!virtualMode && createGroup)
             {
                 listView.Groups.Add(new ListViewGroup("Test Group 1"));
                 listView.Groups.Add(new ListViewGroup("Test Group 2"));
@@ -792,7 +801,7 @@ namespace System.Windows.Forms.Tests
 
             listView.Columns.Add(new ColumnHeader());
 
-            if (createGroup)
+            if (!virtualMode && createGroup)
             {
                 listView.Groups.Add(new ListViewGroup("Test Group 1"));
                 listView.Groups[0].Items.Add(new ListViewItem());
@@ -848,7 +857,7 @@ namespace System.Windows.Forms.Tests
             ListViewItem listViewItem2 = new("Test item 2");
             ListViewItem listViewItem3 = new("Test item 3");
 
-            if (createGroup)
+            if (!virtualMode && createGroup)
             {
                 listView.Groups.Add(new ListViewGroup("Test Group 1"));
                 listView.Groups.Add(new ListViewGroup("Test Group 2"));
@@ -1003,13 +1012,8 @@ namespace System.Windows.Forms.Tests
                 VirtualListSize = 4
             };
 
-            ListViewGroup listViewGroup1 = new ListViewGroup("Test1");
-            ListViewGroup listViewGroup2 = new ListViewGroup("Test2");
-            listView.Groups.Add(listViewGroup1);
-            listView.Groups.Add(listViewGroup2);
-
-            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1, listViewGroup1);
-            ListViewItem listItem2 = new ListViewItem("Group item 2", listViewGroup1);
+            ListViewItem listItem1 = new ListViewItem(new string[] { "Item 1", "Item A" }, -1);
+            ListViewItem listItem2 = new ListViewItem("Group item 2");
             ListViewItem listItem3 = new ListViewItem("Item 3");
             ListViewItem listItem4 = new ListViewItem(new string[] { "Item 4", "Item B" }, -1);
 
@@ -1393,7 +1397,10 @@ namespace System.Windows.Forms.Tests
             ListViewItem listItem3 = new("Item 3");
             ListViewItem listItem4 = new(new string[] { "Test Item 4", "Item B", "Item C", "Item D" }, -1);
 
-            listView.Groups.Add(listViewGroup);
+            if (!virtualMode)
+            {
+                listView.Groups.Add(listViewGroup);
+            }
 
             listView.Columns.Add(new ColumnHeader() { Name = "Column 1" });
             listView.Columns.Add(new ColumnHeader() { Name = "Column 2" });

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Reflection;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
+using static System.Windows.Forms.ListView;
 using static System.Windows.Forms.ListViewGroup;
 using static Interop;
 using static Interop.UiaCore;
@@ -105,63 +106,27 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
-        public void ListViewGroupAccessibleObject_FragmentNavigate_ReturnsExpected_WithDefaultGroup(View view, bool showGroups, bool createHandle, bool virtualMode)
+        [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_FragmentNavigate_ReturnsExpected_WithDefaultGroup(View view, bool showGroups, bool createHandle)
         {
             using ListView listView = new()
             {
                 View = view,
                 ShowGroups = showGroups,
-                VirtualListSize = 6,
-                VirtualMode = virtualMode,
                 Size = new Size(200, 200)
             };
 
-            ListViewGroup listGroup1 = new ListViewGroup("Group1");
-            ListViewGroup listGroup2 = new ListViewGroup("Group2");
-            ListViewItem listItem1 = new ListViewItem(listGroup1);
-            ListViewItem listItem2 = new ListViewItem(listGroup1);
-            ListViewItem listItem3 = new ListViewItem();
-            ListViewItem listItem4 = new ListViewItem(listGroup2);
-            ListViewItem listItem5 = new ListViewItem(listGroup2);
-            ListViewItem listItem6 = new ListViewItem(listGroup2);
-            ListViewItem listItem7 = new ListViewItem(listGroup2);
-            ListViewItem listItem8 = new ListViewItem(listGroup2);
-            listView.Groups.Add(listGroup1);
-            listView.Groups.Add(listGroup2);
+            ListViewGroupCollection groups = listView.Groups;
+            ListViewItemCollection items = listView.Items;
 
-            if (virtualMode)
-            {
-                listView.RetrieveVirtualItem += (s, e) =>
-                {
-                    e.Item = e.ItemIndex switch
-                    {
-                        0 => listItem1,
-                        1 => listItem2,
-                        2 => listItem3,
-                        3 => listItem4,
-                        4 => listItem5,
-                        5 => listItem6,
-                        _ => throw new NotImplementedException()
-                    };
-                };
-
-                listItem1.SetItemIndex(listView, 0);
-                listItem2.SetItemIndex(listView, 1);
-                listItem3.SetItemIndex(listView, 2);
-                listItem4.SetItemIndex(listView, 3);
-                listItem5.SetItemIndex(listView, 4);
-                listItem6.SetItemIndex(listView, 5);
-            }
-            else
-            {
-                listView.Items.Add(listItem1);
-                listView.Items.Add(listItem2);
-                listView.Items.Add(listItem3);
-                listView.Items.Add(listItem4);
-                listView.Items.Add(listItem5);
-                listView.Items.Add(listItem6);
-            }
+            groups.Add(new ListViewGroup("Group1"));
+            groups.Add(new ListViewGroup("Group2"));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem());
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
 
             if (createHandle)
             {
@@ -171,22 +136,22 @@ namespace System.Windows.Forms.Tests
             if (listView.IsHandleCreated && listView.GroupsDisplayed)
             {
                 Assert.Equal(listView.AccessibilityObject, listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
-                Assert.Equal(listGroup1.AccessibilityObject, listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+                Assert.Equal(groups[0].AccessibilityObject, listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
                 Assert.Null(listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
-                Assert.Equal(listItem3.AccessibilityObject, listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
-                Assert.Equal(listItem3.AccessibilityObject, listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+                Assert.Equal(items[2].AccessibilityObject, listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Equal(items[2].AccessibilityObject, listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
 
-                Assert.Equal(listView.AccessibilityObject, listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
-                Assert.Equal(listGroup2.AccessibilityObject, listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
-                Assert.Equal(listView.DefaultGroup.AccessibilityObject, listView.Groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
-                Assert.Equal(listItem1.AccessibilityObject, listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
-                Assert.Equal(listItem2.AccessibilityObject, listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+                Assert.Equal(listView.AccessibilityObject, groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+                Assert.Equal(groups[1].AccessibilityObject, groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+                Assert.Equal(listView.DefaultGroup.AccessibilityObject, groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+                Assert.Equal(items[0].AccessibilityObject, groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Equal(items[1].AccessibilityObject, groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
 
-                Assert.Equal(listView.AccessibilityObject, listView.Groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
-                Assert.Equal(listGroup1.AccessibilityObject, listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
-                Assert.Equal(listItem4.AccessibilityObject, listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
-                Assert.Equal(listItem6.AccessibilityObject, listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+                Assert.Equal(listView.AccessibilityObject, groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+                Assert.Null(groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+                Assert.Equal(groups[0].AccessibilityObject, groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+                Assert.Equal(items[3].AccessibilityObject, groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Equal(items[5].AccessibilityObject, groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
             }
             else
             {
@@ -196,78 +161,41 @@ namespace System.Windows.Forms.Tests
                 Assert.Null(listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
                 Assert.Null(listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
 
-                Assert.Null(listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
-                Assert.Null(listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
-                Assert.Null(listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
-                Assert.Null(listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
-                Assert.Null(listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+                Assert.Null(listView.Groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+                Assert.Null(listView.Groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+                Assert.Null(listView.Groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+                Assert.Null(listView.Groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Null(listView.Groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
 
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+                Assert.Null(listView.Groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+                Assert.Null(listView.Groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+                Assert.Null(listView.Groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+                Assert.Null(listView.Groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Null(listView.Groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
             }
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
-        public void ListViewGroupAccessibleObject_FragmentNavigate_ReturnsExpected_WithoutDefaultGroup(View view, bool showGroups, bool createHandle, bool virtualMode)
+        [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_FragmentNavigate_ReturnsExpected_WithoutDefaultGroup(View view, bool showGroups, bool createHandle)
         {
             using ListView listView = new()
             {
                 View = view,
                 ShowGroups = showGroups,
-                VirtualListSize = 6,
-                VirtualMode = virtualMode,
                 Size = new Size(200, 200)
             };
 
-            ListViewGroup listGroup1 = new ListViewGroup("Group1");
-            ListViewGroup listGroup2 = new ListViewGroup("Group2");
-            ListViewItem listItem1 = new ListViewItem(listGroup1);
-            ListViewItem listItem2 = new ListViewItem(listGroup1);
-            ListViewItem listItem3 = new ListViewItem(listGroup1);
-            ListViewItem listItem4 = new ListViewItem(listGroup2);
-            ListViewItem listItem5 = new ListViewItem(listGroup2);
-            ListViewItem listItem6 = new ListViewItem(listGroup2);
-            ListViewItem listItem7 = new ListViewItem(listGroup2);
-            ListViewItem listItem8 = new ListViewItem(listGroup2);
-            listView.Groups.Add(listGroup1);
-            listView.Groups.Add(listGroup2);
-
-            if (virtualMode)
-            {
-                listView.RetrieveVirtualItem += (s, e) =>
-                {
-                    e.Item = e.ItemIndex switch
-                    {
-                        0 => listItem1,
-                        1 => listItem2,
-                        2 => listItem3,
-                        3 => listItem4,
-                        4 => listItem5,
-                        5 => listItem6,
-                        _ => throw new NotImplementedException()
-                    };
-                };
-
-                listItem1.SetItemIndex(listView, 0);
-                listItem2.SetItemIndex(listView, 1);
-                listItem3.SetItemIndex(listView, 2);
-                listItem4.SetItemIndex(listView, 3);
-                listItem5.SetItemIndex(listView, 4);
-                listItem6.SetItemIndex(listView, 5);
-            }
-            else
-            {
-                listView.Items.Add(listItem1);
-                listView.Items.Add(listItem2);
-                listView.Items.Add(listItem3);
-                listView.Items.Add(listItem4);
-                listView.Items.Add(listItem5);
-                listView.Items.Add(listItem6);
-            }
+            ListViewGroupCollection groups = listView.Groups;
+            ListViewItemCollection items = listView.Items;
+            groups.Add(new ListViewGroup("Group1"));
+            groups.Add(new ListViewGroup("Group2"));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
 
             if (createHandle)
             {
@@ -282,17 +210,17 @@ namespace System.Windows.Forms.Tests
                 Assert.Null(listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
                 Assert.Null(listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
 
-                Assert.Equal(listView.AccessibilityObject, listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
-                Assert.Equal(listGroup2.AccessibilityObject, listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
-                Assert.Null(listView.Groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
-                Assert.Equal(listItem1.AccessibilityObject, listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
-                Assert.Equal(listItem3.AccessibilityObject, listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+                Assert.Equal(listView.AccessibilityObject, groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+                Assert.Equal(groups[1].AccessibilityObject, groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+                Assert.Null(groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+                Assert.Equal(items[0].AccessibilityObject, groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Equal(items[2].AccessibilityObject, groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
 
                 Assert.Equal(listView.AccessibilityObject, listView.Groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
-                Assert.Equal(listGroup1.AccessibilityObject, listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
-                Assert.Equal(listItem4.AccessibilityObject, listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
-                Assert.Equal(listItem6.AccessibilityObject, listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+                Assert.Null(groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+                Assert.Equal(groups[0].AccessibilityObject, groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+                Assert.Equal(items[3].AccessibilityObject, groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Equal(items[5].AccessibilityObject, groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
             }
             else
             {
@@ -302,17 +230,17 @@ namespace System.Windows.Forms.Tests
                 Assert.Null(listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
                 Assert.Null(listView.DefaultGroup.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
 
-                Assert.Null(listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
-                Assert.Null(listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
-                Assert.Null(listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
-                Assert.Null(listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
-                Assert.Null(listGroup1.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+                Assert.Null(groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+                Assert.Null(groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+                Assert.Null(groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+                Assert.Null(groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Null(groups[0].AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
 
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
-                Assert.Null(listGroup2.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+                Assert.Null(groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+                Assert.Null(groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+                Assert.Null(groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+                Assert.Null(groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Null(groups[1].AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
             }
         }
 
@@ -374,63 +302,32 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
-        public void ListViewGroupAccessibleObject_GetChildIndex_ReturnsExpected(View view, bool showGroups, bool createHandle, bool virtualMode)
+        [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_GetChildIndex_ReturnsExpected(View view, bool showGroups, bool createHandle)
         {
             using ListView listView = new()
             {
                 View = view,
                 ShowGroups = showGroups,
-                VirtualListSize = 6,
-                VirtualMode = virtualMode,
                 Size = new Size(200, 200)
             };
 
-            ListViewGroup listGroup1 = new ListViewGroup("Group1");
-            ListViewGroup listGroup2 = new ListViewGroup("Group2");
-            ListViewItem listItem1 = new ListViewItem(listGroup1);
-            ListViewItem listItem2 = new ListViewItem(listGroup1);
-            ListViewItem listItem3 = new ListViewItem();
-            ListViewItem listItem4 = new ListViewItem(listGroup2);
-            ListViewItem listItem5 = new ListViewItem(listGroup2);
-            ListViewItem listItem6 = new ListViewItem(listGroup2);
-            ListViewItem listItem7 = new ListViewItem(listGroup2);
-            ListViewItem listItem8 = new ListViewItem(listGroup2);
-            listView.Groups.Add(listGroup1);
-            listView.Groups.Add(listGroup2);
+            ListViewGroupCollection groups = listView.Groups;
+            ListViewItemCollection items = listView.Items;
 
-            if (virtualMode)
-            {
-                listView.RetrieveVirtualItem += (s, e) =>
-                {
-                    e.Item = e.ItemIndex switch
-                    {
-                        0 => listItem1,
-                        1 => listItem2,
-                        2 => listItem3,
-                        3 => listItem4,
-                        4 => listItem5,
-                        5 => listItem6,
-                        _ => throw new NotImplementedException()
-                    };
-                };
+            groups.Add(new ListViewGroup("Group1"));
+            groups.Add(new ListViewGroup("Group2"));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem());
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
 
-                listItem1.SetItemIndex(listView, 0);
-                listItem2.SetItemIndex(listView, 1);
-                listItem3.SetItemIndex(listView, 2);
-                listItem4.SetItemIndex(listView, 3);
-                listItem5.SetItemIndex(listView, 4);
-                listItem6.SetItemIndex(listView, 5);
-            }
-            else
-            {
-                listView.Items.Add(listItem1);
-                listView.Items.Add(listItem2);
-                listView.Items.Add(listItem3);
-                listView.Items.Add(listItem4);
-                listView.Items.Add(listItem5);
-                listView.Items.Add(listItem6);
-            }
+            ListViewItem itemWithoutListView1 = new(groups[1]);
+            ListViewItem itemWithoutListView2 = new(groups[1]);
 
             if (createHandle)
             {
@@ -439,200 +336,132 @@ namespace System.Windows.Forms.Tests
 
             if (listView.IsHandleCreated && listView.GroupsDisplayed)
             {
-                Assert.Equal(0, listGroup1.AccessibilityObject.GetChildIndex(listItem1.AccessibilityObject));
-                Assert.Equal(1, listGroup1.AccessibilityObject.GetChildIndex(listItem2.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem3.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem4.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem5.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem6.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem7.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem8.AccessibilityObject));
+                Assert.Equal(0, groups[0].AccessibilityObject.GetChildIndex(items[0].AccessibilityObject));
+                Assert.Equal(1, groups[0].AccessibilityObject.GetChildIndex(items[1].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(items[2].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(items[3].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(items[4].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(items[5].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(itemWithoutListView1.AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(itemWithoutListView2.AccessibilityObject));
 
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem1.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem2.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem3.AccessibilityObject));
-                Assert.Equal(0, listGroup2.AccessibilityObject.GetChildIndex(listItem4.AccessibilityObject));
-                Assert.Equal(1, listGroup2.AccessibilityObject.GetChildIndex(listItem5.AccessibilityObject));
-                Assert.Equal(2, listGroup2.AccessibilityObject.GetChildIndex(listItem6.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem7.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem8.AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(items[0].AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(items[1].AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(items[2].AccessibilityObject));
+                Assert.Equal(0, groups[1].AccessibilityObject.GetChildIndex(items[3].AccessibilityObject));
+                Assert.Equal(1, groups[1].AccessibilityObject.GetChildIndex(items[4].AccessibilityObject));
+                Assert.Equal(2, groups[1].AccessibilityObject.GetChildIndex(items[5].AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(itemWithoutListView1.AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(itemWithoutListView2.AccessibilityObject));
 
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem1.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem2.AccessibilityObject));
-                Assert.Equal(0, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem3.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem4.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem5.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem6.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem7.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem8.AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[0].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[1].AccessibilityObject));
+                Assert.Equal(0, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[2].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[3].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[4].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[5].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(itemWithoutListView1.AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(itemWithoutListView2.AccessibilityObject));
             }
             else
             {
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem1.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem2.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem3.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem4.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem5.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem6.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem7.AccessibilityObject));
-                Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(listItem8.AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(items[0].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(items[1].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(items[2].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(items[3].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(items[4].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(items[5].AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(itemWithoutListView1.AccessibilityObject));
+                Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(itemWithoutListView2.AccessibilityObject));
 
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem1.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem2.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem3.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem4.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem5.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem6.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem7.AccessibilityObject));
-                Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(listItem8.AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(items[0].AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(items[1].AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(items[2].AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(items[3].AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(items[4].AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(items[5].AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(itemWithoutListView1.AccessibilityObject));
+                Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(itemWithoutListView2.AccessibilityObject));
 
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem1.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem2.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem3.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem4.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem5.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem6.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem7.AccessibilityObject));
-                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(listItem8.AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[0].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[1].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[2].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[3].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[4].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(items[5].AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(itemWithoutListView1.AccessibilityObject));
+                Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(itemWithoutListView2.AccessibilityObject));
             }
 
             Assert.Equal(createHandle, listView.IsHandleCreated);
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
-        public void ListViewGroupAccessibleObject_GetChildIndex_ReturnsMinusOne_IfChildIsNull(View view, bool showGroups, bool createHandle, bool virtualMode)
+        [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_GetChildIndex_ReturnsMinusOne_IfChildIsNull(View view, bool showGroups, bool createHandle)
         {
             using ListView listView = new()
             {
                 View = view,
                 ShowGroups = showGroups,
-                VirtualListSize = 6,
-                VirtualMode = virtualMode,
                 Size = new Size(200, 200)
             };
 
-            ListViewGroup listGroup1 = new ListViewGroup("Group1");
-            ListViewGroup listGroup2 = new ListViewGroup("Group2");
-            ListViewItem listItem1 = new ListViewItem(listGroup1);
-            ListViewItem listItem2 = new ListViewItem(listGroup1);
-            ListViewItem listItem3 = new ListViewItem();
-            ListViewItem listItem4 = new ListViewItem(listGroup2);
-            ListViewItem listItem5 = new ListViewItem(listGroup2);
-            ListViewItem listItem6 = new ListViewItem(listGroup2);
-            ListViewItem listItem7 = new ListViewItem(listGroup2);
-            ListViewItem listItem8 = new ListViewItem(listGroup2);
-            listView.Groups.Add(listGroup1);
-            listView.Groups.Add(listGroup2);
+            ListViewGroupCollection groups = listView.Groups;
+            ListViewItemCollection items = listView.Items;
 
-            if (virtualMode)
-            {
-                listView.RetrieveVirtualItem += (s, e) =>
-                {
-                    e.Item = e.ItemIndex switch
-                    {
-                        0 => listItem1,
-                        1 => listItem2,
-                        2 => listItem3,
-                        3 => listItem4,
-                        4 => listItem5,
-                        5 => listItem6,
-                        _ => throw new NotImplementedException()
-                    };
-                };
-
-                listItem1.SetItemIndex(listView, 0);
-                listItem2.SetItemIndex(listView, 1);
-                listItem3.SetItemIndex(listView, 2);
-                listItem4.SetItemIndex(listView, 3);
-                listItem5.SetItemIndex(listView, 4);
-                listItem6.SetItemIndex(listView, 5);
-            }
-            else
-            {
-                listView.Items.Add(listItem1);
-                listView.Items.Add(listItem2);
-                listView.Items.Add(listItem3);
-                listView.Items.Add(listItem4);
-                listView.Items.Add(listItem5);
-                listView.Items.Add(listItem6);
-            }
+            groups.Add(new ListViewGroup("Group1"));
+            groups.Add(new ListViewGroup("Group2"));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem());
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
 
             if (createHandle)
             {
                 Assert.NotEqual(IntPtr.Zero, listView.Handle);
             }
 
-            Assert.Equal(-1, listGroup1.AccessibilityObject.GetChildIndex(null));
-            Assert.Equal(-1, listGroup2.AccessibilityObject.GetChildIndex(null));
+            Assert.Equal(-1, groups[0].AccessibilityObject.GetChildIndex(null));
+            Assert.Equal(-1, groups[1].AccessibilityObject.GetChildIndex(null));
             Assert.Equal(-1, listView.DefaultGroup.AccessibilityObject.GetChildIndex(null));
             Assert.Equal(createHandle, listView.IsHandleCreated);
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
-        public void ListViewGroupAccessibleObject_GetChildCount_Invoke_ReturnsExpected(View view, bool showGroups, bool createHandle, bool virtualMode)
+        [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_GetChildCount_Invoke_ReturnsExpected(View view, bool showGroups, bool createHandle)
         {
             using ListView listView = new()
             {
                 View = view,
                 ShowGroups = showGroups,
-                VirtualListSize = 6,
-                VirtualMode = virtualMode,
                 Size = new Size(200, 200)
             };
 
-            ListViewGroup listGroup1 = new ListViewGroup("Group1");
-            ListViewGroup listGroup2 = new ListViewGroup("Group2");
-            ListViewItem listItem1 = new ListViewItem(listGroup1);
-            ListViewItem listItem2 = new ListViewItem(listGroup1);
-            ListViewItem listItem3 = new ListViewItem();
-            ListViewItem listItem4 = new ListViewItem(listGroup2);
-            ListViewItem listItem5 = new ListViewItem(listGroup2);
-            ListViewItem listItem6 = new ListViewItem(listGroup2);
-            listView.Groups.Add(listGroup1);
-            listView.Groups.Add(listGroup2);
+            ListViewGroupCollection groups = listView.Groups;
+            ListViewItemCollection items = listView.Items;
 
-            if (virtualMode)
-            {
-                listView.RetrieveVirtualItem += (s, e) =>
-                {
-                    e.Item = e.ItemIndex switch
-                    {
-                        0 => listItem1,
-                        1 => listItem2,
-                        2 => listItem3,
-                        3 => listItem4,
-                        4 => listItem5,
-                        5 => listItem6,
-                        _ => throw new NotImplementedException()
-                    };
-                };
-
-                listItem1.SetItemIndex(listView, 0);
-                listItem2.SetItemIndex(listView, 1);
-                listItem3.SetItemIndex(listView, 2);
-                listItem4.SetItemIndex(listView, 3);
-                listItem5.SetItemIndex(listView, 4);
-                listItem6.SetItemIndex(listView, 5);
-            }
-            else
-            {
-                listView.Items.Add(listItem1);
-                listView.Items.Add(listItem2);
-                listView.Items.Add(listItem3);
-                listView.Items.Add(listItem4);
-                listView.Items.Add(listItem5);
-                listView.Items.Add(listItem6);
-            }
+            groups.Add(new ListViewGroup("Group1"));
+            groups.Add(new ListViewGroup("Group2"));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem());
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
 
             if (createHandle)
             {
                 Assert.NotEqual(IntPtr.Zero, listView.Handle);
             }
 
-            ListViewGroupAccessibleObject group1AccObj = (ListViewGroupAccessibleObject)listGroup1.AccessibilityObject;
-            ListViewGroupAccessibleObject group2AccObj = (ListViewGroupAccessibleObject)listGroup2.AccessibilityObject;
+            ListViewGroupAccessibleObject group1AccObj = (ListViewGroupAccessibleObject)groups[0].AccessibilityObject;
+            ListViewGroupAccessibleObject group2AccObj = (ListViewGroupAccessibleObject)groups[1].AccessibilityObject;
             ListViewGroupAccessibleObject defaultGroupAccObj = (ListViewGroupAccessibleObject)listView.DefaultGroup.AccessibilityObject;
             bool supportsGetChild = listView.IsHandleCreated && listView.GroupsDisplayed;
 
@@ -686,85 +515,56 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
-        public void ListViewGroupAccessibleObject_GetChild_Invoke_ReturnsExpected(View view, bool showGroups, bool createHandle, bool virtualMode)
+        [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_GetChild_Invoke_ReturnsExpected(View view, bool showGroups, bool createHandle)
         {
             using ListView listView = new()
             {
                 View = view,
                 ShowGroups = showGroups,
-                VirtualListSize = 4,
-                VirtualMode = virtualMode,
                 Size = new Size(200, 200)
             };
 
             listView.Columns.Add(new ColumnHeader());
 
-            ListViewGroup listGroup1 = new ListViewGroup("Group1");
-            ListViewGroup listGroup2 = new ListViewGroup("Group2");
-            ListViewGroup listGroup3 = new ListViewGroup("Group2");
-            ListViewItem listItem1 = new ListViewItem(listGroup1);
-            ListViewItem listItem2 = new ListViewItem();
-            ListViewItem listItem3 = new ListViewItem(listGroup2);
-            ListViewItem listItem4 = new ListViewItem(listGroup2);
-            listView.Groups.Add(listGroup1);
-            listView.Groups.Add(listGroup2);
-            listView.Groups.Add(listGroup3);
+            ListViewGroupCollection groups = listView.Groups;
+            ListViewItemCollection items = listView.Items;
 
-            if (virtualMode)
-            {
-                listView.RetrieveVirtualItem += (s, e) =>
-                {
-                    e.Item = e.ItemIndex switch
-                    {
-                        0 => listItem1,
-                        1 => listItem2,
-                        2 => listItem3,
-                        3 => listItem4,
-                        _ => throw new NotImplementedException()
-                    };
-                };
-
-                listItem1.SetItemIndex(listView, 0);
-                listItem2.SetItemIndex(listView, 1);
-                listItem3.SetItemIndex(listView, 2);
-                listItem4.SetItemIndex(listView, 3);
-            }
-            else
-            {
-                listView.Items.Add(listItem1);
-                listView.Items.Add(listItem2);
-                listView.Items.Add(listItem3);
-                listView.Items.Add(listItem4);
-            }
+            groups.Add(new ListViewGroup("Group1"));
+            groups.Add(new ListViewGroup("Group2"));
+            groups.Add(new ListViewGroup("Group3"));
+            items.Add(new ListViewItem(groups[0]));
+            items.Add(new ListViewItem());
+            items.Add(new ListViewItem(groups[1]));
+            items.Add(new ListViewItem(groups[1]));
 
             if (createHandle)
             {
                 Assert.NotEqual(IntPtr.Zero, listView.Handle);
             }
 
-            ListViewGroupAccessibleObject group1AccObj = (ListViewGroupAccessibleObject)listGroup1.AccessibilityObject;
-            ListViewGroupAccessibleObject group2AccObj = (ListViewGroupAccessibleObject)listGroup2.AccessibilityObject;
-            ListViewGroupAccessibleObject group3AccObj = (ListViewGroupAccessibleObject)listGroup3.AccessibilityObject;
+            ListViewGroupAccessibleObject group1AccObj = (ListViewGroupAccessibleObject)groups[0].AccessibilityObject;
+            ListViewGroupAccessibleObject group2AccObj = (ListViewGroupAccessibleObject)groups[1].AccessibilityObject;
+            ListViewGroupAccessibleObject group3AccObj = (ListViewGroupAccessibleObject)groups[2].AccessibilityObject;
             ListViewGroupAccessibleObject defaultGroupAccObj = (ListViewGroupAccessibleObject)listView.DefaultGroup.AccessibilityObject;
             bool supportsGetChild = listView.IsHandleCreated && listView.GroupsDisplayed;
 
             Assert.Null(group1AccObj.GetChild(-1));
             Assert.Null(group1AccObj.GetChild(1));
 
-            Assert.Equal(supportsGetChild ? listItem1.AccessibilityObject : null, group1AccObj.GetChild(0));
+            Assert.Equal(supportsGetChild ? items[0].AccessibilityObject : null, group1AccObj.GetChild(0));
 
             Assert.Null(group2AccObj.GetChild(-1));
             Assert.Null(group2AccObj.GetChild(2));
-            Assert.Equal(supportsGetChild ? listItem3.AccessibilityObject : null, group2AccObj.GetChild(0));
-            Assert.Equal(supportsGetChild ? listItem4.AccessibilityObject : null, group2AccObj.GetChild(1));
+            Assert.Equal(supportsGetChild ? items[2].AccessibilityObject : null, group2AccObj.GetChild(0));
+            Assert.Equal(supportsGetChild ? items[3].AccessibilityObject : null, group2AccObj.GetChild(1));
 
             Assert.Null(group3AccObj.GetChild(-1));
             Assert.Null(group3AccObj.GetChild(0));
 
             Assert.Null(defaultGroupAccObj.GetChild(-1));
             Assert.Null(defaultGroupAccObj.GetChild(1));
-            Assert.Equal(supportsGetChild ? listItem2.AccessibilityObject : null, defaultGroupAccObj.GetChild(0));
+            Assert.Equal(supportsGetChild ? items[1].AccessibilityObject : null, defaultGroupAccObj.GetChild(0));
             Assert.Equal(createHandle, listView.IsHandleCreated);
         }
 
@@ -1199,10 +999,10 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(ListViewGroup_GroupAddedWithItem_AccessibleObject_TestData))]
-        public void ListViewGroupAccessibleObject_Bounds_ReturnsExpected(View view, bool showGroups, bool createHandle, bool virtualMode)
+        [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_Bounds_ReturnsExpected(View view, bool showGroups, bool createHandle)
         {
-            using ListView listView = GetListViewWithGroups(view, showGroups, createHandle, virtualMode);
+            using ListView listView = GetListViewWithGroups(view, showGroups, createHandle, virtualMode: false);
             ListView.ListViewAccessibleObject accessibleObject = listView.AccessibilityObject as ListView.ListViewAccessibleObject;
             bool showBounds = listView.IsHandleCreated && listView.GroupsDisplayed;
 
@@ -1280,15 +1080,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(ListViewGroupAccessibleObject_GetChild_Invoke_TestData))]
-        public void ListViewGroupAccessibleObject_SetFocus_WorksCorrectly(View view, bool showGroups, bool createHandle, bool virtualMode)
+        [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
+        public void ListViewGroupAccessibleObject_SetFocus_WorksCorrectly(View view, bool showGroups, bool createHandle)
         {
             using ListView listView = new()
             {
                 View = view,
                 ShowGroups = showGroups,
-                VirtualListSize = 3,
-                VirtualMode = virtualMode,
                 Size = new Size(200, 200)
             };
 
@@ -1300,29 +1098,9 @@ namespace System.Windows.Forms.Tests
             listView.Groups.Add(listGroup1);
             listView.Groups.Add(listGroup2);
 
-            if (virtualMode)
-            {
-                listView.RetrieveVirtualItem += (s, e) =>
-                {
-                    e.Item = e.ItemIndex switch
-                    {
-                        0 => listItem1,
-                        1 => listItem2,
-                        2 => listItem3,
-                        _ => throw new NotImplementedException()
-                    };
-                };
-
-                listItem1.SetItemIndex(listView, 0);
-                listItem2.SetItemIndex(listView, 1);
-                listItem3.SetItemIndex(listView, 2);
-            }
-            else
-            {
-                listView.Items.Add(listItem1);
-                listView.Items.Add(listItem2);
-                listView.Items.Add(listItem3);
-            }
+            listView.Items.Add(listItem1);
+            listView.Items.Add(listItem2);
+            listView.Items.Add(listItem3);
 
             if (createHandle)
             {
@@ -1380,9 +1158,14 @@ namespace System.Windows.Forms.Tests
 
             listView.Columns.Add(new ColumnHeader());
 
-            var listViewGroup = new ListViewGroup("Test Group");
-            listView.Groups.Add(listViewGroup);
-            var listViewItem1 = new ListViewItem("Test item 1", listViewGroup);
+            ListViewItem listViewItem1 = new ListViewItem("Test item 1");
+            if (!virtualMode)
+            {
+                var listViewGroup = new ListViewGroup("Test Group");
+                listView.Groups.Add(listViewGroup);
+                listViewItem1.Group = listViewGroup;
+            }
+
             var listViewItem2 = new ListViewItem("Test item 2");
 
             if (virtualMode)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupCollectionTests.cs
@@ -1050,5 +1050,88 @@ namespace System.Windows.Forms.Tests
             collection.CopyTo(array, 0);
             Assert.Equal(new object[] { 1, 2, 3 }, array);
         }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ListViewGroupCollection_Add_Group_DoesNotWork_IfVirtualMode(bool createControl)
+        {
+            using var listView = new ListView() { VirtualMode = true };
+
+            if (createControl)
+            {
+                listView.CreateControl();
+            }
+
+            Assert.Throws<InvalidOperationException>(() => listView.Groups.Add(new ListViewGroup()));
+            Assert.Equal(createControl, listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ListViewGroupCollection_Add_Key_HeaderText_DoesNotWork_IfVirtualMode(bool createControl)
+        {
+            using var listView = new ListView() { VirtualMode = true };
+
+            if (createControl)
+            {
+                listView.CreateControl();
+            }
+
+            Assert.Throws<InvalidOperationException>(() => listView.Groups.Add(key: "key", headerText: "text" ));
+            Assert.Equal(createControl, listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ListViewGroupCollection_AddRange_GroupsArray_DoesNotWork_IfVirtualMode(bool createControl)
+        {
+            using var listView = new ListView() { VirtualMode = true };
+
+            if (createControl)
+            {
+                listView.CreateControl();
+            }
+
+            Assert.Throws<InvalidOperationException>(() => listView.Groups.AddRange(new ListViewGroup[] { new(), new () }));
+            Assert.Equal(createControl, listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ListViewGroupCollection_AddRange_ListViewGroupCollection_DoesNotWork_IfVirtualMode(bool createControl)
+        {
+            using var listView = new ListView() { VirtualMode = true };
+            using var listViewSource = new ListView();
+            ListViewGroupCollection sourceGroup = new(listViewSource);
+            sourceGroup.AddRange(new ListViewGroup[] { new(), new() } );
+
+            if (createControl)
+            {
+                listView.CreateControl();
+            }
+
+            Assert.Throws<InvalidOperationException>(() => listView.Groups.AddRange(sourceGroup));
+            Assert.Equal(createControl, listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ListViewGroupCollection_Insert_DoesNotWork_IfVirtualMode(bool createControl)
+        {
+            using var listView = new ListView() { VirtualMode = true };
+
+            if (createControl)
+            {
+                listView.CreateControl();
+            }
+
+            Assert.Throws<InvalidOperationException>(() => listView.Groups.Insert(0, new ListViewGroup()));
+            Assert.Equal(createControl, listView.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -1148,11 +1148,16 @@ namespace System.Windows.Forms.Tests
                 VirtualListSize = 2
             };
 
-            ListViewGroup listViewGroup = new("Test");
-
             ListViewItem listItem1 = new("Item 1");
-            ListViewItem listItem2 = new("Item 2", group: listViewGroup);
-            listView.Groups.Add(listViewGroup);
+            ListViewItem listItem2 = new("Item 2");
+
+            if (!virtualMode)
+            {
+                ListViewGroup listViewGroup = new("Test");
+                listItem2.Group = listViewGroup;
+                listView.Groups.Add(listViewGroup);
+            }
+
             for (int i = 0; i < subItemCount; i++)
             {
                 listItem1.SubItems.Add(new ListViewSubItem() { Text = $"SubItem {i}" });
@@ -1202,13 +1207,18 @@ namespace System.Windows.Forms.Tests
                 VirtualListSize = 4
             };
 
-            ListViewGroup listViewGroup = new("Test");
-            ListViewItem listItem1 = new(new string[] { "Test Item 1", "Item A" }, -1, listViewGroup);
-            ListViewItem listItem2 = new("Group item 2", listViewGroup);
+            ListViewItem listItem1 = new(new string[] { "Test Item 1", "Item A" }, -1);
+            ListViewItem listItem2 = new("Group item 2");
             ListViewItem listItem3 = new("Item 3");
             ListViewItem listItem4 = new(new string[] { "Test Item 4", "Item B", "Item C", "Item D" }, -1);
 
-            listView.Groups.Add(listViewGroup);
+            if (!virtualMode)
+            {
+                ListViewGroup listViewGroup = new("Test");
+                listView.Groups.Add(listViewGroup);
+                listItem1.Group = listViewGroup;
+                listItem2.Group = listViewGroup;
+            }
 
             listView.Columns.Add(new ColumnHeader() { Name = "Column 1" });
             listView.Columns.Add(new ColumnHeader() { Name = "Column 2" });
@@ -1800,24 +1810,30 @@ namespace System.Windows.Forms.Tests
                 VirtualListSize = 3
             };
 
-            ListViewGroup lvgroup1 = new()
-            {
-                Header = "CollapsibleGroup1",
-                CollapsedState = ListViewGroupCollapsedState.Expanded
-            };
-
-            listView.Groups.Add(lvgroup1);
-            ListViewItem listViewItem1 = new("Item1", lvgroup1);
-
-            ListViewGroup lvgroup2 = new()
-            {
-                Header = "CollapsibleGroup2",
-                CollapsedState = ListViewGroupCollapsedState.Collapsed
-            };
-
-            ListViewItem listViewItem2 = new("Item2", lvgroup2);
+            ListViewItem listViewItem1 = new("Item1");
+            ListViewItem listViewItem2 = new("Item2");
             ListViewItem listViewItem3 = new("Item3");
-            listView.Groups.Add(lvgroup2);
+
+            if (!virtualMode)
+            {
+                ListViewGroup lvgroup1 = new()
+                {
+                    Header = "CollapsibleGroup1",
+                    CollapsedState = ListViewGroupCollapsedState.Expanded
+                };
+
+                ListViewGroup lvgroup2 = new()
+                {
+                    Header = "CollapsibleGroup2",
+                    CollapsedState = ListViewGroupCollapsedState.Collapsed
+                };
+
+                listView.Groups.Add(lvgroup1);
+                listView.Groups.Add(lvgroup2);
+
+                listViewItem1.Group = lvgroup1;
+                listViewItem2.Group = lvgroup2;
+            }
 
             if (virtualMode)
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -798,11 +798,15 @@ namespace System.Windows.Forms.Tests
                 VirtualListSize = 2
             };
 
-            ListViewGroup listViewGroup = new("Test");
-            listView.Groups.Add(listViewGroup);
-
             ListViewItem listItem1 = new("Item 1");
-            ListViewItem listItem2 = new("Item 2", group: listViewGroup);
+            ListViewItem listItem2 = new("Item 2");
+
+            if (!virtualMode)
+            {
+                ListViewGroup listViewGroup = new("Test");
+                listView.Groups.Add(listViewGroup);
+                listItem2.Group = listViewGroup;
+            }
 
             for (int i = 0; i < subItemCount; i++)
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -4577,13 +4577,12 @@ namespace System.Windows.Forms.Tests
             {
                 ShowGroups = true,
                 CheckBoxes = false,
-                VirtualMode = true,
                 VirtualListSize = 2 // we can't add items, just indicate how many we have
             };
 
             ListViewGroup group = new ListViewGroup("Test group");
             control.Groups.Add(group);
-
+            control.VirtualMode = true;
             control.RetrieveVirtualItem += (s, e) =>
             {
                 e.Item = e.ItemIndex switch
@@ -5371,7 +5370,7 @@ namespace System.Windows.Forms.Tests
             ListViewItem listItem1 = new("Test Item 1");
             ListViewItem listItem2 = new("Test Item 2");
 
-            if (withinGroup)
+            if (!virtualMode && withinGroup)
             {
                 ListViewGroup listViewGroup = new("Test");
                 listView.Groups.Add(listViewGroup);


### PR DESCRIPTION
Fixes #4044


## Proposed changes
- Added check in `ListViewGroupCollection` class for `Add`, `AddRange` and `Insert` methods, which prohibits adding a `ListViewGroup` when the `ListView` is in virtual mode.
- Fixed MAUI and unit tests. Added new unit tests. 
- Ported from #5691

## Customer Impact
**Before fix:**
Previously, we only threw an error when the `Handle` was created. This happened because when the `Handle` was created we called the `MoveGroupItems` method, in which we called the property enumerator of the `ListViewGroups.Items`, which threw an exception about Virtual Mode.

**After fix:**
Now, when trying to call `Add`, `AddRange` and `Insert` methods for a sheet in virtual mode, we will always check the virtual mode, regardless of whether the `Handle` is created or not.

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team 
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 6.0.100-rc.1.21430.12

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5723)