### PR TITLE
Move duplicate logic of "GetPropertyValue" method to base classes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -382,6 +382,25 @@ namespace System.Windows.Forms
             {
                 UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsInvokePatternAvailable,
                 UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
+                UiaCore.UIA.NamePropertyId => Name,
+                UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
+                UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId),
+                UiaCore.UIA.IsGridItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.GridItemPatternId),
+                UiaCore.UIA.IsGridPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.GridPatternId),
+                UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
+                UiaCore.UIA.IsMultipleViewPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.MultipleViewPatternId),
+                UiaCore.UIA.IsScrollItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ScrollItemPatternId),
+                UiaCore.UIA.IsScrollPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ScrollPatternId),
+                UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.SelectionItemPatternId),
+                UiaCore.UIA.IsSelectionPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.SelectionPatternId),
+                UiaCore.UIA.IsTableItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TableItemPatternId),
+                UiaCore.UIA.IsTablePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TablePatternId),
+                UiaCore.UIA.IsTextPattern2AvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPattern2Id),
+                UiaCore.UIA.IsTextPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPatternId),
+                UiaCore.UIA.IsTogglePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TogglePatternId),
+                UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
+                UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
+                UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                 _ => null
             };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Button.ButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Button.ButtonAccessibleObject.cs
@@ -17,8 +17,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UIA propertyID)
                 => propertyID switch
                 {
-                    UIA.NamePropertyId
-                        => Name,
                     UIA.AutomationIdPropertyId
                         => Owner.Name,
                     UIA.ControlTypePropertyId

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.CheckBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.CheckBoxAccessibleObject.cs
@@ -70,12 +70,8 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId
-                        => Name,
                     UiaCore.UIA.AutomationIdPropertyId
                         => Owner.Name,
-                    UiaCore.UIA.IsTogglePatternAvailablePropertyId
-                        => IsPatternSupported(UiaCore.UIA.TogglePatternId),
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         =>
                         // This is necessary for compatibility with MSAA proxy:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
@@ -45,9 +45,6 @@ namespace System.Windows.Forms
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.CheckBoxControlTypeId,
                     UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
-                    UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
-                    UiaCore.UIA.IsTogglePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TogglePatternId),
-                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
                     UiaCore.UIA.ValueValuePropertyId => Value,
                     _ => base.GetPropertyValue(propertyID)
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
@@ -207,17 +207,8 @@ namespace System.Windows.Forms
                         return _owningComboBox.AccessibleRole == AccessibleRole.Default
                                ? UiaCore.UIA.ComboBoxControlTypeId
                                : base.GetPropertyValue(propertyID);
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return _owningComboBox.Focused;
-                    case UiaCore.UIA.NativeWindowHandlePropertyId:
-                        return _owningComboBox.InternalHandle;
-                    case UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId);
-                    case UiaCore.UIA.IsValuePatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.ValuePatternId);
-
                     default:
                         return base.GetPropertyValue(propertyID);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
