### PR TITLE
Moving units tests from AccessibleObjects folder

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckedListBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckedListBoxAccessibleObjectTests.cs
@@ -6,7 +6,7 @@ using System.Drawing;
 using Xunit;
 using static Interop;
 
-namespace System.Windows.Forms.Tests.AccessibleObjects
+namespace System.Windows.Forms.Tests
 {
     public class CheckedListBoxAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DirectionButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DirectionButtonAccessibleObjectTests.cs
@@ -4,7 +4,7 @@
 
 using Xunit;
 
-namespace System.Windows.Forms.Tests.AccessibleObjects
+namespace System.Windows.Forms.Tests
 {
     public class DirectionButtonAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownAccessibleObjectTests.cs
@@ -5,7 +5,7 @@
 using Xunit;
 using static Interop;
 
-namespace System.Windows.Forms.Tests.AccessibleObjects
+namespace System.Windows.Forms.Tests
 {
     public class DomainUpDownAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProviderAccessibleObjectTests.cs
@@ -5,7 +5,7 @@
 using Xunit;
 using static Interop;
 
-namespace System.Windows.Forms.Tests.AccessibleObjects
+namespace System.Windows.Forms.Tests
 {
     public class ErrorProviderAccessibleObjectTests : IDisposable, IClassFixture<ThreadExceptionFixture>
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxAccessibleObjectTests.cs
@@ -5,7 +5,7 @@
 using Xunit;
 using static Interop;
 
-namespace System.Windows.Forms.Tests.AccessibleObjects
+namespace System.Windows.Forms.Tests
 {
     public class GroupBoxAccessibleObjectTests
     {


### PR DESCRIPTION
Fixes #5746

## Proposed changes

- Moving unit tests from `AccessibleObjects` folder to make them consistent with other unit tests.

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->
Microsoft Windows [Version 10.0.19043.1165]
.NET SDK 7.0.0-alpha.1.21461.7

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5748)