### PR TITLE
More PropertyGrid related cleanup.

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.cs
@@ -60,8 +60,8 @@ namespace System.ComponentModel.Design
             if (value is IComponent component)
             {
                 // Make sure the component is not being inherited -- we can't delete these!
-                InheritanceAttribute attribute = (InheritanceAttribute)TypeDescriptor.GetAttributes(component)[typeof(InheritanceAttribute)];
-                if (attribute is not null && attribute.InheritanceLevel != InheritanceLevel.NotInherited)
+                if (TypeDescriptorHelper.TryGetAttribute(component, out InheritanceAttribute attribute)
+                    && attribute.InheritanceLevel != InheritanceLevel.NotInherited)
                 {
                     return false;
                 }

--- a/src/System.Windows.Forms.Primitives/src/System/ComponentModel/TypeDescriptorHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/ComponentModel/TypeDescriptorHelper.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.ComponentModel
+{
+    internal static class TypeDescriptorHelper
+    {
+        public static bool TryGetAttribute<T>(
+            object component,
+            [NotNullWhen(true)] out T? attribute) where T : Attribute
+        {
+            attribute = TypeDescriptor.GetAttributes(component)[typeof(T)] as T;
+            return attribute is not null;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiPropertyDescriptorGridEntry.cs
@@ -17,11 +17,11 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public MultiPropertyDescriptorGridEntry(
             PropertyGrid ownerGrid,
-            GridEntry peParent,
+            GridEntry parent,
             object[] objectArray,
             PropertyDescriptor[] propertyDescriptors,
             bool hide)
-            : base(ownerGrid, peParent, hide)
+            : base(ownerGrid, parent, hide)
         {
             _mergedDescriptor = new MergePropertyDescriptor(propertyDescriptors);
             _objects = objectArray;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
@@ -38,8 +38,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     foreach (object target in (Array)Target)
                     {
-                        var readOnlyAttribute = (ReadOnlyAttribute)TypeDescriptor.GetAttributes(target)[typeof(ReadOnlyAttribute)];
-                        if ((readOnlyAttribute is not null && !readOnlyAttribute.IsDefaultAttribute())
+                        if ((TypeDescriptorHelper.TryGetAttribute(target, out ReadOnlyAttribute readOnlyAttribute)
+                            && !readOnlyAttribute.IsDefaultAttribute())
                             || TypeDescriptor.GetAttributes(target).Contains(InheritanceAttribute.InheritedReadOnly))
                         {
                             SetForceReadOnlyFlag();
@@ -77,7 +77,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     SetFlag(Flags.ExpandableFailed, true);
                 }
 
-                CategorizePropEntries();
+                CategorizePropertyEntries();
                 return expandable;
             }
             catch (Exception e) when (!ClientUtils.IsCriticalException(e))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1396,7 +1396,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         internal bool IsExplorerTreeSupported => OwnerGrid.CanShowVisualStyleGlyphs && VisualStyleRenderer.IsSupported;
 
-        public int GetOutlineIconSize() => IsExplorerTreeSupported ? _outlineSizeExplorerTreeStyle : _outlineSize;
+        public int OutlineIconSize => IsExplorerTreeSupported ? _outlineSizeExplorerTreeStyle : _outlineSize;
 
         internal bool IsEditTextBoxCreated => _editTextBox is not null && _editTextBox.IsHandleCreated;
 
@@ -1455,9 +1455,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             return null;
         }
 
-        public int GetSplitterWidth() => 1;
+        public int SplitterWidth => 1;
 
-        public int GetTotalWidth() => LabelWidth + GetSplitterWidth() + GetValueWidth();
+        /// <summary>
+        ///  The width of the label, splitter, and value.
+        /// </summary>
+        public int TotalWidth => LabelWidth + SplitterWidth + ValueWidth;
 
         public int ValuePaintIndent => _paintIndent;
 
@@ -1465,7 +1468,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         public int ValueStringIndent => EditIndent;
 
-        public int GetValueWidth() => (int)(LabelWidth * (_labelRatio - 1));
+        public int ValueWidth => (int)(LabelWidth * (_labelRatio - 1));
 
         public void DropDownControl(Control control)
         {
@@ -1821,7 +1824,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             return -1;
         }
 
-        public int GetDefaultOutlineIndent() => OutlineIndent;
+        public int DefaultOutlineIndent => OutlineIndent;
 
         public int GetScrollOffset()
         {
@@ -2167,7 +2170,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             int widthPS = GetOurSize().Width;
             int startPS = _location.X;
-            int pos = Math.Max(Math.Min(xPosition, widthPS - 10), GetOutlineIconSize() * 2);
+            int pos = Math.Max(Math.Min(xPosition, widthPS - 10), OutlineIconSize * 2);
 
             int oldLabelWidth = LabelWidth;
 
@@ -3405,7 +3408,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     visibleCount = Math.Min(visibleCount, endRow + 1);
 
                     Debug.WriteLineIf(s_gridViewDebugPaint.TraceVerbose, "Drawing splitter");
-                    using var splitterPen = OwnerGrid.LineColor.GetCachedPenScope(GetSplitterWidth());
+                    using var splitterPen = OwnerGrid.LineColor.GetCachedPenScope(SplitterWidth);
                     g.DrawLine(splitterPen, _labelWidth, location.Y, _labelWidth, visibleCount * (RowHeight + 1) + location.Y);
 
                     // Draw lines.
@@ -3417,7 +3420,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     int lineStart = location.X;
 
                     // Draw values.
-                    int totalWidth = GetTotalWidth() + 1;
+                    int totalWidth = TotalWidth + 1;
 
                     // Draw labels. set clip rect.
                     for (int i = startRow; i < visibleCount; i++)
@@ -4085,12 +4088,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             if (TopLevelGridEntries is not null && DpiHelper.IsScalingRequirementMet)
             {
-                int outlineRectIconSize = GetOutlineIconSize();
-                foreach (GridEntry gridentry in TopLevelGridEntries)
+                int outlineRectIconSize = OutlineIconSize;
+                foreach (GridEntry entry in TopLevelGridEntries)
                 {
-                    if (gridentry.OutlineRect.Height != outlineRectIconSize || gridentry.OutlineRect.Width != outlineRectIconSize)
+                    if (entry.OutlineRectangle.Height != outlineRectIconSize || entry.OutlineRectangle.Width != outlineRectIconSize)
                     {
-                        ResetOutline(gridentry);
+                        entry.ResetOutlineRectangle();
                     }
                 }
             }
@@ -5569,29 +5572,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                 _offset2Units = LogicalToDeviceUnits(Offset2Pixels);
                 if (TopLevelGridEntries is not null)
                 {
-                    foreach (GridEntry t in TopLevelGridEntries)
+                    foreach (GridEntry entry in TopLevelGridEntries)
                     {
-                        ResetOutline(t);
+                        entry.ResetOutlineRectangle();
                     }
                 }
             }
-        }
-
-        /// <summary>
-        ///  Recursively reset outline rect for grid entries (both visible and invisible)
-        /// </summary>
-        private void ResetOutline(GridEntry entry)
-        {
-            entry.OutlineRect = Rectangle.Empty;
-            if (entry.ChildCount > 0)
-            {
-                foreach (GridEntry ent in entry.Children)
-                {
-                    ResetOutline(ent);
-                }
-            }
-
-            return;
         }
     }
 }


### PR DESCRIPTION
- Make more methods that should have been properties, properties.
- More devirtualization, sealing, and access modifier restriction.
- Move more collections to generics for clarity
- Move outline rectangle reset into GridEntry.
- Start on helper class for TypeDescriptor.
- Remove BinaryFormatter from MergePropertyDescriptor.
- Fix issue in SingleSelectRootGridEntry where Children would potentially be created for disposal.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5777)