@@ -121,14 +121,10 @@ namespace System.Windows.Forms
             {
                 switch (propertyID)
                 {
-                    case UiaCore.UIA.RuntimeIdPropertyId:
-                        return RuntimeId;
                     case UiaCore.UIA.BoundingRectanglePropertyId:
                         return BoundingRectangle;
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.ButtonControlTypeId;
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.AccessKeyPropertyId:
                         return KeyboardShortcut;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
@@ -137,12 +133,8 @@ namespace System.Windows.Forms
                         return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _owner.Enabled;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
                     case UiaCore.UIA.IsPasswordPropertyId:
                         return false;
-                    case UiaCore.UIA.IsOffscreenPropertyId:
-                        return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
                     default:
                         return base.GetPropertyValue(propertyID);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
@@ -85,10 +85,6 @@ namespace System.Windows.Forms
             {
                 switch (propertyID)
                 {
-                    case UiaCore.UIA.RuntimeIdPropertyId:
-                        return RuntimeId;
-                    case UiaCore.UIA.BoundingRectanglePropertyId:
-                        return Bounds;
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.EditControlTypeId;
                     case UiaCore.UIA.NamePropertyId:
@@ -103,20 +99,12 @@ namespace System.Windows.Forms
                         return _owner.Enabled;
                     case UiaCore.UIA.AutomationIdPropertyId:
                         return COMBO_BOX_EDIT_AUTOMATION_ID;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
                     case UiaCore.UIA.IsPasswordPropertyId:
                         return false;
                     case UiaCore.UIA.NativeWindowHandlePropertyId:
                         return _handle;
                     case UiaCore.UIA.IsOffscreenPropertyId:
                         return false;
-                    case UiaCore.UIA.IsTextPatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.TextPatternId);
-                    case UiaCore.UIA.IsTextPattern2AvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.TextPattern2Id);
-                    case UiaCore.UIA.IsValuePatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.ValuePatternId);
                     default:
                         return base.GetPropertyValue(propertyID);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
@@ -136,14 +136,8 @@ namespace System.Windows.Forms
             {
                 switch (propertyID)
                 {
-                    case UiaCore.UIA.RuntimeIdPropertyId:
-                        return RuntimeId;
-                    case UiaCore.UIA.BoundingRectanglePropertyId:
-                        return Bounds;
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.ListControlTypeId;
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.AccessKeyPropertyId:
                         return string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
@@ -154,8 +148,6 @@ namespace System.Windows.Forms
                         return _owningComboBox.Enabled;
                     case UiaCore.UIA.AutomationIdPropertyId:
                         return COMBO_BOX_LIST_AUTOMATION_ID;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
                     case UiaCore.UIA.IsPasswordPropertyId:
                         return false;
                     case UiaCore.UIA.NativeWindowHandlePropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildTextUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildTextUiaProvider.cs
@@ -113,14 +113,8 @@ namespace System.Windows.Forms
             {
                 switch (propertyID)
                 {
-                    case UiaCore.UIA.RuntimeIdPropertyId:
-                        return RuntimeId;
-                    case UiaCore.UIA.BoundingRectanglePropertyId:
-                        return Bounds;
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.TextControlTypeId;
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.AccessKeyPropertyId:
                         return string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
@@ -129,8 +123,6 @@ namespace System.Windows.Forms
                         return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _owner.Enabled;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
                     case UiaCore.UIA.IsPasswordPropertyId:
                     case UiaCore.UIA.IsOffscreenPropertyId:
                         return false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -117,14 +117,10 @@ namespace System.Windows.Forms
             {
                 switch (propertyID)
                 {
-                    case UiaCore.UIA.RuntimeIdPropertyId:
-                        return RuntimeId;
                     case UiaCore.UIA.BoundingRectanglePropertyId:
                         return BoundingRectangle;
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.ListItemControlTypeId;
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.AccessKeyPropertyId:
                         return KeyboardShortcut ?? string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
@@ -133,18 +129,12 @@ namespace System.Windows.Forms
                         return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _owningComboBox.Enabled;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
                     case UiaCore.UIA.IsControlElementPropertyId:
                         return true;
                     case UiaCore.UIA.IsContentElementPropertyId:
                         return true;
                     case UiaCore.UIA.IsPasswordPropertyId:
                         return false;
-                    case UiaCore.UIA.IsOffscreenPropertyId:
-                        return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
-                    case UiaCore.UIA.IsScrollItemPatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.ScrollItemPatternId);
                     case UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId:
                         return true;
                     case UiaCore.UIA.SelectionItemIsSelectedPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -472,6 +472,10 @@ namespace System.Windows.Forms
                         // "ControlType" value depends on owner's AccessibleRole value.
                         // See: docs/accessibility/accessible-role-controltype.md
                         return AccessibleRoleControlTypeMap.GetControlType(Role);
+                    case UiaCore.UIA.NativeWindowHandlePropertyId:
+                        return Owner.InternalHandle;
+                    case UiaCore.UIA.IsEnabledPropertyId:
+                        return Owner.Enabled;
                 }
 
                 if (Owner.SupportsUiaProviders)
@@ -480,13 +484,10 @@ namespace System.Windows.Forms
                     {
                         case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                             return Owner.CanSelect;
-                        case UiaCore.UIA.IsOffscreenPropertyId:
                         case UiaCore.UIA.IsPasswordPropertyId:
                             return false;
                         case UiaCore.UIA.AccessKeyPropertyId:
                             return KeyboardShortcut;
-                        case UiaCore.UIA.HelpTextPropertyId:
-                            return Help ?? string.Empty;
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -236,22 +236,14 @@ namespace System.Windows.Forms
                         return _ownerDataGridView.AccessibleRole == AccessibleRole.Default
                                ? UiaCore.UIA.DataGridControlTypeId
                                : base.GetPropertyValue(propertyID);
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         // If no inner cell entire DGV should be announced as focused by Narrator.
                         // Else only inner cell should be announced as focused by Narrator but not entire DGV.
                         return RowCount == 0;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return _ownerDataGridView.CanFocus;
-                    case UiaCore.UIA.IsEnabledPropertyId:
-                        return _ownerDataGridView.Enabled;
                     case UiaCore.UIA.IsControlElementPropertyId:
                         return true;
-                    case UiaCore.UIA.IsTablePatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.TablePatternId);
-                    case UiaCore.UIA.IsGridPatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.GridPatternId);
                     case UiaCore.UIA.ItemStatusPropertyId:
                         // Whether the _ownerDataGridView DataGridView can be sorted by some column.
                         // If so, provide not-sorted/sorted-by item status.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
@@ -91,8 +91,6 @@ namespace System.Windows.Forms
                         return _ownerDataGridView.CurrentCell is not null;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _ownerDataGridView.Enabled;
-                    case UiaCore.UIA.IsOffscreenPropertyId:
-                        return false;
                     case UiaCore.UIA.IsControlElementPropertyId:
                     case UiaCore.UIA.IsContentElementPropertyId:
                         return true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -677,18 +677,13 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.DataItemControlTypeId,
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,// Announce the cell when focusing.
                     UiaCore.UIA.IsEnabledPropertyId => _owner?.DataGridView?.Enabled ?? false,
                     UiaCore.UIA.AutomationIdPropertyId => AutomationId,
-                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     UiaCore.UIA.GridItemContainingGridPropertyId => _owner?.DataGridView?.AccessibilityObject,
-                    UiaCore.UIA.IsTableItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TableItemPatternId),
-                    UiaCore.UIA.IsGridItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.GridItemPatternId),
                     _ => base.GetPropertyValue(propertyID),
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.cs
@@ -277,13 +277,10 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyId)
                 => propertyId switch
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.HeaderControlTypeId,
                     UiaCore.UIA.IsEnabledPropertyId => Owner?.DataGridView?.Enabled ?? false,
-                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     var x when x == UiaCore.UIA.HasKeyboardFocusPropertyId || x == UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     _ => base.GetPropertyValue(propertyId)
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.DataGridViewComboBoxCellAccessibleObject.cs
@@ -25,7 +25,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => IsInComboBoxMode
                                                             ? UiaCore.UIA.ComboBoxControlTypeId
                                                             : UiaCore.UIA.DataItemControlTypeId,
-                    UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId),
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
@@ -71,16 +71,6 @@ namespace System.Windows.Forms
                 return base.IsPatternSupported(patternId);
             }
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                if (propertyID == UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId)
-                {
-                    return IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId);
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
-
             internal override UiaCore.ExpandCollapseState ExpandCollapseState
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -496,18 +496,12 @@ namespace System.Windows.Forms
             {
                 switch (propertyId)
                 {
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return Owner?.DataGridView?.Enabled ?? false;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                     case UiaCore.UIA.IsPasswordPropertyId:
                         return false;
-                    case UiaCore.UIA.IsOffscreenPropertyId:
-                        return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
                     case UiaCore.UIA.AccessKeyPropertyId:
                         return string.Empty;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
@@ -273,14 +273,11 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyId)
                 => propertyId switch
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.HeaderControlTypeId,
                     UiaCore.UIA.IsEnabledPropertyId => Owner?.DataGridView?.Enabled ?? false,
-                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
                     UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     _ => base.GetPropertyValue(propertyId),
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
@@ -65,10 +65,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => Owner.AccessibleRole == AccessibleRole.Default
                                                          ? UiaCore.UIA.EditControlTypeId
                                                          : base.GetPropertyValue(propertyID),
-                    UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.IsTextPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPatternId),
-                    UiaCore.UIA.IsTextPattern2AvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPattern2Id),
-                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
                     _ => base.GetPropertyValue(propertyID),
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.cs
@@ -295,14 +295,10 @@ namespace System.Windows.Forms
             {
                 switch (propertyId)
                 {
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.HeaderControlTypeId;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return Owner?.DataGridView?.Enabled ?? false;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                     case UiaCore.UIA.IsPasswordPropertyId:
                     case UiaCore.UIA.IsOffscreenPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
@@ -100,8 +100,6 @@ namespace System.Windows.Forms
             internal override object GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.IsTogglePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TogglePatternId),
-                    UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId),
                     UiaCore.UIA.LocalizedControlTypePropertyId =>
                         // We define a custom "LocalizedControlType" by default.
                         // If DateTimePicker.AccessibleRole value is customized by a user

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
@@ -26,12 +26,6 @@ namespace System.Windows.Forms
             {
                 switch (propertyID)
                 {
-                    case UiaCore.UIA.RuntimeIdPropertyId:
-                        return RuntimeId;
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
-                    case UiaCore.UIA.BoundingRectanglePropertyId:
-                        return Bounds;
                     case UiaCore.UIA.LegacyIAccessibleStatePropertyId:
                         return State;
                     case UiaCore.UIA.LegacyIAccessibleRolePropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObject.cs
@@ -100,22 +100,14 @@ namespace System.Windows.Forms
                 {
                     switch (propertyID)
                     {
-                        case UiaCore.UIA.RuntimeIdPropertyId:
-                            return RuntimeId;
                         case UiaCore.UIA.ControlTypePropertyId:
                             return UiaCore.UIA.ImageControlTypeId;
                         case UiaCore.UIA.BoundingRectanglePropertyId:
                             return BoundingRectangle;
-                        case UiaCore.UIA.NamePropertyId:
-                            return Name;
-                        case UiaCore.UIA.HelpTextPropertyId:
-                            return Help;
                         case UiaCore.UIA.LegacyIAccessibleStatePropertyId:
                             return State;
                         case UiaCore.UIA.NativeWindowHandlePropertyId:
                             return _window.Handle;
-                        case UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId:
-                            return IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId);
                         default:
                             return base.GetPropertyValue(propertyID);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObject.cs
@@ -81,20 +81,12 @@ namespace System.Windows.Forms
                 {
                     switch (propertyID)
                     {
-                        case UiaCore.UIA.RuntimeIdPropertyId:
-                            return RuntimeId;
                         case UiaCore.UIA.ControlTypePropertyId:
                             return UiaCore.UIA.GroupControlTypeId;
-                        case UiaCore.UIA.NamePropertyId:
-                            return Name;
-                        case UiaCore.UIA.HelpTextPropertyId:
-                            return Help;
                         case UiaCore.UIA.LegacyIAccessibleStatePropertyId:
                             return State;
                         case UiaCore.UIA.NativeWindowHandlePropertyId:
                             return _owner.Handle;
-                        case UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId:
-                            return IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId);
                         default:
                             return base.GetPropertyValue(propertyID);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
@@ -33,7 +33,6 @@ namespace System.Windows.Forms
             {
                 return propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
                     // Unlike other controls, here the default "ControlType" doesn't correspond the value from the mapping
                     // depending on the default Role.
                     // In other cases "ControlType" will reflect changes to Form.AccessibleRole (i.e. if it is set to a custom role).

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.GroupBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.GroupBoxAccessibleObject.cs
@@ -31,8 +31,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId
-                        => Name,
                     UiaCore.UIA.AutomationIdPropertyId
                         => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.LabelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.LabelAccessibleObject.cs
@@ -35,7 +35,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.AutomationIdPropertyId => _owningLabel.Name,
                     _ => base.GetPropertyValue(propertyID)
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObject.cs
@@ -88,14 +88,9 @@ namespace System.Windows.Forms
                     => propertyID switch
                     {
                         UiaCore.UIA.IsEnabledPropertyId => _owningLinkLabel.Enabled,
-                        UiaCore.UIA.NamePropertyId => Name,
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.HyperlinkControlTypeId,
-                        UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                         UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                         UiaCore.UIA.HasKeyboardFocusPropertyId => _owningLinkLabel.FocusLink == _owningLink,
-                        UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
-                        UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
-                        UiaCore.UIA.LegacyIAccessiblePatternId => IsPatternSupported(propertyID),
                         UiaCore.UIA.InvokePatternId => IsPatternSupported(propertyID),
                         _ => base.GetPropertyValue(propertyID)
                     };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObject.cs
@@ -91,7 +91,7 @@ namespace System.Windows.Forms
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.HyperlinkControlTypeId,
                         UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                         UiaCore.UIA.HasKeyboardFocusPropertyId => _owningLinkLabel.FocusLink == _owningLink,
-                        UiaCore.UIA.InvokePatternId => IsPatternSupported(propertyID),
+                        UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
                         _ => base.GetPropertyValue(propertyID)
                     };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.LinkLabelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.LinkLabelAccessibleObject.cs
@@ -59,7 +59,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.IsEnabledPropertyId => _owningLinkLabel.Enabled,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => false,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
                     _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
@@ -127,8 +127,6 @@ namespace System.Windows.Forms
                         return _owningListBox.AccessibleRole == AccessibleRole.Default
                                ? UiaCore.UIA.ListControlTypeId
                                : base.GetPropertyValue(propertyID);
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         bool result = _owningListBox.HasKeyboardFocus && _owningListBox.Focused;
                         if (GetChildCount() > 0)
@@ -137,18 +135,6 @@ namespace System.Windows.Forms
                         }
 
                         return result;
-                    case UiaCore.UIA.NativeWindowHandlePropertyId:
-                        return _owningListBox.InternalHandle;
-                    case UiaCore.UIA.IsSelectionPatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.SelectionPatternId);
-                    case UiaCore.UIA.IsScrollPatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.ScrollPatternId);
-                    case UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId:
-                        return IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId);
-                    case UiaCore.UIA.IsEnabledPropertyId:
-                        return _owningListBox.Enabled;
-                    case UiaCore.UIA.RuntimeIdPropertyId:
-                        return RuntimeId;
                     default:
                         return base.GetPropertyValue(propertyID);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -215,20 +215,13 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                  => propertyID switch
                  {
-                     UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
-                     UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
                      UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ListItemControlTypeId,
-                     UiaCore.UIA.NamePropertyId => Name,
                      UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                      UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListBox.Focused && _owningListBox.FocusedIndex == CurrentIndex,
                      UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                      UiaCore.UIA.IsEnabledPropertyId => _owningListBox.Enabled,
-                     UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
                      UiaCore.UIA.IsPasswordPropertyId => false,
                      UiaCore.UIA.NativeWindowHandlePropertyId => _owningListBox.IsHandleCreated ? _owningListBox.Handle : IntPtr.Zero,
-                     UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
-                     UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.SelectionItemPatternId),
-                     UiaCore.UIA.IsScrollItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ScrollItemPatternId),
                      _ => base.GetPropertyValue(propertyID)
                  };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -207,18 +207,15 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.AutomationIdPropertyId => _owningListView.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                     // If we don't set a default role for the accessible object
                     // it will be retrieved from Windows.
                     // And we don't have a 100% guarantee it will be correct, hence set it ourselves.
                     UiaCore.UIA.ControlTypePropertyId => _owningListView.AccessibleRole == AccessibleRole.Default
                                                          ? UiaCore.UIA.ListControlTypeId
                                                          : base.GetPropertyValue(propertyID),
