### PR TITLE
Document more GridEntry flags.

### DIFF
--- a/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Drawing/Design/UITypeEditor.cs
@@ -98,7 +98,8 @@ namespace System.Drawing.Design
         /// <param name="value">The object whose value this type editor will display. </param>
         /// <param name="canvas">A drawing canvas on which to paint the representation of the object's value. </param>
         /// <param name="rectangle">A <see cref="Rectangle" /> within whose boundaries to paint the value. </param>
-        public void PaintValue(object value, Graphics canvas, Rectangle rectangle) => PaintValue(new PaintValueEventArgs(null, value, canvas, rectangle));
+        public void PaintValue(object value, Graphics canvas, Rectangle rectangle)
+            => PaintValue(new PaintValueEventArgs(null, value, canvas, rectangle));
 
         /// <summary>
         ///  Paints a representative value of the specified object to the specified canvas.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyPressEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyPressEventArgs.cs
@@ -10,8 +10,7 @@ namespace System.Windows.Forms
     public class KeyPressEventArgs : EventArgs
     {
         /// <summary>
-        ///  Initializes a new instance of the <see cref='KeyPressEventArgs'/>
-        ///  class.
+        ///  Initializes a new instance of the <see cref='KeyPressEventArgs'/> class.
         /// </summary>
         public KeyPressEventArgs(char keyChar)
         {
@@ -24,8 +23,7 @@ namespace System.Windows.Forms
         public char KeyChar { get; set; }
 
         /// <summary>
-        ///  Gets or sets a value indicating whether the <see cref='Control.KeyPress'/>
-        ///  event was handled.
+        ///  Gets or sets a value indicating whether the <see cref='Control.KeyPress'/> event was handled.
         /// </summary>
         public bool Handled { get; set; }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.MeasureTextHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.MeasureTextHelper.cs
@@ -20,40 +20,28 @@ namespace System.Windows.Forms
                 => MeasureText(owner, g, text, font, new SizeF(width, 999999));
 
             public static SizeF MeasureTextSimple(PropertyGrid owner, Graphics g, string text, Font font, SizeF size)
-            {
-                SizeF bindingSize;
-                if (owner.UseCompatibleTextRendering)
-                {
-                    bindingSize = g.MeasureString(text, font, size);
-                }
-                else
-                {
-                    bindingSize = TextRenderer.MeasureText(g, text, font, Size.Ceiling(size), GetTextRendererFlags());
-                }
-
-                return bindingSize;
-            }
+                => owner.UseCompatibleTextRendering
+                    ? g.MeasureString(text, font, size)
+                    : TextRenderer.MeasureText(
+                        g,
+                        text,
+                        font,
+                        Size.Ceiling(size),
+                        TextFormatFlags.PreserveGraphicsClipping | TextFormatFlags.PreserveGraphicsTranslateTransform);
 
             public static SizeF MeasureText(PropertyGrid owner, Graphics g, string text, Font font, SizeF size)
-            {
-                SizeF bindingSize;
-                if (owner.UseCompatibleTextRendering)
-                {
-                    bindingSize = g.MeasureString(text, font, size);
-                }
-                else
-                {
-                    TextFormatFlags flags =
-                        GetTextRendererFlags() |
-                        TextFormatFlags.LeftAndRightPadding |
-                        TextFormatFlags.WordBreak |
-                        TextFormatFlags.NoFullWidthCharacterBreak;
-
-                    bindingSize = (SizeF)TextRenderer.MeasureText(g, text, font, Size.Ceiling(size), flags);
-                }
-
-                return bindingSize;
-            }
+                => owner.UseCompatibleTextRendering
+                    ? g.MeasureString(text, font, size)
+                    : TextRenderer.MeasureText(
+                        g,
+                        text,
+                        font,
+                        Size.Ceiling(size),
+                        TextFormatFlags.PreserveGraphicsClipping
+                            | TextFormatFlags.PreserveGraphicsTranslateTransform
+                            | TextFormatFlags.LeftAndRightPadding
+                            | TextFormatFlags.WordBreak
+                            | TextFormatFlags.NoFullWidthCharacterBreak);
 
             public static TextFormatFlags GetTextRendererFlags()
                 => TextFormatFlags.PreserveGraphicsClipping | TextFormatFlags.PreserveGraphicsTranslateTransform;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ArrayElementGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/ArrayElementGridEntry.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             : base(ownerGrid, parent)
         {
             _index = index;
-            SetFlag(Flags.RenderReadOnly, (parent.EntryFlags & Flags.RenderReadOnly) != 0 || parent.ForceReadOnly);
+            SetFlag(Flags.RenderReadOnly, parent.EntryFlags.HasFlag(Flags.RenderReadOnly) || parent.ForceReadOnly);
         }
 
         public override GridItemType GridItemType => GridItemType.ArrayValue;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         /// </summary>
         protected override GridEntryAccessibleObject GetAccessibilityObject() => new CategoryGridEntryAccessibleObject(this);
 
-        protected override Color GetBackgroundColor() => OwnerGridView.GetLineColor();
+        protected override Color BackgroundColor => OwnerGridView.LineColor;
 
         protected override Color LabelTextColor => OwnerGrid.CategoryForeColor;
 
@@ -139,8 +139,8 @@ namespace System.Windows.Forms.PropertyGridInternal
             // Draw the focus rect.
             if (selected && HasFocus)
             {
-                bool bold = (EntryFlags & Flags.LabelBold) != 0;
-                Font font = GetFont(bold);
+                bool bold = EntryFlags.HasFlag(Flags.LabelBold);
+                Font font = GetFont(boldFont: bold);
                 int labelWidth = GetLabelTextWidth(PropertyLabel, g, font);
 
                 int indent = PropertyLabelIndent - 2;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.Flags.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.Flags.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Drawing.Design;
 
 namespace System.Windows.Forms.PropertyGridInternal
@@ -17,8 +18,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             ///  The <see cref="TypeConverter"/> supports standard values.
             /// </summary>
             StandardValuesSupported = 0x00000002,
+
+            /// <summary>
+            ///  The current <see cref="UITypeEditor"/> returned true for <see cref="UITypeEditor.GetPaintValueSupported()"/>.
+            /// </summary>
             CustomPaint             = 0x00000004,
-            ImmediatelyEditable     = 0x00000008,
 
             /// <summary>
             ///  The current <see cref="UITypeEditor.GetEditStyle()"/> is <see cref="UITypeEditorEditStyle.Modal"/>.
@@ -29,9 +33,23 @@ namespace System.Windows.Forms.PropertyGridInternal
             ///  The current <see cref="UITypeEditor.GetEditStyle()"/> is <see cref="UITypeEditorEditStyle.DropDown"/>.
             /// </summary>
             DropDownEditable        = 0x00000020,
+
+            /// <summary>
+            ///  True if the label should be rendered in bold text. Used by <see cref="CategoryGridEntry"/>.
+            /// </summary>
             LabelBold               = 0x00000040,
+
+            /// <summary>
+            ///  True when the value cannot be edited via the text box, but has a modal editor (`...` button).
+            /// </summary>
             ReadOnlyEditable        = 0x00000080,
+
             RenderReadOnly          = 0x00000100,
+
+            /// <summary>
+            ///  True when the value is attributed with <see cref="ImmutableObjectAttribute"/> or the
+            ///  <see cref="TypeConverter.GetCreateInstanceSupported()"/> indicates that it is immutable.
+            /// </summary>
             Immutable               = 0x00000200,
 
             /// <summary>
@@ -39,13 +57,25 @@ namespace System.Windows.Forms.PropertyGridInternal
             ///  read-only or one of the objects in the root <see cref="GridEntry"/> (with multiple select) is read-only.
             /// </summary>
             ForceReadOnly           = 0x00000400,
+
+            /// <summary>
+            ///  True when <see cref="PasswordPropertyTextAttribute"/> is set.
+            /// </summary>
             RenderPassword          = 0x00001000,
+
             Disposed                = 0x00002000,
             Expand                  = 0x00010000,
             Expandable              = 0x00020000,
             ExpandableFailed        = 0x00080000,
+
+            /// <summary>
+            ///  Inverse of <see cref="CustomPaint"/> that is only used when full flags have not been checked.
+            /// </summary>
             NoCustomPaint           = 0x00100000,
-            Categories              = 0x00200000,
+
+            /// <summary>
+            ///  Set when all the flags have been checked.
+            /// </summary>
             Checked                 = unchecked((int)0x80000000)
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
@@ -117,7 +117,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             try
             {
-                if (_mergedDescriptor.PropertyType.IsValueType || (EntryFlags & Flags.Immutable) != 0)
+                if (_mergedDescriptor.PropertyType.IsValueType || EntryFlags.HasFlag(Flags.Immutable))
                 {
                     return base.CreateChildren(diffOldChildren);
                 }
@@ -155,7 +155,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         }
 
         internal override object GetValueOwnerInternal()
-            => _mergedDescriptor.PropertyType.IsValueType || (EntryFlags & Flags.Immutable) != 0
+            => _mergedDescriptor.PropertyType.IsValueType || EntryFlags.HasFlag(Flags.Immutable)
                 ? base.GetValueOwnerInternal()
                 : _mergedDescriptor.GetValues(_objects);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
@@ -21,12 +21,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal MultiSelectRootGridEntry(
             PropertyGridView view,
-            object obj,
+            object[] target,
             IServiceProvider baseProvider,
             IDesignerHost host,
             PropertyTab tab,
             PropertySort sortType)
-            : base(view, obj, baseProvider, host, tab, sortType)
+            : base(view, target, baseProvider, host, tab, sortType)
         {
         }
 
@@ -36,11 +36,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (!_forceReadOnlyChecked)
                 {
-                    foreach (object obj in (Array)_value)
+                    foreach (object target in (Array)Target)
                     {
-                        var readOnlyAttribute = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(obj)[typeof(ReadOnlyAttribute)];
+                        var readOnlyAttribute = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(target)[typeof(ReadOnlyAttribute)];
                         if ((readOnlyAttribute is not null && !readOnlyAttribute.IsDefaultAttribute())
-                            || TypeDescriptor.GetAttributes(obj).Contains(InheritanceAttribute.InheritedReadOnly))
+                            || TypeDescriptor.GetAttributes(target).Contains(InheritanceAttribute.InheritedReadOnly))
                         {
                             SetForceReadOnlyFlag();
                             break;
@@ -58,27 +58,27 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             try
             {
-                object[] rgobjs = (object[])_value;
+                object[] targets = (object[])Target;
 
                 ChildCollection.Clear();
 
-                MultiPropertyDescriptorGridEntry[] mergedProps = PropertyMerger.GetMergedProperties(rgobjs, this, _propertySort, OwnerTab);
+                var mergedProperties = PropertyMerger.GetMergedProperties(targets, this, _propertySort, OwnerTab);
 
-                Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose && mergedProps is null, "PropertyGridView: MergedProps returned null!");
+                Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose && mergedProperties is null, "PropertyGridView: MergedProps returned null!");
 
-                if (mergedProps is not null)
+                if (mergedProperties is not null)
                 {
-                    ChildCollection.AddRange(mergedProps);
+                    ChildCollection.AddRange(mergedProperties);
                 }
 
-                bool fExpandable = Children.Count > 0;
-                if (!fExpandable)
+                bool expandable = Children.Count > 0;
+                if (!expandable)
                 {
                     SetFlag(Flags.ExpandableFailed, true);
                 }
 
                 CategorizePropEntries();
-                return fExpandable;
+                return expandable;
             }
             catch (Exception e) when (!ClientUtils.IsCriticalException(e))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.cs
@@ -262,9 +262,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // If read only editable is set, make sure it's valid.
                 if (_propertyDescriptor.IsReadOnly && !_readOnlyVerified && GetFlagSet(Flags.ReadOnlyEditable))
                 {
-                    Type propType = PropertyType;
+                    Type propertyType = PropertyType;
 
-                    if (propType is not null && (propType.IsArray || propType.IsValueType || propType.IsPrimitive))
+                    if (propertyType is not null && (propertyType.IsArray || propertyType.IsValueType || propertyType.IsPrimitive))
                     {
                         SetFlag(Flags.ReadOnlyEditable, false);
                         SetFlag(Flags.RenderReadOnly, true);
@@ -274,7 +274,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 _readOnlyVerified = true;
 
-                return base.ShouldRenderReadOnly && !_isSerializeContentsProperty && !base.NeedsModalEditorButton;
+                return base.ShouldRenderReadOnly && !_isSerializeContentsProperty && !NeedsModalEditorButton;
             }
         }
 
@@ -328,7 +328,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 for (int i = 0; i < _propertyValueUIItems.Length; i++)
                 {
-                    if (_uiItemRects[i].Contains(mouseX, OwnerGridView.GetGridEntryHeight() / 2))
+                    if (_uiItemRects[i].Contains(mouseX, OwnerGridView.GridEntryHeight / 2))
                     {
                         _toolTipText = _propertyValueUIItems[i].ToolTip;
                         return new Point(mouseX, mouseY);
@@ -496,7 +496,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 for (int i = 0; i < _propertyValueUIItems.Length; i++)
                 {
-                    if (_uiItemRects[i].Contains(x, OwnerGridView.GetGridEntryHeight() / 2))
+                    if (_uiItemRects[i].Contains(x, OwnerGridView.GridEntryHeight / 2))
                     {
                         _propertyValueUIItems[i].InvokeHandler(this, _propertyDescriptor, _propertyValueUIItems[i]);
                         return true;
@@ -707,7 +707,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return owner;
         }
 
-        protected void SetPropertyValueCore(object obj, object newValue)
+        protected void SetPropertyValueCore(object owner, object newValue)
         {
             if (_propertyDescriptor is null)
             {
@@ -720,11 +720,11 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 Cursor.Current = Cursors.WaitCursor;
 
-                object target = obj;
+                object realOwner = owner;
 
-                if (target is ICustomTypeDescriptor descriptor)
+                if (realOwner is ICustomTypeDescriptor descriptor)
                 {
-                    target = descriptor.GetPropertyOwner(_propertyDescriptor);
+                    realOwner = descriptor.GetPropertyOwner(_propertyDescriptor);
                 }
 
                 // Check the type of the object we are modifying.  If it's a value type or an array,
@@ -734,25 +734,25 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 if (ParentGridEntry is not null)
                 {
-                    Type propType = ParentGridEntry.PropertyType;
-                    treatAsValueType = propType.IsValueType || propType.IsArray;
+                    Type propertyType = ParentGridEntry.PropertyType;
+                    treatAsValueType = propertyType.IsValueType || propertyType.IsArray;
                 }
 
-                if (target is not null)
+                if (realOwner is not null)
                 {
-                    _propertyDescriptor.SetValue(target, newValue);
+                    _propertyDescriptor.SetValue(realOwner, newValue);
 
                     // Since the value that we modified may not be stored by the parent property, we need to push this
-                    // value back into the parent.  An example here is Size or Location, which return Point objects
-                    // that are unconnected to the object they relate to.  So we modify the Point object and
-                    // push it back into the object we got it from.
+                    // value back into the parent. An example here is Size or Location, which return Point objects that
+                    // are unconnected to the object they relate to. So we modify the Point object and push it back
+                    // into the object we got it from.
 
                     if (treatAsValueType)
                     {
                         GridEntry parent = ParentGridEntry;
                         if (parent is not null && parent.IsValueEditable)
                         {
-                            parent.PropertyValue = obj;
+                            parent.PropertyValue = owner;
                         }
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
@@ -42,7 +42,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 set => _filter = value;
             }
 
-            /// <inheritdoc />
             internal override bool SupportsUiaProviders => true;
 
             public override bool Focused => !HideFocusState && base.Focused;
@@ -76,7 +75,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            /// <inheritdoc />
             protected override AccessibleObject CreateAccessibilityInstance() => new GridViewTextBoxAccessibleObject(this);
 
             protected override void DestroyHandle()
@@ -105,11 +103,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
             }
 
-            /// <summary>
-            ///  Overridden to handle TAB key.
-            /// </summary>
             protected override bool IsInputKey(Keys keyData)
             {
+                // Overridden to handle TAB key.
                 switch (keyData & Keys.KeyCode)
                 {
                     case Keys.Escape:
@@ -184,7 +180,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
             {
-                // Make sure we allow the Edit to handle ctrl-z
+                // Make sure we allow the Edit to handle ctrl-z.
                 switch (keyData & Keys.KeyCode)
                 {
                     case Keys.Z:
@@ -245,7 +241,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 return base.ProcessCmdKey(ref msg, keyData);
             }
 
-            /// <inheritdoc />
             protected override bool ProcessDialogKey(Keys keyData)
             {
                 // We don't do anything with modified keys here.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -61,7 +61,7 @@ namespace System.Windows.Forms.VisualStyles
                     // could fail for some other reason. Try creating a theme handle here - if successful, return true,
                     // else return false.
                     IntPtr hTheme = GetHandle("BUTTON", false); // Button is an arbitrary choice.
-                    supported = (hTheme != IntPtr.Zero);
+                    supported = hTheme != IntPtr.Zero;
                 }
 
                 return supported;


### PR DESCRIPTION
Cleanup work around GridEntry flags.

- Change some methods to properties to better reflect their lack of side-effects.
- Use HasFlag for clarity where possible.
- Fix a brush leak in RedrawExplorerTreeViewClosedGlyph.
- More terminology cleanup for clarity.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5757)