### PR TITLE
Fixing announcement of information about RadioButton

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
@@ -401,7 +401,7 @@ namespace System.Windows.Forms
             AccessibilityNotifyClients(AccessibleEvents.NameChange, -1);
 
             // UIA events:
-            AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.SelectionItemIsSelectedPropertyId, Checked, !Checked);
+            AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.NamePropertyId, Name, Name);
             AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationPropertyChangedEventId);
 
             ((EventHandler)Events[EVENT_CHECKEDCHANGED])?.Invoke(this, e);


### PR DESCRIPTION
Fixes #5235


## Proposed changes
- The issue is reproduced because we are calling the `RaiseAutomationPropertyChangedEvent` method with the wrong parameters.
- Fixed parameters for `RaiseAutomationPropertyChangedEvent` method

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/133263326-9e39ae01-0214-43e4-84c5-3c9f7f695283.png)

**After fix:**
![Issue-5235-afterfix](https://user-images.githubusercontent.com/23376742/133263432-0746dd38-35de-464e-9851-cc410395c4fd.gif)

## Regression? 

- Yes

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.388]
- .NET Core SDK 6.0.100-rc.1.21430.12


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5766)