-                    UiaCore.UIA.IsMultipleViewPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.MultipleViewPatternId),
                     UiaCore.UIA.ItemStatusPropertyId => GetItemStatus(),
                     _ => base.GetPropertyValue(propertyID)
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -182,20 +182,15 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                     UiaCore.UIA.AutomationIdPropertyId => AutomationId,
-                    UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
                     UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
                     UiaCore.UIA.LegacyIAccessibleNamePropertyId => Name,
                     UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.GroupControlTypeId,
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListView.Focused && Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.IsEnabledPropertyId => _owningListView.Enabled,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.NativeWindowHandlePropertyId => _owningListView.IsHandleCreated ? _owningListView.Handle : IntPtr.Zero,
-                    UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -167,20 +167,15 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                     UiaCore.UIA.AutomationIdPropertyId => AutomationId,
-                    UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
                     UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ListItemControlTypeId,
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => OwningListItemFocused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.IsEnabledPropertyId => _owningListView.Enabled,
                     UiaCore.UIA.IsOffscreenPropertyId => OwningGroup?.CollapsedState == ListViewGroupCollapsedState.Collapsed
-                                                        || (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
+                                                        || (bool)(base.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId) ?? false),
                     UiaCore.UIA.NativeWindowHandlePropertyId => _owningListView.IsHandleCreated ? _owningListView.Handle : IntPtr.Zero,
-                    UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.SelectionItemPatternId),
-                    UiaCore.UIA.IsScrollItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ScrollItemPatternId),
                     UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
                     _ => base.GetPropertyValue(propertyID)
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -124,18 +124,12 @@ namespace System.Windows.Forms
                         // has the "edit" control type, and it supports the Text pattern. And its owning subitem accessible
                         // object has the "text" control type, because it is just a container for the edit field.
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TextControlTypeId,
-                        UiaCore.UIA.NamePropertyId => Name,
                         UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
                         UiaCore.UIA.ProcessIdPropertyId => Environment.ProcessId,
                         UiaCore.UIA.AutomationIdPropertyId => AutomationId,
-                        UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                         UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListView.Focused && _owningListView.FocusedItem == _owningItem,
                         UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                         UiaCore.UIA.IsEnabledPropertyId => _owningListView.Enabled,
-                        UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
-                        UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
-                        UiaCore.UIA.IsGridItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.GridItemPatternId),
-                        UiaCore.UIA.IsTableItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TableItemPatternId),
                         _ => base.GetPropertyValue(propertyID)
                     };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuStrip.MenuStripAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuStrip.MenuStripAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using static Interop;
-
 namespace System.Windows.Forms
 {
     public partial class MenuStrip
@@ -27,17 +25,6 @@ namespace System.Windows.Forms
 
                     return AccessibleRole.MenuBar;
                 }
-            }
-
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                switch (propertyID)
-                {
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
-                }
-
-                return base.GetPropertyValue(propertyID);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
@@ -141,8 +141,6 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TableControlTypeId,
-                    UiaCore.UIA.IsGridPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.GridPatternId),
-                    UiaCore.UIA.IsTablePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TablePatternId),
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => IsEnabled,
                     _ => base.GetPropertyValue(propertyID)
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarCellAccessibleObject.cs
@@ -142,10 +142,6 @@ namespace System.Windows.Forms
                         => UiaCore.UIA.DataItemControlTypeId,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         => IsEnabled,
