### PR TITLE
Fixing behavior of ListViewSubItem.Bounds when FullRowSelect = true

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -51,7 +51,7 @@ namespace System.Windows.Forms
                         // When we need to get bounds for first sub item it will return width of all item.
                         int width = bounds.Width;
 
-                        if (index == 0 && _owningListView.Columns.Count > 1)
+                        if (!_owningListView.FullRowSelect && index == 0 && _owningListView.Columns.Count > 1)
                         {
                             width = ParentInternal.GetSubItemBounds(subItemIndex: 1).X - bounds.X;
                         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -860,5 +860,48 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(Environment.ProcessId, actual);
             Assert.False(listView.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_Bounds_Equals_ListViewItem_IfFullRowSelectIsTrue()
+        {
+            using ListView listView = new()
+            {
+                View = View.Details,
+                FullRowSelect = true
+            };
+
+            listView.CreateControl();
+            listView.Columns.AddRange(new ColumnHeader[] { new() { Width = 120, Text = "Column 1" }, new() { Width = 120, Text = "Column 2" } });
+            listView.Items.Add(new ListViewItem("Test item 11"));
+            listView.Items[0].SubItems.Add("Test item 12");
+
+            var itemAccessibleObject = listView.Items[0].AccessibilityObject;
+            var subItemAccessibleObject = listView.Items[0].SubItems[0].AccessibilityObject;
+
+            Assert.Equal(itemAccessibleObject.Bounds, subItemAccessibleObject.Bounds);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewSтubItemAccessibleObject_Bounds_NotEquals_ListViewItem_IfFullRowSelectIsFalse()
+        {
+            using ListView listView = new()
+            {
+                View = View.Details,
+                FullRowSelect = false
+            };
+
+            listView.CreateControl();
+
+            listView.Columns.AddRange(new ColumnHeader[] { new() { Width = 120, Text = "Column 1" }, new() { Width = 120, Text = "Column 2" } });
+            listView.Items.Add(new ListViewItem("Test item 11"));
+            listView.Items[0].SubItems.Add("Test item 12");
+
+            var itemAccessibleObject = listView.Items[0].AccessibilityObject;
+            var subItemAccessibleObject = listView.Items[0].SubItems[0].AccessibilityObject;
+
+            Assert.NotEqual(itemAccessibleObject.Bounds, subItemAccessibleObject.Bounds);
+            Assert.True(listView.IsHandleCreated);
+        }
     }
 }


### PR DESCRIPTION
Fixes #4150


## Proposed changes
- The issue is reproduced because we are limiting the size of the first ListViewSubItem, regardless of the `FullRowSelect` property. Added additional condition for `FullRowSelect` property.
- Added unit tests

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/133250171-1598bb6b-35ba-403d-8ee1-09bb40f04ae1.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/133250798-7fb6c8c4-926b-4f6a-aa3d-b83f7b936cf5.png)

## Regression? 

- Yes

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
-  Inspect
- Accessibility Insights

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 6.0.100-rc.1.21430.12


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5762)