### PR TITLE
Fixing EditTextBox AO position in the PropertyGrid tree (port 6.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
@@ -167,7 +167,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return propertyGridView.DropDownControlHolder.AccessibilityObject;
                     }
 
-                    return propertyGridView.EditAccessibleObject;
+                    if (propertyGridView.IsEditTextBoxCreated)
+                    {
+                        return propertyGridView.EditAccessibleObject;
+                    }
                 }
 
                 return null;
@@ -200,7 +203,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return propertyGridView.DropDownButton.AccessibilityObject;
                     }
 
-                    return propertyGridView.EditAccessibleObject;
+                    if (propertyGridView.IsEditTextBoxCreated)
+                    {
+                        return propertyGridView.EditAccessibleObject;
+                    }
                 }
 
                 return null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1439,6 +1439,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public virtual int GetLabelWidth() => InternalLabelWidth;
 
+        internal bool IsEditTextBoxCreated => _edit is not null && _edit.IsHandleCreated;
+
         internal bool IsExplorerTreeSupported => OwnerGrid.CanShowVisualStyleGlyphs && VisualStyleRenderer.IsSupported;
 
         public virtual int GetOutlineIconSize() => IsExplorerTreeSupported ? _outlineSizeExplorerTreeStyle : _outlineSize;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObjectTests.cs
@@ -31,6 +31,10 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             PropertyDescriptorGridEntry selectedGridEntry = propertyGridView.TestAccessor().Dynamic._selectedGridEntry;
 
             Assert.Equal(gridEntry.PropertyName, selectedGridEntry.PropertyName);
+            // Force the entry edit control Handle creation.
+            // GridViewEditAccessibleObject exists, if its control is already created.
+            // In UI case an entry edit control is created when an PropertyGridView gets focus.
+            Assert.NotEqual(IntPtr.Zero, propertyGridView.TestAccessor().Dynamic.Edit.Handle);
 
             AccessibleObject selectedGridEntryAccessibleObject = gridEntry.AccessibilityObject;
             UiaCore.IRawElementProviderFragment editFieldAccessibleObject = selectedGridEntryAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
@@ -54,6 +58,11 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
 
             propertyGridView.TestAccessor().Dynamic._selectedGridEntry = gridEntry;
 
+            // Force the entry edit control Handle creation.
+            // GridViewEditAccessibleObject exists, if its control is already created.
+            // In UI case an entry edit control is created when an PropertyGridView gets focus.
+            Assert.NotEqual(IntPtr.Zero, propertyGridView.TestAccessor().Dynamic.Edit.Handle);
+
             UiaCore.IRawElementProviderFragment editFieldAccessibleObject = gridEntry.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
             Assert.Equal("GridViewEditAccessibleObject", editFieldAccessibleObject.GetType().Name);
 
@@ -63,7 +72,9 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             propertyGridView.TestAccessor().Dynamic._dropDownHolder = dropDownHolder;
 
             dropDownHolder.SetState(0x00000002, true); // Control class States.Visible flag
+            UiaCore.IRawElementProviderFragment dropDownHolderAccessibleObject = gridEntry.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
 
+            Assert.Equal("DropDownHolderAccessibleObject", dropDownHolderAccessibleObject.GetType().Name);
             Assert.True(propertyGridView.DropDownVisible);
             object previousAccessibleObject = editFieldAccessibleObject.Navigate(UiaCore.NavigateDirection.PreviousSibling);
             Assert.NotNull(previousAccessibleObject);


### PR DESCRIPTION
Fixes #5656 

(cherry picked from commit 28e4b7d4ea6a4fb21bc777b83b36e7765e44bd49 and then additional changes were added)

This is a port from #5724. Please see its description for details.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5725)