-                    UiaCore.UIA.IsGridItemPatternAvailablePropertyId
-                        => IsPatternSupported(UiaCore.UIA.GridItemPatternId),
-                    UiaCore.UIA.IsTableItemPatternAvailablePropertyId
-                        => IsPatternSupported(UiaCore.UIA.TableItemPatternId),
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -401,12 +401,7 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => _owningMonthCalendar.AccessibleRole == AccessibleRole.Default
                         ? UiaCore.UIA.CalendarControlTypeId
                         : base.GetPropertyValue(propertyID),
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => IsEnabled,
-                    UiaCore.UIA.IsGridPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.GridPatternId),
-                    UiaCore.UIA.IsTablePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TablePatternId),
-                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
-                    UiaCore.UIA.IsEnabledPropertyId => _owningMonthCalendar.Enabled,
                     UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
                     _ => base.GetPropertyValue(propertyID)
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarChildAccessibleObject.cs
@@ -26,10 +26,8 @@ namespace System.Windows.Forms
                     UiaCore.UIA.HasKeyboardFocusPropertyId => HasKeyboardFocus,
                     UiaCore.UIA.IsEnabledPropertyId => IsEnabled,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => false,
-                    UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
                     UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
                     UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
-                    UiaCore.UIA.NamePropertyId => Name,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.NumericUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.NumericUpDownAccessibleObject.cs
@@ -45,12 +45,6 @@ namespace System.Windows.Forms
             {
                 switch (propertyID)
                 {
-                    case UiaCore.UIA.RuntimeIdPropertyId:
-                        return RuntimeId;
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
-                    case UiaCore.UIA.BoundingRectanglePropertyId:
-                        return Bounds;
                     case UiaCore.UIA.LegacyIAccessibleStatePropertyId:
                         return State;
                     case UiaCore.UIA.LegacyIAccessibleRolePropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Panel.PanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Panel.PanelAccessibleObject.cs
@@ -37,8 +37,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                => propertyID switch
                {
-                   UiaCore.UIA.NamePropertyId
-                       => Name,
                    UiaCore.UIA.AutomationIdPropertyId
                        => Owner.Name,
                    UiaCore.UIA.IsKeyboardFocusablePropertyId

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
@@ -17,8 +17,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId
-                        => Name,
                     UiaCore.UIA.ControlTypePropertyId
                         // If we don't set a default role for the accessible object
                         // it will be retrieved from Windows.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.ProgressBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.ProgressBarAccessibleObject.cs
@@ -35,8 +35,6 @@ namespace System.Windows.Forms
             {
                 switch (propertyID)
                 {
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.ControlTypePropertyId:
                         // If we don't set a default role for the accessible object
                         // it will be retrieved from Windows.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.PropertyGridAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.PropertyGridAccessibleObject.cs
@@ -235,13 +235,6 @@ namespace System.Windows.Forms
 
                 return -1;
             }
-
-            internal override object GetPropertyValue(UiaCore.UIA propertyID) =>
-                propertyID switch
-                {
-                    UiaCore.UIA.NamePropertyId => Name,
-                    _ => base.GetPropertyValue(propertyID),
-                };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CommandsPane.CommandsPaneAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CommandsPane.CommandsPaneAccessibleObject.cs
@@ -45,7 +45,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.PaneControlTypeId,
-                    UiaCore.UIA.NamePropertyId => Name,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObject.cs
@@ -77,7 +77,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             internal override object GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
             {
                 UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
-                UiaCore.UIA.NamePropertyId => Name,
                 UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => true,
                 UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
                 _ => base.GetPropertyValue(propertyID),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -328,23 +328,18 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 return propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
-
                     // The accessible hierarchy is changed so we cannot use Button type
                     // for the grid items to not break automation logic that searches for the first
                     // button in the PropertyGridView to show dialog/drop-down. In Level < 3 action
                     // button is one of the first children of PropertyGridView.
 
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TreeItemControlTypeId,
-                    UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId),
                     UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningGridEntry.HasFocus,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.IsEnabledPropertyId => true,
                     UiaCore.UIA.AutomationIdPropertyId => GetHashCode().ToString(),
-                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
                     UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.IsGridItemPatternAvailablePropertyId or UiaCore.UIA.IsTableItemPatternAvailablePropertyId => true,
                     UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
                     UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId => DefaultAction,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HelpPane.HelpPaneAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/HelpPane.HelpPaneAccessibleObject.cs
@@ -45,7 +45,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.PaneControlTypeId,
-                    UiaCore.UIA.NamePropertyId => Name,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
@@ -83,16 +83,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 internal override object? GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
                 {
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.EditControlTypeId,
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => Owner.Focused,
                     UiaCore.UIA.IsEnabledPropertyId => !IsReadOnly,
                     UiaCore.UIA.ClassNamePropertyId => Owner.GetType().ToString(),
                     UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
-                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
-                    UiaCore.UIA.IsTextPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPatternId),
-                    UiaCore.UIA.IsTextPattern2AvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPattern2Id),
                     _ => base.GetPropertyValue(propertyID),
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.PropertyGridViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.PropertyGridViewAccessibleObject.cs
@@ -89,7 +89,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TableControlTypeId,
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.IsTablePatternAvailablePropertyId => true,
                     UiaCore.UIA.IsGridPatternAvailablePropertyId => true,
                     _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStrip.PropertyGridToolStripAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStrip.PropertyGridToolStripAccessibleObject.cs
@@ -54,7 +54,6 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ToolBarControlTypeId,
-                    UiaCore.UIA.NamePropertyId => Name,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridToolStripButton.PropertyGridToolStripButtonAccessibleObject.cs
@@ -22,13 +22,6 @@ namespace System.Windows.Forms
             internal override bool IsItemSelected
                 => _owningPropertyGridToolStripButton.Checked;
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                => propertyID switch
-                {
-                    UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.SelectionItemPatternId),
-                    _ => base.GetPropertyValue(propertyID)
-                };
-
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
                 => patternId switch
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.RadioButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.RadioButtonAccessibleObject.cs
@@ -50,12 +50,8 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId
-                        => Name,
                     UiaCore.UIA.AutomationIdPropertyId
                         => Owner.Name,
-                    UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId
-                        => IsPatternSupported(UiaCore.UIA.SelectionItemPatternId),
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:
                         // IsKeyboardFocusable = true regardless the control is enabled/disabled.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
@@ -134,7 +134,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.AutomationIdPropertyId => _owningScrollBar.Name,
                     // If we don't set a default role for the accessible object
                     // it will be retrieved from Windows.
@@ -142,11 +141,7 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => _owningScrollBar.AccessibleRole == AccessibleRole.Default
                                                          ? UiaCore.UIA.ScrollBarControlTypeId
                                                          : base.GetPropertyValue(propertyID),
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
-                    UiaCore.UIA.IsEnabledPropertyId => _owningScrollBar.Enabled,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningScrollBar.Focused,
-                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarChildAccessibleObject.cs
@@ -78,14 +78,10 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                     UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
                     UiaCore.UIA.IsEnabledPropertyId => OwningScrollBar.Enabled,
-                    UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
                     UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => false,
                     _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitterAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitterAccessibleObject.cs
@@ -17,8 +17,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId
-                        => Name,
                     UiaCore.UIA.AutomationIdPropertyId
                         => Owner.Name,
                     UiaCore.UIA.ControlTypePropertyId

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabControlAccessibleObject.cs
@@ -135,15 +135,8 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UIA propertyID)
                 => propertyID switch
                 {
-                    UIA.RuntimeIdPropertyId => RuntimeId,
                     UIA.AutomationIdPropertyId => _owningTabControl.Name,
-                    UIA.IsEnabledPropertyId => _owningTabControl.Enabled,
-                    UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UIA.HasKeyboardFocusPropertyId => _owningTabControl.Focused,
-                    UIA.NamePropertyId => Name,
-                    UIA.NativeWindowHandlePropertyId => _owningTabControl.InternalHandle,
-                    UIA.IsSelectionPatternAvailablePropertyId => IsPatternSupported(UIA.SelectionPatternId),
-                    UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UIA.LegacyIAccessiblePatternId),
                     UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:
                         // IsKeyboardFocusable = true regardless the control is enabled/disabled.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
@@ -116,18 +116,12 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TabItemControlTypeId,
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                     UiaCore.UIA.AutomationIdPropertyId => _owningTabPage.Name,
                     UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut ?? string.Empty,
                     UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
                     UiaCore.UIA.IsEnabledPropertyId => OwningTabControl?.Enabled ?? false,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,
-                    UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.SelectionItemPatternId),
                     UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
