### PR TITLE
Update intellisense

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -45,7 +45,7 @@
   </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>
-    <MicrosoftPrivateIntellisenseVersion>5.0.0-preview-20201009.2</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>6.0.0-preview-20210916.1</MicrosoftPrivateIntellisenseVersion>
   </PropertyGroup>
   <!-- Arcade -->
   <PropertyGroup>


### PR DESCRIPTION
The .NET 6.0 RC1 documentation is live now in MS Docs: docs.microsoft.com/dotnet/api/?view=net-6.0

We generated the IntelliSense NuGet package version for that branch, and we made sure it got pushed to the correct expected feed (dotnet6-transport). Here's the pipeline output of the package push: apidrop.visualstudio.com/Content%20CI/_build/results?buildId=253493&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=11e7ea89-affe-5194-cdc6-0171c3394706

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5785)