### PR TITLE
Fixing ToolStrip Shift+Tab: now focus turns counter-clockwise (merge to 7.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2254,8 +2254,7 @@ namespace System.Windows.Forms
                 case ArrowDirection.Right:
                     return GetNextItemHorizontal(start, forward: true);
                 case ArrowDirection.Left:
-                    bool isRtl = RightToLeft == RightToLeft.Yes;
-                    bool forward = (LastKeyData == (Keys.Shift | Keys.Tab) && !isRtl) || (LastKeyData == Keys.Tab && isRtl);
+                    bool forward = LastKeyData == Keys.Tab;
                     return GetNextItemHorizontal(start, forward);
                 case ArrowDirection.Down:
                     return GetNextItemVertical(start, down: true);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -4776,6 +4776,47 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<InvalidEnumArgumentException>("direction", () => toolStrip.GetNextItem(null, direction));
         }
 
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void ToolStrip_GetNextItem_ReturnsForwardItem(RightToLeft rightToLeft)
+        {
+            using ToolStrip toolStrip = new()
+            {
+                RightToLeft = rightToLeft,
+                TabStop = false
+            };
+            using ToolStripButton toolStripButton1 = new();
+            using ToolStripButton toolStripButton2 = new();
+            using ToolStripButton toolStripButton3 = new();
+            toolStrip.Items.AddRange(new ToolStripItem[] { toolStripButton1, toolStripButton2, toolStripButton3 });
+            ToolStripItem actual = toolStrip.GetNextItem(toolStrip.Items[0], ArrowDirection.Right);
+
+            Assert.Equal(toolStripButton2, actual);
+            Assert.False(toolStrip.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void ToolStrip_GetNextItem_ReturnsBackwardItem(RightToLeft rightToLeft)
+        {
+            using ToolStrip toolStrip = new()
+            {
+                RightToLeft = rightToLeft,
+                TabStop = false
+            };
+            using ToolStripButton toolStripButton1 = new();
+            using ToolStripButton toolStripButton2 = new();
+            using ToolStripButton toolStripButton3 = new();
+            toolStrip.Items.AddRange(new ToolStripItem[] { toolStripButton1, toolStripButton2, toolStripButton3 });
+            toolStrip.TestAccessor().Dynamic.LastKeyData = Keys.Shift | Keys.Tab;
+            ToolStripItem actual = toolStrip.GetNextItem(toolStrip.Items[0], ArrowDirection.Left);
+
+            Assert.Equal(toolStripButton3, actual);
+            Assert.False(toolStrip.IsHandleCreated);
+        }
+
         [WinFormsFact]
         public void ToolStrip_GetAutoSizeMode_Invoke_ReturnsExpected()
         {


### PR DESCRIPTION
Fixes #3835

## Proposed changes

- Making sure both Shift and Tab are pressed simultaneously to move focus counter-clockwise (backward).
- Ported from #5726

## Customer Impact

Pressing `Shift` + `Tab` on `ToolStrip` with `TabStop`=`false`...
- ...before the fix:
![beforeTheFix](https://user-images.githubusercontent.com/87859299/132662749-def40621-0b5a-4e0e-a980-9e1cb70c7ecf.gif)

- ...after the fix:
![afterTheFix](https://user-images.githubusercontent.com/87859299/132662769-6b16cc7c-bcb0-4607-8dbb-4b9f802b264e.gif)

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manual testing 
- Unit tests

## Test environment(s) <!-- Remove any that don't apply -->
Microsoft Windows [Version 10.0.19043.1165]
.NET SDK 6.0.100-preview.7.21379.14

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5751)