-                    UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:
                         // IsKeyboardFocusable = true regardless the control is enabled/disabled.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
@@ -83,16 +83,9 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                     UiaCore.UIA.AutomationIdPropertyId => _owningTabPage.Name,
-                    UiaCore.UIA.IsEnabledPropertyId => _owningTabPage.Enabled,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTabPage.Focused,
-                    UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut,
-                    UiaCore.UIA.NativeWindowHandlePropertyId => _owningTabPage.InternalHandle,
-                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
-                    UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:
                         // IsKeyboardFocusable = true regardless the control is enabled/disabled.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
@@ -31,15 +31,6 @@ namespace System.Windows.Forms
                     _ => base.IsPatternSupported(patternId)
                 };
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID) =>
-                propertyID switch
-                {
-                    UiaCore.UIA.IsTextPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPatternId),
-                    UiaCore.UIA.IsTextPattern2AvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPattern2Id),
-                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
-                    _ => base.GetPropertyValue(propertyID)
-                };
-
             internal override bool IsReadOnly => _owningTextBoxBase.ReadOnly;
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.ToolStripAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.ToolStripAccessibleObject.cs
@@ -458,17 +458,6 @@ namespace System.Windows.Forms
 
                 return base.FragmentNavigate(direction);
             }
-
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                switch (propertyID)
-                {
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
-                }
-
-                return base.GetPropertyValue(propertyID);
-            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxControlAccessibleObject.cs
@@ -50,17 +50,6 @@ namespace System.Windows.Forms
                     }
                 }
 
-                internal override object GetPropertyValue(UiaCore.UIA propertyID)
-                {
-                    switch (propertyID)
-                    {
-                        case UiaCore.UIA.IsOffscreenPropertyId:
-                            return (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen;
-                    }
-
-                    return base.GetPropertyValue(propertyID);
-                }
-
                 internal override bool IsPatternSupported(UiaCore.UIA patternId)
                 {
                     if (patternId == UiaCore.UIA.ExpandCollapsePatternId ||

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.ToolStripDropDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.ToolStripDropDownAccessibleObject.cs
@@ -25,8 +25,6 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                 }
 
                 return base.GetPropertyValue(propertyID);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -113,8 +113,6 @@ namespace System.Windows.Forms
                     // See: docs/accessibility/accessible-role-controltype.md
                     case UiaCore.UIA.ControlTypePropertyId:
                         return AccessibleRoleControlTypeMap.GetControlType(Role);
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name;
                     case UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId:
                         return (object)IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId);
                     case UiaCore.UIA.IsEnabledPropertyId:
@@ -129,8 +127,6 @@ namespace System.Windows.Forms
                         return KeyboardShortcut;
                     case UiaCore.UIA.IsPasswordPropertyId:
                         return false;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return Help ?? string.Empty;
                 }
 
                 return base.GetPropertyValue(propertyID);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripNumericUpDown.ToolStripNumericUpDownControl.ToolStripNumericUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripNumericUpDown.ToolStripNumericUpDownControl.ToolStripNumericUpDownAccessibleObject.cs
@@ -20,11 +20,6 @@ namespace System.Windows.Forms
 
                 internal override object GetPropertyValue(UiaCore.UIA propertyID)
                 {
-                    if (propertyID == UiaCore.UIA.NamePropertyId)
-                    {
-                        return Name;
-                    }
-
                     // If we don't set a default role for the accessible object
                     // it will be retrieved from Windows.
                     // And we don't have a 100% guarantee it will be correct, hence set it ourselves.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControlAccessibleObject.cs
@@ -30,10 +30,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => _owningTextBoxBase.AccessibleRole == AccessibleRole.Default
                                                          ? UiaCore.UIA.EditControlTypeId
                                                          : base.GetPropertyValue(propertyID),
-                    UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.IsTextPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPatternId),
-                    UiaCore.UIA.IsTextPattern2AvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPattern2Id),
-                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarAccessibleObject.cs
@@ -156,14 +156,8 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => _owningTrackBar.AccessibleRole == AccessibleRole.Default
                                                             ? UiaCore.UIA.SliderControlTypeId
                                                             : base.GetPropertyValue(propertyID),
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                     UiaCore.UIA.AutomationIdPropertyId => _owningTrackBar.Name,
-                    UiaCore.UIA.IsEnabledPropertyId => _owningTrackBar.Enabled,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTrackBar.Focused,
-                    UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.NativeWindowHandlePropertyId => _owningTrackBar.InternalHandle,
-                    UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:
                         // IsKeyboardFocusable = true regardless the control is enabled/disabled.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarChildAccessibleObject.cs
@@ -71,13 +71,9 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
                     UiaCore.UIA.IsEnabledPropertyId => OwningTrackBar.Enabled,
-                    UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
                     UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => false,
                     UiaCore.UIA.AccessKeyPropertyId => string.Empty,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObject.cs
@@ -79,7 +79,7 @@ namespace System.Windows.Forms
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
                         UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
                         UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
-                        UiaCore.UIA.InvokePatternId => IsPatternSupported(propertyID),
+                        UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
                         _ => base.GetPropertyValue(propertyID),
                     };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObject.cs
@@ -76,13 +76,9 @@ namespace System.Windows.Forms
 
                     internal override object GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
                     {
-                        UiaCore.UIA.NamePropertyId => Name,
-                        UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
-                        UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
                         UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
                         UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
-                        UiaCore.UIA.LegacyIAccessiblePatternId => IsPatternSupported(propertyID),
                         UiaCore.UIA.InvokePatternId => IsPatternSupported(propertyID),
                         _ => base.GetPropertyValue(propertyID),
                     };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.cs
@@ -64,9 +64,6 @@ namespace System.Windows.Forms
 
                 internal override object GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
                 {
-                    UiaCore.UIA.NamePropertyId => Name,
-                    UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
-                    UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
                     UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
                     UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
                     _ => base.GetPropertyValue(propertyID),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownEdit.UpDownEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownEdit.UpDownEditAccessibleObject.cs
@@ -34,14 +34,6 @@ namespace System.Windows.Forms
 
                 public override string? KeyboardShortcut => _parent.AccessibilityObject.KeyboardShortcut;
 
-                internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                    => propertyID switch
-                    {
-                        UiaCore.UIA.IsTextPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPatternId),
-                        UiaCore.UIA.IsTextPattern2AvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPattern2Id),
-                        _ => base.GetPropertyValue(propertyID),
-                    };
-
                 internal override bool IsPatternSupported(UiaCore.UIA patternId)
                     => patternId switch
                     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
@@ -105,6 +105,19 @@ namespace System.Windows.Forms.Tests
             Assert.NotNull(editAccessibleName);
         }
 
