### PR TITLE
simplify temp file generation

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3418,36 +3418,6 @@ namespace System.Windows.Forms
             }
         }
 
-        private string GenerateRandomName()
-        {
-            Debug.Assert(BackgroundImage is not null, "we need to generate random numbers only when saving the background image to disk");
-            Bitmap bm = new Bitmap(BackgroundImage);
-            int handle = 0;
-
-            try
-            {
-                handle = unchecked((int)(long)bm.GetHicon());
-            }
-            catch
-            {
-                bm.Dispose();
-            }
-
-            Random rnd;
-            if (handle == 0)
-            {
-                // there was a problem when we got the icon handle
-                // use DateTime.Now to seed the randomizer
-                rnd = new Random((int)System.DateTime.Now.Ticks);
-            }
-            else
-            {
-                rnd = new Random(handle);
-            }
-
-            return rnd.Next().ToString(CultureInfo.InvariantCulture);
-        }
-
         // IDs for identifying ListViewItem's
         private int GenerateUniqueID()
         {
@@ -5171,11 +5141,7 @@ namespace System.Windows.Forms
             if (BackgroundImage is not null)
             {
                 // save the image to a temporary file name
-                string tempDirName = System.IO.Path.GetTempPath();
-                Text.StringBuilder sb = new Text.StringBuilder(1024);
-                UnsafeNativeMethods.GetTempFileName(tempDirName, GenerateRandomName(), 0, sb);
-
-                backgroundImageFileName = sb.ToString();
+                backgroundImageFileName = Path.GetTempFileName();
 
                 BackgroundImage.Save(backgroundImageFileName, System.Drawing.Imaging.ImageFormat.Bmp);
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5717


## Proposed changes

- remove custom temp file name generation. It was using a newly allocated image handle to seed a random number generator, which is both unnecessary overhead and was leaking the image handle.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- no more image handle leaks when assigning background images to list view

## Regression? 

- No

## Risk

- probably none, unless someone relied on the temp file name patterns

### Before

- leaking ~3 GDI handles every time the background images was assigned

### After

- no image handle leak


## Test methodology

- manual testing and observing GDI object count in task manager


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5744)