### PR TITLE
Fixing EditTextBox AO position in the PropertyGrid tree

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
@@ -167,7 +167,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return propertyGridView.DropDownControlHolder.AccessibilityObject;
                     }
 
-                    return propertyGridView.EditAccessibleObject;
+                    if (propertyGridView.IsEditTextBoxCreated)
+                    {
+                        return propertyGridView.EditAccessibleObject;
+                    }
                 }
 
                 return null;
@@ -199,7 +202,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return propertyGridView.DropDownButton.AccessibilityObject;
                     }
 
-                    return propertyGridView.EditAccessibleObject;
+                    if (propertyGridView.IsEditTextBoxCreated)
+                    {
+                        return propertyGridView.EditAccessibleObject;
+                    }
                 }
 
                 return null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1433,6 +1433,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public int GetOutlineIconSize() => IsExplorerTreeSupported ? _outlineSizeExplorerTreeStyle : _outlineSize;
 
+        internal bool IsEditTextBoxCreated => _editTextBox is not null && _editTextBox.IsHandleCreated;
+
         public int GetGridEntryHeight() => RowHeight;
 
         internal int GetPropertyLocation(string propName, bool getXY, bool rowValue)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObjectTests.cs
@@ -31,6 +31,10 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             PropertyDescriptorGridEntry selectedGridEntry = propertyGridView.TestAccessor().Dynamic._selectedGridEntry;
 
             Assert.Equal(gridEntry.PropertyName, selectedGridEntry.PropertyName);
+            // Force the entry edit control Handle creation.
+            // GridViewEditAccessibleObject exists, if its control is already created.
+            // In UI case an entry edit control is created when an PropertyGridView gets focus.
+            Assert.NotEqual(IntPtr.Zero, propertyGridView.TestAccessor().Dynamic.EditTextBox.Handle);
 
             AccessibleObject selectedGridEntryAccessibleObject = gridEntry.AccessibilityObject;
             UiaCore.IRawElementProviderFragment editFieldAccessibleObject = selectedGridEntryAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
@@ -54,6 +58,11 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
 
             propertyGridView.TestAccessor().Dynamic._selectedGridEntry = gridEntry;
 
+            // Force the entry edit control Handle creation.
+            // GridViewEditAccessibleObject exists, if its control is already created.
+            // In UI case an entry edit control is created when an PropertyGridView gets focus.
+            Assert.NotEqual(IntPtr.Zero, propertyGridView.TestAccessor().Dynamic.EditTextBox.Handle);
+
             UiaCore.IRawElementProviderFragment editFieldAccessibleObject = gridEntry.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
             Assert.Equal("GridViewTextBoxAccessibleObject", editFieldAccessibleObject.GetType().Name);
 
@@ -63,7 +72,9 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             propertyGridView.TestAccessor().Dynamic._dropDownHolder = dropDownHolder;
 
             dropDownHolder.TestAccessor().Dynamic.SetState(0x00000002, true); // Control class States.Visible flag
+            UiaCore.IRawElementProviderFragment dropDownHolderAccessibleObject = gridEntry.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
 
+            Assert.Equal("DropDownHolderAccessibleObject", dropDownHolderAccessibleObject.GetType().Name);
             Assert.True(propertyGridView.DropDownVisible);
             object previousAccessibleObject = editFieldAccessibleObject.Navigate(UiaCore.NavigateDirection.PreviousSibling);
             Assert.NotNull(previousAccessibleObject);


### PR DESCRIPTION
Fixes #5656

The bug repro-steps:
- Create a `PropertyGrid` with `Form` as `SelectedObject`
- Run the app - don't click on the `PropertyGridView`
- Check the Text entry using Inspect - there will be an edit accessible object as a child (incorrect)
- Click any entry (thereby create the edit control) - after that everything is good, the edit acc obj has correct position in the tree and correct properties values.

The fix doesn't allow to create and put EditAccessibleObject to the accessibility tree, if the TextBox control is not created,
because otherwise EditAccessibleObject doesn't get correct native properties, and a user see some AO of not created control.

PropertyGridView EditTextBox creates on the first click on the GridView and if there is a selected GridEntry.

I tried just to implement correct values of the necessary accessibility properties (`Bounds`, `Role`, `State`), but the implementation looks horrible and unsafe. Also, there is no way to get a correct Bounds without a TextBox `Handle`, because we have to send Win messages, that require the `Handle` (`RectangleToScreen` method). And this implementation just fixes symptoms of the bug. So not using AO for not created Control is better, I guess.

## Proposed changes

- Return null in FragmentNavigate of an entry if a entry TextBox is not created thereby remove it from the accessibility tree.
You can try to select some entry, but check another one with Inspect/AI. You will see, that only the selected entry has the edit sub-item. The rest entries don't have this child in the accessibility tree. And if a PropertyGridView doesn't have a selected entry, there should not be a edit child for any entry (because this edit text box is not created yet). 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user doesn't see an edit accessible object for not created control.

## Regression? 

- No

## Risk

- Minimal

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- There is an edit accessible object of a not created control, so its properties values are incorrect:
![image](https://user-images.githubusercontent.com/49272759/132652782-705800c8-9ea8-4b19-9b3a-cb48e8a54910.png)

<!-- TODO -->

### After

- There is no an edit accessible object, because its control is not created:
![image](https://user-images.githubusercontent.com/49272759/132651737-20afa679-0703-48d6-bd1d-5f5ce8f4cb3c.png)

- There is an edit accessible object with correct accessible properties values after click on the entry
(thereby creating the edit control):
![image](https://user-images.githubusercontent.com/49272759/132652126-58809396-07cf-463b-99ee-5183a218874f.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manual testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Inspect and Accessibility Insights


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 6.0-rc2
- Windows 10


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5724)