+        [WinFormsFact]
+        public void ComboBoxEditAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        {
+            const string name = "Test text";
+            using ComboBox comboBox = new();
+            comboBox.AccessibleName = name;
+            comboBox.CreateControl(false);
+            object actual = comboBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+
+            Assert.Equal(name, actual);
+            Assert.True(comboBox.IsHandleCreated);
+        }
+
         public static IEnumerable<object[]> ComboBoxAccessibleObject_FragmentNavigate_FirstChild_ReturnsExpected_TestData()
         {
             foreach (ComboBoxStyle comboBoxStyle in Enum.GetValues(typeof(ComboBoxStyle)))
@@ -247,6 +260,43 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(expected, actual);
             Assert.False(comboBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ComboBoxEditAccessibleObject_GetPropertyValue_NativeWindowHandle_ReturnsExpected()
+        {
+            using ComboBox comboBox = new();
+            comboBox.CreateControl(false);
+            object actual = comboBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NativeWindowHandlePropertyId);
+
+            Assert.True(comboBox.IsHandleCreated);
+            Assert.Equal(comboBox.InternalHandle, actual);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, ((int)UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsGridItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsGridPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsMultipleViewPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTableItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTablePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPattern2AvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTogglePatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsValuePatternAvailablePropertyId))]
+        public void ComboBoxAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
+        {
+            using ComboBox comboBox = new();
+            comboBox.CreateControl(false);
+            ComboBox.ComboBoxAccessibleObject accessibleObject = (ComboBox.ComboBoxAccessibleObject)comboBox.AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
+            Assert.True(comboBox.IsHandleCreated);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
@@ -539,6 +539,79 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(UiaCore.UIA.DataItemControlTypeId, provider.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
         }
 
+        [WinFormsFact]
+        public void DataGridViewCellsAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add(new DataGridViewRow());
+
+            DataGridViewCellAccessibleObject accessibleObject = new(dataGridView.Rows[0].Cells[0]);
+
+            object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+
+            //DataGridViewCellAccessibleObject name couldn't be set, it's gathered dynamically in the Name property accessor
+            Assert.Equal(accessibleObject.Name, actual);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellsAccessibleObject_GetPropertyValue_HelpText_ReturnsExpected()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add(new DataGridViewRow());
+
+            DataGridViewCellAccessibleObject accessibleObject = new(dataGridView.Rows[0].Cells[0]);
+
+            object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.HelpTextPropertyId);
+
+            Assert.Equal(accessibleObject.Help ?? string.Empty, actual);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellsAccessibleObject_GetPropertyValue_IsOffscreen_ReturnsFalse()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add(new DataGridViewRow());
+
+            DataGridViewCellAccessibleObject accessibleObject = new(dataGridView.Rows[0].Cells[0]);
+
+            bool actual = (bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId);
+
+            Assert.False(actual);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, ((int)UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsGridItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsGridPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsMultipleViewPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsTableItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTablePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPattern2AvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTogglePatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsValuePatternAvailablePropertyId))]
+        public void DataGridViewCellAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add(new DataGridViewRow());
+            DataGridViewCellAccessibleObject accessibleObject = new(dataGridView.Rows[0].Cells[0]);
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
         private class SubDataGridViewCell : DataGridViewCell
         {
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObjectTests.cs
@@ -180,6 +180,18 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void LinkAccessibleObject_GetPropertyValue_RuntimeId_ReturnsExpected()
+        {
+            using LinkLabel linkLabel = new();
+            LinkAccessibleObject accessibleObject = linkLabel.Links[0].AccessibleObject;
+
+            object actual = accessibleObject.GetPropertyValue(UIA.RuntimeIdPropertyId);
+
+            Assert.Equal(accessibleObject.RuntimeId, actual);
+            Assert.False(linkLabel.IsHandleCreated);
+        }
+
+        [WinFormsFact]
         public void LinkAccessibleObject_GetPropertyValue_Name_IsExpected_ForOneLink()
         {
             using LinkLabel linkLabel = new();
@@ -214,6 +226,55 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(names[index], actual);
             }
 
+            Assert.False(linkLabel.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void LinkAccessibleObject_GetPropertyValue_HelpText_ReturnsExpected()
+        {
+            using LinkLabel linkLabel = new();
+            LinkAccessibleObject accessibleObject = linkLabel.Links[0].AccessibleObject;
+
+            object actual = accessibleObject.GetPropertyValue(UIA.HelpTextPropertyId);
+
+            Assert.Equal(accessibleObject.Help ?? string.Empty, actual);
+            Assert.False(linkLabel.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void LinkAccessibleObject_GetPropertyValue_IsOffscreen_ReturnsFalse()
+        {
+            using LinkLabel linkLabel = new();
+            LinkAccessibleObject accessibleObject = linkLabel.Links[0].AccessibleObject;
+
+            var actual = (bool)accessibleObject.GetPropertyValue(UIA.IsOffscreenPropertyId);
+
+            Assert.False(actual);
+            Assert.False(linkLabel.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, ((int)UIA.IsExpandCollapsePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsGridItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsGridPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsMultipleViewPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsScrollItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsScrollPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsSelectionItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsSelectionPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTableItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTablePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTextPattern2AvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTextPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTogglePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsValuePatternAvailablePropertyId))]
+        public void LinkAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
+        {
+            using LinkLabel linkLabel = new();
+            LinkAccessibleObject accessibleObject = linkLabel.Links[0].AccessibleObject;
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue((UIA)propertyId) ?? false);
             Assert.False(linkLabel.IsHandleCreated);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObjectTests.cs
@@ -154,14 +154,14 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(((int)UiaCore.UIA.LegacyIAccessiblePatternId))]
-        [InlineData(((int)UiaCore.UIA.InvokePatternId))]
-        public void LinkAccessibleObject_GetPropertyValue_IsPatternSupported(int patternId)
+        [InlineData(((int)UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(((int)UiaCore.UIA.IsInvokePatternAvailablePropertyId))]
+        public void LinkAccessibleObject_GetPropertyValue_IsPatternSupported(int propertyId)
         {
             using LinkLabel linkLabel = new();
             LinkAccessibleObject accessibleObject = linkLabel.Links[0].AccessibleObject;
 
-            bool actual = (bool)accessibleObject.GetPropertyValue((UiaCore.UIA)patternId);
+            bool actual = (bool)accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId);
 
             Assert.True(actual);
             Assert.False(linkLabel.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBox.ListBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBox.ListBoxItemAccessibleObjectTests.cs
@@ -4,6 +4,7 @@
 
 using System.Windows.Forms.IntegrationTests.Common;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -42,6 +43,113 @@ namespace System.Windows.Forms.Tests
             }
 
             Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListBoxItemAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        {
+            using ListBox listBox = new();
+            listBox.Items.Add(item: "testItem");
+            ListBox.ListBoxAccessibleObject accessibleObject = new(listBox);
+            AccessibleObject itemAccessibleObject = accessibleObject.GetChild(0);
+
+            Assert.IsType<ListBox.ListBoxItemAccessibleObject>(itemAccessibleObject);
+
+            object actual = itemAccessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+
+            Assert.Equal(itemAccessibleObject.Name, actual);
+            Assert.False(listBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListBoxItemAccessibleObject_GetPropertyValue_RuntimeId_ReturnsExpected()
+        {
+            using ListBox listBox = new();
+            listBox.Items.Add(item: "testItem");
+            ListBox.ListBoxAccessibleObject accessibleObject = new(listBox);
+            AccessibleObject itemAccessibleObject = accessibleObject.GetChild(0);
+
+            Assert.IsType<ListBox.ListBoxItemAccessibleObject>(itemAccessibleObject);
+
+            object actual = itemAccessibleObject.GetPropertyValue(UiaCore.UIA.RuntimeIdPropertyId);
+
+            Assert.Equal(itemAccessibleObject.RuntimeId, actual);
+            Assert.False(listBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListBoxItemAccessibleObject_GetPropertyValue_BoundingRectangle_ReturnsExpected()
+        {
+            using ListBox listBox = new();
+            listBox.Items.Add(item: "testItem");
+            ListBox.ListBoxAccessibleObject accessibleObject = new(listBox);
+            AccessibleObject itemAccessibleObject = accessibleObject.GetChild(0);
+
+            Assert.IsType<ListBox.ListBoxItemAccessibleObject>(itemAccessibleObject);
+
+            object actual = itemAccessibleObject.GetPropertyValue(UiaCore.UIA.BoundingRectanglePropertyId);
+
+            Assert.Equal(itemAccessibleObject.BoundingRectangle, actual);
+            Assert.False(listBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListBoxItemAccessibleObject_GetPropertyValue_HelpText_ReturnsExpected()
+        {
+            using ListBox listBox = new();
+            listBox.Items.Add(item: "testItem");
+            ListBox.ListBoxAccessibleObject accessibleObject = new(listBox);
+            AccessibleObject itemAccessibleObject = accessibleObject.GetChild(0);
+
+            Assert.IsType<ListBox.ListBoxItemAccessibleObject>(itemAccessibleObject);
+
+            object actual = itemAccessibleObject.GetPropertyValue(UiaCore.UIA.HelpTextPropertyId);
+
+            Assert.Equal(itemAccessibleObject.Help ?? string.Empty, actual);
+            Assert.False(listBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListBoxItemAccessibleObject_GetPropertyValue_IsOffscreen_ReturnsFalse()
+        {
+            using ListBox listBox = new();
+            listBox.Items.Add(item: "testItem");
+            ListBox.ListBoxAccessibleObject accessibleObject = new(listBox);
+            AccessibleObject itemAccessibleObject = accessibleObject.GetChild(0);
+
+            Assert.IsType<ListBox.ListBoxItemAccessibleObject>(itemAccessibleObject);
+
+            bool actual = (bool)itemAccessibleObject.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId);
+
+            Assert.False(actual);
+            Assert.False(listBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, ((int)UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsGridItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsGridPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsMultipleViewPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsScrollItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTableItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTablePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPattern2AvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTogglePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsValuePatternAvailablePropertyId))]
+        public void ListBoxItemAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
+        {
+            using ListBox listBox = new();
+            listBox.Items.Add(item: "testItem");
+            ListBox.ListBoxAccessibleObject listBoxAccessibleObject = new(listBox);
+            ListBox.ListBoxItemAccessibleObject accessibleObject = (ListBox.ListBoxItemAccessibleObject)listBoxAccessibleObject.GetChild(0);
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
+            Assert.False(listBox.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -883,7 +883,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ListViewSтubItemAccessibleObject_Bounds_NotEquals_ListViewItem_IfFullRowSelectIsFalse()
+        public void ListViewSubItemAccessibleObject_Bounds_NotEquals_ListViewItem_IfFullRowSelectIsFalse()
         {
             using ListView listView = new()
             {
@@ -902,6 +902,76 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(itemAccessibleObject.Bounds, subItemAccessibleObject.Bounds);
             Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_GetPropertyValue_RuntimeId_ReturnsExpected()
+        {
+            using ListView listView = new();
+            ListViewItem listViewItem = new("Test item");
+            listView.Items.Add(listViewItem);
+            ListViewItem.ListViewSubItem listViewSubItem = new(listViewItem, "Test subItem");
+            ListViewSubItemAccessibleObject listViewSubItemAccessibleObject = new(listViewSubItem, listViewItem);
+            object actual = listViewSubItemAccessibleObject.GetPropertyValue(UiaCore.UIA.RuntimeIdPropertyId);
+
+            Assert.Equal(listViewSubItem.AccessibilityObject.RuntimeId, actual);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_GetPropertyValue_BoundingRectangle_ReturnsExpected()
+        {
+            using ListView listView = new();
+            ListViewItem listViewItem = new("Test item");
+            listView.Items.Add(listViewItem);
+            ListViewItem.ListViewSubItem listViewSubItem = new(listViewItem, "Test subItem");
+            ListViewSubItemAccessibleObject listViewSubItemAccessibleObject = new(listViewSubItem, listViewItem);
+            object actual = listViewSubItemAccessibleObject.GetPropertyValue(UiaCore.UIA.BoundingRectanglePropertyId);
+
+            Assert.Equal(listViewSubItem.AccessibilityObject.BoundingRectangle, actual);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_GetPropertyValue_IsOffscreen_ReturnsFalse()
+        {
+            using ListView listView = new();
+            ListViewItem listViewItem = new("Test item");
+            listView.Items.Add(listViewItem);
+            ListViewItem.ListViewSubItem listViewSubItem = new(listViewItem, "Test subItem");
+            ListViewSubItemAccessibleObject listViewSubItemAccessibleObject = new(listViewSubItem, listViewItem);
+            var actual = (bool)listViewSubItemAccessibleObject.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId);
+
+            Assert.False(actual);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, ((int)UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsGridItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsGridPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsMultipleViewPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsTableItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTablePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPattern2AvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTogglePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsValuePatternAvailablePropertyId))]
+        public void ListViewSubItemAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
+        {
+            using ListView listView = new() { View = View.Details };
+            ListViewItem listViewItem = new("Test item");
+            listView.Items.Add(listViewItem);
+            ListViewItem.ListViewSubItem listViewSubItem = new(listViewItem, "Test subItem");
+            ListViewSubItemAccessibleObject accessibleObject = new(listViewSubItem, listViewItem);
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
+            Assert.False(listView.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObjectTests.cs
@@ -98,6 +98,58 @@ namespace System.Windows.Forms.Tests
             Assert.False(scrollBar.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ScrollBarAccessibleObject_GetPropertyValue_RuntimeId_ReturnsExpected()
+        {
+            using SubScrollBar scrollBar = new();
+
+            object actual = scrollBar.AccessibilityObject.GetPropertyValue(UiaCore.UIA.RuntimeIdPropertyId);
+
+            Assert.Equal(scrollBar.AccessibilityObject.RuntimeId, actual);
+            Assert.False(scrollBar.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ScrollBarAccessibleObject_GetPropertyValue_IsEnabled_ReturnsExpected(bool enabled)
+        {
+            using SubScrollBar scrollBar = new()
+            {
+                Enabled = enabled
+            };
+
+            object actual = scrollBar.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsEnabledPropertyId);
+
+            Assert.Equal(scrollBar.Enabled, actual);
+            Assert.False(scrollBar.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, ((int)UIA.IsExpandCollapsePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsGridItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsGridPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsMultipleViewPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsScrollItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsScrollPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsSelectionItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsSelectionPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTableItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTablePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTextPattern2AvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTextPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTogglePatternAvailablePropertyId))]
+        [InlineData(true, ((int)UIA.IsValuePatternAvailablePropertyId))]
+        public void ScrollBarAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
+        {
+            using SubScrollBar scrollBar = new() { Enabled = true };
+            ScrollBar.ScrollBarAccessibleObject accessibleObject = (ScrollBar.ScrollBarAccessibleObject)scrollBar.AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
+            Assert.False(scrollBar.IsHandleCreated);
+        }
+
         private class SubScrollBar : ScrollBar
         {
             public SubScrollBar() : base()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
@@ -701,5 +701,72 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedKeyboardShortcut, accessibleObject.GetPropertyValue(UIA.AccessKeyPropertyId));
             Assert.Equal(createControl, tabControl.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_GetPropertyValue_RuntimeId_ReturnsExpected()
+        {
+            using TabControl tabControl = new();
+
+            object actual = tabControl.AccessibilityObject.GetPropertyValue(UiaCore.UIA.RuntimeIdPropertyId);
+
+            Assert.Equal(tabControl.AccessibilityObject.RuntimeId, actual);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TabControlAccessibleObject_GetPropertyValue_IsEnabled_ReturnsExpected(bool enabled)
+        {
+            using TabControl tabControl = new()
+            {
+                Enabled = enabled
+            };
+
+            object actual = tabControl.AccessibilityObject.GetPropertyValue(UIA.IsEnabledPropertyId);
+
+            Assert.Equal(tabControl.Enabled, actual);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TabControlAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        {
+            const string name = "Test name";
+            using TabControl tabControl = new()
+            {
+                AccessibleName = name
+            };
+
+            object actual = tabControl.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+
+            Assert.Equal(name, actual);
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, ((int)UIA.IsExpandCollapsePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsGridItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsGridPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsMultipleViewPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsScrollItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsScrollPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsSelectionItemPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UIA.IsSelectionPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTableItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTablePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTextPattern2AvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTextPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTogglePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsValuePatternAvailablePropertyId))]
+        public void TabControlAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
+        {
+            using TabControl tabControl = new();
+            TabControlAccessibleObject accessibleObject = (TabControlAccessibleObject)tabControl.AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue((UIA)propertyId) ?? false);
+            Assert.False(tabControl.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
@@ -478,5 +478,45 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedKeyboardShortcut, accessibleObject.GetPropertyValue(UIA.AccessKeyPropertyId));
             Assert.Equal(createControl, tabPage.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void TabPageAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        {
+            const string name = "Test name";
+            using TabPage tabPage = new()
+            {
+                AccessibleName = name
+            };
+
+            object actual = tabPage.AccessibilityObject.GetPropertyValue(UIA.NamePropertyId);
+
+            Assert.Equal(name, actual);
+            Assert.False(tabPage.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, ((int)UIA.IsExpandCollapsePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsGridItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsGridPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsMultipleViewPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsScrollItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsScrollPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsSelectionItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsSelectionPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTableItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTablePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTextPattern2AvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTextPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsTogglePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UIA.IsValuePatternAvailablePropertyId))]
+        public void TabPageAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
+        {
+            using TabPage tabPage = new();
+            TabPageAccessibleObject accessibleObject = (TabPageAccessibleObject)tabPage.AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue((UIA)propertyId) ?? false);
+            Assert.False(tabPage.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TrackBar.TrackBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TrackBar.TrackBarAccessibleObjectTests.cs
@@ -391,6 +391,65 @@ namespace System.Windows.Forms.Tests
             Assert.False(trackBar.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void TrackBarAccessibilityObject_GetPropertyValue_RuntimeId_ReturnsExpected()
+        {
+            using TrackBar trackBar = new();
+            object actual = trackBar.AccessibilityObject.GetPropertyValue(UiaCore.UIA.RuntimeIdPropertyId);
+
+            Assert.Equal(trackBar.AccessibilityObject.RuntimeId, actual);
+            Assert.False(trackBar.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TrackBarAccessibilityObject_GetPropertyValue_Name_ReturnsExpected()
+        {
+            const string name = "Test name";
+            using TrackBar trackBar = new()
+            {
+                AccessibleName = name
+            };
+            object actual = trackBar.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+
+            Assert.Equal(name, actual);
+            Assert.False(trackBar.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TrackBarAccessibilityObject_GetPropertyValue_NativeWindowHandle_ReturnsExpected()
+        {
+            using TrackBar trackBar = new();
+            trackBar.CreateControl(false);
+            object actual = trackBar.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NativeWindowHandlePropertyId);
+
+            Assert.Equal(trackBar.InternalHandle, actual);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, ((int)UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsGridItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsGridPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsMultipleViewPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTableItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTablePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPattern2AvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTogglePatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsValuePatternAvailablePropertyId))]
+        public void TrackBarAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
+        {
+            using TrackBar trackBar = new();
+            TrackBar.TrackBarAccessibleObject accessibleObject = (TrackBar.TrackBarAccessibleObject)trackBar.AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
+            Assert.False(trackBar.IsHandleCreated);
+        }
+
         private TrackBar GetTrackBar(Orientation orientation, RightToLeft rightToLeft, bool rightToLeftLayout, bool createControl, int value, int minimum, int maximum)
         {
             TrackBar trackBar = new()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObjectTests.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static System.Windows.Forms.UpDownBase;
+using static System.Windows.Forms.UpDownBase.UpDownButtons;
+using static Interop;
+
+namespace System.Windows.Forms.Tests
+{
+    public class UpDownBase_UpDownButtons_UpDownButtonsAccessibleObject_DirectionButtonAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsTheory]
+        [InlineData(((int)UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(((int)UiaCore.UIA.IsInvokePatternAvailablePropertyId))]
+        public void UpDownButtonsAccessibleObject_DirectionButtonAccessibleObject_GetPropertyValue_IsPatternSupported(int propertyId)
+        {
+            using SubUpDownBase upDownBase = new();
+            using UpDownButtons upDownButtons = upDownBase.UpDownButtonsInternal;
+            UpDownButtonsAccessibleObject accessibleObject = new(upDownButtons);
+            // UpButton has 0 index
+            AccessibleObject upButton = accessibleObject.GetChild(index: 0);
+            bool actual = (bool)upButton.GetPropertyValue((UiaCore.UIA)propertyId);
+
+            Assert.True(actual);
+            Assert.False(upDownButtons.IsHandleCreated);
+            Assert.False(upDownBase.IsHandleCreated);
+        }
+
+        private class SubUpDownBase : UpDownBase
+        {
+            protected override void UpdateEditText() => throw new NotImplementedException();
+
+            public override void UpButton() => throw new NotImplementedException();
+
+            public override void DownButton() => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObjectTests.cs
@@ -79,6 +79,70 @@ namespace System.Windows.Forms.Tests
             Assert.False(upDownBase.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void UpDownButtonsAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        {
+            const string name = "Test name";
+            using SubUpDownBase upDownBase = new();
+            UpDownButtons upDownButtons = upDownBase.UpDownButtonsInternal;
+            upDownButtons.AccessibleName = name;
+
+            object actual = upDownButtons.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+
+            Assert.Equal(name, actual);
+            Assert.False(upDownBase.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void UpDownButtonsAccessibleObject_GetPropertyValue_RuntimeId_ReturnsExpected()
+        {
+            using SubUpDownBase upDownBase = new();
+            UpDownButtons upDownButtons = upDownBase.UpDownButtonsInternal;
+
+            object actual = upDownButtons.AccessibilityObject.GetPropertyValue(UiaCore.UIA.RuntimeIdPropertyId);
+
+            Assert.Equal(upDownButtons.AccessibilityObject.RuntimeId, actual);
+            Assert.False(upDownBase.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void UpDownButtonsAccessibleObject_GetPropertyValue_BoundingRectangle_ReturnsExpected()
+        {
+            using SubUpDownBase upDownBase = new();
+            UpDownButtons upDownButtons = upDownBase.UpDownButtonsInternal;
+            object actual = upDownButtons.AccessibilityObject.GetPropertyValue(UiaCore.UIA.BoundingRectanglePropertyId);
+
+            Assert.Equal(upDownButtons.AccessibilityObject.BoundingRectangle, actual);
+            Assert.False(upDownBase.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, ((int)UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsGridItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsGridPatternAvailablePropertyId))]
+        [InlineData(true, ((int)UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsMultipleViewPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsScrollPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsSelectionPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTableItemPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTablePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPattern2AvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTextPatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsTogglePatternAvailablePropertyId))]
+        [InlineData(false, ((int)UiaCore.UIA.IsValuePatternAvailablePropertyId))]
+        public void UpDownButtonsAccessibleObject_GetPropertyValue_Pattern_ReturnsExpected(bool expected, int propertyId)
+        {
+            using TrackBar trackBar = new();
+            using SubUpDownBase upDownBase = new();
+            UpDownButtons upDownButtons = upDownBase.UpDownButtonsInternal;
+            UpDownButtonsAccessibleObject accessibleObject = (UpDownButtonsAccessibleObject)upDownButtons.AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
+            Assert.False(upDownBase.IsHandleCreated);
+        }
+
         private class SubUpDownBase : UpDownBase
         {
             protected override void UpdateEditText() => throw new NotImplementedException();


### PR DESCRIPTION
Fixes #5494

## Proposed changes

Moving switch cases with these properties to base classes with the same logic.

Moved to AccessibleObject:
- RuntimeIdPropertyId
- NamePropertyId
- IsOffscreenPropertyId
- IsLegacyIAccessiblePatternAvailablePropertyId 
- HelpTextPropertyId 
 
Moved to ControlAccessibleObject:
- NativeWindowHandlePropertyId
- IsEnabledPropertyId

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Manually checking
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->
Microsoft Windows [Version 10.0.19043.1165]
.NET SDK 7.0.0-alpha.1.21461.7

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5745)