### PR TITLE
Filling empty test files for missing ao (part 2)

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CategoryGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CategoryGridEntryAccessibleObjectTests.cs
@@ -4,18 +4,18 @@
 
 using System.Windows.Forms.PropertyGridInternal;
 using Xunit;
+using static System.Windows.Forms.PropertyGridInternal.CategoryGridEntry;
 
 namespace System.Windows.Forms.Tests
 {
     public class CategoryGridEntryAccessibleObjectTests
     {
         [WinFormsFact]
-        public void CategoryGridEntryAccessibleObject_Ctor_OwnerGridEntryCannotBeNull()
+        public void CategoryGridEntryAccessibleObject_Ctor_OwnerCategoryGridEntryCannotBeNull()
         {
-            using PropertyGrid control = new();
-            SubGridEntry gridEntry = new(control, null);
-
-            Assert.Throws<NullReferenceException>(() => new CategoryGridEntry(control, null, "Name", new []{ gridEntry }));
+            using NoAssertContext context = new();
+            var accessibilityObject = new CategoryGridEntryAccessibleObject(null);
+            Assert.Null(accessibilityObject.TestAccessor().Dynamic._owningCategoryGridEntry);
         }
 
         private class SubGridEntry: GridEntry

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ChildAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ChildAccessibleObjectTests.cs
@@ -14,9 +14,26 @@ namespace System.Windows.Forms.Tests
             using var control = new ComboBox();
             control.CreateControl();
 
-            Assert.True(control.IsHandleCreated);
             var accessibleObject = new ComboBox.ChildAccessibleObject(control, IntPtr.Zero);
+
             Assert.NotNull(accessibleObject.TestAccessor().Dynamic._owner);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("Some string for test")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ChildAccessibleObject_Name_Default(string testName)
+        {
+            using var control = new ComboBox();
+            control.AccessibilityObject.Name = testName;
+            control.CreateControl();
+
+            var accessibleObject = new ComboBox.ChildAccessibleObject(control, IntPtr.Zero);
+
+            Assert.Equal(testName, accessibleObject.Name);
+            Assert.True(control.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridView.GridViewListBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridView.GridViewListBoxItemAccessibleObjectTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Windows.Forms.PropertyGridInternal;
 using Xunit;
 using static System.Windows.Forms.PropertyGridInternal.PropertyGridView;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -26,6 +27,47 @@ namespace System.Windows.Forms.Tests
             Type type = typeof(PropertyGridView)
                 .GetNestedType("GridViewListBoxItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.Throws<TargetInvocationException>(() => (AccessibleObject)Activator.CreateInstance(type, new object[] { control, null }));
+        }
+
+        [WinFormsFact]
+        public void GridViewListBoxItemAccessibleObject_FragmentRoot_ReturnsExpected()
+        {
+            using GridViewListBox control = new(new PropertyGridView(null, null));
+            Type type = typeof(PropertyGridView)
+                .GetNestedType("GridViewListBoxItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control, new ItemArray.Entry("A") });
+
+            Assert.Equal(control.AccessibilityObject, accessibleObject.FragmentRoot);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("Some string for test")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void GridViewListBoxItemAccessibleObject_Name_ReturnsExpected(string testName)
+        {
+            using GridViewListBox control = new(new PropertyGridView(null, null));
+            Type type = typeof(PropertyGridView)
+                .GetNestedType("GridViewListBoxItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var itemEntry = new ItemArray.Entry(testName);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control, itemEntry });
+
+            Assert.Equal(itemEntry.ToString(), accessibleObject.Name);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.InvokePatternId)]
+        public void GridViewListBoxItemAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
+        {
+            using GridViewListBox control = new(new PropertyGridView(null, null));
+            Type type = typeof(PropertyGridView)
+                .GetNestedType("GridViewListBoxItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control, new ItemArray.Entry("A") });
+
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.False(control.IsHandleCreated);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

This opportunity appears after creating test files for missing ao classes in pr #5731.
Added unit tests for the following classes:
- `ComboBox.ChildAccessibleObject`
- `GridViewListBoxItemAccessibleObject`

Reworked `ctor` test for class `CategoryGridEntryAccessibleObject`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5775)