### PR TITLE
Move from IntPtr to nint to avoid runtime casting errors.

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -608,7 +608,7 @@ namespace System.ComponentModel.Design
                         IntPtr hWndCapture = User32.GetCapture();
                         if (hWndCapture != IntPtr.Zero)
                         {
-                            User32.SendMessageW(hWndCapture, User32.WM.CANCELMODE, IntPtr.Zero, IntPtr.Zero);
+                            User32.SendMessageW(hWndCapture, User32.WM.CANCELMODE);
                             User32.ReleaseCapture();
                         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.cs
@@ -72,7 +72,7 @@ namespace System.ComponentModel.Design
             IntPtr hwnd = treeView.Handle;
             ComCtl32.TVS_EX exstyle = (ComCtl32.TVS_EX)User32.SendMessageW(hwnd, (User32.WM)ComCtl32.TVM.GETEXTENDEDSTYLE);
             exstyle |= ComCtl32.TVS_EX.DOUBLEBUFFER | ComCtl32.TVS_EX.FADEINOUTEXPANDOS;
-            User32.SendMessageW(hwnd, (User32.WM)ComCtl32.TVM.SETEXTENDEDSTYLE, IntPtr.Zero, (IntPtr)exstyle);
+            User32.SendMessageW(hwnd, (User32.WM)ComCtl32.TVM.SETEXTENDEDSTYLE, 0, (nint)exstyle);
         }
 
         public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context) => UITypeEditorEditStyle.DropDown;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ResizeBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ResizeBehavior.cs
@@ -618,7 +618,7 @@ namespace System.Windows.Forms.Design.Behavior
                 Rectangle oldBorderRect = BehaviorService.ControlRectInAdornerWindow(control);
                 bool needToUpdate = true;
                 // The ResizeBehavior can easily get into a situation where we are fighting with a layout engine. E.g., We resize control to 50px, LayoutEngine lays out and finds 50px was too small and resized back to 100px.  This is what should happen, but it looks bad in the designer.  To avoid the flicker we temporarily turn off painting while we do the resize.
-                User32.SendMessageW(control, User32.WM.SETREDRAW, PARAM.FromBool(false));
+                User32.SendMessageW(control, User32.WM.SETREDRAW, (nint)BOOL.FALSE);
                 try
                 {
                     bool fRTL = false;
@@ -772,7 +772,7 @@ namespace System.Windows.Forms.Design.Behavior
                 finally
                 {
                     // While we were resizing we discarded painting messages to reduce flicker.  We now turn painting back on and manually refresh the controls.
-                    User32.SendMessageW(control, User32.WM.SETREDRAW, PARAM.FromBool(true));
+                    User32.SendMessageW(control, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
                     //update the control
                     if (needToUpdate)
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -782,7 +782,7 @@ namespace System.Windows.Forms.Design
                     IntPtr hwnd = User32.WindowFromPoint(p);
                     if (hwnd != IntPtr.Zero)
                     {
-                        User32.SendMessageW(hwnd, User32.WM.SETCURSOR, hwnd, (IntPtr)User32.HT.CLIENT);
+                        User32.SendMessageW(hwnd, User32.WM.SETCURSOR, hwnd, (nint)User32.HT.CLIENT);
                     }
                     else
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -1950,7 +1950,7 @@ namespace System.Windows.Forms.Design
 
                     // We don't really want the focus, but we want to focus the designer. Below we handle WM_SETFOCUS
                     // and do the right thing.
-                    User32.SendMessageW(Control.Handle, User32.WM.SETFOCUS, IntPtr.Zero, IntPtr.Zero);
+                    User32.SendMessageW(Control.Handle, User32.WM.SETFOCUS);
 
                     // We simulate doubleclick for things that don't...
                     if (button == MouseButtons.Left && IsDoubleClick(x, y))
@@ -1984,7 +1984,7 @@ namespace System.Windows.Forms.Design
 
                         if (_toolPassThrough)
                         {
-                            User32.SendMessageW(Control.Parent.Handle, (User32.WM)m.Msg, m.WParam, (IntPtr)GetParentPointFromLparam(m.LParam));
+                            User32.SendMessageW(Control.Parent.Handle, (User32.WM)m.Msg, m.WParam, GetParentPointFromLparam(m.LParam));
                             return;
                         }
 
@@ -2033,7 +2033,7 @@ namespace System.Windows.Forms.Design
                                 Control.Parent.Handle,
                                 (User32.WM)m.Msg,
                                 m.WParam,
-                                (IntPtr)GetParentPointFromLparam(m.LParam));
+                                GetParentPointFromLparam(m.LParam));
                             return;
                         }
 
@@ -2080,7 +2080,7 @@ namespace System.Windows.Forms.Design
                                 Control.Parent.Handle,
                                 (User32.WM)m.Msg,
                                 m.WParam,
-                                (IntPtr)GetParentPointFromLparam(m.LParam));
+                                GetParentPointFromLparam(m.LParam));
                             _toolPassThrough = false;
                             return;
                         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
@@ -105,7 +105,7 @@ namespace System.Windows.Forms.Design
         {
             if (_designer != null && _designer.IsHandleCreated)
             {
-                User32.SendMessageW(_designer.Handle, User32.WM.NCACTIVATE, PARAM.FromBool(focus), IntPtr.Zero);
+                User32.SendMessageW(_designer.Handle, User32.WM.NCACTIVATE, PARAM.FromBool(focus));
                 User32.RedrawWindow(_designer.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
             }
         }
@@ -256,7 +256,7 @@ namespace System.Windows.Forms.Design
                     if ((msg == User32.WM.VSCROLL) || (msg == User32.WM.HSCROLL))
                     {
                         // Send a message to ourselves to scroll
-                        User32.SendMessageW(_designerRegion.Handle, msg, (IntPtr)PARAM.ToInt((int)wScrollNotify, 0), IntPtr.Zero);
+                        User32.SendMessageW(_designerRegion.Handle, msg, PARAM.ToInt((int)wScrollNotify, 0));
                         return;
                     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerUtils.cs
@@ -438,30 +438,33 @@ namespace System.Windows.Forms.Design
             IntPtr hWnd = control.Handle;
             image = new Bitmap(Math.Max(control.Width, MINCONTROLBITMAPSIZE), Math.Max(control.Height, MINCONTROLBITMAPSIZE), PixelFormat.Format32bppPArgb);
 
-            //Have to do this BEFORE we set the testcolor.
+            // Have to do this BEFORE we set the testcolor.
             if (control.BackColor == Color.Transparent)
             {
-                using (Graphics g = Graphics.FromImage(image))
-                {
-                    g.Clear(SystemColors.Control);
-                }
+                using Graphics g = Graphics.FromImage(image);
+                g.Clear(SystemColors.Control);
             }
 
-            // To validate that the control responded to the wm_print message, we pre-populate the bitmap with a colored center pixel.  We assume that the control _did not_ respond to wm_print if these center pixel is still this value
+            //  To validate that the control responded to the wm_print message, we pre-populate the bitmap with a
+            //  colored center pixel.  We assume that the control _did not_ respond to wm_print if these center pixel
+            //  is still this value.
+
             Color testColor = Color.FromArgb(255, 252, 186, 238);
             ((Bitmap)image).SetPixel(image.Width / 2, image.Height / 2, testColor);
             using (Graphics g = Graphics.FromImage(image))
             {
                 IntPtr hDc = g.GetHdc();
-                //send the actual wm_print message
-                User32.SendMessageW(hWnd, User32.WM.PRINT, hDc, (IntPtr)(User32.PRF.CHILDREN | User32.PRF.CLIENT | User32.PRF.ERASEBKGND | User32.PRF.NONCLIENT));
+                User32.SendMessageW(
+                    hWnd,
+                    User32.WM.PRINT,
+                    hDc,
+                    (nint)(User32.PRF.CHILDREN | User32.PRF.CLIENT | User32.PRF.ERASEBKGND | User32.PRF.NONCLIENT));
                 g.ReleaseHdc(hDc);
             }
 
-            //now check to see if our center pixel was cleared, if not then our wm_print failed
+            // Now check to see if our center pixel was cleared, if not then our WM_PRINT failed
             if (((Bitmap)image).GetPixel(image.Width / 2, image.Height / 2).Equals(testColor))
             {
-                //wm_print failed
                 return false;
             }
 
@@ -863,9 +866,7 @@ namespace System.Windows.Forms.Design
             => DpiHelper.IsScalingRequired ? DpiHelper.LogicalToDeviceUnitsX(unit) : unit;
 
         private static ComCtl32.TVS_EX TreeView_GetExtendedStyle(IntPtr handle)
-        {
-            return (ComCtl32.TVS_EX)User32.SendMessageW(handle, (User32.WM)ComCtl32.TVM.GETEXTENDEDSTYLE);
-        }
+            => (ComCtl32.TVS_EX)User32.SendMessageW(handle, (User32.WM)ComCtl32.TVM.GETEXTENDEDSTYLE);
 
         /// <summary>
         ///  Modify a WinForms TreeView control to use the new Explorer style theme
@@ -884,7 +885,7 @@ namespace System.Windows.Forms.Design
             UxTheme.SetWindowTheme(hwnd, "Explorer", null);
             ComCtl32.TVS_EX exstyle = TreeView_GetExtendedStyle(hwnd);
             exstyle |= ComCtl32.TVS_EX.DOUBLEBUFFER | ComCtl32.TVS_EX.FADEINOUTEXPANDOS;
-            User32.SendMessageW(hwnd, (User32.WM)ComCtl32.TVM.SETEXTENDEDSTYLE, IntPtr.Zero, (IntPtr)exstyle);
+            User32.SendMessageW(hwnd, (User32.WM)ComCtl32.TVM.SETEXTENDEDSTYLE, 0, (nint)exstyle);
         }
 
         /// <summary>
@@ -900,7 +901,11 @@ namespace System.Windows.Forms.Design
 
             IntPtr hwnd = listView.Handle;
             UxTheme.SetWindowTheme(hwnd, "Explorer", null);
-            User32.SendMessageW(hwnd, (User32.WM)ComCtl32.LVM.SETEXTENDEDLISTVIEWSTYLE, (IntPtr)ComCtl32.LVS_EX.DOUBLEBUFFER, (IntPtr)ComCtl32.LVS_EX.DOUBLEBUFFER);
+            User32.SendMessageW(
+                hwnd,
+                (User32.WM)ComCtl32.LVM.SETEXTENDEDLISTVIEWSTYLE,
+                (nint)ComCtl32.LVS_EX.DOUBLEBUFFER,
+                (nint)ComCtl32.LVS_EX.DOUBLEBUFFER);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
@@ -1206,9 +1206,9 @@ namespace System.Windows.Forms.Design
         private unsafe void OnDesignerDeactivate(object sender, EventArgs e)
         {
             Control control = Control;
-            if (control != null && control.IsHandleCreated)
+            if (control is not null && control.IsHandleCreated)
             {
-                User32.SendMessageW(control.Handle, User32.WM.NCACTIVATE);
+                User32.SendMessageW(control.Handle, User32.WM.NCACTIVATE, (nint)BOOL.FALSE);
                 User32.RedrawWindow(control.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
@@ -379,7 +379,7 @@ namespace System.Windows.Forms.Design
             Control control = Control;
             if (control != null && control.IsHandleCreated)
             {
-                User32.SendMessageW(control.Handle, User32.WM.NCACTIVATE, (IntPtr)1, IntPtr.Zero);
+                User32.SendMessageW(control.Handle, User32.WM.NCACTIVATE, (nint)BOOL.TRUE);
                 User32.RedrawWindow(control.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
             }
         }
@@ -392,7 +392,7 @@ namespace System.Windows.Forms.Design
             Control control = Control;
             if (control != null && control.IsHandleCreated)
             {
-                User32.SendMessageW(control.Handle, User32.WM.NCACTIVATE, IntPtr.Zero, IntPtr.Zero);
+                User32.SendMessageW(control.Handle, User32.WM.NCACTIVATE, (nint)BOOL.FALSE);
                 User32.RedrawWindow(control.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListBoxDesigner.cs
@@ -195,7 +195,7 @@ namespace System.Windows.Forms.Design
             if (lb.IsHandleCreated && lb.Items.Count == 0)
             {
                 User32.SendMessageW(lb, (User32.WM)User32.LB.RESETCONTENT);
-                User32.SendMessageW(lb, (User32.WM)User32.LB.ADDSTRING, IntPtr.Zero, name);
+                User32.SendMessageW(lb, (User32.WM)User32.LB.ADDSTRING, 0, name);
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
@@ -67,11 +67,10 @@ namespace System.Windows.Forms.Design
             }
         }
 
-        /// <summary>
-        ///  We override GetHitTest to make the header in report view UI-active.
-        /// </summary>
         protected unsafe override bool GetHitTest(Point point)
         {
+            // We override GetHitTest to make the header in report view UI-active.
+
             ListView listView = (ListView)Component;
             if (listView.View == View.Details)
             {
@@ -85,7 +84,7 @@ namespace System.Windows.Forms.Design
                     {
                         User32.MapWindowPoints(IntPtr.Zero, headerHwnd, &point, 1);
                         _hdrhit.pt = point;
-                        User32.SendMessageW(headerHwnd, (User32.WM)ComCtl32.HDM.HITTEST, IntPtr.Zero, ref _hdrhit);
+                        User32.SendMessageW(headerHwnd, (User32.WM)ComCtl32.HDM.HITTEST, 0, ref _hdrhit);
                         if (_hdrhit.flags == ComCtl32.HHT.ONDIVIDER)
                             return true;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDesignerDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/MaskDesignerDialog.cs
@@ -484,7 +484,7 @@ namespace System.Windows.Forms.Design
             // Since we need to pre-process each item before inserting it in the ListView, it is better to remove all items
             // from it first and then add the sorted ones back (no replace).  Stop redrawing while we change the list.
 
-            User32.SendMessageW(_listViewCannedMasks, User32.WM.SETREDRAW, PARAM.FromBool(false));
+            User32.SendMessageW(_listViewCannedMasks, User32.WM.SETREDRAW, (nint)BOOL.FALSE);
 
             try
             {
@@ -518,7 +518,7 @@ namespace System.Windows.Forms.Design
             finally
             {
                 // Resume redraw.
-                User32.SendMessageW(_listViewCannedMasks, User32.WM.SETREDRAW, PARAM.FromBool(true));
+                User32.SendMessageW(_listViewCannedMasks, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
                 _listViewCannedMasks.Invalidate();
             }
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
@@ -891,17 +891,13 @@ namespace System.Windows.Forms.Design
 
                                 try
                                 {
-                                    name = null;
-                                    if (comp.Site != null)
-                                    {
-                                        name = comp.Site.Name;
-                                    }
+                                    name = comp.Site?.Name;
 
                                     Control oldDesignerControl = null;
                                     if (updateLocation)
                                     {
                                         oldDesignerControl = client.GetDesignerControl();
-                                        User32.SendMessageW(oldDesignerControl.Handle, User32.WM.SETREDRAW);
+                                        User32.SendMessageW(oldDesignerControl.Handle, User32.WM.SETREDRAW, (nint)BOOL.FALSE);
                                     }
 
                                     Point dropPt = client.GetDesignerControl().PointToClient(new Point(de.X, de.Y));
@@ -950,10 +946,10 @@ namespace System.Windows.Forms.Design
                                         }
                                     }
 
-                                    if (oldDesignerControl != null)
+                                    if (oldDesignerControl is not null)
                                     {
                                         //((ComponentDataObject)dataObj).ShowControls();
-                                        User32.SendMessageW(oldDesignerControl.Handle, User32.WM.SETREDRAW, (IntPtr)1);
+                                        User32.SendMessageW(oldDesignerControl.Handle, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
                                         oldDesignerControl.Invalidate(true);
                                     }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ScrollableControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ScrollableControlDesigner.cs
@@ -28,8 +28,7 @@ namespace System.Windows.Forms.Design
                 return true;
             }
 
-            // The scroll bars on a form are "live"
-            //
+            // The scroll bars on a form are "live".
             ScrollableControl f = (ScrollableControl)Control;
             if (f.IsHandleCreated && f.AutoScroll)
             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ScrollableControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ScrollableControlDesigner.cs
@@ -33,7 +33,7 @@ namespace System.Windows.Forms.Design
             ScrollableControl f = (ScrollableControl)Control;
             if (f.IsHandleCreated && f.AutoScroll)
             {
-                int hitTest = (int)(long)User32.SendMessageW(f.Handle, User32.WM.NCHITTEST, IntPtr.Zero, PARAM.FromLowHigh(pt.X, pt.Y));
+                int hitTest = (int)User32.SendMessageW(f.Handle, User32.WM.NCHITTEST, 0, PARAM.FromLowHigh(pt.X, pt.Y));
                 if (hitTest == (int)User32.HT.VSCROLL || hitTest == (int)User32.HT.HSCROLL)
                 {
                     return true;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
@@ -909,12 +909,12 @@ namespace System.Windows.Forms.Design
                     tb.KeyDown += new KeyEventHandler(OnKeyDown);
                     tb.SelectAll();
                     Control baseComponent = null;
-                    if (_designerHost != null)
+                    if (_designerHost is not null)
                     {
                         baseComponent = (Control)_designerHost.RootComponent;
-                        User32.SendMessageW(baseComponent.Handle, User32.WM.SETREDRAW, IntPtr.Zero, IntPtr.Zero);
+                        User32.SendMessageW(baseComponent.Handle, User32.WM.SETREDRAW, (nint)BOOL.FALSE);
                         tb.Focus();
-                        User32.SendMessageW(baseComponent.Handle, User32.WM.SETREDRAW, (IntPtr)1, IntPtr.Zero);
+                        User32.SendMessageW(baseComponent.Handle, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
                     }
                 }
                 finally
@@ -994,15 +994,13 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void FocusForm()
         {
-            if (_component.Site.GetService(typeof(ISplitWindowService)) is DesignerFrame designerFrame)
+            if (_component.Site.GetService(typeof(ISplitWindowService)) is DesignerFrame designerFrame
+                && _designerHost is not null)
             {
-                if (_designerHost != null)
-                {
-                    Control baseComponent = (Control)_designerHost.RootComponent;
-                    User32.SendMessageW(baseComponent.Handle, User32.WM.SETREDRAW, IntPtr.Zero, IntPtr.Zero);
-                    designerFrame.Focus();
-                    User32.SendMessageW(baseComponent.Handle, User32.WM.SETREDRAW, (IntPtr)1, IntPtr.Zero);
-                }
+                Control baseComponent = (Control)_designerHost.RootComponent;
+                User32.SendMessageW(baseComponent.Handle, User32.WM.SETREDRAW, (nint)BOOL.FALSE);
+                designerFrame.Focus();
+                User32.SendMessageW(baseComponent.Handle, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TreeViewDesigner.cs
@@ -17,9 +17,9 @@ namespace System.Windows.Forms.Design
     /// </summary>
     internal class TreeViewDesigner : ControlDesigner
     {
-        private ComCtl32.TVHITTESTINFO tvhit;
+        private ComCtl32.TVHITTESTINFO _tvhit;
         private DesignerActionListCollection _actionLists;
-        private TreeView treeView;
+        private TreeView _treeView;
 
         public TreeViewDesigner()
         {
@@ -33,11 +33,11 @@ namespace System.Windows.Forms.Design
         {
             if (disposing)
             {
-                if (treeView != null)
+                if (_treeView != null)
                 {
-                    treeView.AfterExpand -= new TreeViewEventHandler(TreeViewInvalidate);
-                    treeView.AfterCollapse -= new TreeViewEventHandler(TreeViewInvalidate);
-                    treeView = null;
+                    _treeView.AfterExpand -= TreeViewInvalidate;
+                    _treeView.AfterCollapse -= TreeViewInvalidate;
+                    _treeView = null;
                 }
             }
 
@@ -45,53 +45,37 @@ namespace System.Windows.Forms.Design
         }
 
         /// <summary>
-        ///  <para>Allows your component to support a design time user interface. A TabStrip
+        ///  Allows your component to support a design time user interface. A TabStrip
         ///  control, for example, has a design time user interface that allows the user
         ///  to click the tabs to change tabs. To implement this, TabStrip returns
-        ///  true whenever the given point is within its tabs.</para>
+        ///  true whenever the given point is within its tabs.
         /// </summary>
         protected override bool GetHitTest(Point point)
         {
             point = Control.PointToClient(point);
-            tvhit.pt = point;
-            User32.SendMessageW(Control, (User32.WM)ComCtl32.TVM.HITTEST, IntPtr.Zero, ref tvhit);
-            if (tvhit.flags == ComCtl32.TVHT.ONITEMBUTTON)
-                return true;
-            return false;
+            _tvhit.pt = point;
+            User32.SendMessageW(Control, (User32.WM)ComCtl32.TVM.HITTEST, 0, ref _tvhit);
+            return _tvhit.flags == ComCtl32.TVHT.ONITEMBUTTON;
         }
 
         public override void Initialize(IComponent component)
         {
             base.Initialize(component);
-            treeView = component as TreeView;
-            Debug.Assert(treeView != null, "TreeView is null in TreeViewDesigner");
-            if (treeView != null)
+            _treeView = component as TreeView;
+            Debug.Assert(_treeView != null, "TreeView is null in TreeViewDesigner");
+            if (_treeView != null)
             {
-                treeView.AfterExpand += new TreeViewEventHandler(TreeViewInvalidate);
-                treeView.AfterCollapse += new TreeViewEventHandler(TreeViewInvalidate);
+                _treeView.AfterExpand += TreeViewInvalidate;
+                _treeView.AfterCollapse += TreeViewInvalidate;
             }
         }
 
-        private void TreeViewInvalidate(object sender, TreeViewEventArgs e)
-        {
-            if (treeView != null)
-            {
-                treeView.Invalidate();
-            }
-        }
+        private void TreeViewInvalidate(object sender, TreeViewEventArgs e) => _treeView?.Invalidate();
 
         public override DesignerActionListCollection ActionLists
-        {
-            get
-            {
-                if (_actionLists == null)
+            => _actionLists ??= new DesignerActionListCollection
                 {
-                    _actionLists = new DesignerActionListCollection();
-                    _actionLists.Add(new TreeViewActionList(this));
-                }
-
-                return _actionLists;
-            }
-        }
+                    new TreeViewActionList(this)
+                };
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVFINDINFOW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.LVFINDINFOW.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
         {
             public LVFI flags;
             public char* psz;
-            public IntPtr lParam;
+            public nint lParam;
             public Point pt;
             public uint vkDirection;
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
@@ -56,7 +56,7 @@ internal static partial class Interop
                 _handle = handle;
             }
 
-            public unsafe IntPtr SendMessage(IHandle sender, User32.WM message, BOOL state = BOOL.FALSE)
+            public unsafe nint SendMessage(IHandle sender, User32.WM message, BOOL state = BOOL.FALSE)
             {
                 Info.cbSize = (uint)sizeof(TTOOLINFOW);
                 fixed (char* c = Text)
@@ -67,7 +67,7 @@ internal static partial class Interop
                         Info.lpszText = c;
                     }
 
-                    IntPtr result = User32.SendMessageW(sender, message, (IntPtr)state, (IntPtr)i);
+                    nint result = User32.SendMessageW(sender, message, (nint)state, (nint)i);
                     GC.KeepAlive(_handle);
                     return result;
                 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateDcScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateDcScope.cs
@@ -47,7 +47,7 @@ internal static partial class Interop
 
             public static implicit operator HDC(in CreateDcScope dcScope) => dcScope.HDC;
             public static implicit operator HGDIOBJ(in CreateDcScope dcScope) => dcScope.HDC;
-            public static explicit operator IntPtr(in CreateDcScope dcScope) => dcScope.HDC.Handle;
+            public static implicit operator nint(in CreateDcScope dcScope) => dcScope.HDC.Handle;
 
             public bool IsNull => HDC.IsNull;
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.DeleteObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.DeleteObject.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        public static extern BOOL DeleteObject(IntPtr hObject);
+        private static extern BOOL DeleteObject(IntPtr hObject);
 
         public static BOOL DeleteObject(HGDIOBJ hObject) => DeleteObject(hObject.Handle);
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.HDC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.HDC.cs
@@ -8,15 +8,15 @@ internal static partial class Interop
     {
         public readonly struct HDC
         {
-            public IntPtr Handle { get; }
+            public nint Handle { get; }
 
-            public HDC(IntPtr handle) => Handle = handle;
+            public HDC(nint handle) => Handle = handle;
 
-            public bool IsNull => Handle == IntPtr.Zero;
+            public bool IsNull => Handle == 0;
 
-            public static explicit operator IntPtr(HDC hdc) => hdc.Handle;
-            public static explicit operator HDC(IntPtr hdc) => new HDC(hdc);
-            public static implicit operator HGDIOBJ(HDC hdc) => new HGDIOBJ(hdc.Handle);
+            public static implicit operator nint(HDC hdc) => hdc.Handle;
+            public static explicit operator HDC(nint hdc) => new(hdc);
+            public static implicit operator HGDIOBJ(HDC hdc) => new(hdc.Handle);
 
             public static bool operator ==(HDC value1, HDC value2) => value1.Handle == value2.Handle;
             public static bool operator !=(HDC value1, HDC value2) => value1.Handle != value2.Handle;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.HFONT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.HFONT.cs
@@ -8,16 +8,16 @@ internal static partial class Interop
     {
         public readonly struct HFONT
         {
-            public IntPtr Handle { get; }
+            public nint Handle { get; }
 
-            public HFONT(IntPtr handle) => Handle = handle;
+            public HFONT(nint handle) => Handle = handle;
 
-            public bool IsNull => Handle == IntPtr.Zero;
+            public bool IsNull => Handle == 0;
 
             public static implicit operator HGDIOBJ(HFONT hfont) => new HGDIOBJ(hfont.Handle);
             public static explicit operator HFONT(HGDIOBJ hfont) => new HFONT(hfont.Handle);
-            public static explicit operator HFONT(IntPtr hfont) => new HFONT(hfont);
-            public static explicit operator IntPtr(HFONT hfont) => hfont.Handle;
+            public static explicit operator HFONT(nint hfont) => new HFONT(hfont);
+            public static implicit operator IntPtr(HFONT hfont) => hfont.Handle;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Drawing;
-
 internal partial class Interop
 {
     /// <summary>
@@ -51,9 +49,6 @@ internal partial class Interop
         public static nint FromBool(bool value)
             => (nint)(value ? BOOL.TRUE : BOOL.FALSE);
 
-        public static nint FromColor(Color color)
-            => ColorTranslator.ToWin32(color);
-
         /// <summary>
         ///  Hard casts to <see langword="int" /> without bounds checks.
         /// </summary>
@@ -63,18 +58,5 @@ internal partial class Interop
         ///  Hard casts to <see langword="uint" /> without bounds checks.
         /// </summary>
         public static uint ToUInt(nint param) => (uint)param;
-
-        /// <summary>
-        ///  Hard casts to <see langword="long" /> without bounds checks.
-        /// </summary>
-        /// <remarks>
-        ///  Technically not needed, but here for completeness.
-        /// </remarks>
-        public static long ToLong(nint param) => param;
-
-        /// <summary>
-        ///  Hard casts to <see langword="ulong" /> without bounds checks.
-        /// </summary>
-        public static ulong ToULong(nint param) => (ulong)param;
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
@@ -11,15 +11,15 @@ internal partial class Interop
     /// </summary>
     internal static class PARAM
     {
-        public static IntPtr FromLowHigh(int low, int high)
-            => (IntPtr)ToInt(low, high);
+        public static nint FromLowHigh(int low, int high)
+            => (nint)ToInt(low, high);
 
-        public static IntPtr FromLowHighUnsigned(int low, int high)
+        public static nint FromLowHighUnsigned(int low, int high)
             // Convert the int to an uint before converting it to a pointer type,
             // which ensures the high dword being zero for 64-bit pointers.
             // This corresponds to the logic of the MAKELPARAM/MAKEWPARAM/MAKELRESULT
             // macros.
-            => unchecked((nint)(nuint)(uint)ToInt(low, high));
+            => (nint)(uint)ToInt(low, high);
 
         public static int ToInt(int low, int high)
             => (high << 16) | (low & 0xffff);
@@ -43,16 +43,16 @@ internal partial class Interop
             => SignedLOWORD(unchecked((int)n));
 
         public static int SignedHIWORD(int n)
-            => (int)(short)HIWORD(n);
+            => (short)HIWORD(n);
 
         public static int SignedLOWORD(int n)
-            => (int)(short)LOWORD(n);
+            => (short)LOWORD(n);
 
-        public static IntPtr FromBool(bool value)
-            => (IntPtr)(value ? BOOL.TRUE : BOOL.FALSE);
+        public static nint FromBool(bool value)
+            => (nint)(value ? BOOL.TRUE : BOOL.FALSE);
 
-        public static IntPtr FromColor(Color color)
-            => (IntPtr)ColorTranslator.ToWin32(color);
+        public static nint FromColor(Color color)
+            => ColorTranslator.ToWin32(color);
 
         /// <summary>
         ///  Hard casts to <see langword="int" /> without bounds checks.

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.SYSTEMTIME.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.SYSTEMTIME.cs
@@ -32,6 +32,21 @@ internal partial class Interop
                     sysTime.wMonth, sysTime.wDay, sysTime.wHour,
                     sysTime.wMinute, sysTime.wSecond, sysTime.wMilliseconds);
             }
+
+            /// <summary>
+            ///  Converts <see cref="DateTime"/> value with a 1 second granularity.
+            /// </summary>
+            public static implicit operator SYSTEMTIME(DateTime time) => new Kernel32.SYSTEMTIME
+            {
+                wYear = (short)time.Year,
+                wMonth = (short)time.Month,
+                wDayOfWeek = (short)time.DayOfWeek,
+                wDay = (short)time.Day,
+                wHour = (short)time.Hour,
+                wMinute = (short)time.Minute,
+                wSecond = (short)time.Second,
+                wMilliseconds = 0
+            };
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GWL.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GWL.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
     internal static partial class User32
     {
         /// <summary>
-        ///  Window long values for <see cref="SetWindowLong(IntPtr, GWL, IntPtr)"/> and
+        ///  Window long values for <see cref="SetWindowLong(IntPtr, GWL, nint)"/> and
         ///  <see cref="GetWindowLong(IntPtr, GWL)"/>.
         /// </summary>
         public enum GWL : int

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowLong.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowLong.cs
@@ -10,14 +10,14 @@ internal static partial class Interop
     {
         // We only ever call this on 32 bit so IntPtr is correct
         [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        private static extern IntPtr GetWindowLongW(IntPtr hWnd, GWL nIndex);
+        private static extern nint GetWindowLongW(IntPtr hWnd, GWL nIndex);
 
         [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr GetWindowLongPtrW(IntPtr hWnd, GWL nIndex);
+        public static extern nint GetWindowLongPtrW(IntPtr hWnd, GWL nIndex);
 
-        public static IntPtr GetWindowLong(IntPtr hWnd, GWL nIndex)
+        public static nint GetWindowLong(IntPtr hWnd, GWL nIndex)
         {
-            if (IntPtr.Size == 4)
+            if (!Environment.Is64BitProcess)
             {
                 return GetWindowLongW(hWnd, nIndex);
             }
@@ -25,16 +25,16 @@ internal static partial class Interop
             return GetWindowLongPtrW(hWnd, nIndex);
         }
 
-        public static IntPtr GetWindowLong(IHandle hWnd, GWL nIndex)
+        public static nint GetWindowLong(IHandle hWnd, GWL nIndex)
         {
-            IntPtr result = GetWindowLong(hWnd.Handle, nIndex);
+            nint result = GetWindowLong(hWnd.Handle, nIndex);
             GC.KeepAlive(hWnd);
             return result;
         }
 
-        public static IntPtr GetWindowLong(HandleRef hWnd, GWL nIndex)
+        public static nint GetWindowLong(HandleRef hWnd, GWL nIndex)
         {
-            IntPtr result = GetWindowLong(hWnd.Handle, nIndex);
+            nint result = GetWindowLong(hWnd.Handle, nIndex);
             GC.KeepAlive(hWnd.Wrapper);
             return result;
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.PostMessageW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.PostMessageW.cs
@@ -12,14 +12,14 @@ internal static partial class Interop
         public static extern BOOL PostMessageW(
             IntPtr hWnd,
             WM Msg,
-            IntPtr wParam = default,
-            IntPtr lParam = default);
+            nint wParam = default,
+            nint lParam = default);
 
         public static BOOL PostMessageW(
             IHandle hWnd,
             WM Msg,
-            IntPtr wParam = default,
-            IntPtr lParam = default)
+            nint wParam = default,
+            nint lParam = default)
         {
             BOOL result = PostMessageW(hWnd.Handle, Msg, wParam, lParam);
             GC.KeepAlive(hWnd);
@@ -29,8 +29,8 @@ internal static partial class Interop
         public static BOOL PostMessageW(
             HandleRef hWnd,
             WM Msg,
-            IntPtr wParam = default,
-            IntPtr lParam = default)
+            nint wParam = default,
+            nint lParam = default)
         {
             BOOL result = PostMessageW(hWnd.Handle, Msg, wParam, lParam);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendMessageW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendMessageW.cs
@@ -9,95 +9,72 @@ internal static partial class Interop
     internal static partial class User32
     {
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr SendMessageW(
+        public static extern nint SendMessageW(
             IntPtr hWnd,
             WM Msg,
-            IntPtr wParam = default,
-            IntPtr lParam = default);
+            nint wParam = default,
+            nint lParam = default);
 
-        public static IntPtr SendMessageW(
-            HandleRef hWnd,
-            WM Msg,
-            IntPtr wParam = default,
-            IntPtr lParam = default)
-        {
-            IntPtr result = SendMessageW(hWnd.Handle, Msg, wParam, lParam);
-            GC.KeepAlive(hWnd.Wrapper);
-            return result;
-        }
-
-        public static IntPtr SendMessageW(
+        public static nint SendMessageW(
             IHandle hWnd,
             WM Msg,
-            IntPtr wParam = default,
-            IntPtr lParam = default)
+            nint wParam = default,
+            nint lParam = default)
         {
-            IntPtr result = SendMessageW(hWnd.Handle, Msg, wParam, lParam);
+            nint result = SendMessageW(hWnd.Handle, Msg, wParam, lParam);
             GC.KeepAlive(hWnd);
             return result;
         }
 
-        public unsafe static IntPtr SendMessageW(
+        public unsafe static nint SendMessageW(
             IntPtr hWnd,
             WM Msg,
-            IntPtr wParam,
+            nint wParam,
             string lParam)
         {
             fixed (char* c = lParam)
             {
-                return SendMessageW(hWnd, Msg, wParam, (IntPtr)(void*)c);
+                return SendMessageW(hWnd, Msg, wParam, (nint)c);
             }
         }
 
-        public unsafe static IntPtr SendMessageW(
-            HandleRef hWnd,
-            WM Msg,
-            IntPtr wParam,
-            string lParam)
-        {
-            fixed (char* c = lParam)
-            {
-                return SendMessageW(hWnd, Msg, wParam, (IntPtr)(void*)c);
-            }
-        }
-
-        public unsafe static IntPtr SendMessageW(
+        public unsafe static nint SendMessageW(
             IHandle hWnd,
             WM Msg,
-            IntPtr wParam,
+            nint wParam,
             string lParam)
         {
             fixed (char* c = lParam)
             {
-                return SendMessageW(hWnd, Msg, wParam, (IntPtr)(void*)c);
+                return SendMessageW(hWnd, Msg, wParam, (nint)c);
             }
         }
 
-        public unsafe static IntPtr SendMessageW<T>(
+        public unsafe static nint SendMessageW<T>(
             IntPtr hWnd,
             WM Msg,
-            IntPtr wParam,
+            nint wParam,
             ref T lParam) where T : unmanaged
         {
             fixed (void* l = &lParam)
             {
-                return SendMessageW(hWnd, Msg, wParam, (IntPtr)l);
+                return SendMessageW(hWnd, Msg, wParam, (nint)l);
             }
         }
 
-        public unsafe static IntPtr SendMessageW<T>(
+        public unsafe static nint SendMessageW<T>(
             IHandle hWnd,
             WM Msg,
-            IntPtr wParam,
+            nint wParam,
             ref T lParam) where T : unmanaged
         {
             fixed (void* l = &lParam)
             {
-                return SendMessageW(hWnd, Msg, wParam, (IntPtr)l);
+                return SendMessageW(hWnd, Msg, wParam, (nint)l);
             }
         }
 
-        public unsafe static IntPtr SendMessageW<TWParam, TLParam>(
+        public unsafe static nint SendMessageW<TWParam, TLParam>(
             IHandle hWnd,
             WM Msg,
             ref TWParam wParam,
@@ -107,7 +84,7 @@ internal static partial class Interop
         {
             fixed (void* w = &wParam, l = &lParam)
             {
-                return SendMessageW(hWnd, Msg, (IntPtr)w, (IntPtr)l);
+                return SendMessageW(hWnd, Msg, (nint)w, (nint)l);
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowLong.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowLong.cs
@@ -10,14 +10,14 @@ internal static partial class Interop
     {
         // We only ever call this on 32 bit so IntPtr is correct
         [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        private static extern IntPtr SetWindowLongW(IntPtr hWnd, GWL nIndex, IntPtr dwNewLong);
+        private static extern IntPtr SetWindowLongW(IntPtr hWnd, GWL nIndex, nint dwNewLong);
 
         [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr SetWindowLongPtrW(IntPtr hWnd, GWL nIndex, IntPtr dwNewLong);
+        public static extern IntPtr SetWindowLongPtrW(IntPtr hWnd, GWL nIndex, nint dwNewLong);
 
-        public static IntPtr SetWindowLong(IntPtr hWnd, GWL nIndex, IntPtr dwNewLong)
+        public static IntPtr SetWindowLong(IntPtr hWnd, GWL nIndex, nint dwNewLong)
         {
-            if (IntPtr.Size == 4)
+            if (!Environment.Is64BitProcess)
             {
                 return SetWindowLongW(hWnd, nIndex, dwNewLong);
             }
@@ -25,18 +25,10 @@ internal static partial class Interop
             return SetWindowLongPtrW(hWnd, nIndex, dwNewLong);
         }
 
-        public static IntPtr SetWindowLong(IHandle hWnd, GWL nIndex, IntPtr dwNewLong)
+        public static IntPtr SetWindowLong(IHandle hWnd, GWL nIndex, nint dwNewLong)
         {
             IntPtr result = SetWindowLong(hWnd.Handle, nIndex, dwNewLong);
             GC.KeepAlive(hWnd);
-            return result;
-        }
-
-        public static IntPtr SetWindowLong(IHandle hWnd, GWL nIndex, IHandle dwNewLong)
-        {
-            IntPtr result = SetWindowLong(hWnd.Handle, nIndex, dwNewLong.Handle);
-            GC.KeepAlive(hWnd);
-            GC.KeepAlive(dwNewLong);
             return result;
         }
 
@@ -56,27 +48,10 @@ internal static partial class Interop
             return result;
         }
 
-        public static IntPtr SetWindowLong(IntPtr hWnd, GWL nIndex, WNDPROC dwNewLong)
+        public static IntPtr SetWindowLong(IntPtr hWnd, GWL nIndex, WNDPROCINT dwNewLong)
         {
             IntPtr pointer = Marshal.GetFunctionPointerForDelegate(dwNewLong);
             IntPtr result = SetWindowLong(hWnd, nIndex, pointer);
-            GC.KeepAlive(dwNewLong);
-            return result;
-        }
-
-        public static IntPtr SetWindowLong(HandleRef hWnd, GWL nIndex, WNDPROCINT dwNewLong)
-        {
-            IntPtr pointer = Marshal.GetFunctionPointerForDelegate(dwNewLong);
-            IntPtr result = SetWindowLong(hWnd.Handle, nIndex, pointer);
-            GC.KeepAlive(hWnd.Wrapper);
-            return result;
-        }
-
-        public static IntPtr SetWindowLong(HandleRef hWnd, GWL nIndex, HandleRef dwNewLong)
-        {
-            IntPtr result = SetWindowLong(hWnd.Handle, nIndex, dwNewLong.Handle);
-            GC.KeepAlive(hWnd.Wrapper);
-            GC.KeepAlive(dwNewLong.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/System/Drawing/ColorExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Drawing/ColorExtensions.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Drawing
+{
+    internal static class ColorExtensions
+    {
+        public static int ToWin32(this Color color) => ColorTranslator.ToWin32(color);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextHdcScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextHdcScope.cs
@@ -34,12 +34,15 @@ namespace System.Windows.Forms
         ///  Gets the <see cref="Gdi32.HDC"/> from the given <paramref name="deviceContext"/>.
         /// </summary>
         /// <remarks>
-        ///  When a <see cref="Graphics"/> object is created from a <see cref="Gdi32.HDC"/> the clipping region and
-        ///  the viewport origin are applied (<see cref="Gdi32.GetViewportExtEx(Gdi32.HDC, out Size)"/>). The clipping
-        ///  region isn't reflected in <see cref="Graphics.Clip"/>, which is combined with the HDC HRegion.
-        ///
-        ///  The Graphics object saves and restores DC state when performing operations that would modify the DC to
-        ///  maintain the DC in its original or returned state after <see cref="Graphics.ReleaseHdc()"/>.
+        ///  <para>
+        ///   When a <see cref="Graphics"/> object is created from a <see cref="Gdi32.HDC"/> the clipping region and
+        ///   the viewport origin are applied (<see cref="Gdi32.GetViewportExtEx(Gdi32.HDC, out Size)"/>). The clipping
+        ///   region isn't reflected in <see cref="Graphics.Clip"/>, which is combined with the HDC HRegion.
+        ///  </para>
+        ///  <para>
+        ///   The Graphics object saves and restores DC state when performing operations that would modify the DC to
+        ///   maintain the DC in its original or returned state after <see cref="Graphics.ReleaseHdc()"/>.
+        ///  </para>
         /// </remarks>
         /// <param name="applyGraphicsState">
         ///  Applies the origin transform and clipping region of the <paramref name="deviceContext"/> if it is an
@@ -62,7 +65,9 @@ namespace System.Windows.Forms
         ///  Prefer to use <see cref="DeviceContextHdcScope(IDeviceContext, bool, bool)"/>.
         /// </summary>
         /// <remarks>
-        ///  Ideally we'd not bifurcate what properties we apply unless we're absolutely sure we only want one.
+        ///  <para>
+        ///   Ideally we'd not bifurcate what properties we apply unless we're absolutely sure we only want one.
+        ///  </para>
         /// </remarks>
         public unsafe DeviceContextHdcScope(
             IDeviceContext deviceContext,
@@ -74,7 +79,9 @@ namespace System.Windows.Forms
                 // As we're throwing in the constructor, `this` will never be passed back and as such .Dispose()
                 // can't be called. We don't have anything to release at this point so there is no point in having
                 // the finalizer run.
+#if DEBUG
                 DisposalTracking.SuppressFinalize(this!);
+#endif
                 throw new ArgumentNullException(nameof(deviceContext));
             }
 
@@ -204,7 +211,7 @@ namespace System.Windows.Forms
         }
 
         public static implicit operator Gdi32.HDC(in DeviceContextHdcScope scope) => scope.HDC;
-        public static explicit operator IntPtr(in DeviceContextHdcScope scope) => scope.HDC.Handle;
+        public static implicit operator nint(in DeviceContextHdcScope scope) => scope.HDC.Handle;
 
         [Conditional("DEBUG")]
         private void ValidateHDC()
@@ -212,7 +219,9 @@ namespace System.Windows.Forms
             if (HDC.IsNull)
             {
                 // We don't want the disposal tracking to fire as it will take down unrelated tests.
+#if DEBUG
                 DisposalTracking.SuppressFinalize(this!);
+#endif
                 throw new InvalidOperationException("Null HDC");
             }
 
@@ -225,7 +234,9 @@ namespace System.Windows.Forms
                 case Gdi32.OBJ.ENHMETADC:
                     break;
                 default:
+#if DEBUG
                     DisposalTracking.SuppressFinalize(this!);
+#endif
                     throw new InvalidOperationException($"Invalid handle ({type})");
             }
         }
@@ -238,12 +249,14 @@ namespace System.Windows.Forms
             }
 
             // Note that Graphics keeps track of the HDC it passes back, so we don't need to pass it back in
-            if (!(DeviceContext is IGraphicsHdcProvider))
+            if (DeviceContext is not IGraphicsHdcProvider)
             {
                 DeviceContext?.ReleaseHdc();
             }
 
+#if DEBUG
             DisposalTracking.SuppressFinalize(this!);
+#endif
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/DeviceContextScopeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/DeviceContextScopeTests.cs
@@ -84,7 +84,7 @@ namespace System.Windows.Forms.Tests
             try
             {
                 // We get the same HDC out
-                Assert.Equal(dcScope.HDC.Handle, hdc);
+                Assert.Equal(dcScope.HDC.Handle, (nint)hdc);
                 current = Gdi32.GetCurrentObject(dcScope, Gdi32.OBJ.BRUSH);
                 Assert.Equal(blueBrush.HBrush.Handle, current.Handle);
                 Gdi32.SelectObject(dcScope, redBrush);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ModalApplicationContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ModalApplicationContext.cs
@@ -31,7 +31,7 @@ namespace System.Windows.Forms
                 if (MainForm is not null && MainForm.IsHandleCreated)
                 {
                     // Get ahold of the parenting control
-                    IntPtr parentHandle = Interop.User32.GetWindowLong(new HandleRef(this, MainForm.Handle), User32.GWL.HWNDPARENT);
+                    IntPtr parentHandle = Interop.User32.GetWindowLong(MainForm, User32.GWL.HWNDPARENT);
 
                     parentControl = Control.FromHandle(parentHandle);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -1059,19 +1059,14 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  "Parks" the given HWND to a temporary HWND.  This allows WS_CHILD windows to
-        ///  be parked.
+        ///  "Parks" the given HWND to a temporary HWND. This allows WS_CHILD windows to be parked.
         /// </summary>
         internal static void ParkHandle(HandleRef handle, IntPtr dpiAwarenessContext)
         {
             Debug.Assert(User32.IsWindow(handle).IsTrue(), "Handle being parked is not a valid window handle");
-            Debug.Assert((PARAM.ToInt(User32.GetWindowLong(handle, User32.GWL.STYLE)) & (int)User32.WS.CHILD) != 0, "Only WS_CHILD windows should be parked.");
+            Debug.Assert(((User32.WS)User32.GetWindowLong(handle, User32.GWL.STYLE)).HasFlag(User32.WS.CHILD), "Only WS_CHILD windows should be parked.");
 
-            ThreadContext threadContext = GetContextForHandle(handle);
-            if (threadContext is not null)
-            {
-                threadContext.GetParkingWindow(dpiAwarenessContext).ParkHandle(handle);
-            }
+            GetContextForHandle(handle)?.GetParkingWindow(dpiAwarenessContext).ParkHandle(handle);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -1400,7 +1400,7 @@ namespace System.Windows.Forms
                 return true;
             }
 
-            if (unchecked((int)(long)User32.SendMessageW(this, REGMSG_MSG)) == (int)REGMSG_RETVAL)
+            if ((int)User32.SendMessageW(this, REGMSG_MSG) == (int)REGMSG_RETVAL)
             {
                 wndprocAddr = currentWndproc;
                 return true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -1099,7 +1099,7 @@ namespace System.Windows.Forms
                     //
                     if (!OwnerDraw)
                     {
-                        User32.SendMessageW(this, (User32.WM)User32.BM.SETSTATE, PARAM.FromBool(true));
+                        User32.SendMessageW(this, (User32.WM)User32.BM.SETSTATE, (nint)BOOL.TRUE);
                     }
 
                     Invalidate(DownChangeRectangle);
@@ -1128,7 +1128,7 @@ namespace System.Windows.Forms
                 {
                     SetFlag(FlagMousePressed, false);
                     SetFlag(FlagMouseDown, false);
-                    User32.SendMessageW(this, (User32.WM)User32.BM.SETSTATE, PARAM.FromBool(false));
+                    User32.SendMessageW(this, (User32.WM)User32.BM.SETSTATE, (nint)BOOL.FALSE);
                 }
 
                 // Breaking change: specifically filter out Keys.Enter and Keys.Space as the only

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.cs
@@ -214,7 +214,7 @@ namespace System.Windows.Forms
 
                     if (IsHandleCreated)
                     {
-                        User32.SendMessageW(this, (User32.WM)User32.BM.SETCHECK, (IntPtr)_checkState);
+                        User32.SendMessageW(this, (User32.WM)User32.BM.SETCHECK, (nint)_checkState);
                     }
 
                     if (oldChecked != Checked)
@@ -529,7 +529,7 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)User32.BM.SETCHECK, (IntPtr)_checkState);
+                User32.SendMessageW(this, (User32.WM)User32.BM.SETCHECK, (nint)_checkState);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -421,10 +421,7 @@ namespace System.Windows.Forms
         ///  Indicates if the given item is, in any way, shape, or form, checked.
         ///  This will return true if the item is fully or indeterminately checked.
         /// </summary>
-        public bool GetItemChecked(int index)
-        {
-            return (GetItemCheckState(index) != CheckState.Unchecked);
-        }
+        public bool GetItemChecked(int index) => GetItemCheckState(index) != CheckState.Unchecked;
 
         /// <summary>
         ///  Invalidates the given item in the listbox
@@ -434,7 +431,7 @@ namespace System.Windows.Forms
             if (IsHandleCreated)
             {
                 var rect = new RECT();
-                SendMessageW(this, (WM)LB.GETITEMRECT, (IntPtr)index, ref rect);
+                SendMessageW(this, (WM)LB.GETITEMRECT, index, ref rect);
                 InvalidateRect(new HandleRef(this, Handle), &rect, BOOL.FALSE);
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -503,7 +503,7 @@ namespace System.Windows.Forms
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            SendMessageW(this, (WM)LB.SETITEMHEIGHT, IntPtr.Zero, (IntPtr)ItemHeight);
+            SendMessageW(this, (WM)LB.SETITEMHEIGHT, 0, ItemHeight);
         }
 
         /// <summary>
@@ -803,14 +803,12 @@ namespace System.Windows.Forms
         protected override void OnFontChanged(EventArgs e)
         {
             // Update the item height
-            //
             if (IsHandleCreated)
             {
-                SendMessageW(this, (WM)LB.SETITEMHEIGHT, IntPtr.Zero, (IntPtr)ItemHeight);
+                SendMessageW(this, (WM)LB.SETITEMHEIGHT, 0, ItemHeight);
             }
 
             // The base OnFontChanged will adjust the height of the CheckedListBox accordingly
-            //
             base.OnFontChanged(e);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -404,10 +404,10 @@ namespace System.Windows.Forms
                     IntPtr hwndHdr = User32.SendMessageW(ListView, (User32.WM)LVM.GETHEADER);
                     if (hwndHdr != IntPtr.Zero)
                     {
-                        int nativeColumnCount = PARAM.ToInt(User32.SendMessageW(hwndHdr, (User32.WM)HDM.GETITEMCOUNT));
+                        int nativeColumnCount = (int)User32.SendMessageW(hwndHdr, (User32.WM)HDM.GETITEMCOUNT);
                         if (Index < nativeColumnCount)
                         {
-                            _width = PARAM.ToInt(User32.SendMessageW(ListView, (User32.WM)LVM.GETCOLUMNWIDTH, (IntPtr)Index));
+                            _width = (int)User32.SendMessageW(ListView, (User32.WM)LVM.GETCOLUMNWIDTH, Index);
                         }
                     }
                 }
@@ -489,7 +489,7 @@ namespace System.Windows.Forms
             {
                 fixed (int* pCols = cols)
                 {
-                    User32.SendMessageW(ListView, (User32.WM)LVM.SETCOLUMNORDERARRAY, (IntPtr)cols.Length, (IntPtr)pCols);
+                    User32.SendMessageW(ListView, (User32.WM)LVM.SETCOLUMNORDERARRAY, cols.Length, (nint)pCols);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -46,11 +46,11 @@ namespace System.Windows.Forms
                     IntPtr listHandle = _owningComboBox.GetListHandle();
                     RECT itemRect = new();
 
-                    int result = unchecked((int)(long)User32.SendMessageW(
+                    int result = (int)User32.SendMessageW(
                         listHandle,
                         (User32.WM)User32.LB.GETITEMRECT,
-                        (IntPtr)currentIndex,
-                        ref itemRect));
+                        currentIndex,
+                        ref itemRect);
 
                     if (result == User32.LB_ERR)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -263,7 +263,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                User32.SendMessageW(_owningComboBox, (User32.WM)User32.CB.SETTOPINDEX, (IntPtr)GetCurrentIndex());
+                User32.SendMessageW(_owningComboBox, (User32.WM)User32.CB.SETTOPINDEX, GetCurrentIndex());
             }
 
             internal override void SetFocus()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
@@ -73,7 +73,7 @@ namespace System.Windows.Forms
                         return false;
                     }
 
-                    ES extendedStyle = (ES)(long)GetWindowLong(_owningChildEdit, GWL.STYLE);
+                    ES extendedStyle = (ES)GetWindowLong(_owningChildEdit, GWL.STYLE);
                     return extendedStyle.HasFlag(ES.AUTOHSCROLL);
                 }
             }
@@ -391,7 +391,7 @@ namespace System.Windows.Forms
             {
                 // Send an EM_GETRECT message to find out the bounding rectangle.
                 RECT rectangle = new RECT();
-                SendMessageW(_owningChildEdit, (WM)EM.GETRECT, IntPtr.Zero, ref rectangle);
+                SendMessageW(_owningChildEdit, (WM)EM.GETRECT, 0, ref rectangle);
 
                 return rectangle;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
@@ -360,12 +360,12 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                SendMessageW(_owningChildEdit, (WM)EM.SETSEL, (IntPtr)start, (IntPtr)end);
+                SendMessageW(_owningChildEdit, (WM)EM.SETSEL, start, end);
             }
 
             private int GetCharIndexFromPosition(Point pt)
             {
-                int index = (int)User32.SendMessageW(_owningChildEdit, (WM)EM.CHARFROMPOS, IntPtr.Zero, PARAM.FromLowHigh(pt.X, pt.Y));
+                int index = (int)User32.SendMessageW(_owningChildEdit, (WM)EM.CHARFROMPOS, 0, PARAM.FromLowHigh(pt.X, pt.Y));
                 index = PARAM.LOWORD(index);
 
                 if (index < 0)
@@ -403,7 +403,7 @@ namespace System.Windows.Forms
                     return Point.Empty;
                 }
 
-                int i = (int)SendMessageW(_owningChildEdit, (WM)EM.POSFROMCHAR, (IntPtr)index);
+                int i = (int)SendMessageW(_owningChildEdit, (WM)EM.POSFROMCHAR, index);
 
                 return new Point(PARAM.SignedLOWORD(i), PARAM.SignedHIWORD(i));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
@@ -115,7 +115,7 @@ namespace System.Windows.Forms
 
             public override int TextLength
                 => _owningComboBox.IsHandleCreated
-                    ? (int)(long)SendMessageW(_owningChildEdit, WM.GETTEXTLENGTH)
+                    ? (int)SendMessageW(_owningChildEdit, WM.GETTEXTLENGTH)
                     : -1;
 
             public override WS_EX WindowExStyle
@@ -365,7 +365,7 @@ namespace System.Windows.Forms
 
             private int GetCharIndexFromPosition(Point pt)
             {
-                int index = (int)(long)User32.SendMessageW(_owningChildEdit, (WM)EM.CHARFROMPOS, IntPtr.Zero, PARAM.FromLowHigh(pt.X, pt.Y));
+                int index = (int)User32.SendMessageW(_owningChildEdit, (WM)EM.CHARFROMPOS, IntPtr.Zero, PARAM.FromLowHigh(pt.X, pt.Y));
                 index = PARAM.LOWORD(index);
 
                 if (index < 0)
@@ -403,7 +403,7 @@ namespace System.Windows.Forms
                     return Point.Empty;
                 }
 
-                int i = (int)(long)SendMessageW(_owningChildEdit, (WM)EM.POSFROMCHAR, (IntPtr)index);
+                int i = (int)SendMessageW(_owningChildEdit, (WM)EM.POSFROMCHAR, (IntPtr)index);
 
                 return new Point(PARAM.SignedLOWORD(i), PARAM.SignedHIWORD(i));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -1106,7 +1106,7 @@ namespace System.Windows.Forms
                     CreateControl();
                     if (IsHandleCreated && _childEdit is not null)
                     {
-                        SendMessageW(new HandleRef(this, _childEdit.Handle), (WM)EM.REPLACESEL, (IntPtr)(-1), str);
+                        SendMessageW(_childEdit, (WM)EM.REPLACESEL, -1, str);
                     }
                 }
             }
@@ -1739,7 +1739,7 @@ namespace System.Windows.Forms
                     DefChildWndProc(ref m);
                     if (_childEdit is not null && m.HWnd == _childEdit.Handle)
                     {
-                        SendMessageW(new HandleRef(this, _childEdit.Handle), (WM)EM.SETMARGINS, (IntPtr)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
+                        SendMessageW(_childEdit, (WM)EM.SETMARGINS, (nint)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
                     }
 
                     break;
@@ -2330,13 +2330,12 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Adds the given item to the native combo box.  This asserts if the handle hasn't been
-        ///  created.
+        ///  Adds the given item to the native combo box.
         /// </summary>
         private int NativeAdd(object item)
         {
             Debug.Assert(IsHandleCreated, "Shouldn't be calling Native methods before the handle is created.");
-            int insertIndex = unchecked((int)(long)SendMessageW(this, (WM)CB.ADDSTRING, IntPtr.Zero, GetItemText(item)));
+            int insertIndex = (int)SendMessageW(this, (WM)CB.ADDSTRING, 0, GetItemText(item));
             if (insertIndex < 0)
             {
                 throw new OutOfMemoryException(SR.ComboBoxItemOverflow);
@@ -2400,13 +2399,13 @@ namespace System.Windows.Forms
         private int NativeInsert(int index, object item)
         {
             Debug.Assert(IsHandleCreated, "Shouldn't be calling Native methods before the handle is created.");
-            int insertIndex = unchecked((int)(long)SendMessageW(this, (WM)CB.INSERTSTRING, (IntPtr)index, GetItemText(item)));
+            int insertIndex = (int)SendMessageW(this, (WM)CB.INSERTSTRING, index, GetItemText(item));
             if (insertIndex < 0)
             {
                 throw new OutOfMemoryException(SR.ComboBoxItemOverflow);
             }
 
-            Debug.Assert(insertIndex == index, "NativeComboBox inserted at " + insertIndex + " not the requested index of " + index);
+            Debug.Assert(insertIndex == index, $"NativeComboBox inserted at {insertIndex} not the requested index of {index}");
             return insertIndex;
         }
 
@@ -2421,7 +2420,7 @@ namespace System.Windows.Forms
             // currently selected item.  Test for this and invalidate.  Note that because
             // invalidate will lazy-paint we can actually invalidate before we send the
             // delete message.
-            //
+
             if (DropDownStyle == ComboBoxStyle.DropDownList && SelectedIndex == index)
             {
                 Invalidate();
@@ -2477,23 +2476,21 @@ namespace System.Windows.Forms
                 IntPtr hwnd = GetWindow(new HandleRef(this, Handle), GW.CHILD);
                 if (hwnd != IntPtr.Zero)
                 {
-                    // if it's a simple dropdown list, the first HWND is the list box.
-                    //
+                    // If it's a simple dropdown list, the first HWND is the list box.
                     if (DropDownStyle == ComboBoxStyle.Simple)
                     {
                         _childListBox = new ComboBoxChildNativeWindow(this, ChildWindowType.ListBox);
                         _childListBox.AssignHandle(hwnd);
 
-                        // get the edits hwnd...
-                        //
+                        // Get the edits hwnd...
                         hwnd = GetWindow(new HandleRef(this, hwnd), GW.HWNDNEXT);
                     }
 
                     _childEdit = new ComboBoxChildNativeWindow(this, ChildWindowType.Edit);
                     _childEdit.AssignHandle(hwnd);
 
-                    // set the initial margin for combobox to be zero (this is also done whenever the font is changed).
-                    SendMessageW(new HandleRef(this, _childEdit.Handle), (WM)EM.SETMARGINS, (IntPtr)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
+                    // Set the initial margin for combobox to be zero (this is also done whenever the font is changed).
+                    SendMessageW(_childEdit, (WM)EM.SETMARGINS, (nint)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
                 }
             }
 
@@ -3614,7 +3611,7 @@ namespace System.Windows.Forms
             {
                 if (_childEdit is not null && _childEdit.Handle != IntPtr.Zero)
                 {
-                    SendMessageW(new HandleRef(this, _childEdit.Handle), WM.SETTEXT, IntPtr.Zero, s);
+                    SendMessageW(_childEdit, WM.SETTEXT, IntPtr.Zero, s);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -486,7 +486,7 @@ namespace System.Windows.Forms
                     Properties.SetInteger(PropDropDownWidth, value);
                     if (IsHandleCreated)
                     {
-                        SendMessageW(this, (WM)CB.SETDROPPEDWIDTH, (IntPtr)value);
+                        SendMessageW(this, (WM)CB.SETDROPPEDWIDTH, value);
                     }
                 }
             }
@@ -556,7 +556,7 @@ namespace System.Windows.Forms
                     CreateHandle();
                 }
 
-                SendMessageW(this, (WM)CB.SHOWDROPDOWN, (IntPtr)(value ? -1 : 0));
+                SendMessageW(this, (WM)CB.SHOWDROPDOWN, value ? -1 : 0);
             }
         }
 
@@ -812,7 +812,7 @@ namespace System.Windows.Forms
                     Properties.SetInteger(PropMaxLength, value);
                     if (IsHandleCreated)
                     {
-                        SendMessageW(this, (WM)CB.LIMITTEXT, (IntPtr)value);
+                        SendMessageW(this, (WM)CB.LIMITTEXT, value);
                     }
                 }
             }
@@ -1018,7 +1018,7 @@ namespace System.Windows.Forms
 
                     if (IsHandleCreated)
                     {
-                        SendMessageW(this, (WM)CB.SETCURSEL, (IntPtr)value);
+                        SendMessageW(this, (WM)CB.SETCURSEL, value);
                     }
                     else
                     {
@@ -1124,7 +1124,7 @@ namespace System.Windows.Forms
             {
                 int end = 0;
                 int start = 0;
-                SendMessageW(this, (WM)CB.GETEDITSEL, (IntPtr)(&start), (IntPtr)(&end));
+                SendMessageW(this, (WM)CB.GETEDITSEL, (nint)(&start), (nint)(&end));
                 return end - start;
             }
             set
@@ -1145,7 +1145,7 @@ namespace System.Windows.Forms
             get
             {
                 int value = 0;
-                SendMessageW(this, (WM)CB.GETEDITSEL, (IntPtr)(&value), IntPtr.Zero);
+                SendMessageW(this, (WM)CB.GETEDITSEL, (nint)(&value), 0);
                 return value;
             }
             set
@@ -2143,7 +2143,7 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                int h = (int)SendMessageW(this, (WM)CB.GETITEMHEIGHT, (IntPtr)index);
+                int h = (int)SendMessageW(this, (WM)CB.GETITEMHEIGHT, index);
                 if (h == -1)
                 {
                     throw new Win32Exception();
@@ -2368,7 +2368,7 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe string NativeGetItemText(int index)
         {
-            int maxLength = PARAM.ToInt(SendMessageW(this, (WM)CB.GETLBTEXTLEN, (IntPtr)index));
+            int maxLength = (int)SendMessageW(this, (WM)CB.GETLBTEXTLEN, index);
             if (maxLength == LB_ERR)
             {
                 return string.Empty;
@@ -2378,7 +2378,7 @@ namespace System.Windows.Forms
             string result;
             fixed (char* pText = text)
             {
-                int actualLength = PARAM.ToInt(SendMessageW(this, (WM)CB.GETLBTEXT, (IntPtr)index, (IntPtr)pText));
+                int actualLength = (int)SendMessageW(this, (WM)CB.GETLBTEXT, index, (nint)pText);
                 Debug.Assert(actualLength != LB_ERR, "Should have validated the index above");
                 if (actualLength == LB_ERR)
                 {
@@ -2426,7 +2426,7 @@ namespace System.Windows.Forms
                 Invalidate();
             }
 
-            SendMessageW(this, (WM)CB.DELETESTRING, (IntPtr)index);
+            SendMessageW(this, (WM)CB.DELETESTRING, index);
         }
 
         internal override void RecreateHandleCore()
@@ -2461,7 +2461,7 @@ namespace System.Windows.Forms
 
             if (MaxLength > 0)
             {
-                SendMessageW(this, (WM)CB.LIMITTEXT, (IntPtr)MaxLength);
+                SendMessageW(this, (WM)CB.LIMITTEXT, MaxLength);
             }
 
             // Get the handles and wndprocs of the ComboBox's child windows
@@ -2497,7 +2497,7 @@ namespace System.Windows.Forms
             int dropDownWidth = Properties.GetInteger(PropDropDownWidth, out bool found);
             if (found)
             {
-                SendMessageW(this, (WM)CB.SETDROPPEDWIDTH, (IntPtr)dropDownWidth);
+                SendMessageW(this, (WM)CB.SETDROPPEDWIDTH, dropDownWidth);
             }
 
             found = false;
@@ -2539,7 +2539,7 @@ namespace System.Windows.Forms
                 //
                 if (_selectedIndex >= 0)
                 {
-                    SendMessageW(this, (WM)CB.SETCURSEL, (IntPtr)_selectedIndex);
+                    SendMessageW(this, (WM)CB.SETCURSEL, _selectedIndex);
                     UpdateText();
                     _selectedIndex = -1;
                 }
@@ -3409,7 +3409,7 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException(nameof(length), length, string.Format(SR.InvalidArgument, nameof(length), length));
             }
 
-            SendMessageW(this, (WM)CB.SETEDITSEL, IntPtr.Zero, PARAM.FromLowHigh(start, end));
+            SendMessageW(this, (WM)CB.SETEDITSEL, 0, PARAM.FromLowHigh(start, end));
         }
 
         /// <summary>
@@ -3454,7 +3454,7 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    SendMessageW(this, (WM)CB.SETCURSEL, (IntPtr)DataManager.Position);
+                    SendMessageW(this, (WM)CB.SETCURSEL, DataManager.Position);
                 }
                 else
                 {
@@ -3548,27 +3548,27 @@ namespace System.Windows.Forms
         {
             if (!IsHandleCreated)
             {
-                // if we don't create control here we report item heights incorrectly later on.
+                // If we don't create control here we report item heights incorrectly later on.
                 CreateControl();
             }
 
             if (DrawMode == DrawMode.OwnerDrawFixed)
             {
-                SendMessageW(this, (WM)CB.SETITEMHEIGHT, (IntPtr)(-1), (IntPtr)ItemHeight);
-                SendMessageW(this, (WM)CB.SETITEMHEIGHT, IntPtr.Zero, (IntPtr)ItemHeight);
+                SendMessageW(this, (WM)CB.SETITEMHEIGHT, -1, ItemHeight);
+                SendMessageW(this, (WM)CB.SETITEMHEIGHT, 0, ItemHeight);
             }
             else if (DrawMode == DrawMode.OwnerDrawVariable)
             {
-                SendMessageW(this, (WM)CB.SETITEMHEIGHT, (IntPtr)(-1), (IntPtr)ItemHeight);
+                SendMessageW(this, (WM)CB.SETITEMHEIGHT, -1, ItemHeight);
                 Graphics graphics = CreateGraphicsInternal();
                 for (int i = 0; i < Items.Count; i++)
                 {
-                    int original = (int)SendMessageW(this, (WM)CB.GETITEMHEIGHT, (IntPtr)i);
+                    int original = (int)SendMessageW(this, (WM)CB.GETITEMHEIGHT, i);
                     MeasureItemEventArgs mievent = new MeasureItemEventArgs(graphics, i, original);
                     OnMeasureItem(mievent);
                     if (mievent.ItemHeight != original)
                     {
-                        SendMessageW(this, (WM)CB.SETITEMHEIGHT, (IntPtr)i, (IntPtr)mievent.ItemHeight);
+                        SendMessageW(this, (WM)CB.SETITEMHEIGHT, i, mievent.ItemHeight);
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -544,7 +544,7 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-                    return unchecked((int)(long)SendMessageW(this, (WM)CB.GETDROPPEDSTATE)) != 0;
+                    return (int)SendMessageW(this, (WM)CB.GETDROPPEDSTATE) != 0;
                 }
 
                 return false;
@@ -680,7 +680,7 @@ namespace System.Windows.Forms
                 // Note that the above if clause deals with the case when the handle has not yet been created
                 Debug.Assert(IsHandleCreated, "Handle should be created at this point");
 
-                int h = unchecked((int)(long)SendMessageW(this, (WM)CB.GETITEMHEIGHT));
+                int h = (int)SendMessageW(this, (WM)CB.GETITEMHEIGHT);
                 if (h == -1)
                 {
                     throw new Win32Exception();
@@ -996,7 +996,7 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-                    return unchecked((int)(long)SendMessageW(this, (WM)CB.GETCURSEL));
+                    return (int)SendMessageW(this, (WM)CB.GETCURSEL);
                 }
 
                 return _selectedIndex;
@@ -2143,7 +2143,7 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                int h = unchecked((int)(long)SendMessageW(this, (WM)CB.GETITEMHEIGHT, (IntPtr)index));
+                int h = (int)SendMessageW(this, (WM)CB.GETITEMHEIGHT, (IntPtr)index);
                 if (h == -1)
                 {
                     throw new Win32Exception();
@@ -2203,7 +2203,7 @@ namespace System.Windows.Forms
             {
                 Debug.Assert((ModifierKeys & Keys.Alt) == 0);
                 // Keys.Delete only triggers a WM_KEYDOWN and WM_KEYUP, and no WM_CHAR. That's why it's treated separately.
-                if ((Keys)unchecked((int)(long)m.WParam) == Keys.Delete)
+                if ((Keys)(int)(long)m.WParam == Keys.Delete)
                 {
                     // Reset matching text and remove any selection
                     MatchingText = string.Empty;
@@ -3563,7 +3563,7 @@ namespace System.Windows.Forms
                 Graphics graphics = CreateGraphicsInternal();
                 for (int i = 0; i < Items.Count; i++)
                 {
-                    int original = unchecked((int)(long)SendMessageW(this, (WM)CB.GETITEMHEIGHT, (IntPtr)i));
+                    int original = (int)SendMessageW(this, (WM)CB.GETITEMHEIGHT, (IntPtr)i);
                     MeasureItemEventArgs mievent = new MeasureItemEventArgs(graphics, i, original);
                     OnMeasureItem(mievent);
                     if (mievent.ItemHeight != original)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1760,7 +1760,7 @@ namespace System.Windows.Forms
                     User32.GetWindowRect(this, ref r);
                     if ((r.left <= p.X && p.X < r.right && r.top <= p.Y && p.Y < r.bottom) || User32.GetCapture() == Handle)
                     {
-                        User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (IntPtr)User32.HT.CLIENT);
+                        User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (nint)User32.HT.CLIENT);
                     }
                 }
 
@@ -3663,7 +3663,7 @@ namespace System.Windows.Forms
                         User32.SendMessageW(
                             TopMostParent,
                             User32.WM.CHANGEUISTATE,
-                            (IntPtr)(actionMask | (int)User32.UIS.SET));
+                            actionMask | (int)User32.UIS.SET);
                     }
                 }
 
@@ -3709,7 +3709,7 @@ namespace System.Windows.Forms
                         // state (has been this way forever)
                         User32.SendMessageW(TopMostParent,
                             User32.WM.CHANGEUISTATE,
-                            (IntPtr)(actionMask | (int)User32.UIS.SET));
+                            actionMask | (int)User32.UIS.SET);
                     }
                 }
 
@@ -4697,7 +4697,7 @@ namespace System.Windows.Forms
 
             if (_updateCount == 0)
             {
-                User32.SendMessageW(this, User32.WM.SETREDRAW, PARAM.FromBool(false));
+                User32.SendMessageW(this, User32.WM.SETREDRAW, (nint)BOOL.FALSE);
             }
 
             _updateCount++;
@@ -5304,8 +5304,8 @@ namespace System.Windows.Forms
             User32.SendMessageW(
                 this,
                 User32.WM.PRINT,
-                (IntPtr)hDc,
-                (IntPtr)(User32.PRF.CHILDREN | User32.PRF.CLIENT | User32.PRF.ERASEBKGND | User32.PRF.NONCLIENT));
+                hDc,
+                (nint)(User32.PRF.CHILDREN | User32.PRF.CLIENT | User32.PRF.ERASEBKGND | User32.PRF.NONCLIENT));
 
             // Now BLT the result to the destination bitmap.
             using Graphics destGraphics = Graphics.FromImage(bitmap);
@@ -5380,7 +5380,7 @@ namespace System.Windows.Forms
                 _updateCount--;
                 if (_updateCount == 0)
                 {
-                    User32.SendMessageW(this, User32.WM.SETREDRAW, PARAM.FromBool(true));
+                    User32.SendMessageW(this, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
                     if (invalidate)
                     {
                         Invalidate();
@@ -7895,7 +7895,7 @@ namespace System.Windows.Forms
                 if (User32.GetScrollInfo(this, User32.SB.HORZ, ref si).IsTrue())
                 {
                     si.nPos = (RightToLeft == RightToLeft.Yes) ? si.nMax : si.nMin;
-                    User32.SendMessageW(this, User32.WM.HSCROLL, PARAM.FromLowHigh((int)User32.SBH.THUMBPOSITION, si.nPos), IntPtr.Zero);
+                    User32.SendMessageW(this, User32.WM.HSCROLL, PARAM.FromLowHigh((int)User32.SBH.THUMBPOSITION, si.nPos), 0);
                 }
             }
         }
@@ -9319,7 +9319,7 @@ namespace System.Windows.Forms
             if (GetStyle(ControlStyles.UserPaint))
             {
                 // We let user paint controls paint directly into the metafile
-                User32.SendMessageW(this, User32.WM.PRINT, (IntPtr)hDC, lParam);
+                User32.SendMessageW(this, User32.WM.PRINT, hDC, lParam);
             }
             else
             {
@@ -9336,7 +9336,7 @@ namespace System.Windows.Forms
                 // which is then copied into the metafile.  (Old GDI line drawing
                 // is 1px thin, which causes borders to disappear, etc.)
                 using MetafileDCWrapper dcWrapper = new MetafileDCWrapper(hDC, Size);
-                User32.SendMessageW(this, User32.WM.PRINT, (IntPtr)dcWrapper.HDC, lParam);
+                User32.SendMessageW(this, User32.WM.PRINT, dcWrapper.HDC, lParam);
             }
         }
 
@@ -9357,7 +9357,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected virtual bool ProcessDialogChar(char charCode)
         {
-            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Control.ProcessDialogChar [" + charCode.ToString() + "]");
+            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"Control.ProcessDialogChar [{charCode.ToString()}]");
             return _parent is null ? false : _parent.ProcessDialogChar(charCode);
         }
 
@@ -9622,7 +9622,7 @@ namespace System.Windows.Forms
                 User32.SendMessageW(
                     topMostParent,
                     User32.GetParent(topMostParent.Handle) == IntPtr.Zero ? User32.WM.CHANGEUISTATE : User32.WM.UPDATEUISTATE,
-                    (IntPtr)((int)User32.UIS.CLEAR | ((int)toClear << 16)));
+                    (int)User32.UIS.CLEAR | ((int)toClear << 16));
             }
         }
 
@@ -11312,13 +11312,13 @@ namespace System.Windows.Forms
 
         private void SetWindowFont()
         {
-            User32.SendMessageW(this, User32.WM.SETFONT, (IntPtr)FontHandle, PARAM.FromBool(false));
+            User32.SendMessageW(this, User32.WM.SETFONT, FontHandle, (nint)BOOL.FALSE);
         }
 
         private void SetWindowStyle(int flag, bool value)
         {
-            int styleFlags = unchecked((int)((long)User32.GetWindowLong(this, User32.GWL.STYLE)));
-            User32.SetWindowLong(this, User32.GWL.STYLE, new HandleRef(null, (IntPtr)(value ? styleFlags | flag : styleFlags & ~flag)));
+            int styleFlags = (int)User32.GetWindowLong(this, User32.GWL.STYLE);
+            User32.SetWindowLong(this, User32.GWL.STYLE, value ? styleFlags | flag : styleFlags & ~flag);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6704,7 +6704,7 @@ namespace System.Windows.Forms
                 mask = (int)(User32.DLGC.WANTCHARS | User32.DLGC.WANTALLKEYS);
             }
 
-            return (unchecked((int)(long)User32.SendMessageW(this, User32.WM.GETDLGCODE)) & mask) != 0;
+            return ((int)User32.SendMessageW(this, User32.WM.GETDLGCODE) & mask) != 0;
         }
 
         /// <summary>
@@ -6744,7 +6744,7 @@ namespace System.Windows.Forms
             }
 
             return IsHandleCreated
-                && (unchecked((int)(long)User32.SendMessageW(this, User32.WM.GETDLGCODE)) & (int)mask) != 0;
+                && ((User32.DLGC)User32.SendMessageW(this, User32.WM.GETDLGCODE) & mask) != 0;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -30387,7 +30387,7 @@ namespace System.Windows.Forms
                 if (!string.IsNullOrEmpty(toolTip))
                 {
                     // Setting the max width has the added benefit of enabling multiline tool tips
-                    User32.SendMessageW(nmhdr->hwndFrom, (User32.WM)ComCtl32.TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                    User32.SendMessageW(nmhdr->hwndFrom, (User32.WM)ComCtl32.TTM.SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
 
                     ComCtl32.NMTTDISPINFOW* ttt = (ComCtl32.NMTTDISPINFOW*)m.LParam;
                     _toolTipBuffer.SetText(toolTip);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -809,7 +809,7 @@ namespace System.Windows.Forms
                 {
                     // The dropdown width may have been previously adjusted to the items because of the owning column autosized.
                     // The dropdown width needs to be realigned to the DropDownWidth property value.
-                    int dropDownWidth = unchecked((int)(long)User32.SendMessageW(comboBox, (User32.WM)User32.CB.GETDROPPEDWIDTH));
+                    int dropDownWidth = (int)User32.SendMessageW(comboBox, (User32.WM)User32.CB.GETDROPPEDWIDTH);
                     if (dropDownWidth != DropDownWidth)
                     {
                         User32.SendMessageW(comboBox, (User32.WM)User32.CB.SETDROPPEDWIDTH, (IntPtr)DropDownWidth);
@@ -829,11 +829,10 @@ namespace System.Windows.Forms
             }
             else
             {
-                //
                 dataGridViewCell = (DataGridViewComboBoxCell)System.Activator.CreateInstance(thisType);
             }
 
-            base.CloneInternal(dataGridViewCell);
+            CloneInternal(dataGridViewCell);
             dataGridViewCell.DropDownWidth = DropDownWidth;
             dataGridViewCell.MaxDropDownItems = MaxDropDownItems;
             dataGridViewCell.CreateItemsFromDataSource = false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -802,7 +802,7 @@ namespace System.Windows.Forms
                         }
 
                         Debug.Assert(s_cachedDropDownWidth >= 1);
-                        User32.SendMessageW(comboBox, (User32.WM)User32.CB.SETDROPPEDWIDTH, (IntPtr)s_cachedDropDownWidth);
+                        User32.SendMessageW(comboBox, (User32.WM)User32.CB.SETDROPPEDWIDTH, s_cachedDropDownWidth);
                     }
                 }
                 else
@@ -812,7 +812,7 @@ namespace System.Windows.Forms
                     int dropDownWidth = (int)User32.SendMessageW(comboBox, (User32.WM)User32.CB.GETDROPPEDWIDTH);
                     if (dropDownWidth != DropDownWidth)
                     {
-                        User32.SendMessageW(comboBox, (User32.WM)User32.CB.SETDROPPEDWIDTH, (IntPtr)DropDownWidth);
+                        User32.SendMessageW(comboBox, (User32.WM)User32.CB.SETDROPPEDWIDTH, DropDownWidth);
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
@@ -146,7 +146,7 @@ namespace System.Windows.Forms
             {
                 if (Owner.IsHandleCreated && ExpandCollapseState == UiaCore.ExpandCollapseState.Collapsed)
                 {
-                    SendMessageW(Owner, WM.SYSKEYDOWN, (IntPtr)Keys.Down);
+                    SendMessageW(Owner, WM.SYSKEYDOWN, (nint)Keys.Down);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -18,12 +18,12 @@ using static Interop.ComCtl32;
 namespace System.Windows.Forms
 {
     /// <summary>
-    ///  Date/DateTime picker control
+    ///  Date/DateTime picker control.
     /// </summary>
     [DefaultProperty(nameof(Value))]
     [DefaultEvent(nameof(ValueChanged))]
     [DefaultBindingProperty(nameof(Value))]
-    [Designer("System.Windows.Forms.Design.DateTimePickerDesigner, " + AssemblyRef.SystemDesign)]
+    [Designer($"System.Windows.Forms.Design.DateTimePickerDesigner, {AssemblyRef.SystemDesign}")]
     [SRDescription(nameof(SR.DescriptionDateTimePicker))]
     public partial class DateTimePicker : Control
     {
@@ -31,20 +31,23 @@ namespace System.Windows.Forms
         ///  Specifies the default title back color. This field is read-only.
         /// </summary>
         protected static readonly Color DefaultTitleBackColor = SystemColors.ActiveCaption;
+
         /// <summary>
         ///  Specifies the default foreground color. This field is read-only.
         /// </summary>
         protected static readonly Color DefaultTitleForeColor = SystemColors.ActiveCaptionText;
+
         /// <summary>
         ///  Specifies the default month background color. This field is read-only.
         /// </summary>
         protected static readonly Color DefaultMonthBackColor = SystemColors.Window;
+
         /// <summary>
         ///  Specifies the default trailing foreground color. This field is read-only.
         /// </summary>
         protected static readonly Color DefaultTrailingForeColor = SystemColors.GrayText;
 
-        private static readonly object s_formatChangedEvent = new object();
+        private static readonly object s_formatChangedEvent = new();
 
         private static readonly string s_dateTimePickerLocalizedControlTypeString = SR.DateTimePickerLocalizedControlType;
 
@@ -56,80 +59,71 @@ namespace System.Windows.Forms
 
         private UiaCore.ExpandCollapseState _expandCollapseState;
 
-        // We need to restrict the available dates because of limitations in the comctl
-        // DateTime and MonthCalendar controls
-        //
+        // We need to restrict the available dates because of limitations in the comctl DateTime and MonthCalendar controls
+
         /// <summary>
         ///  Specifies the minimum date value. This field is read-only.
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly DateTime MinDateTime = new DateTime(1753, 1, 1);
+        public static readonly DateTime MinDateTime = new(1753, 1, 1);
 
         /// <summary>
         ///  Specifies the maximum date value. This field is read-only.
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static readonly DateTime MaxDateTime = new DateTime(9998, 12, 31);
+        public static readonly DateTime MaxDateTime = new(9998, 12, 31);
 
         private DTS _style;
-        private short prefHeightCache = -1;
+        private short _prefHeightCache = -1;
 
         /// <summary>
-        ///  validTime determines whether the CheckBox in the DTP is checked.  The CheckBox is only
+        ///  Determines whether the CheckBox in the DTP is checked. The CheckBox is only
         ///  displayed when ShowCheckBox is true.
         /// </summary>
-        private bool validTime = true;
+        private bool _validTime = true;
 
         // DateTime changeover: DateTime is a value class, not an object, so we need to keep track
         // of whether or not its values have been initialised in a separate boolean.
-        private bool userHasSetValue;
-        private DateTime value = DateTime.Now;
-        private DateTime creationTime = DateTime.Now;
+        private bool _userHasSetValue;
+        private DateTime _value = DateTime.Now;
+        private DateTime _creationTime = DateTime.Now;
         // Reconcile out-of-range min/max values in the property getters.
-        private DateTime max = DateTime.MaxValue;
-        private DateTime min = DateTime.MinValue;
-        private Color calendarForeColor = DefaultForeColor;
-        private Color calendarTitleBackColor = DefaultTitleBackColor;
-        private Color calendarTitleForeColor = DefaultTitleForeColor;
-        private Color calendarMonthBackground = DefaultMonthBackColor;
-        private Color calendarTrailingText = DefaultTrailingForeColor;
-        private Font calendarFont;
-        private FontHandleWrapper calendarFontHandleWrapper;
+        private DateTime _maxDateTime = DateTime.MaxValue;
+        private DateTime _minDateTime = DateTime.MinValue;
+        private Color _calendarForeColor = DefaultForeColor;
+        private Color _calendarTitleBackColor = DefaultTitleBackColor;
+        private Color _calendarTitleForeColor = DefaultTitleForeColor;
+        private Color _calendarMonthBackground = DefaultMonthBackColor;
+        private Color _calendarTrailingText = DefaultTrailingForeColor;
+        private Font _calendarFont;
+        private FontHandleWrapper _calendarFontHandleWrapper;
 
-        // Since there is no way to get the customFormat from the DTP, we need to
-        // cache it. Also we have to track if the user wanted customFormat or
-        // shortDate format (shortDate is the lack of being in Long or DateTime format
-        // without a customFormat). What fun!
-        //
-        private string customFormat;
+        // Since there is no way to get the customFormat from the DTP, we need to cache it. Also we have to track if
+        // the user wanted customFormat or shortDate format (shortDate is the lack of being in Long or DateTime format
+        // without a customFormat).
+        private string _customFormat;
 
-        private DateTimePickerFormat format;
+        private DateTimePickerFormat _format;
 
-        private bool rightToLeftLayout;
+        private bool _rightToLeftLayout;
 
         /// <summary>
         ///  Initializes a new instance of the <see cref='DateTimePicker'/> class.
         /// </summary>
-        public DateTimePicker()
-        : base()
+        public DateTimePicker() : base()
         {
-            // this class overrides GetPreferredSizeCore, let Control automatically cache the result
+            // This class overrides GetPreferredSizeCore, let Control automatically cache the result.
             SetExtendedState(ExtendedStates.UserPreferredSizeCache, true);
 
             SetStyle(ControlStyles.FixedHeight, true);
 
-            // Since DateTimePicker does its own mouse capturing, we do not want
-            // to receive standard click events, or we end up with mismatched mouse
-            // button up and button down messages.
-            //
-            SetStyle(ControlStyles.UserPaint |
-                     ControlStyles.StandardClick, false);
+            // Since DateTimePicker does its own mouse capturing, we do not want to receive standard click events, or
+            // we end up with mismatched mouse button up and button down messages.
+            SetStyle(ControlStyles.UserPaint | ControlStyles.StandardClick, false);
 
-            // Set default flags here...
-            //
-            format = DateTimePickerFormat.Long;
+            _format = DateTimePickerFormat.Long;
 
             SetStyle(ControlStyles.UseTextForAccessibility, false);
         }
@@ -138,17 +132,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override Color BackColor
         {
-            get
-            {
-                if (ShouldSerializeBackColor())
-                {
-                    return base.BackColor;
-                }
-                else
-                {
-                    return SystemColors.Window;
-                }
-            }
+            get => ShouldSerializeBackColor() ? base.BackColor : SystemColors.Window;
             set => base.BackColor = value;
         }
 
@@ -199,22 +183,17 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.DateTimePickerCalendarForeColorDescr))]
         public Color CalendarForeColor
         {
-            get
-            {
-                return calendarForeColor;
-            }
-
+            get => _calendarForeColor;
             set
             {
                 if (value.IsEmpty)
                 {
-                    throw new ArgumentException(string.Format(SR.InvalidNullArgument,
-                                                              "value"));
+                    throw new ArgumentException(string.Format(SR.InvalidNullArgument, nameof(value)));
                 }
 
-                if (!value.Equals(calendarForeColor))
+                if (!value.Equals(_calendarForeColor))
                 {
-                    calendarForeColor = value;
+                    _calendarForeColor = value;
                     SetControlColor(MCSC.TEXT, value);
                 }
             }
@@ -229,22 +208,13 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.DateTimePickerCalendarFontDescr))]
         public Font CalendarFont
         {
-            get
-            {
-                if (calendarFont is null)
-                {
-                    return Font;
-                }
-
-                return calendarFont;
-            }
-
+            get => _calendarFont ?? Font;
             set
             {
-                if ((value is null && calendarFont is not null) || (value is not null && !value.Equals(calendarFont)))
+                if ((value is null && _calendarFont is not null) || (value is not null && !value.Equals(_calendarFont)))
                 {
-                    calendarFont = value;
-                    calendarFontHandleWrapper = null;
+                    _calendarFont = value;
+                    _calendarFontHandleWrapper = null;
                     SetControlCalendarFont();
                 }
             }
@@ -254,18 +224,14 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (calendarFont is null)
+                if (_calendarFont is null)
                 {
-                    Debug.Assert(calendarFontHandleWrapper is null, "font handle out of sync with Font");
+                    Debug.Assert(_calendarFontHandleWrapper is null, "font handle out of sync with Font");
                     return FontHandle;
                 }
 
-                if (calendarFontHandleWrapper is null)
-                {
-                    calendarFontHandleWrapper = new FontHandleWrapper(CalendarFont);
-                }
-
-                return calendarFontHandleWrapper.Handle;
+                _calendarFontHandleWrapper ??= new FontHandleWrapper(CalendarFont);
+                return _calendarFontHandleWrapper.Handle;
             }
         }
 
@@ -276,22 +242,17 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.DateTimePickerCalendarTitleBackColorDescr))]
         public Color CalendarTitleBackColor
         {
-            get
-            {
-                return calendarTitleBackColor;
-            }
-
+            get => _calendarTitleBackColor;
             set
             {
                 if (value.IsEmpty)
                 {
-                    throw new ArgumentException(string.Format(SR.InvalidNullArgument,
-                                                              "value"));
+                    throw new ArgumentException(string.Format(SR.InvalidNullArgument, nameof(value)));
                 }
 
-                if (!value.Equals(calendarTitleBackColor))
+                if (!value.Equals(_calendarTitleBackColor))
                 {
-                    calendarTitleBackColor = value;
+                    _calendarTitleBackColor = value;
                     SetControlColor(MCSC.TITLEBK, value);
                 }
             }
@@ -304,22 +265,17 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.DateTimePickerCalendarTitleForeColorDescr))]
         public Color CalendarTitleForeColor
         {
-            get
-            {
-                return calendarTitleForeColor;
-            }
-
+            get => _calendarTitleForeColor;
             set
             {
                 if (value.IsEmpty)
                 {
-                    throw new ArgumentException(string.Format(SR.InvalidNullArgument,
-                                                              "value"));
+                    throw new ArgumentException(string.Format(SR.InvalidNullArgument, nameof(value)));
                 }
 
-                if (!value.Equals(calendarTitleForeColor))
+                if (!value.Equals(_calendarTitleForeColor))
                 {
-                    calendarTitleForeColor = value;
+                    _calendarTitleForeColor = value;
                     SetControlColor(MCSC.TITLETEXT, value);
                 }
             }
@@ -332,22 +288,17 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.DateTimePickerCalendarTrailingForeColorDescr))]
         public Color CalendarTrailingForeColor
         {
-            get
-            {
-                return calendarTrailingText;
-            }
-
+            get => _calendarTrailingText;
             set
             {
                 if (value.IsEmpty)
                 {
-                    throw new ArgumentException(string.Format(SR.InvalidNullArgument,
-                                                              "value"));
+                    throw new ArgumentException(string.Format(SR.InvalidNullArgument, nameof(value)));
                 }
 
-                if (!value.Equals(calendarTrailingText))
+                if (!value.Equals(_calendarTrailingText))
                 {
-                    calendarTrailingText = value;
+                    _calendarTrailingText = value;
                     SetControlColor(MCSC.TRAILINGTEXT, value);
                 }
             }
@@ -360,22 +311,17 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.DateTimePickerCalendarMonthBackgroundDescr))]
         public Color CalendarMonthBackground
         {
-            get
-            {
-                return calendarMonthBackground;
-            }
-
+            get => _calendarMonthBackground;
             set
             {
                 if (value.IsEmpty)
                 {
-                    throw new ArgumentException(string.Format(SR.InvalidNullArgument,
-                                                              "value"));
+                    throw new ArgumentException(string.Format(SR.InvalidNullArgument, nameof(value)));
                 }
 
-                if (!value.Equals(calendarMonthBackground))
+                if (!value.Equals(_calendarMonthBackground))
                 {
-                    calendarMonthBackground = value;
+                    _calendarMonthBackground = value;
                     SetControlColor(MCSC.MONTHBK, value);
                 }
             }
@@ -392,16 +338,16 @@ namespace System.Windows.Forms
         {
             get
             {
-                // the information from win32 DateTimePicker is reliable only when ShowCheckBoxes is True
+                // The information from win32 DateTimePicker is reliable only when ShowCheckBoxes is True
                 if (ShowCheckBox && IsHandleCreated)
                 {
                     var sys = new Kernel32.SYSTEMTIME();
-                    GDT gdt = (GDT)User32.SendMessageW(this, (User32.WM)DTM.GETSYSTEMTIME, IntPtr.Zero, ref sys);
+                    GDT gdt = (GDT)User32.SendMessageW(this, (User32.WM)DTM.GETSYSTEMTIME, 0, ref sys);
                     return gdt == GDT.VALID;
                 }
                 else
                 {
-                    return validTime;
+                    return _validTime;
                 }
             }
             set
@@ -413,19 +359,19 @@ namespace System.Windows.Forms
                     {
                         if (value)
                         {
-                            Kernel32.SYSTEMTIME sys = DateTimePicker.DateTimeToSysTime(Value);
-                            User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (IntPtr)GDT.VALID, ref sys);
+                            Kernel32.SYSTEMTIME systemTime = _value;
+                            User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (nint)GDT.VALID, ref systemTime);
                         }
                         else
                         {
-                            User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (IntPtr)GDT.NONE);
+                            User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (nint)GDT.NONE);
                         }
                     }
 
                     // this.validTime is used when the DateTimePicker receives date time change notification
                     // from the Win32 control. this.validTime will be used to know when we transition from valid time to unvalid time
                     // also, validTime will be used when ShowCheckBox == false
-                    validTime = value;
+                    _validTime = value;
                 }
             }
         }
@@ -450,7 +396,7 @@ namespace System.Windows.Forms
 
                 cp.Style |= (int)_style;
 
-                switch (format)
+                switch (_format)
                 {
                     case DateTimePickerFormat.Long:
                         cp.Style |= (int)DTS.LONGDATEFORMAT;
@@ -488,45 +434,27 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.DateTimePickerCustomFormatDescr))]
         public string CustomFormat
         {
-            get
-            {
-                return customFormat;
-            }
-
+            get => _customFormat;
             set
             {
-                if ((value is not null && !value.Equals(customFormat)) ||
-                    (value is null && customFormat is not null))
+                if ((value is not null && !value.Equals(_customFormat)) ||
+                    (value is null && _customFormat is not null))
                 {
-                    customFormat = value;
+                    _customFormat = value;
 
                     if (IsHandleCreated)
                     {
-                        if (format == DateTimePickerFormat.Custom)
+                        if (_format == DateTimePickerFormat.Custom)
                         {
-                            User32.SendMessageW(this, (User32.WM)DTM.SETFORMATW, IntPtr.Zero, customFormat);
+                            User32.SendMessageW(this, (User32.WM)DTM.SETFORMATW, 0, _customFormat);
                         }
                     }
                 }
             }
         }
 
-        /// <summary>
-        ///  Deriving classes can override this to configure a default size for their control.
-        ///  This is more efficient than setting the size in the control's constructor.
-        /// </summary>
-        protected override Size DefaultSize
-        {
-            get
-            {
-                return new Size(200, PreferredHeight);
-            }
-        }
+        protected override Size DefaultSize => new(200, PreferredHeight);
 
-        /// <summary>
-        ///  This property is overridden and hidden from statement completion
-        ///  on controls that are based on Win32 Native Controls.
-        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected override bool DoubleBuffered
         {
@@ -543,8 +471,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  The current value of the dropDownAlign property.  The calendar
-        ///  dropDown can be aligned to the left or right of the control.
+        ///  The calendar dropdown can be aligned to the left or right of the control.
         /// </summary>
         [DefaultValue(LeftRightAlignment.Left)]
         [SRCategory(nameof(SR.CatAppearance))]
@@ -552,16 +479,10 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.DateTimePickerDropDownAlignDescr))]
         public LeftRightAlignment DropDownAlign
         {
-            get
-            {
-                return (_style & DTS.RIGHTALIGN) != 0
-                    ? LeftRightAlignment.Right
-                    : LeftRightAlignment.Left;
-            }
-
+            get => (_style & DTS.RIGHTALIGN) != 0 ? LeftRightAlignment.Right : LeftRightAlignment.Left;
             set
             {
-                //valid values are 0x0 to 0x1
+                // Valid values are 0x0 to 0x1
                 SourceGenerated.EnumValidator.Validate(value);
 
                 SetStyleBit(value == LeftRightAlignment.Right, DTS.RIGHTALIGN);
@@ -572,17 +493,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override Color ForeColor
         {
-            get
-            {
-                if (ShouldSerializeForeColor())
-                {
-                    return base.ForeColor;
-                }
-                else
-                {
-                    return SystemColors.WindowText;
-                }
-            }
+            get => ShouldSerializeForeColor() ? base.ForeColor : SystemColors.WindowText;
             set => base.ForeColor = value;
         }
 
@@ -603,18 +514,14 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.DateTimePickerFormatDescr))]
         public DateTimePickerFormat Format
         {
-            get
-            {
-                return format;
-            }
-
+            get => _format;
             set
             {
                 EnumValidator.Validate(value);
 
-                if (format != value)
+                if (_format != value)
                 {
-                    format = value;
+                    _format = value;
                     RecreateHandle();
 
                     OnFormatChanged(EventArgs.Empty);
@@ -642,13 +549,13 @@ namespace System.Windows.Forms
             remove => base.Paint -= value;
         }
 
-        //Make sure the passed in minDate respects the current culture: this
-        //is especially important if the culture changes from a Gregorian or
-        //other calendar with a lowish minDate (see comment on MinimumDateTime)
-        //to a calendar, which has a minimum date of 1/1/1912.
-        static internal DateTime EffectiveMinDate(DateTime minDate)
+        // Make sure the passed in minDate respects the current culture: this
+        // is especially important if the culture changes from a Gregorian or
+        // other calendar with a lowish minDate (see comment on MinimumDateTime)
+        // to a calendar, which has a minimum date of 1/1/1912.
+        internal static DateTime EffectiveMinDate(DateTime minDate)
         {
-            DateTime minSupportedDate = DateTimePicker.MinimumDateTime;
+            DateTime minSupportedDate = MinimumDateTime;
             if (minDate < minSupportedDate)
             {
                 return minSupportedDate;
@@ -657,13 +564,13 @@ namespace System.Windows.Forms
             return minDate;
         }
 
-        //Similarly, make sure the maxDate respects the current culture.  No
-        //problems are anticipated here: I don't believe there are calendars
-        //around that have max dates on them.  But if there are, we'll deal with
-        //them correctly.
+        // Similarly, make sure the maxDate respects the current culture.  No
+        // problems are anticipated here: I don't believe there are calendars
+        // around that have max dates on them.  But if there are, we'll deal with
+        // them correctly.
         static internal DateTime EffectiveMaxDate(DateTime maxDate)
         {
-            DateTime maxSupportedDate = DateTimePicker.MaximumDateTime;
+            DateTime maxSupportedDate = MaximumDateTime;
             if (maxDate > maxSupportedDate)
             {
                 return maxSupportedDate;
@@ -673,8 +580,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Indicates the maximum date and time
-        ///  selectable in the control.
+        ///  Indicates the maximum date and time selectable in the control.
         /// </summary>
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.DateTimePickerMaxDateDescr))]
@@ -682,31 +588,38 @@ namespace System.Windows.Forms
         {
             get
             {
-                return EffectiveMaxDate(max);
+                return EffectiveMaxDate(_maxDateTime);
             }
             set
             {
-                if (value != max)
+                if (value == _maxDateTime)
                 {
-                    if (value < EffectiveMinDate(min))
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(MaxDate), FormatDateTime(value), nameof(MinDate)));
-                    }
+                    return;
+                }
 
-                    if (value > MaximumDateTime)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.DateTimePickerMaxDate, FormatDateTime(DateTimePicker.MaxDateTime)));
-                    }
+                if (value < EffectiveMinDate(_minDateTime))
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        string.Format(SR.InvalidLowBoundArgumentEx, nameof(MaxDate), FormatDateTime(value), nameof(MinDate)));
+                }
 
-                    max = value;
-                    SetRange();
+                if (value > MaximumDateTime)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        string.Format(SR.DateTimePickerMaxDate, FormatDateTime(MaxDateTime)));
+                }
 
-                    //If Value (which was once valid) is suddenly greater than the max (since we just set it)
-                    //then adjust this...
-                    if (Value > max)
-                    {
-                        Value = max;
-                    }
+                _maxDateTime = value;
+                SetRange();
+
+                // If Value (which was once valid) is suddenly greater than the max (since we just set it) then adjust this.
+                if (Value > _maxDateTime)
+                {
+                    Value = _maxDateTime;
                 }
             }
         }
@@ -729,8 +642,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Indicates the minimum date and time
-        ///  selectable in the control.
+        ///  Indicates the minimum date and time selectable in the control.
         /// </summary>
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.DateTimePickerMinDateDescr))]
@@ -738,31 +650,38 @@ namespace System.Windows.Forms
         {
             get
             {
-                return EffectiveMinDate(min);
+                return EffectiveMinDate(_minDateTime);
             }
             set
             {
-                if (value != min)
+                if (value == _minDateTime)
                 {
-                    if (value > EffectiveMaxDate(max))
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidHighBoundArgument, nameof(MinDate), FormatDateTime(value), nameof(MaxDate)));
-                    }
+                    return;
+                }
 
-                    if (value < MinimumDateTime)
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.DateTimePickerMinDate, FormatDateTime(DateTimePicker.MinimumDateTime)));
-                    }
+                if (value > EffectiveMaxDate(_maxDateTime))
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        string.Format(SR.InvalidHighBoundArgument, nameof(MinDate), FormatDateTime(value), nameof(MaxDate)));
+                }
 
-                    min = value;
-                    SetRange();
+                if (value < MinimumDateTime)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        string.Format(SR.DateTimePickerMinDate, FormatDateTime(MinimumDateTime)));
+                }
 
-                    //If Value (which was once valid) is suddenly less than the min (since we just set it)
-                    //then adjust this...
-                    if (Value < min)
-                    {
-                        Value = min;
-                    }
+                _minDateTime = value;
+                SetRange();
+
+                // If Value (which was once valid) is suddenly less than the min (since we just set it) then adjust this.
+                if (Value < _minDateTime)
+                {
+                    Value = _minDateTime;
                 }
             }
         }
@@ -770,7 +689,7 @@ namespace System.Windows.Forms
         // We restrict the available dates to >= 1753 because of oddness in the Gregorian calendar about
         // that time.  We do this even for cultures that don't use the Gregorian calendar -- we're not
         // really that worried about calendars for >250 years ago.
-        //
+
         /// <summary>
         ///  Specifies the minimum date value. This property is read-only.
         /// </summary>
@@ -830,9 +749,9 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (prefHeightCache > -1)
+                if (_prefHeightCache > -1)
                 {
-                    return (int)prefHeightCache;
+                    return (int)_prefHeightCache;
                 }
 
                 // Base the preferred height on the current font
@@ -840,7 +759,7 @@ namespace System.Windows.Forms
 
                 // Adjust for the border
                 height += SystemInformation.BorderSize.Height * 4 + 3;
-                prefHeightCache = (short)height;
+                _prefHeightCache = (short)height;
 
                 return height;
             }
@@ -857,16 +776,12 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ControlRightToLeftLayoutDescr))]
         public virtual bool RightToLeftLayout
         {
-            get
-            {
-                return rightToLeftLayout;
-            }
-
+            get => _rightToLeftLayout;
             set
             {
-                if (value != rightToLeftLayout)
+                if (value != _rightToLeftLayout)
                 {
-                    rightToLeftLayout = value;
+                    _rightToLeftLayout = value;
                     using (new LayoutTransaction(this, this, PropertyNames.RightToLeftLayout))
                     {
                         OnRightToLeftLayoutChanged(EventArgs.Empty);
@@ -876,8 +791,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Indicates whether a check box is displayed to toggle the NoValueSelected property
-        ///  value.
+        ///  Indicates whether a check box is displayed to toggle the NoValueSelected property value.
         /// </summary>
         [DefaultValue(false)]
         [SRCategory(nameof(SR.CatAppearance))]
@@ -889,8 +803,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Indicates
-        ///  whether an up-down control is used to adjust the time values.
+        ///  Indicates whether an up-down control is used to adjust the time values.
         /// </summary>
         [DefaultValue(false)]
         [SRCategory(nameof(SR.CatAppearance))]
@@ -952,51 +865,54 @@ namespace System.Windows.Forms
         {
             get
             {
-                //checkbox clicked, no value set - no value set state should never occur, but just in case
-                if (!userHasSetValue && validTime)
-                {
-                    return creationTime;
-                }
-                else
-                {
-                    return value;
-                }
+                // Checkbox clicked, no value set - no value set state should never occur, but just in case.
+                return !_userHasSetValue && _validTime ? _creationTime : _value;
             }
             set
             {
                 bool valueChanged = !DateTime.Equals(Value, value);
-                // Check for value set here; if we've not set the value yet, it'll be Now, so the second
-                // part of the test will fail.
-                // So, if userHasSetValue isn't set, we don't care if the value is still the same - and we'll
-                // update anyway.
-                if (!userHasSetValue || valueChanged)
+
+                // Check for value set here; if we've not set the value yet, it'll be Now, so the second part of the
+                // test will fail. So, if userHasSetValue isn't set, we don't care if the value is still the same -
+                // and we'll update anyway.
+                if (_userHasSetValue && !valueChanged)
                 {
-                    if ((value < MinDate) || (value > MaxDate))
-                    {
-                        throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidBoundArgument, nameof(Value), FormatDateTime(value), $"'{nameof(MinDate)}'", $"'{nameof(MaxDate)}'"));
-                    }
+                    return;
+                }
 
-                    string oldText = Text;
+                if ((value < MinDate) || (value > MaxDate))
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        string.Format(
+                            SR.InvalidBoundArgument,
+                            nameof(Value),
+                            FormatDateTime(value),
+                            $"'{nameof(MinDate)}'",
+                            $"'{nameof(MaxDate)}'"));
+                }
 
-                    this.value = value;
-                    userHasSetValue = true;
+                string oldText = Text;
 
-                    if (IsHandleCreated)
-                    {
-                        // Make sure any changes to this code get propagated to createHandle
-                        Kernel32.SYSTEMTIME sys = DateTimePicker.DateTimeToSysTime(value);
-                        User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (IntPtr)GDT.VALID, ref sys);
-                    }
+                _value = value;
+                _userHasSetValue = true;
 
-                    if (valueChanged)
-                    {
-                        OnValueChanged(EventArgs.Empty);
-                    }
+                if (IsHandleCreated)
+                {
+                    // Make sure any changes to this code get propagated to createHandle
+                    Kernel32.SYSTEMTIME systemTime = value;
+                    User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (nint)GDT.VALID, ref systemTime);
+                }
 
-                    if (!oldText.Equals(Text))
-                    {
-                        OnTextChanged(EventArgs.Empty);
-                    }
+                if (valueChanged)
+                {
+                    OnValueChanged(EventArgs.Empty);
+                }
+
+                if (!oldText.Equals(Text))
+                {
+                    OnTextChanged(EventArgs.Empty);
                 }
             }
         }
@@ -1042,14 +958,7 @@ namespace System.Windows.Forms
             remove => _onDropDown -= value;
         }
 
-        /// <summary>
-        ///  Constructs the new instance of the accessibility object for this control. Subclasses
-        ///  should not call base.CreateAccessibilityObject.
-        /// </summary>
-        protected override AccessibleObject CreateAccessibilityInstance()
-        {
-            return new DateTimePickerAccessibleObject(this);
-        }
+        protected override AccessibleObject CreateAccessibilityInstance() => new DateTimePickerAccessibleObject(this);
 
         /// <summary>
         ///  Creates the physical window handle.
@@ -1074,24 +983,24 @@ namespace System.Windows.Forms
                 }
             }
 
-            creationTime = DateTime.Now;
+            _creationTime = DateTime.Now;
 
             base.CreateHandle();
 
-            if (userHasSetValue && validTime)
+            if (_userHasSetValue && _validTime)
             {
                 // Make sure any changes to this code get propagated to setValue
-                Kernel32.SYSTEMTIME sys = DateTimePicker.DateTimeToSysTime(Value);
-                User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (IntPtr)GDT.VALID, ref sys);
+                Kernel32.SYSTEMTIME systemTime = Value;
+                User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (nint)GDT.VALID, ref systemTime);
             }
-            else if (!validTime)
+            else if (!_validTime)
             {
-                User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (IntPtr)GDT.NONE);
+                User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (nint)GDT.NONE);
             }
 
-            if (format == DateTimePickerFormat.Custom)
+            if (_format == DateTimePickerFormat.Custom)
             {
-                User32.SendMessageW(this, (User32.WM)DTM.SETFORMATW, IntPtr.Zero, customFormat);
+                User32.SendMessageW(this, (User32.WM)DTM.SETFORMATW, 0, _customFormat);
             }
 
             UpdateUpDown();
@@ -1105,13 +1014,13 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void DestroyHandle()
         {
-            value = Value;
+            _value = Value;
             base.DestroyHandle();
         }
 
-        // Return a localized string representation of the given DateTime value.
-        // Used for throwing exceptions, etc.
-        //
+        /// <summary>
+        ///  Return a localized string representation of the given DateTime value.
+        /// </summary>
         private static string FormatDateTime(DateTime value)
         {
             return value.ToString("G", CultureInfo.CurrentCulture);
@@ -1155,8 +1064,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Raises the <see cref='CloseUp'/>
-        ///  event.
+        ///  Raises the <see cref='CloseUp'/> event.
         /// </summary>
         protected virtual void OnCloseUp(EventArgs eventargs)
         {
@@ -1187,7 +1095,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Add/remove SystemEvents in OnHandleCreated/Destroyed for robustness
+        ///  Add/remove SystemEvents in OnHandleCreated/Destroyed for robustness.
         /// </summary>
         protected override void OnHandleCreated(EventArgs e)
         {
@@ -1196,7 +1104,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Add/remove SystemEvents in OnHandleCreated/Destroyed for robustness
+        ///  Add/remove SystemEvents in OnHandleCreated/Destroyed for robustness.
         /// </summary>
         protected override void OnHandleDestroyed(EventArgs e)
         {
@@ -1204,7 +1112,6 @@ namespace System.Windows.Forms
             base.OnHandleDestroyed(e);
         }
 
-        /// <inheritdoc />
         protected override void OnEnabledChanged(EventArgs e)
         {
             base.OnEnabledChanged(e);
@@ -1243,21 +1150,18 @@ namespace System.Windows.Forms
             _onRightToLeftLayoutChanged?.Invoke(this, e);
         }
 
-        /// <summary>
-        ///  Occurs when a property for the control changes.
-        /// </summary>
         protected override void OnFontChanged(EventArgs e)
         {
             base.OnFontChanged(e);
 
             //clear the pref height cache
-            prefHeightCache = -1;
+            _prefHeightCache = -1;
 
             Height = PreferredHeight;
 
-            if (calendarFont is null)
+            if (_calendarFont is null)
             {
-                calendarFontHandleWrapper = null;
+                _calendarFontHandleWrapper = null;
                 SetControlCalendarFont();
             }
         }
@@ -1293,8 +1197,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Resets the <see cref='Format'/> property to its default
-        ///  value.
+        ///  Resets the <see cref='Format'/> property to its default value.
         /// </summary>
         private void ResetFormat()
         {
@@ -1323,25 +1226,23 @@ namespace System.Windows.Forms
         private void ResetValue()
         {
             // always update on reset with ShowNone = false -- as it'll take the current time.
-            value = DateTime.Now;
+            _value = DateTime.Now;
 
             // If ShowCheckBox = true, then userHasSetValue can be false (null value).
             // otherwise, userHasSetValue is valid...
             // userHasSetValue = !ShowCheckBox;
 
-            // After ResetValue() the flag indicating whether the user
-            // has set the value should be false.
-            userHasSetValue = false;
+            // After ResetValue() the flag indicating whether the user has set the value should be false.
+            _userHasSetValue = false;
 
-            // Update the text displayed in the DateTimePicker
+            // Update the text displayed in the DateTimePicker.
             if (IsHandleCreated)
             {
-                Kernel32.SYSTEMTIME sys = DateTimePicker.DateTimeToSysTime(value);
-                User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (IntPtr)GDT.VALID, ref sys);
+                Kernel32.SYSTEMTIME systemTime = _value;
+                User32.SendMessageW(this, (User32.WM)DTM.SETSYSTEMTIME, (nint)GDT.VALID, ref systemTime);
             }
 
-            // Updating Checked to false will set the control to "no date",
-            // and clear its checkbox.
+            // Updating Checked to false will set the control to "no date" and clear its checkbox.
             Checked = false;
 
             OnValueChanged(EventArgs.Empty);
@@ -1375,36 +1276,35 @@ namespace System.Windows.Forms
         /// </summary>
         private void SetAllControlColors()
         {
-            SetControlColor(MCSC.MONTHBK, calendarMonthBackground);
-            SetControlColor(MCSC.TEXT, calendarForeColor);
-            SetControlColor(MCSC.TITLEBK, calendarTitleBackColor);
-            SetControlColor(MCSC.TITLETEXT, calendarTitleForeColor);
-            SetControlColor(MCSC.TRAILINGTEXT, calendarTrailingText);
+            SetControlColor(MCSC.MONTHBK, _calendarMonthBackground);
+            SetControlColor(MCSC.TEXT, _calendarForeColor);
+            SetControlColor(MCSC.TITLEBK, _calendarTitleBackColor);
+            SetControlColor(MCSC.TITLETEXT, _calendarTitleForeColor);
+            SetControlColor(MCSC.TRAILINGTEXT, _calendarTrailingText);
         }
 
         /// <summary>
-        ///  Updates the window handle with the min/max ranges if it has been
-        ///  created.
+        ///  Updates the window handle with the min/max ranges if it has been created.
         /// </summary>
         private void SetRange()
         {
-            SetRange(EffectiveMinDate(min), EffectiveMaxDate(max));
+            SetRange(EffectiveMinDate(_minDateTime), EffectiveMaxDate(_maxDateTime));
         }
 
         private void SetRange(DateTime min, DateTime max)
         {
             if (IsHandleCreated)
             {
-                Span<Kernel32.SYSTEMTIME> sa = stackalloc Kernel32.SYSTEMTIME[2];
-                sa[0] = DateTimeToSysTime(min);
-                sa[1] = DateTimeToSysTime(max);
+                Span<Kernel32.SYSTEMTIME> times = stackalloc Kernel32.SYSTEMTIME[2];
+                times[0] = min;
+                times[1] = max;
                 GDTR flags = GDTR.MIN | GDTR.MAX;
-                User32.SendMessageW(this, (User32.WM)DTM.SETRANGE, (IntPtr)flags, ref sa[0]);
+                User32.SendMessageW(this, (User32.WM)DTM.SETRANGE, (nint)flags, ref times[0]);
             }
         }
 
         /// <summary>
-        ///  Turns on or off a given style bit
+        ///  Turns on or off a given style bit.
         /// </summary>
         private void SetStyleBit(bool flag, DTS bit)
         {
@@ -1431,8 +1331,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Determines if the <see cref='CalendarForeColor'/> property needs to be
-        ///  persisted.
+        ///  Determines if the <see cref='CalendarForeColor'/> property needs to be persisted.
         /// </summary>
         private bool ShouldSerializeCalendarForeColor()
         {
@@ -1444,7 +1343,7 @@ namespace System.Windows.Forms
         /// </summary>
         private bool ShouldSerializeCalendarFont()
         {
-            return calendarFont is not null;
+            return _calendarFont is not null;
         }
 
         /// <summary>
@@ -1452,7 +1351,7 @@ namespace System.Windows.Forms
         /// </summary>
         private bool ShouldSerializeCalendarTitleBackColor()
         {
-            return !calendarTitleBackColor.Equals(DefaultTitleBackColor);
+            return !_calendarTitleBackColor.Equals(DefaultTitleBackColor);
         }
 
         /// <summary>
@@ -1460,7 +1359,7 @@ namespace System.Windows.Forms
         /// </summary>
         private bool ShouldSerializeCalendarTitleForeColor()
         {
-            return !calendarTitleForeColor.Equals(DefaultTitleForeColor);
+            return !_calendarTitleForeColor.Equals(DefaultTitleForeColor);
         }
 
         /// <summary>
@@ -1468,7 +1367,7 @@ namespace System.Windows.Forms
         /// </summary>
         private bool ShouldSerializeCalendarTrailingForeColor()
         {
-            return !calendarTrailingText.Equals(DefaultTrailingForeColor);
+            return !_calendarTrailingText.Equals(DefaultTrailingForeColor);
         }
 
         /// <summary>
@@ -1476,7 +1375,7 @@ namespace System.Windows.Forms
         /// </summary>
         private bool ShouldSerializeCalendarMonthBackground()
         {
-            return !calendarMonthBackground.Equals(DefaultMonthBackColor);
+            return !_calendarMonthBackground.Equals(DefaultMonthBackColor);
         }
 
         /// <summary>
@@ -1484,7 +1383,7 @@ namespace System.Windows.Forms
         /// </summary>
         private bool ShouldSerializeMaxDate()
         {
-            return max != MaximumDateTime && max != DateTime.MaxValue;
+            return _maxDateTime != MaximumDateTime && _maxDateTime != DateTime.MaxValue;
         }
 
         /// <summary>
@@ -1492,7 +1391,7 @@ namespace System.Windows.Forms
         /// </summary>
         private bool ShouldSerializeMinDate()
         {
-            return min != MinimumDateTime && min != DateTime.MinValue;
+            return _minDateTime != MinimumDateTime && _minDateTime != DateTime.MinValue;
         }
 
         /// <summary>
@@ -1500,7 +1399,7 @@ namespace System.Windows.Forms
         /// </summary>
         private bool ShouldSerializeValue()
         {
-            return userHasSetValue;
+            return _userHasSetValue;
         }
 
         /// <summary>
@@ -1511,14 +1410,7 @@ namespace System.Windows.Forms
             return (Format != DateTimePickerFormat.Long);
         }
 
-        /// <summary>
-        ///  Returns the control as a string
-        /// </summary>
-        public override string ToString()
-        {
-            string s = base.ToString();
-            return s + ", Value: " + FormatDateTime(Value);
-        }
+        public override string ToString() => $"{base.ToString()}, Value: {FormatDateTime(Value)}";
 
         /// <summary>
         ///  Forces a repaint of the updown control if it is displayed.
@@ -1542,10 +1434,10 @@ namespace System.Windows.Forms
         {
             try
             {
-                //use begininvoke instead of invoke in case the destination thread is not processing messages.
+                // Use begininvoke instead of invoke in case the destination thread is not processing messages.
                 BeginInvoke(new UserPreferenceChangedEventHandler(UserPreferenceChanged), new object[] { sender, pref });
             }
-            catch (InvalidOperationException) { } //if the destination thread does not exist, don't send.
+            catch (InvalidOperationException) { } // If the destination thread does not exist, don't send.
         }
 
         private void UserPreferenceChanged(object sender, UserPreferenceChangedEventArgs pref)
@@ -1554,39 +1446,30 @@ namespace System.Windows.Forms
             {
                 // We need to recreate the monthcalendar handle when the locale changes, because
                 // the day names etc. are only updated on a handle recreate (comctl32 limitation).
-                //
                 RecreateHandle();
             }
         }
 
         /// <summary>
-        ///  Handles the DTN_CLOSEUP notification
-        /// </summary>
-        private void WmCloseUp(ref Message m)
-        {
-            OnCloseUp(EventArgs.Empty);
-        }
-
-        /// <summary>
-        ///  Handles the DTN_DATETIMECHANGE notification
+        ///  Handles the DTN_DATETIMECHANGE notification.
         /// </summary>
         private unsafe void WmDateTimeChange(ref Message m)
         {
             NMDATETIMECHANGE* nmdtc = (NMDATETIMECHANGE*)m.LParam;
-            DateTime temp = value;
-            bool oldvalid = validTime;
+            DateTime temp = _value;
+            bool oldvalid = _validTime;
             if (nmdtc->dwFlags != GDT.NONE)
             {
-                validTime = true;
-                value = DateTimePicker.SysTimeToDateTime(nmdtc->st);
-                userHasSetValue = true;
+                _validTime = true;
+                _value = nmdtc->st;
+                _userHasSetValue = true;
             }
             else
             {
-                validTime = false;
+                _validTime = false;
             }
 
-            if (value != temp || oldvalid != validTime)
+            if (_value != temp || oldvalid != _validTime)
             {
                 OnValueChanged(EventArgs.Empty);
                 OnTextChanged(EventArgs.Empty);
@@ -1594,19 +1477,20 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles the DTN_DROPDOWN notification
+        ///  Handles the DTN_DROPDOWN notification.
         /// </summary>
-        private void WmDropDown(ref Message m)
+        private void WmDropDown()
         {
             if (RightToLeftLayout == true && RightToLeft == RightToLeft.Yes)
             {
                 IntPtr handle = User32.SendMessageW(this, (User32.WM)DTM.GETMONTHCAL);
                 if (handle != IntPtr.Zero)
                 {
-                    int style = unchecked((int)((long)User32.GetWindowLong(new HandleRef(this, handle), User32.GWL.EXSTYLE)));
-                    style |= (int)(User32.WS_EX.LAYOUTRTL | User32.WS_EX.NOINHERITLAYOUT);
-                    style &= ~(int)(User32.WS_EX.RIGHT | User32.WS_EX.RTLREADING);
-                    User32.SetWindowLong(new HandleRef(this, handle), User32.GWL.EXSTYLE, new HandleRef(this, (IntPtr)style));
+                    User32.WS_EX style = (User32.WS_EX)User32.GetWindowLong(handle, User32.GWL.EXSTYLE);
+                    style |= User32.WS_EX.LAYOUTRTL | User32.WS_EX.NOINHERITLAYOUT;
+                    style &= ~(User32.WS_EX.RIGHT | User32.WS_EX.RTLREADING);
+                    User32.SetWindowLong(handle, User32.GWL.EXSTYLE, (nint)style);
+                    GC.KeepAlive(this);
                 }
             }
 
@@ -1614,7 +1498,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles system color changes
+        ///  Handles system color changes.
         /// </summary>
         protected override void OnSystemColorsChanged(EventArgs e)
         {
@@ -1633,21 +1517,18 @@ namespace System.Windows.Forms
                 switch ((DTN)nmhdr->code)
                 {
                     case DTN.CLOSEUP:
-                        WmCloseUp(ref m);
+                        OnCloseUp(EventArgs.Empty);
                         break;
                     case DTN.DATETIMECHANGE:
                         WmDateTimeChange(ref m);
                         break;
                     case DTN.DROPDOWN:
-                        WmDropDown(ref m);
+                        WmDropDown();
                         break;
                 }
             }
         }
 
-        /// <summary>
-        ///  Overridden wndProc
-        /// </summary>
         protected override void WndProc(ref Message m)
         {
             switch ((User32.WM)m.Msg)
@@ -1672,41 +1553,6 @@ namespace System.Windows.Forms
                     base.WndProc(ref m);
                     break;
             }
-        }
-
-        /// <summary>
-        ///  Takes a DateTime value and returns a SYSTEMTIME struct
-        ///  Note: 1 second granularity
-        /// </summary>
-        internal static Kernel32.SYSTEMTIME DateTimeToSysTime(DateTime time)
-        {
-            var sys = new Kernel32.SYSTEMTIME
-            {
-                wYear = (short)time.Year,
-                wMonth = (short)time.Month,
-                wDayOfWeek = (short)time.DayOfWeek,
-                wDay = (short)time.Day,
-                wHour = (short)time.Hour,
-                wMinute = (short)time.Minute,
-                wSecond = (short)time.Second,
-                wMilliseconds = 0
-            };
-            return sys;
-        }
-
-        /// <summary>
-        ///  Takes a SYSTEMTIME struct and returns a DateTime value
-        ///  Note: 1 second granularity.
-        /// </summary>
-        internal static DateTime SysTimeToDateTime(Kernel32.SYSTEMTIME s)
-        {
-            if (s.wYear <= 0 || s.wMonth <= 0 || s.wDay <= 0)
-            {
-                Debug.Fail("Incorrect SYSTEMTIME info!");
-                return DateTime.MinValue;
-            }
-
-            return new DateTime(s.wYear, s.wMonth, s.wDay, s.wHour, s.wMinute, s.wSecond);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -1256,7 +1256,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)DTM.SETMCCOLOR, (IntPtr)colorIndex, PARAM.FromColor(value));
+                User32.SendMessageW(this, (User32.WM)DTM.SETMCCOLOR, (nint)colorIndex, value.ToWin32());
             }
         }
 
@@ -1267,7 +1267,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)DTM.SETMCFONT, (IntPtr)CalendarFontHandle, NativeMethods.InvalidIntPtr);
+                User32.SendMessageW(this, (User32.WM)DTM.SETMCFONT, CalendarFontHandle, NativeMethods.InvalidIntPtr);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.PageSelector.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.PageSelector.cs
@@ -185,7 +185,7 @@ namespace System.Windows.Forms.Design
 
                 int itemHeight = (int)User32.SendMessageW(this, (User32.WM)ComCtl32.TVM.GETITEMHEIGHT);
                 itemHeight += 2 * PADDING_VERT;
-                User32.SendMessageW(this, (User32.WM)ComCtl32.TVM.SETITEMHEIGHT, (IntPtr)itemHeight);
+                User32.SendMessageW(this, (User32.WM)ComCtl32.TVM.SETITEMHEIGHT, itemHeight);
 
                 if (_hbrushDither.IsNull)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.cs
@@ -136,12 +136,12 @@ namespace System.Windows.Forms
                     _tipWindow = new NativeWindow();
                     _tipWindow.CreateHandle(cparams);
 
-                    User32.SendMessageW(_tipWindow, (User32.WM)ComCtl32.TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                    User32.SendMessageW(_tipWindow, (User32.WM)ComCtl32.TTM.SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
                     User32.SetWindowPos(
                         new HandleRef(_tipWindow, _tipWindow.Handle),
                         User32.HWND_TOP,
                         flags: User32.SWP.NOSIZE | User32.SWP.NOMOVE | User32.SWP.NOACTIVATE);
-                    User32.SendMessageW(_tipWindow, (User32.WM)ComCtl32.TTM.SETDELAYTIME, (IntPtr)ComCtl32.TTDT.INITIAL, (IntPtr)0);
+                    User32.SendMessageW(_tipWindow, (User32.WM)ComCtl32.TTM.SETDELAYTIME, (nint)ComCtl32.TTDT.INITIAL, 0);
                 }
 
                 return true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
@@ -16,21 +16,21 @@ namespace System.Windows.Forms
         /// </summary>
         internal class IconRegion : IHandle
         {
-            private Region region;
-            private readonly Icon icon;
+            private Region _region;
+            private readonly Icon _icon;
 
             /// <summary>
             ///  Constructor that takes an Icon and extracts its 16x16 version.
             /// </summary>
             public IconRegion(Icon icon)
             {
-                this.icon = new Icon(icon, 16, 16);
+                _icon = new Icon(icon, 16, 16);
             }
 
             /// <summary>
             ///  Returns the handle of the icon.
             /// </summary>
-            public IntPtr Handle => icon.Handle;
+            public IntPtr Handle => _icon.Handle;
 
             /// <summary>
             ///  Returns the handle of the region.
@@ -39,15 +39,15 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (region is null)
+                    if (_region is null)
                     {
-                        region = new Region(new Rectangle(0, 0, 0, 0));
+                        _region = new Region(new Rectangle(0, 0, 0, 0));
 
                         IntPtr mask = IntPtr.Zero;
                         try
                         {
-                            Size size = icon.Size;
-                            Bitmap bitmap = icon.ToBitmap();
+                            Size size = _icon.Size;
+                            Bitmap bitmap = _icon.ToBitmap();
                             mask = ControlPaint.CreateHBitmapTransparencyMask(bitmap);
                             bitmap.Dispose();
 
@@ -67,43 +67,43 @@ namespace System.Windows.Forms
                                     // see if bit is set in mask. bits in byte are reversed. 0 is black (set).
                                     if ((bits[y * widthInBytes + x / 8] & (1 << (7 - (x % 8)))) == 0)
                                     {
-                                        region.Union(new Rectangle(x, y, 1, 1));
+                                        _region.Union(new Rectangle(x, y, 1, 1));
                                     }
                                 }
                             }
 
-                            region.Intersect(new Rectangle(0, 0, size.Width, size.Height));
+                            _region.Intersect(new Rectangle(0, 0, size.Width, size.Height));
                         }
                         finally
                         {
                             if (mask != IntPtr.Zero)
                             {
-                                Gdi32.DeleteObject(mask);
+                                Gdi32.DeleteObject((Gdi32.HGDIOBJ)mask);
                             }
                         }
                     }
 
-                    return region;
+                    return _region;
                 }
             }
 
             /// <summary>
             ///  Return the size of the icon.
             /// </summary>
-            public Size Size => icon.Size;
+            public Size Size => _icon.Size;
 
             /// <summary>
             ///  Release any resources held by this Object.
             /// </summary>
             public void Dispose()
             {
-                if (region != null)
+                if (_region != null)
                 {
-                    region.Dispose();
-                    region = null;
+                    _region.Dispose();
+                    _region = null;
                 }
 
-                icon.Dispose();
+                _icon.Dispose();
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -508,7 +508,7 @@ namespace System.Windows.Forms
                             NativeMethods.OPENFILENAME_I ofn = Marshal.PtrToStructure<NativeMethods.OPENFILENAME_I>(notify->lpOFN);
 
                             // Get the buffer size required to store the selected file names.
-                            int sizeNeeded = (int)User32.SendMessageW(new HandleRef(this, _dialogHWnd), (User32.WM)1124 /*CDM_GETSPEC*/, IntPtr.Zero, IntPtr.Zero);
+                            int sizeNeeded = (int)User32.SendMessageW(_dialogHWnd, (User32.WM)1124 /*CDM_GETSPEC*/);
                             if (sizeNeeded > ofn.nMaxFile)
                             {
                                 // A bigger buffer is required.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -416,13 +416,13 @@ namespace System.Windows.Forms
                     if (_initialDirectory.Length != 0)
                     {
                         // Try to expand the folder specified by initialDir
-                        User32.SendMessageW(hwnd, (User32.WM)BFFM.SETEXPANDED, PARAM.FromBool(true), _initialDirectory);
+                        User32.SendMessageW(hwnd, (User32.WM)BFFM.SETEXPANDED, (nint)BOOL.TRUE, _initialDirectory);
                     }
 
                     if (_selectedPath.Length != 0)
                     {
                         // Try to select the folder specified by selectedPath
-                        User32.SendMessageW(hwnd, (User32.WM)BFFM.SETSELECTIONW, PARAM.FromBool(true), _selectedPath);
+                        User32.SendMessageW(hwnd, (User32.WM)BFFM.SETSELECTIONW, (nint)BOOL.TRUE, _selectedPath);
                     }
 
                     break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -433,7 +433,7 @@ namespace System.Windows.Forms
                     {
                         // Try to retrieve the path from the IDList
                         bool isFileSystemFolder = SHGetPathFromIDListLongPath(selectedPidl, out _);
-                        User32.SendMessageW(hwnd, (User32.WM)BFFM.ENABLEOK, IntPtr.Zero, PARAM.FromBool(isFileSystemFolder));
+                        User32.SendMessageW(hwnd, (User32.WM)BFFM.ENABLEOK, 0, (nint)isFileSystemFolder.ToBOOL());
                     }
 
                     break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FontDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FontDialog.cs
@@ -358,7 +358,7 @@ namespace System.Windows.Forms
                     if (PARAM.ToInt(wparam) == 0x402)
                     {
                         var logFont = new User32.LOGFONTW();
-                        User32.SendMessageW(hWnd, User32.WM.CHOOSEFONT_GETLOGFONT, IntPtr.Zero, ref logFont);
+                        User32.SendMessageW(hWnd, User32.WM.CHOOSEFONT_GETLOGFONT, 0, ref logFont);
                         UpdateFont(ref logFont);
                         int index = PARAM.ToInt(User32.SendDlgItemMessageW(hWnd, User32.DialogItemID.cmb4, (User32.WM)User32.CB.GETCURSEL));
                         if (index != User32.CB_ERR)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.EnumThreadWindowsCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.EnumThreadWindowsCallback.cs
@@ -2,43 +2,36 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Runtime.InteropServices;
 using static Interop;
 
 namespace System.Windows.Forms
 {
     public partial class Form
     {
-        // Class used to temporarily reset the owners of windows owned by this Form
-        // before its handle recreation, then setting them back to the new handle
-        // after handle recreation
+        /// <summary>
+        ///  Class used to temporarily reset the owners of windows owned by this Form before its handle recreation,
+        ///  then setting them back to the new handle after handle recreation.
+        /// </summary>
         private class EnumThreadWindowsCallback
         {
-            private List<HandleRef> ownedWindows;
+            private List<IntPtr>? _ownedWindows;
 
             private readonly IntPtr _formHandle;
 
             internal EnumThreadWindowsCallback(IntPtr formHandle)
             {
-                this._formHandle = formHandle;
+                _formHandle = formHandle;
             }
 
-            internal BOOL Callback(IntPtr hWnd)
+            internal BOOL Callback(IntPtr hwnd)
             {
-                HandleRef hRef = new HandleRef(null, hWnd);
-                IntPtr parent = User32.GetWindowLong(hRef, User32.GWL.HWNDPARENT);
+                IntPtr parent = User32.GetWindowLong(hwnd, User32.GWL.HWNDPARENT);
                 if (parent == _formHandle)
                 {
                     // Enumerated window is owned by this Form.
                     // Store it in a list for further treatment.
-                    if (ownedWindows is null)
-                    {
-                        ownedWindows = new List<HandleRef>();
-                    }
-
-                    ownedWindows.Add(hRef);
+                    _ownedWindows ??= new();
+                    _ownedWindows.Add(parent);
                 }
 
                 return BOOL.TRUE;
@@ -47,23 +40,23 @@ namespace System.Windows.Forms
             // Resets the owner of all the windows owned by this Form before handle recreation.
             internal void ResetOwners()
             {
-                if (ownedWindows != null)
+                if (_ownedWindows != null)
                 {
-                    foreach (HandleRef hRef in ownedWindows)
+                    foreach (IntPtr hwnd in _ownedWindows)
                     {
-                        User32.SetWindowLong(hRef, User32.GWL.HWNDPARENT, NativeMethods.NullHandleRef);
+                        User32.SetWindowLong(hwnd, User32.GWL.HWNDPARENT, 0);
                     }
                 }
             }
 
             // Sets the owner of the windows back to this Form after its handle recreation.
-            internal void SetOwners(HandleRef hRefOwner)
+            internal void SetOwners(IntPtr ownerHwnd)
             {
-                if (ownedWindows != null)
+                if (_ownedWindows != null)
                 {
-                    foreach (HandleRef hRef in ownedWindows)
+                    foreach (IntPtr hwnd in _ownedWindows)
                     {
-                        User32.SetWindowLong(hRef, User32.GWL.HWNDPARENT, hRefOwner);
+                        User32.SetWindowLong(hwnd, User32.GWL.HWNDPARENT, ownerHwnd);
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -2599,7 +2599,7 @@ namespace System.Windows.Forms
             {
                 if (IsMdiChild)
                 {
-                    User32.SendMessageW(MdiParentInternal.MdiClient, User32.WM.MDIACTIVATE, Handle, IntPtr.Zero);
+                    User32.SendMessageW(MdiParentInternal.MdiClient, User32.WM.MDIACTIVATE, Handle, 0);
                 }
                 else
                 {
@@ -3575,7 +3575,7 @@ namespace System.Windows.Forms
             // If this form is a MdiChild, then we need to set the focus differently.
             if (IsMdiChild)
             {
-                User32.SendMessageW(MdiParentInternal.MdiClient, User32.WM.MDIACTIVATE, Handle, IntPtr.Zero);
+                User32.SendMessageW(MdiParentInternal.MdiClient, User32.WM.MDIACTIVATE, Handle, 0);
                 return Focused;
             }
 
@@ -4820,7 +4820,7 @@ namespace System.Windows.Forms
             else if (IsMdiChild)
             {
                 User32.SetActiveWindow(new HandleRef(MdiParentInternal, MdiParentInternal.Handle));
-                User32.SendMessageW(MdiParentInternal.MdiClient, User32.WM.MDIACTIVATE, Handle, IntPtr.Zero);
+                User32.SendMessageW(MdiParentInternal.MdiClient, User32.WM.MDIACTIVATE, Handle, 0);
             }
             else
             {
@@ -5583,7 +5583,7 @@ namespace System.Windows.Forms
                         Properties.SetObject(PropDummyMdiMenu, dummyMenu);
                     }
 
-                    User32.SendMessageW(ctlClient, User32.WM.MDISETMENU, dummyMenu.Value, IntPtr.Zero);
+                    User32.SendMessageW(ctlClient, User32.WM.MDISETMENU, dummyMenu.Value, 0);
                 }
 
                 // (New fix: Only destroy Win32 Menu if using a MenuStrip)
@@ -5862,8 +5862,8 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
-                    User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+                    User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)User32.ICON.SMALL, 0);
+                    User32.SendMessageW(this, User32.WM.SETICON, (IntPtr)User32.ICON.BIG, 0);
                 }
 
                 if (WindowState == FormWindowState.Maximized && MdiParent?.MdiControlStrip != null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms
     [ToolboxItemFilter("System.Windows.Forms.Control.TopLevel")]
     [ToolboxItem(false)]
     [DesignTimeVisible(false)]
-    [Designer("System.Windows.Forms.Design.FormDocumentDesigner, " + AssemblyRef.SystemDesign, typeof(IRootDesigner))]
+    [Designer($"System.Windows.Forms.Design.FormDocumentDesigner, {AssemblyRef.SystemDesign}", typeof(IRootDesigner))]
     [DefaultEvent(nameof(Load))]
     [InitializationEvent(nameof(Load))]
     [DesignerCategory("Form")]
@@ -149,7 +149,7 @@ namespace System.Windows.Forms
         private BoundsSpecified restoredWindowBoundsSpecified;
         private DialogResult dialogResult;
         private MdiClient ctlClient;
-        private NativeWindow ownerWindow;
+        private NativeWindow _ownerWindow;
         private bool rightToLeftLayout;
 
         private Rectangle restoreBounds = new Rectangle(-1, -1, -1, -1);
@@ -788,7 +788,7 @@ namespace System.Windows.Forms
             {
                 CreateParams cp = base.CreateParams;
 
-                if (IsHandleCreated && (WindowStyle & (int)User32.WS.DISABLED) != 0)
+                if (IsHandleCreated && WindowStyle.HasFlag(User32.WS.DISABLED))
                 {
                     // Forms that are parent of a modal dialog must keep their WS_DISABLED style
                     cp.Style |= (int)User32.WS.DISABLED;
@@ -808,7 +808,7 @@ namespace System.Windows.Forms
                 IWin32Window dialogOwner = (IWin32Window)Properties.GetObject(PropDialogOwner);
                 if (dialogOwner != null)
                 {
-                    cp.Parent = Control.GetSafeHandle(dialogOwner);
+                    cp.Parent = GetSafeHandle(dialogOwner);
                 }
 
                 FillInCreateParamsBorderStyles(cp);
@@ -1738,11 +1738,10 @@ namespace System.Windows.Forms
                     formState[FormStateLayered] = (TransparencyKey != Color.Empty) ? 1 : 0;
                     if (oldLayered != (formState[FormStateLayered] != 0))
                     {
-                        int exStyle = unchecked((int)(long)User32.GetWindowLong(this, User32.GWL.EXSTYLE));
                         CreateParams cp = CreateParams;
-                        if (exStyle != cp.ExStyle)
+                        if ((int)ExtendedWindowStyle != cp.ExStyle)
                         {
-                            User32.SetWindowLong(this, User32.GWL.EXSTYLE, (IntPtr)cp.ExStyle);
+                            User32.SetWindowLong(this, User32.GWL.EXSTYLE, cp.ExStyle);
                         }
                     }
                 }
@@ -2095,28 +2094,25 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  For forms that are show in task bar false, this returns a HWND
-        ///  they must be parented to in order for it to work.
+        ///  For forms that are show in task bar false, this returns a HWND they must be parented to in order for it to work.
         /// </summary>
-        private HandleRef TaskbarOwner
+        private IHandle TaskbarOwner
         {
             get
             {
-                if (ownerWindow is null)
-                {
-                    ownerWindow = new NativeWindow();
-                }
+                _ownerWindow ??= new NativeWindow();
 
-                if (ownerWindow.Handle == IntPtr.Zero)
+                if (_ownerWindow.Handle == IntPtr.Zero)
                 {
                     CreateParams cp = new CreateParams
                     {
                         ExStyle = (int)User32.WS_EX.TOOLWINDOW
                     };
-                    ownerWindow.CreateHandle(cp);
+
+                    _ownerWindow.CreateHandle(cp);
                 }
 
-                return new HandleRef(ownerWindow, ownerWindow.Handle);
+                return _ownerWindow;
             }
         }
 
@@ -3200,19 +3196,17 @@ namespace System.Windows.Forms
                     UpdateMenuHandles();
                 }
 
-                // In order for a window not to have a taskbar entry, it must
-                // be owned.
-                //
+                // In order for a window not to have a taskbar entry, it must be owned.
                 if (!ShowInTaskbar && OwnerInternal is null && TopLevel)
                 {
-                    User32.SetWindowLong(this, User32.GWL.HWNDPARENT, TaskbarOwner);
+                    User32.SetWindowLong(this, User32.GWL.HWNDPARENT, (nint)TaskbarOwner.Handle);
 
                     // Make sure the large icon is set so the ALT+TAB icon
                     // reflects the real icon of the application
                     Icon icon = Icon;
                     if (icon != null && TaskbarOwner.Handle != IntPtr.Zero)
                     {
-                        User32.SendMessageW(TaskbarOwner, User32.WM.SETICON, (IntPtr)User32.ICON.BIG, icon.Handle);
+                        User32.SendMessageW(TaskbarOwner, User32.WM.SETICON, (nint)User32.ICON.BIG, icon.Handle);
                     }
                 }
 
@@ -3710,46 +3704,47 @@ namespace System.Windows.Forms
         /// </summary>
         protected void CenterToParent()
         {
-            if (TopLevel)
+            if (!TopLevel)
             {
-                Point p = new Point();
-                Size s = Size;
-                IntPtr ownerHandle = IntPtr.Zero;
+                return;
+            }
 
-                ownerHandle = User32.GetWindowLong(this, User32.GWL.HWNDPARENT);
-                if (ownerHandle != IntPtr.Zero)
+            Point p = new Point();
+            Size s = Size;
+            IntPtr ownerHandle = User32.GetWindowLong(this, User32.GWL.HWNDPARENT);
+
+            if (ownerHandle != IntPtr.Zero)
+            {
+                Screen desktop = Screen.FromHandle(ownerHandle);
+                Rectangle screenRect = desktop.WorkingArea;
+                var ownerRect = new RECT();
+                User32.GetWindowRect(ownerHandle, ref ownerRect);
+
+                p.X = (ownerRect.left + ownerRect.right - s.Width) / 2;
+                if (p.X < screenRect.X)
                 {
-                    Screen desktop = Screen.FromHandle(ownerHandle);
-                    Rectangle screenRect = desktop.WorkingArea;
-                    var ownerRect = new RECT();
-                    User32.GetWindowRect(ownerHandle, ref ownerRect);
-
-                    p.X = (ownerRect.left + ownerRect.right - s.Width) / 2;
-                    if (p.X < screenRect.X)
-                    {
-                        p.X = screenRect.X;
-                    }
-                    else if (p.X + s.Width > screenRect.X + screenRect.Width)
-                    {
-                        p.X = screenRect.X + screenRect.Width - s.Width;
-                    }
-
-                    p.Y = (ownerRect.top + ownerRect.bottom - s.Height) / 2;
-                    if (p.Y < screenRect.Y)
-                    {
-                        p.Y = screenRect.Y;
-                    }
-                    else if (p.Y + s.Height > screenRect.Y + screenRect.Height)
-                    {
-                        p.Y = screenRect.Y + screenRect.Height - s.Height;
-                    }
-
-                    Location = p;
+                    p.X = screenRect.X;
                 }
-                else
+                else if (p.X + s.Width > screenRect.X + screenRect.Width)
                 {
-                    CenterToScreen();
+                    p.X = screenRect.X + screenRect.Width - s.Width;
                 }
+
+                p.Y = (ownerRect.top + ownerRect.bottom - s.Height) / 2;
+                if (p.Y < screenRect.Y)
+                {
+                    p.Y = screenRect.Y;
+                }
+                else if (p.Y + s.Height > screenRect.Y + screenRect.Height)
+                {
+                    p.Y = screenRect.Y + screenRect.Height - s.Height;
+                }
+
+                Location = p;
+            }
+            else
+            {
+                CenterToScreen();
             }
         }
 
@@ -3762,7 +3757,7 @@ namespace System.Windows.Forms
         protected void CenterToScreen()
         {
             Point p = new Point();
-            Screen desktop = null;
+            Screen desktop;
             if (OwnerInternal != null)
             {
                 desktop = Screen.FromControl(OwnerInternal);
@@ -3775,14 +3770,7 @@ namespace System.Windows.Forms
                     hWndOwner = User32.GetWindowLong(this, User32.GWL.HWNDPARENT);
                 }
 
-                if (hWndOwner != IntPtr.Zero)
-                {
-                    desktop = Screen.FromHandle(hWndOwner);
-                }
-                else
-                {
-                    desktop = Screen.FromPoint(Control.MousePosition);
-                }
+                desktop = hWndOwner != IntPtr.Zero ? Screen.FromHandle(hWndOwner) : Screen.FromPoint(MousePosition);
             }
 
             Rectangle screenRect = desktop.WorkingArea;
@@ -4627,31 +4615,29 @@ namespace System.Windows.Forms
             if (StartPosition != FormStartPosition.Manual)
             {
                 oldStartPosition = StartPosition;
+
                 // Set the startup postion to manual, to stop the form from
                 // changing position each time RecreateHandle() is called.
                 StartPosition = FormStartPosition.Manual;
             }
 
-            EnumThreadWindowsCallback etwcb = null;
+            EnumThreadWindowsCallback callback = null;
             if (IsHandleCreated)
             {
                 // First put all the owned windows into a list
-                etwcb = new EnumThreadWindowsCallback(Handle);
-                User32.EnumThreadWindows(
-                    Kernel32.GetCurrentThreadId(),
-                    etwcb.Callback);
-                GC.KeepAlive(this);
+                callback = new EnumThreadWindowsCallback(Handle);
+                User32.EnumThreadWindows(Kernel32.GetCurrentThreadId(), callback.Callback);
+
                 // Reset the owner of the windows in the list
-                etwcb.ResetOwners();
+                callback.ResetOwners();
             }
 
             base.RecreateHandleCore();
 
-            if (etwcb != null)
-            {
-                // Set the owner of the windows in the list back to the new Form's handle
-                etwcb.SetOwners(new HandleRef(this, Handle));
-            }
+            // Set the owner of the windows in the list back to the new Form's handle
+            callback?.SetOwners(Handle);
+
+            GC.KeepAlive(this);
 
             if (oldStartPosition != FormStartPosition.Manual)
             {
@@ -5114,22 +5100,22 @@ namespace System.Windows.Forms
         {
             if (owner == this)
             {
-                throw new InvalidOperationException(string.Format(SR.OwnsSelfOrOwner, "Show"));
+                throw new InvalidOperationException(string.Format(SR.OwnsSelfOrOwner, nameof(Show)));
             }
 
             if (Visible)
             {
-                throw new InvalidOperationException(string.Format(SR.ShowDialogOnVisible, "Show"));
+                throw new InvalidOperationException(string.Format(SR.ShowDialogOnVisible, nameof(Show)));
             }
 
             if (!Enabled)
             {
-                throw new InvalidOperationException(string.Format(SR.ShowDialogOnDisabled, "Show"));
+                throw new InvalidOperationException(string.Format(SR.ShowDialogOnDisabled, nameof(Show)));
             }
 
             if (!TopLevel)
             {
-                throw new InvalidOperationException(string.Format(SR.ShowDialogOnNonTopLevel, "Show"));
+                throw new InvalidOperationException(string.Format(SR.ShowDialogOnNonTopLevel, nameof(Show)));
             }
 
             if (!SystemInformation.UserInteractive)
@@ -5137,18 +5123,17 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.CantShowModalOnNonInteractive);
             }
 
-            if ((owner != null) && ((int)User32.GetWindowLong(new HandleRef(owner, Control.GetSafeHandle(owner)), User32.GWL.EXSTYLE)
-                     & (int)User32.WS_EX.TOPMOST) == 0)
-            {   // It's not the top-most window
+            if ((owner != null) && owner.GetExtendedStyle().HasFlag(User32.WS_EX.TOPMOST))
+            {
+                // It's not the top-most window
                 if (owner is Control ownerControl)
                 {
                     owner = ownerControl.TopLevelControlInternal;
                 }
             }
 
-            IntPtr hWndActive = User32.GetActiveWindow();
-            IntPtr hWndOwner = owner is null ? hWndActive : Control.GetSafeHandle(owner);
-            IntPtr hWndOldOwner = IntPtr.Zero;
+            IntPtr activeHwnd = User32.GetActiveWindow();
+            IntPtr ownerHwnd = owner is null ? activeHwnd : GetSafeHandle(owner);
             Properties.SetObject(PropDialogOwner, owner);
             Form oldOwner = OwnerInternal;
             if (owner is Form ownerForm && owner != oldOwner)
@@ -5156,18 +5141,19 @@ namespace System.Windows.Forms
                 Owner = ownerForm;
             }
 
-            if (hWndOwner != IntPtr.Zero && hWndOwner != Handle)
+            if (ownerHwnd != IntPtr.Zero && ownerHwnd != Handle)
             {
                 // Catch the case of a window trying to own its owner
-                if (User32.GetWindowLong(new HandleRef(owner, hWndOwner), User32.GWL.HWNDPARENT) == Handle)
+                if (User32.GetWindowLong(ownerHwnd, User32.GWL.HWNDPARENT) == Handle)
                 {
-                    throw new ArgumentException(string.Format(SR.OwnsSelfOrOwner, "show"), nameof(owner));
+                    throw new ArgumentException(string.Format(SR.OwnsSelfOrOwner, nameof(Show)), nameof(owner));
                 }
 
                 // Set the new owner.
-                hWndOldOwner = User32.GetWindowLong(this, User32.GWL.HWNDPARENT);
-                User32.SetWindowLong(this, User32.GWL.HWNDPARENT, new HandleRef(owner, hWndOwner));
+                User32.SetWindowLong(this, User32.GWL.HWNDPARENT, ownerHwnd);
             }
+
+            GC.KeepAlive(owner);
 
             Visible = true;
         }
@@ -5175,10 +5161,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Displays this form as a modal dialog box with no owner window.
         /// </summary>
-        public DialogResult ShowDialog()
-        {
-            return ShowDialog(null);
-        }
+        public DialogResult ShowDialog() => ShowDialog(null);
 
         /// <summary>
         ///  Shows this form as a modal dialog with the specified owner.
@@ -5187,27 +5170,27 @@ namespace System.Windows.Forms
         {
             if (owner == this)
             {
-                throw new ArgumentException(string.Format(SR.OwnsSelfOrOwner, "showDialog"), nameof(owner));
+                throw new ArgumentException(string.Format(SR.OwnsSelfOrOwner, nameof(ShowDialog)), nameof(owner));
             }
 
             if (Visible)
             {
-                throw new InvalidOperationException(string.Format(SR.ShowDialogOnVisible, "showDialog"));
+                throw new InvalidOperationException(string.Format(SR.ShowDialogOnVisible, nameof(ShowDialog)));
             }
 
             if (!Enabled)
             {
-                throw new InvalidOperationException(string.Format(SR.ShowDialogOnDisabled, "showDialog"));
+                throw new InvalidOperationException(string.Format(SR.ShowDialogOnDisabled, nameof(ShowDialog)));
             }
 
             if (!TopLevel)
             {
-                throw new InvalidOperationException(string.Format(SR.ShowDialogOnNonTopLevel, "showDialog"));
+                throw new InvalidOperationException(string.Format(SR.ShowDialogOnNonTopLevel, nameof(ShowDialog)));
             }
 
             if (Modal)
             {
-                throw new InvalidOperationException(string.Format(SR.ShowDialogOnModal, "showDialog"));
+                throw new InvalidOperationException(string.Format(SR.ShowDialogOnModal, nameof(ShowDialog)));
             }
 
             if (!SystemInformation.UserInteractive)
@@ -5215,9 +5198,9 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.CantShowModalOnNonInteractive);
             }
 
-            if ((owner != null) && ((int)User32.GetWindowLong(new HandleRef(owner, GetSafeHandle(owner)), User32.GWL.EXSTYLE)
-                     & (int)User32.WS_EX.TOPMOST) == 0)
-            {   // It's not the top-most window
+            if ((owner != null) && owner.GetExtendedStyle().HasFlag(User32.WS_EX.TOPMOST))
+            {
+                // It's not the top-most window
                 if (owner is Control ownerControl)
                 {
                     owner = ownerControl.TopLevelControlInternal;
@@ -5230,15 +5213,15 @@ namespace System.Windows.Forms
             // for modal dialogs make sure we reset close reason.
             CloseReason = CloseReason.None;
 
-            IntPtr hWndCapture = User32.GetCapture();
-            if (hWndCapture != IntPtr.Zero)
+            IntPtr captureHwnd = User32.GetCapture();
+            if (captureHwnd != IntPtr.Zero)
             {
-                User32.SendMessageW(hWndCapture, User32.WM.CANCELMODE);
+                User32.SendMessageW(captureHwnd, User32.WM.CANCELMODE);
                 User32.ReleaseCapture();
             }
 
-            IntPtr hWndActive = User32.GetActiveWindow();
-            IntPtr hWndOwner = owner is null ? hWndActive : Control.GetSafeHandle(owner);
+            IntPtr activeHwnd = User32.GetActiveWindow();
+            IntPtr ownerHwnd = owner is null ? activeHwnd : GetSafeHandle(owner);
 
             Form oldOwner = OwnerInternal;
 
@@ -5253,22 +5236,20 @@ namespace System.Windows.Forms
                 // we'll know to terminate the RunDialog loop immediately.
                 // Thus we must initialize the DialogResult *before* the call
                 // to CreateControl().
-                //
                 dialogResult = DialogResult.None;
 
                 // If "this" is an MDI parent then the window gets activated,
                 // causing GetActiveWindow to return "this.handle"... to prevent setting
                 // the owner of this to this, we must create the control AFTER calling
                 // GetActiveWindow.
-                //
                 CreateControl();
 
-                if (hWndOwner != IntPtr.Zero && hWndOwner != Handle)
+                if (ownerHwnd != IntPtr.Zero && ownerHwnd != Handle)
                 {
                     // Catch the case of a window trying to own its owner
-                    if (User32.GetWindowLong(new HandleRef(owner, hWndOwner), User32.GWL.HWNDPARENT) == Handle)
+                    if (User32.GetWindowLong(ownerHwnd, User32.GWL.HWNDPARENT) == Handle)
                     {
-                        throw new ArgumentException(string.Format(SR.OwnsSelfOrOwner, "showDialog"), nameof(owner));
+                        throw new ArgumentException(string.Format(SR.OwnsSelfOrOwner, nameof(ShowDialog)), nameof(owner));
                     }
 
                     // In a multi Dpi environment and applications in PMV2 mode, Dpi changed events triggered
@@ -5285,15 +5266,13 @@ namespace System.Windows.Forms
                     else
                     {
                         // Set the new parent.
-                        User32.SetWindowLong(this, User32.GWL.HWNDPARENT, new HandleRef(owner, hWndOwner));
+                        User32.SetWindowLong(this, User32.GWL.HWNDPARENT, ownerHwnd);
                     }
                 }
 
                 try
                 {
-                    // If the DialogResult was already set, then there's
-                    // no need to actually display the dialog.
-                    //
+                    // If the DialogResult was already set, then there's no need to actually display the dialog.
                     if (dialogResult == DialogResult.None)
                     {
                         // Application.RunDialog sets this dialog to be visible.
@@ -5303,20 +5282,19 @@ namespace System.Windows.Forms
                 finally
                 {
                     // Call SetActiveWindow before setting Visible = false.
-                    //
 
-                    if (User32.IsWindow(hWndActive).IsFalse())
+                    if (User32.IsWindow(activeHwnd).IsFalse())
                     {
-                        hWndActive = hWndOwner;
+                        activeHwnd = ownerHwnd;
                     }
 
-                    if (User32.IsWindow(hWndActive).IsTrue() && User32.IsWindowVisible(hWndActive).IsTrue())
+                    if (User32.IsWindow(activeHwnd).IsTrue() && User32.IsWindowVisible(activeHwnd).IsTrue())
                     {
-                        User32.SetActiveWindow(hWndActive);
+                        User32.SetActiveWindow(activeHwnd);
                     }
-                    else if (User32.IsWindow(hWndOwner).IsTrue() && User32.IsWindowVisible(hWndOwner).IsTrue())
+                    else if (User32.IsWindow(ownerHwnd).IsTrue() && User32.IsWindowVisible(ownerHwnd).IsTrue())
                     {
-                        User32.SetActiveWindow(hWndOwner);
+                        User32.SetActiveWindow(ownerHwnd);
                     }
 
                     SetVisibleCore(false);
@@ -5342,6 +5320,7 @@ namespace System.Windows.Forms
             {
                 Owner = oldOwner;
                 Properties.SetObject(PropDialogOwner, null);
+                GC.KeepAlive(owner);
             }
 
             return DialogResult;
@@ -5427,11 +5406,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Returns a string representation for this control.
         /// </summary>
-        public override string ToString()
-        {
-            string s = base.ToString();
-            return s + ", Text: " + Text;
-        }
+        public override string ToString() => $"{base.ToString()}, Text: {Text}";
 
         /// <summary>
         ///  Updates the autoscalebasesize based on the current font.
@@ -5485,10 +5460,6 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <summary>
-        ///  Updates the default button based on current selection, and the
-        ///  acceptButton property.
-        /// </summary>
         protected override void UpdateDefaultButton()
         {
             ContainerControl cc = this;
@@ -5525,13 +5496,13 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated && TopLevel)
             {
-                HandleRef ownerHwnd = NativeMethods.NullHandleRef;
+                IHandle ownerHwnd = null;
 
                 Form owner = (Form)Properties.GetObject(PropOwner);
 
-                if (owner != null)
+                if (owner is not null)
                 {
-                    ownerHwnd = new HandleRef(owner, owner.Handle);
+                    ownerHwnd = owner;
                 }
                 else
                 {
@@ -5541,7 +5512,8 @@ namespace System.Windows.Forms
                     }
                 }
 
-                User32.SetWindowLong(this, User32.GWL.HWNDPARENT, ownerHwnd);
+                User32.SetWindowLong(this, User32.GWL.HWNDPARENT, ownerHwnd?.Handle ?? default);
+                GC.KeepAlive(ownerHwnd);
             }
         }
 
@@ -6384,10 +6356,10 @@ namespace System.Windows.Forms
             // that point our handle is not actually destroyed so
             // destroying our parent actually causes a recursive
             // WM_DESTROY.
-            if (ownerWindow != null)
+            if (_ownerWindow != null)
             {
-                ownerWindow.DestroyHandle();
-                ownerWindow = null;
+                _ownerWindow.DestroyHandle();
+                _ownerWindow = null;
             }
 
             if (Modal && dialogResult == DialogResult.None)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -255,7 +255,7 @@ namespace System.Windows.Forms
                 {
                     if (suspendRedraw && IsHandleCreated)
                     {
-                        User32.SendMessageW(this, User32.WM.SETREDRAW, PARAM.FromBool(false));
+                        User32.SendMessageW(this, User32.WM.SETREDRAW, (nint)BOOL.FALSE);
                     }
 
                     base.Text = value;
@@ -264,7 +264,7 @@ namespace System.Windows.Forms
                 {
                     if (suspendRedraw && IsHandleCreated)
                     {
-                        User32.SendMessageW(this, User32.WM.SETREDRAW, PARAM.FromBool(true));
+                        User32.SendMessageW(this, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms
     public sealed partial class ImageList
     {
         // Everything other than set_All, Add, and Clear will force handle creation.
-        [Editor("System.Windows.Forms.Design.ImageCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Editor($"System.Windows.Forms.Design.ImageCollectionEditor, {AssemblyRef.SystemDesign}", typeof(UITypeEditor))]
         public sealed partial class ImageCollection : IList
         {
             private readonly ImageList _owner;
@@ -172,8 +172,8 @@ namespace System.Windows.Forms
                         }
                         finally
                         {
-                            Gdi32.DeleteObject(hBitmap);
-                            Gdi32.DeleteObject(hMask);
+                            Gdi32.DeleteObject((Gdi32.HGDIOBJ)hBitmap);
+                            Gdi32.DeleteObject((Gdi32.HGDIOBJ)hMask);
                         }
 
                         if (!ok)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -22,13 +22,13 @@ namespace System.Windows.Forms
     /// </summary>
     [DefaultProperty(nameof(Text))]
     [DefaultBindingProperty(nameof(Text))]
-    [Designer("System.Windows.Forms.Design.LabelDesigner, " + AssemblyRef.SystemDesign)]
-    [ToolboxItem("System.Windows.Forms.Design.AutoSizeToolboxItem," + AssemblyRef.SystemDesign)]
+    [Designer($"System.Windows.Forms.Design.LabelDesigner, {AssemblyRef.SystemDesign}")]
+    [ToolboxItem($"System.Windows.Forms.Design.AutoSizeToolboxItem,{AssemblyRef.SystemDesign}")]
     [SRDescription(nameof(SR.DescriptionLabel))]
     // If not for FormatControl, we could inherit from ButtonBase and get foreground images for free.
     public partial class Label : Control, IAutomationLiveRegion
     {
-        private static readonly object s_eventTextAlignChanged = new object();
+        private static readonly object s_eventTextAlignChanged = new();
 
         private static readonly BitVector32.Section s_stateUseMnemonic = BitVector32.CreateSection(1);
         private static readonly BitVector32.Section s_stateAutoSize = BitVector32.CreateSection(1, s_stateUseMnemonic);
@@ -806,34 +806,35 @@ namespace System.Windows.Forms
             get => _labelState[s_stateUseMnemonic] != 0;
             set
             {
-                if (UseMnemonic != value)
+                if (UseMnemonic == value)
                 {
-                    _labelState[s_stateUseMnemonic] = value ? 1 : 0;
-                    MeasureTextCache.InvalidateCache();
+                    return;
+                }
 
-                    // The size of the label need to be adjusted when the Mnemonic
-                    // is set irrespective of auto-sizing
-                    using (LayoutTransaction.CreateTransactionIf(AutoSize, ParentInternal, this, PropertyNames.Text))
+                _labelState[s_stateUseMnemonic] = value ? 1 : 0;
+                MeasureTextCache.InvalidateCache();
+
+                // The size of the label need to be adjusted when the Mnemonic is set irrespective of auto-sizing.
+                using (LayoutTransaction.CreateTransactionIf(AutoSize, ParentInternal, this, PropertyNames.Text))
+                {
+                    AdjustSize();
+                    Invalidate();
+                }
+
+                // Set windowStyle directly instead of recreating handle to increase efficiency.
+                if (IsHandleCreated)
+                {
+                    User32.WS style = WindowStyle;
+                    if (!UseMnemonic)
                     {
-                        AdjustSize();
-                        Invalidate();
+                        style |= (User32.WS)User32.SS.NOPREFIX;
+                    }
+                    else
+                    {
+                        style &= ~(User32.WS)User32.SS.NOPREFIX;
                     }
 
-                    //set windowStyle directly instead of recreating handle to increase efficiency
-                    if (IsHandleCreated)
-                    {
-                        int style = WindowStyle;
-                        if (!UseMnemonic)
-                        {
-                            style |= (int)User32.SS.NOPREFIX;
-                        }
-                        else
-                        {
-                            style &= ~(int)User32.SS.NOPREFIX;
-                        }
-
-                        WindowStyle = style;
-                    }
+                    WindowStyle = style;
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -400,7 +400,7 @@ namespace System.Windows.Forms
                         User32.GetWindowRect(this, ref r);
                         if ((r.left <= p.X && p.X < r.right && r.top <= p.Y && p.Y < r.bottom) || User32.GetCapture() == Handle)
                         {
-                            User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (IntPtr)User32.HT.CLIENT);
+                            User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (nint)User32.HT.CLIENT);
                         }
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -266,14 +266,14 @@ namespace System.Windows.Forms
 
                 if (_owningListBox.SelectedIndex == -1) //no item selected
                 {
-                    User32.SendMessageW(_owningListBox, (User32.WM)User32.LB.SETCARETINDEX, (IntPtr)currentIndex);
+                    User32.SendMessageW(_owningListBox, (User32.WM)User32.LB.SETCARETINDEX, currentIndex);
                     return;
                 }
 
-                int firstVisibleIndex = (int)(long)User32.SendMessageW(_owningListBox, (User32.WM)User32.LB.GETTOPINDEX);
+                int firstVisibleIndex = (int)User32.SendMessageW(_owningListBox, (User32.WM)User32.LB.GETTOPINDEX);
                 if (currentIndex < firstVisibleIndex)
                 {
-                    User32.SendMessageW(_owningListBox, (User32.WM)User32.LB.SETTOPINDEX, (IntPtr)currentIndex);
+                    User32.SendMessageW(_owningListBox, (User32.WM)User32.LB.SETTOPINDEX, currentIndex);
                     return;
                 }
 
@@ -283,7 +283,7 @@ namespace System.Windows.Forms
 
                 for (int i = firstVisibleIndex; i < itemsCount; i++)
                 {
-                    int itemHeight = (int)(long)User32.SendMessageW(_owningListBox, (User32.WM)User32.LB.GETITEMHEIGHT, (IntPtr)i);
+                    int itemHeight = (int)User32.SendMessageW(_owningListBox, (User32.WM)User32.LB.GETITEMHEIGHT, i);
 
                     if ((itemsHeightSum += itemHeight) <= listBoxHeight)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.SelectedObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.SelectedObjectCollection.cs
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
 
                             case SelectionMode.MultiSimple:
                             case SelectionMode.MultiExtended:
-                                return unchecked((int)(long)SendMessageW(_owner, (WM)LB.GETSELCOUNT));
+                                return (int)SendMessageW(_owner, (WM)LB.GETSELCOUNT);
                         }
 
                         return 0;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -1504,7 +1504,7 @@ namespace System.Windows.Forms
         {
             CheckIndex(index);
             var rect = new RECT();
-            if (SendMessageW(this, (WM)LB.GETITEMRECT, (IntPtr)index, ref rect) == IntPtr.Zero)
+            if (SendMessageW(this, (WM)LB.GETITEMRECT, index, ref rect) == 0)
             {
                 return Rectangle.Empty;
             }
@@ -1590,13 +1590,12 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Adds the given item to the native List box.  This asserts if the handle hasn't been
-        ///  created.
+        ///  Adds the given item to the native List box.
         /// </summary>
         private int NativeAdd(object item)
         {
             Debug.Assert(IsHandleCreated, "Shouldn't be calling Native methods before the handle is created.");
-            int insertIndex = unchecked((int)(long)SendMessageW(this, (WM)LB.ADDSTRING, IntPtr.Zero, GetItemText(item)));
+            int insertIndex = (int)SendMessageW(this, (WM)LB.ADDSTRING, 0, GetItemText(item));
             if (insertIndex == LB_ERRSPACE)
             {
                 throw new OutOfMemoryException();
@@ -1659,7 +1658,7 @@ namespace System.Windows.Forms
         private int NativeInsert(int index, object item)
         {
             Debug.Assert(IsHandleCreated, "Shouldn't be calling Native methods before the handle is created.");
-            int insertIndex = unchecked((int)(long)SendMessageW(this, (WM)LB.INSERTSTRING, (IntPtr)index, GetItemText(item)));
+            int insertIndex = (int)SendMessageW(this, (WM)LB.INSERTSTRING, index, GetItemText(item));
 
             if (insertIndex == LB_ERRSPACE)
             {
@@ -1675,7 +1674,7 @@ namespace System.Windows.Forms
                 throw new OutOfMemoryException(SR.ListBoxItemOverflow);
             }
 
-            Debug.Assert(insertIndex == index, "NativeListBox inserted at " + insertIndex + " not the requested index of " + index);
+            Debug.Assert(insertIndex == index, $"NativeListBox inserted at {insertIndex} not the requested index of {index}");
             return insertIndex;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -436,20 +436,7 @@ namespace System.Windows.Forms
             }
         }
 
-        // Used internally to find the currently focused item
-        //
-        internal int FocusedIndex
-        {
-            get
-            {
-                if (IsHandleCreated)
-                {
-                    return unchecked((int)(long)SendMessageW(this, (WM)LB.GETCARETINDEX));
-                }
-
-                return -1;
-            }
-        }
+        internal int FocusedIndex => IsHandleCreated ? (int)SendMessageW(this, (WM)LB.GETCARETINDEX) : -1;
 
         // The scroll bars don't display properly when the IntegralHeight == false
         // and the control is resized before the font size is change and the new font size causes
@@ -876,7 +863,7 @@ namespace System.Windows.Forms
 
                 if (current == SelectionMode.One && IsHandleCreated)
                 {
-                    return unchecked((int)(long)SendMessageW(this, (WM)LB.GETCURSEL));
+                    return (int)SendMessageW(this, (WM)LB.GETCURSEL);
                 }
 
                 if (itemsCollection is not null && SelectedItems.Count > 0)
@@ -1164,17 +1151,7 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ListBoxTopIndexDescr))]
         public int TopIndex
         {
-            get
-            {
-                if (IsHandleCreated)
-                {
-                    return unchecked((int)(long)SendMessageW(this, (WM)LB.GETTOPINDEX));
-                }
-                else
-                {
-                    return topIndex;
-                }
-            }
+            get => IsHandleCreated ? (int)SendMessageW(this, (WM)LB.GETTOPINDEX) : topIndex;
             set
             {
                 if (IsHandleCreated)
@@ -1468,9 +1445,7 @@ namespace System.Windows.Forms
         {
             int itemCount = (itemsCollection is null) ? 0 : itemsCollection.Count;
 
-            // Note: index == 0 is OK even if the ListBox currently has
-            // no items.
-            //
+            // Note: index == 0 is OK even if the ListBox currently has no items.
             if (index < 0 || (index > 0 && index >= itemCount))
             {
                 throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));
@@ -1483,13 +1458,13 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                int h = unchecked((int)(long)SendMessageW(this, (WM)LB.GETITEMHEIGHT, (IntPtr)index));
-                if (h == -1)
+                int height = (int)SendMessageW(this, (WM)LB.GETITEMHEIGHT, index);
+                if (height == -1)
                 {
                     throw new Win32Exception();
                 }
 
-                return h;
+                return height;
             }
 
             return itemHeight;
@@ -1526,8 +1501,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Tells you whether or not the item at the supplied index is selected
-        ///  or not.
+        ///  Tells you whether or not the item at the supplied index is selected or not.
         /// </summary>
         public bool GetSelected(int index)
         {
@@ -1539,13 +1513,13 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                int sel = unchecked((int)(long)SendMessageW(this, (WM)LB.GETSEL, (IntPtr)index));
-                if (sel == -1)
+                int selection = (int)SendMessageW(this, (WM)LB.GETSEL, index);
+                if (selection == -1)
                 {
                     throw new Win32Exception();
                 }
 
-                return sel > 0;
+                return selection > 0;
             }
             else
             {
@@ -1571,14 +1545,13 @@ namespace System.Windows.Forms
         /// </summary>
         public int IndexFromPoint(int x, int y)
         {
-            //NT4 SP6A : SendMessage Fails. So First check whether the point is in Client Co-ordinates and then
-            //call Sendmessage.
-            //
+            // NT4 SP6A : SendMessage Fails. So First check whether the point is in Client Co-ordinates and then
+            // call Sendmessage.
             RECT r = new RECT();
             GetClientRect(new HandleRef(this, Handle), ref r);
             if (r.left <= x && x < r.right && r.top <= y && y < r.bottom)
             {
-                int index = unchecked((int)(long)SendMessageW(this, (WM)LB.ITEMFROMPOINT, IntPtr.Zero, PARAM.FromLowHigh(x, y)));
+                int index = (int)SendMessageW(this, (WM)LB.ITEMFROMPOINT, 0, PARAM.FromLowHigh(x, y));
                 if (PARAM.HIWORD(index) == 0)
                 {
                     // Inside ListBox client area
@@ -1685,7 +1658,7 @@ namespace System.Windows.Forms
         {
             Debug.Assert(IsHandleCreated, "Shouldn't be calling Native methods before the handle is created.");
 
-            bool selected = (unchecked((int)(long)SendMessageW(this, (WM)LB.GETSEL, (IntPtr)index, IntPtr.Zero)) > 0);
+            bool selected = (int)SendMessageW(this, (WM)LB.GETSEL, index, 0) > 0;
             SendMessageW(this, (WM)LB.DELETESTRING, (IntPtr)index);
 
             //If the item currently selected is removed then we should fire a Selectionchanged event...
@@ -1735,7 +1708,7 @@ namespace System.Windows.Forms
             switch (selectionMode)
             {
                 case SelectionMode.One:
-                    int index = unchecked((int)(long)SendMessageW(this, (WM)LB.GETCURSEL));
+                    int index = (int)SendMessageW(this, (WM)LB.GETCURSEL);
                     if (index >= 0)
                     {
                         SelectedItems.SetSelected(index, true);
@@ -1745,7 +1718,7 @@ namespace System.Windows.Forms
 
                 case SelectionMode.MultiSimple:
                 case SelectionMode.MultiExtended:
-                    int count = unchecked((int)(long)SendMessageW(this, (WM)LB.GETSELCOUNT));
+                    int count = (int)SendMessageW(this, (WM)LB.GETSELCOUNT);
                     if (count > 0)
                     {
                         var result = new int[count];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -281,7 +281,7 @@ namespace System.Windows.Forms
                     }
                     else if (IsHandleCreated)
                     {
-                        SendMessageW(this, (WM)LB.SETCOLUMNWIDTH, (IntPtr)columnWidth);
+                        SendMessageW(this, (WM)LB.SETCOLUMNWIDTH, columnWidth);
                     }
                 }
             }
@@ -616,10 +616,9 @@ namespace System.Windows.Forms
                     if (drawMode == DrawMode.OwnerDrawFixed && IsHandleCreated)
                     {
                         BeginUpdate();
-                        SendMessageW(this, (WM)LB.SETITEMHEIGHT, IntPtr.Zero, (IntPtr)value);
+                        SendMessageW(this, (WM)LB.SETITEMHEIGHT, 0, value);
 
                         // Changing the item height might require a resize for IntegralHeight list boxes
-                        //
                         if (IntegralHeight)
                         {
                             Size oldSize = Size;
@@ -1156,7 +1155,7 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-                    SendMessageW(this, (WM)LB.SETTOPINDEX, (IntPtr)value);
+                    SendMessageW(this, (WM)LB.SETTOPINDEX, value);
                 }
                 else
                 {
@@ -1600,7 +1599,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal unsafe string NativeGetItemText(int index)
         {
-            int maxLength = PARAM.ToInt(SendMessageW(this, (WM)LB.GETTEXTLEN, (IntPtr)index));
+            int maxLength = (int)SendMessageW(this, (WM)LB.GETTEXTLEN, index);
             if (maxLength == LB_ERR)
             {
                 return string.Empty;
@@ -1610,7 +1609,7 @@ namespace System.Windows.Forms
             string result;
             fixed (char* pText = text)
             {
-                int actualLength = PARAM.ToInt(SendMessageW(this, (WM)LB.GETTEXT, (IntPtr)index, (IntPtr)pText));
+                int actualLength = (int)SendMessageW(this, (WM)LB.GETTEXT, index, (nint)pText);
                 Debug.Assert(actualLength != LB_ERR, "Should have validated the index above");
                 if (actualLength == LB_ERR)
                 {
@@ -1659,10 +1658,10 @@ namespace System.Windows.Forms
             Debug.Assert(IsHandleCreated, "Shouldn't be calling Native methods before the handle is created.");
 
             bool selected = (int)SendMessageW(this, (WM)LB.GETSEL, index, 0) > 0;
-            SendMessageW(this, (WM)LB.DELETESTRING, (IntPtr)index);
+            SendMessageW(this, (WM)LB.DELETESTRING, index);
 
-            //If the item currently selected is removed then we should fire a Selectionchanged event...
-            //as the next time selected index returns -1...
+            // If the item currently selected is removed then we should fire a Selectionchanged event
+            // as the next time selected index returns -1.
 
             if (selected)
             {
@@ -1681,11 +1680,11 @@ namespace System.Windows.Forms
 
             if (selectionMode == SelectionMode.One)
             {
-                SendMessageW(this, (WM)LB.SETCURSEL, (IntPtr)(value ? index : -1));
+                SendMessageW(this, (WM)LB.SETCURSEL, value ? index : -1);
             }
             else
             {
-                SendMessageW(this, (WM)LB.SETSEL, PARAM.FromBool(value), (IntPtr)index);
+                SendMessageW(this, (WM)LB.SETSEL, PARAM.FromBool(value), index);
             }
         }
 
@@ -1724,7 +1723,7 @@ namespace System.Windows.Forms
                         var result = new int[count];
                         fixed (int* pResult = result)
                         {
-                            SendMessageW(this, (WM)LB.GETSELITEMS, (IntPtr)count, (IntPtr)pResult);
+                            SendMessageW(this, (WM)LB.GETSELITEMS, count, (nint)pResult);
                         }
 
                         foreach (int i in result)
@@ -1795,21 +1794,21 @@ namespace System.Windows.Forms
 
             //for getting the current Locale to set the Scrollbars...
             //
-            SendMessageW(this, (WM)LB.SETLOCALE, (IntPtr)Kernel32.GetThreadLocale().RawValue);
+            SendMessageW(this, (WM)LB.SETLOCALE, (nint)Kernel32.GetThreadLocale().RawValue);
 
             if (columnWidth != 0)
             {
-                SendMessageW(this, (WM)LB.SETCOLUMNWIDTH, (IntPtr)columnWidth);
+                SendMessageW(this, (WM)LB.SETCOLUMNWIDTH, columnWidth);
             }
 
             if (drawMode == DrawMode.OwnerDrawFixed)
             {
-                SendMessageW(this, (WM)LB.SETITEMHEIGHT, IntPtr.Zero, (IntPtr)ItemHeight);
+                SendMessageW(this, (WM)LB.SETITEMHEIGHT, 0, ItemHeight);
             }
 
             if (topIndex != 0)
             {
-                SendMessageW(this, (WM)LB.SETTOPINDEX, (IntPtr)topIndex);
+                SendMessageW(this, (WM)LB.SETTOPINDEX, topIndex);
             }
 
             if (UseCustomTabOffsets && CustomTabOffsets is not null)
@@ -1820,7 +1819,7 @@ namespace System.Windows.Forms
 
                 fixed (int* pOffsets = offsets)
                 {
-                    SendMessageW(this, (WM)LB.SETTABSTOPS, (IntPtr)wpar, (IntPtr)pOffsets);
+                    SendMessageW(this, (WM)LB.SETTABSTOPS, wpar, (nint)pOffsets);
                 }
             }
 
@@ -2174,7 +2173,7 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    SendMessageW(this, (WM)LB.SETCURSEL, (IntPtr)DataManager.Position);
+                    SendMessageW(this, (WM)LB.SETCURSEL, DataManager.Position);
                 }
 
                 // if the list changed and we still did not fire the
@@ -2306,7 +2305,7 @@ namespace System.Windows.Forms
                     width = MaxItemWidth;
                 }
 
-                SendMessageW(this, (WM)LB.SETHORIZONTALEXTENT, (IntPtr)width);
+                SendMessageW(this, (WM)LB.SETHORIZONTALEXTENT, width);
             }
         }
 
@@ -2366,7 +2365,7 @@ namespace System.Windows.Forms
                 CustomTabOffsets.CopyTo(offsets, 0);
                 fixed (int* pOffsets = offsets)
                 {
-                    SendMessageW(this, (WM)LB.SETTABSTOPS, (IntPtr)wpar, (IntPtr)pOffsets);
+                    SendMessageW(this, (WM)LB.SETTABSTOPS, wpar, (nint)pOffsets);
                 }
 
                 Invalidate();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
@@ -529,7 +529,7 @@ namespace System.Windows.Forms
                 // in Tile view our ListView uses the column header collection to update the Tile Information
                 if (owner.IsHandleCreated && owner.View != View.Tile)
                 {
-                    int retval = unchecked((int)(long)User32.SendMessageW(owner, (User32.WM)LVM.DELETECOLUMN, (IntPtr)index));
+                    int retval = (int)User32.SendMessageW(owner, (User32.WM)LVM.DELETECOLUMN, index);
                     if (0 == retval)
                     {
                         throw new ArgumentOutOfRangeException(nameof(index), index, string.Format(SR.InvalidArgument, nameof(index), index));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
@@ -352,7 +352,7 @@ namespace System.Windows.Forms
                             int w = owner.columnHeaders[colIdx].Width; // Update width before detaching from ListView
                             if (owner.IsHandleCreated)
                             {
-                                User32.SendMessageW(owner, (User32.WM)LVM.DELETECOLUMN, (IntPtr)colIdx);
+                                User32.SendMessageW(owner, (User32.WM)LVM.DELETECOLUMN, colIdx);
                             }
 
                             owner.columnHeaders[colIdx].OwnerListview = null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
@@ -221,7 +221,8 @@ namespace System.Windows.Forms
                         mask = LVIF.PARAM,
                         iItem = displayIndex
                     };
-                    User32.SendMessageW(owner, (User32.WM)LVM.GETITEMW, IntPtr.Zero, ref lvItem);
+
+                    User32.SendMessageW(owner, (User32.WM)LVM.GETITEMW, 0, ref lvItem);
                     return PARAM.ToInt(lvItem.lParam);
                 }
                 else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
@@ -428,7 +428,7 @@ namespace System.Windows.Forms
 
                 if (owner.IsHandleCreated && !owner.CheckBoxes && this[index].Checked)
                 {
-                    owner.UpdateSavedCheckedItems(this[index], false /*addItem*/);
+                    owner.UpdateSavedCheckedItems(this[index], addItem: false);
                 }
 
                 owner.ApplyUpdateCachedItems();
@@ -438,7 +438,7 @@ namespace System.Windows.Forms
                 if (owner.IsHandleCreated)
                 {
                     Debug.Assert(owner.listItemsArray is null, "listItemsArray not null, even though handle created");
-                    int retval = unchecked((int)(long)User32.SendMessageW(owner, (User32.WM)LVM.DELETEITEM, (IntPtr)index));
+                    int retval = (int)User32.SendMessageW(owner, (User32.WM)LVM.DELETEITEM, index);
 
                     if (0 == retval)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.SelectedIndexCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.SelectedIndexCollection.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms
                 {
                     if (owner.IsHandleCreated)
                     {
-                        return unchecked((int)(long)User32.SendMessageW(owner, (User32.WM)LVM.GETSELECTEDCOUNT));
+                        return (int)User32.SendMessageW(owner, (User32.WM)LVM.GETSELECTEDCOUNT);
                     }
                     else
                     {
@@ -61,7 +61,7 @@ namespace System.Windows.Forms
                         int displayIndex = -1;
                         for (int i = 0; i < count; i++)
                         {
-                            int fidx = unchecked((int)(long)User32.SendMessageW(owner, (User32.WM)LVM.GETNEXTITEM, (IntPtr)displayIndex, (IntPtr)LVNI.SELECTED));
+                            int fidx = (int)User32.SendMessageW(owner, (User32.WM)LVM.GETNEXTITEM, displayIndex, (nint)LVNI.SELECTED);
                             if (fidx > -1)
                             {
                                 indices[i] = fidx;
@@ -100,13 +100,11 @@ namespace System.Windows.Forms
 
                     if (owner.IsHandleCreated)
                     {
-                        // Count through the selected items in the ListView, until
-                        // we reach the 'index'th selected item.
-                        //
+                        // Count through the selected items in the ListView, until we reach the 'index'th selected item.
                         int fidx = -1;
                         for (int count = 0; count <= index; count++)
                         {
-                            fidx = unchecked((int)(long)User32.SendMessageW(owner, (User32.WM)LVM.GETNEXTITEM, (IntPtr)fidx, (IntPtr)LVNI.SELECTED));
+                            fidx = (int)User32.SendMessageW(owner, (User32.WM)LVM.GETNEXTITEM, fidx, (nint)LVNI.SELECTED);
                             Debug.Assert(fidx != -1, "Invalid index returned from LVM_GETNEXTITEM");
                         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.SelectedListViewItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.SelectedListViewItemCollection.cs
@@ -36,7 +36,7 @@ namespace System.Windows.Forms
                 {
                     if (owner.IsHandleCreated)
                     {
-                        int cnt = unchecked((int)(long)User32.SendMessageW(owner, (User32.WM)LVM.GETSELECTEDCOUNT));
+                        int cnt = (int)User32.SendMessageW(owner, (User32.WM)LVM.GETSELECTEDCOUNT);
 
                         ListViewItem[] lvitems = new ListViewItem[cnt];
 
@@ -44,7 +44,7 @@ namespace System.Windows.Forms
 
                         for (int i = 0; i < cnt; i++)
                         {
-                            int fidx = unchecked((int)(long)User32.SendMessageW(owner, (User32.WM)LVM.GETNEXTITEM, (IntPtr)displayIndex, (IntPtr)LVNI.SELECTED));
+                            int fidx = (int)User32.SendMessageW(owner, (User32.WM)LVM.GETNEXTITEM, displayIndex, (nint)LVNI.SELECTED);
                             if (fidx > -1)
                             {
                                 lvitems[i] = owner.Items[fidx];
@@ -93,7 +93,7 @@ namespace System.Windows.Forms
 
                     if (owner.IsHandleCreated)
                     {
-                        return unchecked((int)(long)User32.SendMessageW(owner, (User32.WM)LVM.GETSELECTEDCOUNT));
+                        return (int)User32.SendMessageW(owner, (User32.WM)LVM.GETSELECTEDCOUNT);
                     }
                     else
                     {
@@ -126,13 +126,11 @@ namespace System.Windows.Forms
 
                     if (owner.IsHandleCreated)
                     {
-                        // Count through the selected items in the ListView, until
-                        // we reach the 'index'th selected item.
-                        //
+                        // Count through the selected items in the ListView, until we reach the 'index'th selected item.
                         int fidx = -1;
                         for (int count = 0; count <= index; count++)
                         {
-                            fidx = unchecked((int)(long)User32.SendMessageW(owner, (User32.WM)LVM.GETNEXTITEM, (IntPtr)fidx, (IntPtr)LVNI.SELECTED));
+                            fidx = (int)User32.SendMessageW(owner, (User32.WM)LVM.GETNEXTITEM, fidx, (nint)LVNI.SELECTED);
                             Debug.Assert(fidx != -1, "Invalid index returned from LVM_GETNEXTITEM");
                         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -1757,7 +1757,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                topIndex = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)LVM.GETTOPINDEX));
+                topIndex = (int)User32.SendMessageW(this, (User32.WM)LVM.GETTOPINDEX);
                 if (topIndex >= 0 && topIndex < Items.Count)
                 {
                     return Items[topIndex];
@@ -1910,7 +1910,7 @@ namespace System.Windows.Forms
                 int topIndex = -1;
                 if (keepTopItem)
                 {
-                    topIndex = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)LVM.GETTOPINDEX));
+                    topIndex = (int)(long)User32.SendMessageW(this, (User32.WM)LVM.GETTOPINDEX);
                 }
 
                 virtualListSize = value;
@@ -4570,7 +4570,7 @@ namespace System.Windows.Forms
 
             base.OnHandleCreated(e);
 
-            int version = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)CCM.GETVERSION));
+            int version = (int)User32.SendMessageW(this, (User32.WM)CCM.GETVERSION);
             if (version < 5)
             {
                 User32.SendMessageW(this, (User32.WM)CCM.SETVERSION, (IntPtr)5);
@@ -5491,7 +5491,7 @@ namespace System.Windows.Forms
 
             if (View == View.List && subItemIndex == 0)
             {
-                int colWidth = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)LVM.GETCOLUMNWIDTH));
+                int colWidth = (int)User32.SendMessageW(this, (User32.WM)LVM.GETCOLUMNWIDTH);
 
                 using Graphics g = CreateGraphicsInternal();
 
@@ -5806,12 +5806,11 @@ namespace System.Windows.Forms
         }
 
         // ListViewGroupCollection::Clear needs to remove the items from the Default group
-        //
         internal void UpdateGroupView()
         {
             if (IsHandleCreated && Application.ComCtlSupportsVisualStyles && !VirtualMode)
             {
-                int retval = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)LVM.ENABLEGROUPVIEW, PARAM.FromBool(GroupsEnabled)));
+                int retval = (int)User32.SendMessageW(this, (User32.WM)LVM.ENABLEGROUPVIEW, PARAM.FromBool(GroupsEnabled));
                 Debug.Assert(retval != -1, "Error enabling group view");
             }
         }
@@ -6788,7 +6787,7 @@ namespace System.Windows.Forms
                             if (lvi is not null && !string.IsNullOrEmpty(lvi.ToolTipText))
                             {
                                 // Setting the max width has the added benefit of enabling multiline tool tips
-                                User32.SendMessageW(nmhdr->hwndFrom, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                                User32.SendMessageW(nmhdr->hwndFrom, (User32.WM)TTM.SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
 
                                 // UNICODE. Use char.
                                 // we need to copy the null terminator character ourselves

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -356,7 +356,7 @@ namespace System.Windows.Forms
                 base.BackColor = value;
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, (User32.WM)LVM.SETBKCOLOR, IntPtr.Zero, PARAM.FromColor(BackColor));
+                    User32.SendMessageW(this, (User32.WM)LVM.SETBKCOLOR, 0, BackColor.ToWin32());
                 }
             }
         }
@@ -568,12 +568,13 @@ namespace System.Windows.Forms
                         if (IsHandleCreated && _imageListState is not null)
                         {
                             if (CheckBoxes)
-                            { // we want custom checkboxes
-                                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, _imageListState.Handle);
+                            {
+                                // We want custom checkboxes.
+                                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.STATE, _imageListState.Handle);
                             }
                             else
                             {
-                                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
+                                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.STATE, 0);
                             }
                         }
 
@@ -833,7 +834,7 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-                    int displayIndex = PARAM.ToInt(User32.SendMessageW(this, (User32.WM)LVM.GETNEXTITEM, (IntPtr)(-1), (IntPtr)LVNI.FOCUSED));
+                    int displayIndex = (int)User32.SendMessageW(this, (User32.WM)LVM.GETNEXTITEM, -1, (nint)LVNI.FOCUSED);
                     if (displayIndex > -1)
                     {
                         return Items[displayIndex];
@@ -869,7 +870,7 @@ namespace System.Windows.Forms
                 base.ForeColor = value;
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, (User32.WM)LVM.SETTEXTCOLOR, IntPtr.Zero, PARAM.FromColor(ForeColor));
+                    User32.SendMessageW(this, (User32.WM)LVM.SETTEXTCOLOR, 0, ForeColor.ToWin32());
                 }
             }
         }
@@ -982,8 +983,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER,
-                        value is null ? IntPtr.Zero : value.Handle);
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.GROUPHEADER, value is null ? 0 : value.Handle);
             }
         }
 
@@ -1249,7 +1249,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, value is null ? IntPtr.Zero : value.Handle);
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.NORMAL, value is null ? 0 : value.Handle);
                 if (AutoArrange && !listViewState1[LISTVIEWSTATE1_disposingImageLists])
                 {
                     UpdateListViewItemsLocations();
@@ -1490,7 +1490,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, value is null ? IntPtr.Zero : value.Handle);
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.SMALL, value is null ? 0 : value.Handle);
 
                 if (View == View.SmallIcon)
                 {
@@ -1595,7 +1595,7 @@ namespace System.Windows.Forms
 
                     if (IsHandleCreated)
                     {
-                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, value is null ? IntPtr.Zero : value.Handle);
+                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.STATE, value is null ? 0 : value.Handle);
                     }
                 }
                 else
@@ -1610,7 +1610,7 @@ namespace System.Windows.Forms
                         // (Yes, it does exactly that even though our wrapper sets LVS_SHAREIMAGELISTS on the native listView.)
                         // So we make the native listView forget about its StateImageList just before we recreate the handle.
                         // Likely related to https://devblogs.microsoft.com/oldnewthing/20171128-00/?p=97475
-                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
+                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.STATE, 0);
                     }
 
                     _imageListState = value;
@@ -1623,13 +1623,16 @@ namespace System.Windows.Forms
 
                     if (CheckBoxes)
                     {
-                        // need to recreate to get the new images pushed in.
+                        // Need to recreate to get the new images pushed in.
                         RecreateHandleInternal();
                     }
                     else
                     {
-                        User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE,
-                            (_imageListState is null || _imageListState.Images.Count == 0) ? IntPtr.Zero : _imageListState.Handle);
+                        User32.SendMessageW(
+                            this,
+                            (User32.WM)LVM.SETIMAGELIST,
+                            (nint)LVSIL.STATE,
+                            (_imageListState is null || _imageListState.Images.Count == 0) ? 0 : _imageListState.Handle);
                     }
 
                     // Comctl should handle auto-arrange for us, but doesn't
@@ -1865,7 +1868,7 @@ namespace System.Windows.Forms
                     viewStyle = value;
                     if (IsHandleCreated && Application.ComCtlSupportsVisualStyles)
                     {
-                        User32.SendMessageW(this, (User32.WM)LVM.SETVIEW, (IntPtr)viewStyle);
+                        User32.SendMessageW(this, (User32.WM)LVM.SETVIEW, (nint)viewStyle);
                         UpdateGroupView();
 
                         // if we switched to Tile view we should update the win32 list view tile view info
@@ -1910,14 +1913,14 @@ namespace System.Windows.Forms
                 int topIndex = -1;
                 if (keepTopItem)
                 {
-                    topIndex = (int)(long)User32.SendMessageW(this, (User32.WM)LVM.GETTOPINDEX);
+                    topIndex = (int)User32.SendMessageW(this, (User32.WM)LVM.GETTOPINDEX);
                 }
 
                 virtualListSize = value;
 
                 if (IsHandleCreated && VirtualMode && !DesignMode)
                 {
-                    User32.SendMessageW(this, (User32.WM)LVM.SETITEMCOUNT, (IntPtr)virtualListSize);
+                    User32.SendMessageW(this, (User32.WM)LVM.SETITEMCOUNT, virtualListSize);
                 }
 
                 if (keepTopItem)
@@ -3200,7 +3203,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated && GroupsEnabled)
             {
-                if (User32.SendMessageW(this, (User32.WM)LVM.HASGROUP, (IntPtr)DefaultGroup.ID) == IntPtr.Zero)
+                if (User32.SendMessageW(this, (User32.WM)LVM.HASGROUP, DefaultGroup.ID) == 0)
                 {
                     UpdateGroupView();
                     InsertGroupNative(0, DefaultGroup);
@@ -3221,7 +3224,7 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.ENSUREVISIBLE, (IntPtr)index);
+                User32.SendMessageW(this, (User32.WM)LVM.ENSUREVISIBLE, index);
             }
         }
 
@@ -3407,13 +3410,12 @@ namespace System.Windows.Forms
         private void ForceCheckBoxUpdate()
         {
             // Force ListView to update its checkbox bitmaps.
-            //
             if (CheckBoxes && IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETEXTENDEDLISTVIEWSTYLE, (IntPtr)LVS_EX.CHECKBOXES, IntPtr.Zero);
-                User32.SendMessageW(this, (User32.WM)LVM.SETEXTENDEDLISTVIEWSTYLE, (IntPtr)LVS_EX.CHECKBOXES, (IntPtr)LVS_EX.CHECKBOXES);
+                User32.SendMessageW(this, (User32.WM)LVM.SETEXTENDEDLISTVIEWSTYLE, (nint)LVS_EX.CHECKBOXES, 0);
+                User32.SendMessageW(this, (User32.WM)LVM.SETEXTENDEDLISTVIEWSTYLE, (nint)LVS_EX.CHECKBOXES, (nint)LVS_EX.CHECKBOXES);
 
-                // Comctl should handle auto-arrange for us, but doesn't
+                // Comctl should handle auto-arrange for us, but doesn't.
                 if (AutoArrange)
                 {
                     ArrangeIcons(Alignment);
@@ -3747,8 +3749,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (GroupImageList is null) ? IntPtr.Zero : GroupImageList.Handle;
-            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, handle);
+            nint handle = (GroupImageList is null) ? 0 : GroupImageList.Handle;
+            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.GROUPHEADER, handle);
         }
 
         public ListViewHitTestInfo HitTest(Point point)
@@ -4174,7 +4176,7 @@ namespace System.Windows.Forms
             try
             {
                 // Set the count of items first.
-                User32.SendMessageW(this, (User32.WM)LVM.SETITEMCOUNT, (IntPtr)itemCount);
+                User32.SendMessageW(this, (User32.WM)LVM.SETITEMCOUNT, itemCount);
 
                 // Now add the items.
                 for (int i = 0; i < items.Length; i++)
@@ -4201,13 +4203,12 @@ namespace System.Windows.Forms
 #if DEBUG
                         IntPtr result = User32.SendMessageW(this, (User32.WM)LVM.ISGROUPVIEWENABLED);
                         Debug.Assert(result != IntPtr.Zero, "Groups not enabled");
-                        result = User32.SendMessageW(this, (User32.WM)LVM.HASGROUP, (IntPtr)lvItem.iGroupId);
-                        Debug.Assert(result != IntPtr.Zero, "Doesn't contain group id: " + lvItem.iGroupId.ToString(CultureInfo.InvariantCulture));
+                        result = User32.SendMessageW(this, (User32.WM)LVM.HASGROUP, lvItem.iGroupId);
+                        Debug.Assert(result != IntPtr.Zero, $"Doesn't contain group id: {lvItem.iGroupId}");
 #endif
                     }
 
-                    // make sure that our columns memory is big enough.
-                    // if not, then realloc it.
+                    // Make sure that our columns memory is big enough. If not, then realloc it.
                     if (lvItem.cColumns > maxColumns || hGlobalColumns == IntPtr.Zero)
                     {
                         if (hGlobalColumns != IntPtr.Zero)
@@ -4355,8 +4356,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (LargeImageList is null) ? IntPtr.Zero : LargeImageList.Handle;
-            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, handle);
+            nint handle = (LargeImageList is null) ? 0 : LargeImageList.Handle;
+            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.NORMAL, handle);
 
             ForceCheckBoxUpdate();
         }
@@ -4550,7 +4551,7 @@ namespace System.Windows.Forms
                 BeginUpdate();
                 try
                 {
-                    User32.SendMessageW(this, (User32.WM)LVM.UPDATE, (IntPtr)(-1));
+                    User32.SendMessageW(this, (User32.WM)LVM.UPDATE, -1);
                 }
                 finally
                 {
@@ -4558,8 +4559,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            // If font changes and we have headers, they need to be explicitly invalidated
-            //
+            // If font changes and we have headers, they need to be explicitly invalidated.
             InvalidateColumnHeaders();
         }
 
@@ -4573,45 +4573,43 @@ namespace System.Windows.Forms
             int version = (int)User32.SendMessageW(this, (User32.WM)CCM.GETVERSION);
             if (version < 5)
             {
-                User32.SendMessageW(this, (User32.WM)CCM.SETVERSION, (IntPtr)5);
+                User32.SendMessageW(this, (User32.WM)CCM.SETVERSION, 5);
             }
 
             UpdateExtendedStyles();
             RealizeProperties();
-            User32.SendMessageW(this, (User32.WM)LVM.SETBKCOLOR, IntPtr.Zero, PARAM.FromColor(BackColor));
-            User32.SendMessageW(this, (User32.WM)LVM.SETTEXTCOLOR, IntPtr.Zero, PARAM.FromColor(base.ForeColor));
+            User32.SendMessageW(this, (User32.WM)LVM.SETBKCOLOR, 0, BackColor.ToWin32());
+            User32.SendMessageW(this, (User32.WM)LVM.SETTEXTCOLOR, 0, base.ForeColor.ToWin32());
 
             // The native list view will not invalidate the entire list view item area if the BkColor is not CLR_NONE.
             // This not noticeable if the customer paints the items w/ the same background color as the list view itself.
             // However, if the customer paints the items w/ a color different from the list view's back color
             // then when the user changes selection the native list view will not invalidate the entire list view item area.
-            User32.SendMessageW(this, (User32.WM)LVM.SETTEXTBKCOLOR, IntPtr.Zero, (IntPtr)CLR.NONE);
+            User32.SendMessageW(this, (User32.WM)LVM.SETTEXTBKCOLOR, 0, (nint)CLR.NONE);
 
             // LVS_NOSCROLL does not work well when the list view is in View.Details or in View.List modes.
             // we have to set this style after the list view was created and before we position the native list view items.
-            //
             if (!Scrollable)
             {
-                int style = unchecked((int)((long)User32.GetWindowLong(this, User32.GWL.STYLE)));
+                int style = (int)User32.GetWindowLong(this, User32.GWL.STYLE);
                 style |= (int)LVS.NOSCROLL;
-                User32.SetWindowLong(this, User32.GWL.STYLE, (IntPtr)style);
+                User32.SetWindowLong(this, User32.GWL.STYLE, style);
             }
 
-            // in VirtualMode we have to tell the list view to ask for the list view item's state image index
+            // In VirtualMode we have to tell the list view to ask for the list view item's state image index.
             if (VirtualMode)
             {
-                LVIS callbackMask = unchecked((LVIS)(long)User32.SendMessageW(this, (User32.WM)LVM.GETCALLBACKMASK));
+                LVIS callbackMask = (LVIS)User32.SendMessageW(this, (User32.WM)LVM.GETCALLBACKMASK);
                 callbackMask |= LVIS.STATEIMAGEMASK;
-                User32.SendMessageW(this, (User32.WM)LVM.SETCALLBACKMASK, (IntPtr)callbackMask);
+                User32.SendMessageW(this, (User32.WM)LVM.SETCALLBACKMASK, (nint)callbackMask);
             }
 
             if (Application.ComCtlSupportsVisualStyles)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETVIEW, (IntPtr)viewStyle);
+                User32.SendMessageW(this, (User32.WM)LVM.SETVIEW, (nint)viewStyle);
                 UpdateGroupView();
 
-                // Add groups
-                //
+                // Add groups.
                 if (groups is not null)
                 {
                     for (int index = 0; index < groups.Count; index++)
@@ -4620,8 +4618,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                // Set tile view settings
-                //
+                // Set tile view settings.
                 if (viewStyle == View.Tile)
                 {
                     UpdateTileView();
@@ -4631,7 +4628,6 @@ namespace System.Windows.Forms
             ListViewHandleDestroyed = false;
 
             // Use a copy of the list items array so that we can maintain the (handle created || listItemsArray is not null) invariant
-            //
             ListViewItem[] listViewItemsToAdd = null;
             if (listItemsArray is not null)
             {
@@ -4653,8 +4649,7 @@ namespace System.Windows.Forms
                 SetDisplayIndices(indices);
             }
 
-            // make sure that we're not in a begin/end update call.
-            //
+            // Make sure that we're not in a begin/end update call.
             if (itemCount > 0 && listViewItemsToAdd is not null)
             {
                 InsertItemsNative(0, listViewItemsToAdd);
@@ -4662,7 +4657,7 @@ namespace System.Windows.Forms
 
             if (VirtualMode && VirtualListSize > -1 && !DesignMode)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETITEMCOUNT, (IntPtr)VirtualListSize);
+                User32.SendMessageW(this, (User32.WM)LVM.SETITEMCOUNT, VirtualListSize);
             }
 
             if (columnCount > 0)
@@ -4912,10 +4907,11 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETBKCOLOR, IntPtr.Zero, PARAM.FromColor(BackColor));
+                User32.SendMessageW(this, (User32.WM)LVM.SETBKCOLOR, 0, BackColor.ToWin32());
+
                 // We should probably be OK if we don't set the TEXTBKCOLOR to CLR_NONE.
                 // However, for the sake of being more robust, reset the TECTBKCOLOR to CLR_NONE when the system palette changes.
-                User32.SendMessageW(this, (User32.WM)LVM.SETTEXTBKCOLOR, IntPtr.Zero, (IntPtr)CLR.NONE);
+                User32.SendMessageW(this, (User32.WM)LVM.SETTEXTBKCOLOR, 0, (nint)CLR.NONE);
             }
         }
 
@@ -4926,7 +4922,7 @@ namespace System.Windows.Forms
 
         private unsafe void PositionHeader()
         {
-            IntPtr hdrHWND = User32.GetWindow(new HandleRef(this, Handle), User32.GW.CHILD);
+            IntPtr hdrHWND = User32.GetWindow(this, User32.GW.CHILD);
             if (hdrHWND != IntPtr.Zero)
             {
                 var rc = new RECT();
@@ -4969,39 +4965,39 @@ namespace System.Windows.Forms
 
         protected void RealizeProperties()
         {
-            //Realize state information
+            // Realize state information
             Color c;
 
             c = BackColor;
             if (c != SystemColors.Window)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETBKCOLOR, IntPtr.Zero, PARAM.FromColor(c));
+                User32.SendMessageW(this, (User32.WM)LVM.SETBKCOLOR, 0, c.ToWin32());
             }
 
             c = ForeColor;
             if (c != SystemColors.WindowText)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETTEXTCOLOR, IntPtr.Zero, PARAM.FromColor(c));
+                User32.SendMessageW(this, (User32.WM)LVM.SETTEXTCOLOR, 0, c.ToWin32());
             }
 
             if (_imageListLarge is not null)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.NORMAL, _imageListLarge.Handle);
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.NORMAL, _imageListLarge.Handle);
             }
 
             if (_imageListSmall is not null)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, _imageListSmall.Handle);
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.SMALL, _imageListSmall.Handle);
             }
 
             if (_imageListState is not null)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, _imageListState.Handle);
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.STATE, _imageListState.Handle);
             }
 
             if (_imageListGroup is not null)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, _imageListGroup.Handle);
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.GROUPHEADER, _imageListGroup.Handle);
             }
         }
 
@@ -5043,8 +5039,9 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                int retval = (int)User32.SendMessageW(this, (User32.WM)LVM.REDRAWITEMS, (IntPtr)startIndex, (IntPtr)endIndex);
+                int retval = (int)User32.SendMessageW(this, (User32.WM)LVM.REDRAWITEMS, startIndex, endIndex);
                 Debug.Assert(retval != 0);
+
                 // ListView control seems to be bogus. Items affected need to be invalidated in LargeIcon and SmallIcons views.
                 if (View == View.LargeIcon || View == View.SmallIcon)
                 {
@@ -5119,13 +5116,13 @@ namespace System.Windows.Forms
         private void RemoveGroupNative(ListViewGroup group)
         {
             Debug.Assert(IsHandleCreated, "RemoveGroupNative precondition: list-view handle must be created");
-            User32.SendMessageW(this, (User32.WM)LVM.REMOVEGROUP, (IntPtr)group.ID);
+            User32.SendMessageW(this, (User32.WM)LVM.REMOVEGROUP, group.ID);
         }
 
         private void Scroll(int fromLVItem, int toLVItem)
         {
             int scrollY = GetItemPosition(toLVItem).Y - GetItemPosition(fromLVItem).Y;
-            User32.SendMessageW(this, (User32.WM)LVM.SCROLL, IntPtr.Zero, (IntPtr)scrollY);
+            User32.SendMessageW(this, (User32.WM)LVM.SCROLL, IntPtr.Zero, scrollY);
         }
 
         private unsafe void SetBackgroundImage()
@@ -5309,7 +5306,7 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETCOLUMNWIDTH, (IntPtr)columnIndex, PARAM.FromLowHigh(width, 0));
+                User32.SendMessageW(this, (User32.WM)LVM.SETCOLUMNWIDTH, columnIndex, PARAM.FromLowHigh(width, 0));
             }
 
             if (IsHandleCreated &&
@@ -5319,7 +5316,7 @@ namespace System.Windows.Forms
                 if (compensate != 0)
                 {
                     int newWidth = columnHeaders[columnIndex].Width + compensate;
-                    User32.SendMessageW(this, (User32.WM)LVM.SETCOLUMNWIDTH, (IntPtr)columnIndex, PARAM.FromLowHigh(newWidth, 0));
+                    User32.SendMessageW(this, (User32.WM)LVM.SETCOLUMNWIDTH, columnIndex, PARAM.FromLowHigh(newWidth, 0));
                 }
             }
         }
@@ -5328,7 +5325,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETCOLUMNWIDTH, (IntPtr)index, PARAM.FromLowHigh(width, 0));
+                User32.SendMessageW(this, (User32.WM)LVM.SETCOLUMNWIDTH, index, PARAM.FromLowHigh(width, 0));
             }
         }
 
@@ -5346,7 +5343,7 @@ namespace System.Windows.Forms
             {
                 fixed (int* pOrderedColumns = orderedColumns)
                 {
-                    User32.SendMessageW(this, (User32.WM)LVM.SETCOLUMNORDERARRAY, (IntPtr)orderedColumns.Length, (IntPtr)pOrderedColumns);
+                    User32.SendMessageW(this, (User32.WM)LVM.SETCOLUMNORDERARRAY, orderedColumns.Length, (nint)pOrderedColumns);
                 }
             }
         }
@@ -5387,7 +5384,7 @@ namespace System.Windows.Forms
             toolTipCaption = toolTip.GetToolTip(this);
 
             // native ListView expects tooltip HWND as a wParam and ignores lParam
-            IntPtr oldHandle = User32.SendMessageW(this, (User32.WM)LVM.SETTOOLTIPS, toolTip.Handle, IntPtr.Zero);
+            IntPtr oldHandle = User32.SendMessageW(this, (User32.WM)LVM.SETTOOLTIPS, toolTip.Handle, 0);
             GC.KeepAlive(toolTip);
             User32.DestroyWindow(oldHandle);
         }
@@ -5528,7 +5525,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            User32.SendMessageW(this, (User32.WM)LVM.SETSELECTIONMARK, IntPtr.Zero, (IntPtr)itemIndex);
+            User32.SendMessageW(this, (User32.WM)LVM.SETSELECTIONMARK, 0, itemIndex);
         }
 
         private void SmallImageListRecreateHandle(object sender, EventArgs e)
@@ -5538,8 +5535,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (SmallImageList is null) ? IntPtr.Zero : SmallImageList.Handle;
-            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.SMALL, handle);
+            nint handle = (SmallImageList is null) ? 0 : SmallImageList.Handle;
+            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.SMALL, handle);
 
             ForceCheckBoxUpdate();
         }
@@ -5571,8 +5568,8 @@ namespace System.Windows.Forms
                 return;
             }
 
-            IntPtr handle = (StateImageList is null) ? IntPtr.Zero : StateImageList.Handle;
-            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, handle);
+            nint handle = (StateImageList is null) ? 0 : StateImageList.Handle;
+            User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.STATE, handle);
         }
 
         /// <summary>
@@ -5610,11 +5607,11 @@ namespace System.Windows.Forms
         {
             if (!VirtualMode && IsHandleCreated && AutoArrange && (View == View.LargeIcon || View == View.SmallIcon))
             {
-                // this only has an affect for large icon and small icon views.
+                // This only has an affect for large icon and small icon views.
                 try
                 {
                     BeginUpdate();
-                    User32.SendMessageW(this, (User32.WM)LVM.UPDATE, (IntPtr)(-1));
+                    User32.SendMessageW(this, (User32.WM)LVM.UPDATE, -1);
                 }
                 finally
                 {
@@ -5695,7 +5692,7 @@ namespace System.Windows.Forms
                     exStyle |= LVS_EX.INFOTIP;
                 }
 
-                User32.SendMessageW(this, (User32.WM)LVM.SETEXTENDEDLISTVIEWSTYLE, (IntPtr)exMask, (IntPtr)exStyle);
+                User32.SendMessageW(this, (User32.WM)LVM.SETEXTENDEDLISTVIEWSTYLE, (nint)exMask, (nint)exStyle);
                 Invalidate();
             }
         }
@@ -6381,13 +6378,12 @@ namespace System.Windows.Forms
 
         internal void RecreateHandleInternal()
         {
-            //
-            // For some reason, if CheckBoxes are set to true and the list view has a state imageList, then the native listView destroys
-            // the state imageList.
+            // For some reason, if CheckBoxes are set to true and the list view has a state imageList, then the native
+            // listView destroys the state imageList.
             // (Yes, it does exactly that even though our wrapper sets LVS_SHAREIMAGELISTS on the native listView.)
             if (IsHandleCreated && StateImageList is not null)
             {
-                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.STATE, IntPtr.Zero);
+                User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.STATE, 0);
             }
 
             RecreateHandle();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -62,7 +62,7 @@ namespace System.Windows.Forms
                     // Using the "top" property, we set which rectangle type of the group we want to get
                     // This is described in more detail in https://docs.microsoft.com/windows/win32/controls/lvm-getgrouprect
                     groupRect.top = (int)rectType;
-                    User32.SendMessageW(_owningListView, (User32.WM)LVM.GETGROUPRECT, (IntPtr)nativeGroupId, ref groupRect);
+                    User32.SendMessageW(_owningListView, (User32.WM)LVM.GETGROUPRECT, nativeGroupId, ref groupRect);
 
                     // Using the following code, we limit the size of the ListViewGroup rectangle
                     // so that it does not go beyond the rectangle of the ListView
@@ -173,7 +173,7 @@ namespace System.Windows.Forms
                     mask = LVGF.GROUPID,
                 };
 
-                return User32.SendMessageW(_owningListView, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)CurrentIndex, ref lvgroup) == IntPtr.Zero
+                return User32.SendMessageW(_owningListView, (User32.WM)LVM.GETGROUPINFOBYINDEX, CurrentIndex, ref lvgroup) == 0
                     ? -1
                     : lvgroup.iGroupId;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -162,7 +162,7 @@ namespace System.Windows.Forms
                     return false;
                 }
 
-                return LVGS.FOCUSED == unchecked((LVGS)(long)User32.SendMessageW(_owningListView, (User32.WM)LVM.GETGROUPSTATE, (IntPtr)nativeGroupId, (IntPtr)LVGS.FOCUSED));
+                return LVGS.FOCUSED == (LVGS)User32.SendMessageW(_owningListView, (User32.WM)LVM.GETGROUPSTATE, nativeGroupId, (nint)LVGS.FOCUSED);
             }
 
             private unsafe int GetNativeGroupId()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
@@ -60,7 +60,7 @@ namespace System.Windows.Forms
             get
             {
                 var rect = new RECT();
-                User32.SendMessageW(listView, (User32.WM)LVM.GETINSERTMARKRECT, IntPtr.Zero, ref rect);
+                User32.SendMessageW(listView, (User32.WM)LVM.GETINSERTMARKRECT, 0, ref rect);
                 return Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
             }
         }
@@ -115,8 +115,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Performs a hit-test at the specified insertion point
-        ///  and returns the closest item.
+        ///  Performs a hit-test at the specified insertion point and returns the closest item.
         /// </summary>
         public unsafe int NearestIndex(Point pt)
         {
@@ -124,7 +123,8 @@ namespace System.Windows.Forms
             {
                 cbSize = (uint)sizeof(LVINSERTMARK)
             };
-            User32.SendMessageW(listView, (User32.WM)LVM.INSERTMARKHITTEST, (IntPtr)(&pt), ref lvInsertMark);
+
+            User32.SendMessageW(listView, (User32.WM)LVM.INSERTMARKHITTEST, (nint)(&pt), ref lvInsertMark);
 
             return lvInsertMark.iItem;
         }
@@ -138,7 +138,8 @@ namespace System.Windows.Forms
                 dwFlags = appearsAfterItem ? LVIM.AFTER : LVIM.BEFORE,
                 iItem = index
             };
-            User32.SendMessageW(listView, (User32.WM)LVM.SETINSERTMARK, IntPtr.Zero, ref lvInsertMark);
+
+            User32.SendMessageW(listView, (User32.WM)LVM.SETINSERTMARK, 0, ref lvInsertMark);
 
             if (!color.IsEmpty)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms
                     color = value;
                     if (listView.IsHandleCreated)
                     {
-                        User32.SendMessageW(listView, (User32.WM)LVM.SETINSERTMARKCOLOR, IntPtr.Zero, PARAM.FromColor(color));
+                        User32.SendMessageW(listView, (User32.WM)LVM.SETINSERTMARKCOLOR, 0, color.ToWin32());
                     }
                 }
             }
@@ -143,7 +143,7 @@ namespace System.Windows.Forms
 
             if (!color.IsEmpty)
             {
-                User32.SendMessageW(listView, (User32.WM)LVM.SETINSERTMARKCOLOR, IntPtr.Zero, PARAM.FromColor(color));
+                User32.SendMessageW(listView, (User32.WM)LVM.SETINSERTMARKCOLOR, 0, color.ToWin32());
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -1061,12 +1061,12 @@ namespace System.Windows.Forms
                 IntPtr result = User32.SendMessageW(listView, (User32.WM)LVM.ISGROUPVIEWENABLED);
                 Debug.Assert(!updateOwner || result != IntPtr.Zero, "Groups not enabled");
                 result = User32.SendMessageW(listView, (User32.WM)LVM.HASGROUP, (IntPtr)lvItem.iGroupId);
-                Debug.Assert(!updateOwner || result != IntPtr.Zero, "Doesn't contain group id: " + lvItem.iGroupId.ToString(CultureInfo.InvariantCulture));
+                Debug.Assert(!updateOwner || result != IntPtr.Zero, $"Doesn't contain group id: {lvItem.iGroupId}");
             }
 
             if (updateOwner)
             {
-                User32.SendMessageW(listView, (User32.WM)LVM.SETITEMW, IntPtr.Zero, ref lvItem);
+                User32.SendMessageW(listView, (User32.WM)LVM.SETITEMW, 0, ref lvItem);
             }
         }
 
@@ -1095,7 +1095,7 @@ namespace System.Windows.Forms
                 }
 
                 lvItem.iItem = displayIndex;
-                User32.SendMessageW(listView, (User32.WM)LVM.GETITEMW, IntPtr.Zero, ref lvItem);
+                User32.SendMessageW(listView, (User32.WM)LVM.GETITEMW, 0, ref lvItem);
 
                 // Update this class' information
                 if (checkSelection)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -863,7 +863,7 @@ namespace System.Windows.Forms
                     lv.Focus();
                 }
 
-                User32.SendMessageW(lv, (User32.WM)LVM.EDITLABELW, (IntPtr)Index);
+                User32.SendMessageW(lv, (User32.WM)LVM.EDITLABELW, Index);
             }
         }
 
@@ -873,11 +873,12 @@ namespace System.Windows.Forms
             for (int index = 0; index < SubItems.Count; ++index)
             {
                 ListViewSubItem subItem = SubItems[index];
-                clonedSubItems[index] = new ListViewSubItem(null,
-                                                            subItem.Text,
-                                                            subItem.ForeColor,
-                                                            subItem.BackColor,
-                                                            subItem.Font)
+                clonedSubItems[index] = new ListViewSubItem(
+                    owner: null,
+                    subItem.Text,
+                    subItem.ForeColor,
+                    subItem.BackColor,
+                    subItem.Font)
                 {
                     Tag = subItem.Tag
                 };
@@ -1058,10 +1059,10 @@ namespace System.Windows.Forms
                 lvItem.mask |= LVIF.GROUPID;
                 lvItem.iGroupId = listView.GetNativeGroupId(this);
 
-                IntPtr result = User32.SendMessageW(listView, (User32.WM)LVM.ISGROUPVIEWENABLED);
-                Debug.Assert(!updateOwner || result != IntPtr.Zero, "Groups not enabled");
-                result = User32.SendMessageW(listView, (User32.WM)LVM.HASGROUP, (IntPtr)lvItem.iGroupId);
-                Debug.Assert(!updateOwner || result != IntPtr.Zero, $"Doesn't contain group id: {lvItem.iGroupId}");
+                nint result = User32.SendMessageW(listView, (User32.WM)LVM.ISGROUPVIEWENABLED);
+                Debug.Assert(!updateOwner || result != 0, "Groups not enabled");
+                result = User32.SendMessageW(listView, (User32.WM)LVM.HASGROUP, lvItem.iGroupId);
+                Debug.Assert(!updateOwner || result != 0, $"Doesn't contain group id: {lvItem.iGroupId}");
             }
 
             if (updateOwner)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
@@ -161,10 +161,10 @@ namespace System.Windows.Forms
                     User32.SendMessageW(this, User32.WM.MDICASCADE);
                     break;
                 case MdiLayout.TileVertical:
-                    User32.SendMessageW(this, User32.WM.MDITILE, (IntPtr)User32.MDITILE.VERTICAL);
+                    User32.SendMessageW(this, User32.WM.MDITILE, (nint)User32.MDITILE.VERTICAL);
                     break;
                 case MdiLayout.TileHorizontal:
-                    User32.SendMessageW(this, User32.WM.MDITILE, (IntPtr)User32.MDITILE.HORIZONTAL);
+                    User32.SendMessageW(this, User32.WM.MDITILE, (nint)User32.MDITILE.HORIZONTAL);
                     break;
                 case MdiLayout.ArrangeIcons:
                     User32.SendMessageW(this, User32.WM.MDIICONARRANGE);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
@@ -98,12 +98,13 @@ namespace System.Windows.Forms
 
         private Image GetTargetWindowIcon()
         {
-            IntPtr hIcon = User32.SendMessageW(new HandleRef(this, GetSafeHandle(_target)), User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            IntPtr hIcon = User32.SendMessageW(GetSafeHandle(_target), User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, 0);
             Icon icon = hIcon != IntPtr.Zero ? Icon.FromHandle(hIcon) : Form.DefaultIcon;
             Icon smallIcon = new Icon(icon, SystemInformation.SmallIconSize);
 
             Image systemIcon = smallIcon.ToBitmap();
             smallIcon.Dispose();
+            GC.KeepAlive(_target);
 
             return systemIcon;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIControlStrip.cs
@@ -98,7 +98,7 @@ namespace System.Windows.Forms
 
         private Image GetTargetWindowIcon()
         {
-            IntPtr hIcon = User32.SendMessageW(GetSafeHandle(_target), User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, 0);
+            IntPtr hIcon = User32.SendMessageW(GetSafeHandle(_target), User32.WM.GETICON, (nint)User32.ICON.SMALL);
             Icon icon = hIcon != IntPtr.Zero ? Icon.FromHandle(hIcon) : Form.DefaultIcon;
             Icon smallIcon = new Icon(icon, SystemInformation.SmallIconSize);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
@@ -1109,7 +1109,7 @@ namespace System.Windows.Forms
             if (IsHandleCreated)
             {
                 // This message does not return a value.
-                User32.SendMessageW(this, (User32.WM)EM.SETPASSWORDCHAR, (IntPtr)pwdChar);
+                User32.SendMessageW(this, (User32.WM)EM.SETPASSWORDCHAR, (nint)pwdChar);
                 Invalidate();
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MessageBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MessageBox.cs
@@ -344,9 +344,15 @@ namespace System.Windows.Forms
             return result;
         }
 
-        private static DialogResult ShowCore(IWin32Window owner, string text, string caption,
-                                             MessageBoxButtons buttons, MessageBoxIcon icon, MessageBoxDefaultButton defaultButton,
-                                             MessageBoxOptions options, bool showHelp)
+        private static DialogResult ShowCore(
+            IWin32Window owner,
+            string text,
+            string caption,
+            MessageBoxButtons buttons,
+            MessageBoxIcon icon,
+            MessageBoxDefaultButton defaultButton,
+            MessageBoxOptions options,
+            bool showHelp)
         {
             MB style = GetMessageBoxStyle(owner, buttons, icon, defaultButton, options, showHelp);
 
@@ -385,7 +391,7 @@ namespace System.Windows.Forms
             Application.BeginModalMessageLoop();
             try
             {
-                return (DialogResult)MessageBoxW(new HandleRef(owner, handle), text, caption, style);
+                return (DialogResult)MessageBoxW(handle, text, caption, style);
             }
             finally
             {
@@ -395,7 +401,8 @@ namespace System.Windows.Forms
                 // Right after the dialog box is closed, Windows sends WM_SETFOCUS back to the previously active control
                 // but since we have disabled this thread main window the message is lost. So we have to send it again after
                 // we enable the main window.
-                User32.SendMessageW(new HandleRef(owner, handle), User32.WM.SETFOCUS);
+                User32.SendMessageW(handle, User32.WM.SETFOCUS);
+                GC.KeepAlive(owner);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -224,7 +224,7 @@ namespace System.Windows.Forms
                     iRow = rowIndex
                 };
 
-                bool success = User32.SendMessageW(_owningMonthCalendar, (User32.WM)MCM.GETCALENDARGRIDINFO, IntPtr.Zero, ref gridInfo) != IntPtr.Zero;
+                bool success = User32.SendMessageW(_owningMonthCalendar, (User32.WM)MCM.GETCALENDARGRIDINFO, 0, ref gridInfo) != 0;
 
                 return success ? new(gridInfo.stStart, gridInfo.stEnd) : null;
             }
@@ -246,7 +246,7 @@ namespace System.Windows.Forms
                     iRow = rowIndex
                 };
 
-                bool success = User32.SendMessageW(_owningMonthCalendar, (User32.WM)MCM.GETCALENDARGRIDINFO, IntPtr.Zero, ref gridInfo) != IntPtr.Zero;
+                bool success = User32.SendMessageW(_owningMonthCalendar, (User32.WM)MCM.GETCALENDARGRIDINFO, 0, ref gridInfo) != 0;
 
                 return success ? _owningMonthCalendar.RectangleToScreen(gridInfo.rc) : default;
             }
@@ -275,7 +275,7 @@ namespace System.Windows.Forms
                         cchName = (UIntPtr)name.Length - 1
                     };
 
-                    User32.SendMessageW(_owningMonthCalendar, (User32.WM)MCM.GETCALENDARGRIDINFO, IntPtr.Zero, ref gridInfo);
+                    User32.SendMessageW(_owningMonthCalendar, (User32.WM)MCM.GETCALENDARGRIDINFO, 0, ref gridInfo);
                 }
 
                 string text = string.Empty;
@@ -372,7 +372,7 @@ namespace System.Windows.Forms
                     pt = point
                 };
 
-                User32.SendMessageW(_owningMonthCalendar, (User32.WM)MCM.HITTEST, IntPtr.Zero, ref hitTestInfo);
+                User32.SendMessageW(_owningMonthCalendar, (User32.WM)MCM.HITTEST, 0, ref hitTestInfo);
 
                 return hitTestInfo;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -372,10 +372,11 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETFIRSTDAYOFWEEK, IntPtr.Zero, (IntPtr)value);
+                        User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETFIRSTDAYOFWEEK, 0, (nint)value);
                     }
 
                     UpdateDisplayRange();
+
                     // Add the extra call to make the accessibility tree to rebuild correctly
                     OnDisplayRangeChanged(EventArgs.Empty);
                 }
@@ -465,7 +466,7 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    if (User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETMAXSELCOUNT, (IntPtr)value) == IntPtr.Zero)
+                    if (User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETMAXSELCOUNT, value) == 0)
                     {
                         throw new ArgumentException(string.Format(SR.MonthCalendarMaxSelCount, value.ToString("D")), nameof(value));
                     }
@@ -625,7 +626,7 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETMONTHDELTA, (IntPtr)value);
+                    User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETMONTHDELTA, value);
                 }
 
                 _scrollChange = value;
@@ -1419,7 +1420,7 @@ namespace System.Windows.Forms
             SetSelRange(_selectionStart, _selectionEnd);
             if (_maxSelectionCount != DefaultMaxSelectionCount)
             {
-                User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETMAXSELCOUNT, (IntPtr)_maxSelectionCount);
+                User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETMAXSELCOUNT, _maxSelectionCount);
             }
 
             AdjustSize();
@@ -1446,20 +1447,20 @@ namespace System.Windows.Forms
                 firstDay = (int)_firstDayOfWeek;
             }
 
-            User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETFIRSTDAYOFWEEK, IntPtr.Zero, (IntPtr)firstDay);
+            User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETFIRSTDAYOFWEEK, 0, firstDay);
 
             SetRange();
             if (_scrollChange != DefaultScrollChange)
             {
-                User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETMONTHDELTA, (IntPtr)_scrollChange);
+                User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETMONTHDELTA, _scrollChange);
             }
 
-            SystemEvents.UserPreferenceChanged += new UserPreferenceChangedEventHandler(MarshaledUserPreferenceChanged);
+            SystemEvents.UserPreferenceChanged += MarshaledUserPreferenceChanged;
         }
 
         protected override void OnHandleDestroyed(EventArgs e)
         {
-            SystemEvents.UserPreferenceChanged -= new UserPreferenceChangedEventHandler(MarshaledUserPreferenceChanged);
+            SystemEvents.UserPreferenceChanged -= MarshaledUserPreferenceChanged;
             base.OnHandleDestroyed(e);
         }
 
@@ -1734,7 +1735,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETCOLOR, (IntPtr)colorIndex, PARAM.FromColor(value));
+                User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.SETCOLOR, (nint)colorIndex, value.ToWin32());
             }
         }
 
@@ -2104,7 +2105,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    User32.SendMessageW(this, (User32.WM)User32.MCM.SETTODAY, 0, IntPtr.Zero);
+                    User32.SendMessageW(this, (User32.WM)User32.MCM.SETTODAY, 0, 0);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1300,7 +1300,7 @@ namespace System.Windows.Forms
             // If the width we've calculated is too small to fit the Today string, enlarge the width to fit
             if (IsHandleCreated)
             {
-                int maxTodayWidth = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.GETMAXTODAYWIDTH));
+                int maxTodayWidth = (int)User32.SendMessageW(this, (User32.WM)ComCtl32.MCM.GETMAXTODAYWIDTH);
                 if (maxTodayWidth > minSize.Width)
                 {
                     minSize.Width = maxTodayWidth;
@@ -1903,7 +1903,7 @@ namespace System.Windows.Forms
             {
                 // Update display dates states.
                 // For more info see docs: https://docs.microsoft.com/windows/win32/controls/mcm-setdaystate
-                User32.SendMessageW(Handle, (User32.WM)ComCtl32.MCM.SETDAYSTATE, (IntPtr)(void*)monthsCount, (IntPtr)arr);
+                User32.SendMessageW(Handle, (User32.WM)ComCtl32.MCM.SETDAYSTATE, (nint)(void*)monthsCount, (nint)arr);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBar.cs
@@ -237,11 +237,11 @@ namespace System.Windows.Forms
             {
                 if (_marqueeAnimationSpeed == 0)
                 {
-                    User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETMARQUEE, IntPtr.Zero, (IntPtr)_marqueeAnimationSpeed);
+                    User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETMARQUEE, (nint)BOOL.FALSE, _marqueeAnimationSpeed);
                 }
                 else
                 {
-                    User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETMARQUEE, (IntPtr)1, (IntPtr)_marqueeAnimationSpeed);
+                    User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETMARQUEE, (nint)BOOL.TRUE, _marqueeAnimationSpeed);
                 }
             }
         }
@@ -280,7 +280,7 @@ namespace System.Windows.Forms
 
                     if (IsHandleCreated)
                     {
-                        User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETRANGE32, (IntPtr)_minimum, (IntPtr)_maximum);
+                        User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETRANGE32, _minimum, _maximum);
                         UpdatePos();
                     }
                 }
@@ -321,7 +321,7 @@ namespace System.Windows.Forms
 
                     if (IsHandleCreated)
                     {
-                        User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETRANGE32, (IntPtr)_minimum, (IntPtr)_maximum);
+                        User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETRANGE32, _minimum, _maximum);
                         UpdatePos();
                     }
                 }
@@ -333,7 +333,7 @@ namespace System.Windows.Forms
             base.OnBackColorChanged(e);
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBKCOLOR, IntPtr.Zero, PARAM.FromColor(BackColor));
+                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBKCOLOR, 0, BackColor.ToWin32());
             }
         }
 
@@ -342,7 +342,7 @@ namespace System.Windows.Forms
             base.OnForeColorChanged(e);
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBARCOLOR, IntPtr.Zero, PARAM.FromColor(ForeColor));
+                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBARCOLOR, 0, ForeColor.ToWin32());
             }
         }
 
@@ -411,7 +411,7 @@ namespace System.Windows.Forms
                 _step = value;
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETSTEP, (IntPtr)_step);
+                    User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETSTEP, _step);
                 }
             }
         }
@@ -595,11 +595,11 @@ namespace System.Windows.Forms
             base.OnHandleCreated(e);
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETRANGE32, (IntPtr)_minimum, (IntPtr)_maximum);
-                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETSTEP, (IntPtr)_step);
-                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETPOS, (IntPtr)_value);
-                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBKCOLOR, IntPtr.Zero, PARAM.FromColor(BackColor));
-                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBARCOLOR, IntPtr.Zero, PARAM.FromColor(ForeColor));
+                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETRANGE32, _minimum, _maximum);
+                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETSTEP, _step);
+                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETPOS, _value);
+                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBKCOLOR, 0, BackColor.ToWin32());
+                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBARCOLOR, 0, ForeColor.ToWin32());
             }
 
             StartMarquee();
@@ -679,7 +679,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETPOS, (IntPtr)_value);
+                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETPOS, _value);
             }
         }
 
@@ -691,8 +691,8 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBARCOLOR, IntPtr.Zero, PARAM.FromColor(ForeColor));
-                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBKCOLOR, IntPtr.Zero, PARAM.FromColor(BackColor));
+                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBARCOLOR, 0, ForeColor.ToWin32());
+                User32.SendMessageW(this, (User32.WM)ComCtl32.PBM.SETBKCOLOR, 0, BackColor.ToWin32());
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -609,7 +609,7 @@ namespace System.Windows.Forms
                 {
                     if (0 == _paintFrozen++)
                     {
-                        User32.SendMessageW(this, User32.WM.SETREDRAW, PARAM.FromBool(false));
+                        User32.SendMessageW(this, User32.WM.SETREDRAW, (nint)BOOL.FALSE);
                     }
                 }
 
@@ -622,7 +622,7 @@ namespace System.Windows.Forms
 
                     if (0 == --_paintFrozen)
                     {
-                        User32.SendMessageW(this, User32.WM.SETREDRAW, PARAM.FromBool(true));
+                        User32.SendMessageW(this, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
                         Invalidate(true);
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
@@ -150,8 +150,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                 User32.SendMessageW(
                     this,
                     (User32.WM)ComCtl32.TTM.SETMAXTIPWIDTH,
-                    IntPtr.Zero,
-                    (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                    0,
+                    SystemInformation.MaxWindowTrackSize.Width);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -3903,7 +3903,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             RECT rect = itemRect;
 
-            User32.SendMessageW(toolTip, (User32.WM)ComCtl32.TTM.ADJUSTRECT, (IntPtr)1, ref rect);
+            User32.SendMessageW(toolTip, (User32.WM)ComCtl32.TTM.ADJUSTRECT, 1, ref rect);
 
             // Now offset it back to screen coords.
             Point location = parent.PointToScreen(new(rect.left, rect.top));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -188,7 +188,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return false;
                 }
 
-                return User32.SendMessageW(EditTextBox, (User32.WM)User32.EM.CANUNDO) != IntPtr.Zero;
+                return User32.SendMessageW(EditTextBox, (User32.WM)User32.EM.CANUNDO) != 0;
             }
         }
 
@@ -2691,7 +2691,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     Math.Abs(screenPoint.Y - _rowSelectPos.Y) < SystemInformation.DoubleClickSize.Height)
                 {
                     DoubleClickRow(_selectedRow, toggleExpand: false, RowValue);
-                    User32.SendMessageW(EditTextBox, User32.WM.LBUTTONUP, IntPtr.Zero, PARAM.FromLowHigh(e.X, e.Y));
+                    User32.SendMessageW(EditTextBox, User32.WM.LBUTTONUP, 0, PARAM.FromLowHigh(e.X, e.Y));
                     EditTextBox.SelectAll();
                 }
 
@@ -3550,8 +3550,8 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 Point editPoint = PointToScreen(_lastMouseDown);
                 editPoint = EditTextBox.PointToClient(editPoint);
-                User32.SendMessageW(EditTextBox, User32.WM.LBUTTONDOWN, IntPtr.Zero, PARAM.FromLowHigh(editPoint.X, editPoint.Y));
-                User32.SendMessageW(EditTextBox, User32.WM.LBUTTONUP, IntPtr.Zero, PARAM.FromLowHigh(editPoint.X, editPoint.Y));
+                User32.SendMessageW(EditTextBox, User32.WM.LBUTTONDOWN, 0, PARAM.FromLowHigh(editPoint.X, editPoint.Y));
+                User32.SendMessageW(EditTextBox, User32.WM.LBUTTONUP, 0, PARAM.FromLowHigh(editPoint.X, editPoint.Y));
             }
 
             if (setSelectTime)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -352,7 +352,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             {
                 if (_editTextBox is not null && _editTextBox.IsHandleCreated)
                 {
-                    int exStyle = unchecked((int)(long)User32.GetWindowLong(_editTextBox, User32.GWL.EXSTYLE));
+                    int exStyle = (int)User32.GetWindowLong(_editTextBox, User32.GWL.EXSTYLE);
                     return (exStyle & (int)User32.WS_EX.RTLREADING) != 0;
                 }
                 else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -347,20 +347,9 @@ namespace System.Windows.Forms.PropertyGridInternal
             => DropDownListBox.Visible ? DropDownListBox.AccessibilityObject : null;
 
         internal bool DrawValuesRightToLeft
-        {
-            get
-            {
-                if (_editTextBox is not null && _editTextBox.IsHandleCreated)
-                {
-                    int exStyle = (int)User32.GetWindowLong(_editTextBox, User32.GWL.EXSTYLE);
-                    return (exStyle & (int)User32.WS_EX.RTLREADING) != 0;
-                }
-                else
-                {
-                    return false;
-                }
-            }
-        }
+            => _editTextBox is not null
+                && _editTextBox.IsHandleCreated
+                && ((User32.WS_EX)User32.GetWindowLong(_editTextBox, User32.GWL.EXSTYLE)).HasFlag(User32.WS_EX.RTLREADING);
 
         internal DropDownHolder DropDownControlHolder => _dropDownHolder;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.cs
@@ -386,7 +386,7 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)User32.BM.SETCHECK, PARAM.FromBool(isChecked));
+                User32.SendMessageW(this, (User32.WM)User32.BM.SETCHECK, (nint)isChecked.ToBOOL());
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -762,8 +762,8 @@ namespace System.Windows.Forms
                     cbSize = (uint)sizeof(PARAFORMAT)
                 };
 
-                // get the format for our currently selected paragraph
-                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Get the format for our currently selected paragraph.
+                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, 0, ref pf);
 
                 // check if alignment has been set yet
                 if ((PFM.ALIGNMENT & pf.dwMask) != 0)
@@ -797,6 +797,7 @@ namespace System.Windows.Forms
                     cbSize = (uint)sizeof(PARAFORMAT),
                     dwMask = PFM.ALIGNMENT
                 };
+
                 switch (value)
                 {
                     case HorizontalAlignment.Left:
@@ -812,8 +813,8 @@ namespace System.Windows.Forms
                         break;
                 }
 
-                // set the format for our current paragraph or selection
-                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Set the format for our current paragraph or selection.
+                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, 0, ref pf);
             }
         }
 
@@ -837,8 +838,8 @@ namespace System.Windows.Forms
                     cbSize = (uint)sizeof(PARAFORMAT)
                 };
 
-                // get the format for our currently selected paragraph
-                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Get the format for our currently selected paragraph.
+                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, 0, ref pf);
 
                 // check if alignment has been set yet
                 if ((PFM.NUMBERING & pf.dwMask) != 0)
@@ -877,8 +878,8 @@ namespace System.Windows.Forms
                     pf.dxOffset = Pixel2Twip(bulletIndent, true);
                 }
 
-                // set the format for our current paragraph or selection
-                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Set the format for our current paragraph or selection.
+                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, 0, ref pf);
             }
         }
 
@@ -903,7 +904,10 @@ namespace System.Windows.Forms
             {
                 if (value > 2000 || value < -2000)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidBoundArgument, nameof(SelectionCharOffset), value, -2000, 2000));
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        string.Format(SR.InvalidBoundArgument, nameof(SelectionCharOffset), value, -2000, 2000));
                 }
 
                 ForceHandleCreate();
@@ -914,19 +918,19 @@ namespace System.Windows.Forms
                     yOffset = Pixel2Twip(value, false)
                 };
 
-                // Set the format information
+                // Set the format information.
+                //
                 // SendMessage will force the handle to be created if it hasn't already. Normally,
                 // we would cache property values until the handle is created - but for this property,
                 // it's far more simple to just create the handle.
-                User32.SendMessageW(this, (User32.WM)EM.SETCHARFORMAT, (IntPtr)SCF.SELECTION, ref cf);
+                User32.SendMessageW(this, (User32.WM)EM.SETCHARFORMAT, (nint)SCF.SELECTION, ref cf);
             }
         }
 
         /// <summary>
-        ///  The color of the currently selected text in the
-        ///  RichTextBox control.
-        ///  Returns Color.Empty if the selection has more than one color.
+        ///  The color of the currently selected text in the RichTextBox control.
         /// </summary>
+        /// <returns>The color or <see cref="Color.Empty"/> if the selection has more than one color.</returns>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [SRDescription(nameof(SR.RichTextBoxSelColor))]
@@ -954,8 +958,8 @@ namespace System.Windows.Forms
                 cf.dwEffects = 0;
                 cf.crTextColor = ColorTranslator.ToWin32(value);
 
-                // set the format information
-                User32.SendMessageW(this, (User32.WM)EM.SETCHARFORMAT, (IntPtr)SCF.SELECTION, ref cf);
+                // Set the format information.
+                User32.SendMessageW(this, (User32.WM)EM.SETCHARFORMAT, (nint)SCF.SELECTION, ref cf);
             }
         }
 
@@ -1013,7 +1017,7 @@ namespace System.Windows.Forms
                         cf2.crBackColor = ColorTranslator.ToWin32(value);
                     }
 
-                    User32.SendMessageW(this, (User32.WM)EM.SETCHARFORMAT, (IntPtr)SCF.SELECTION, ref cf2);
+                    User32.SendMessageW(this, (User32.WM)EM.SETCHARFORMAT, (nint)SCF.SELECTION, ref cf2);
                 }
             }
         }
@@ -1059,10 +1063,10 @@ namespace System.Windows.Forms
                     cbSize = (uint)sizeof(PARAFORMAT)
                 };
 
-                // get the format for our currently selected paragraph
-                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Get the format for our currently selected paragraph.
+                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, 0, ref pf);
 
-                // check if alignment has been set yet
+                // Check if alignment has been set yet.
                 if ((PFM.OFFSET & pf.dwMask) != 0)
                 {
                     selHangingIndent = pf.dxOffset;
@@ -1081,8 +1085,8 @@ namespace System.Windows.Forms
                     dxOffset = Pixel2Twip(value, true)
                 };
 
-                // set the format for our current paragraph or selection
-                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Set the format for our current paragraph or selection.
+                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, 0, ref pf);
             }
         }
 
@@ -1107,10 +1111,10 @@ namespace System.Windows.Forms
                     cbSize = (uint)sizeof(PARAFORMAT)
                 };
 
-                // get the format for our currently selected paragraph
-                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Get the format for our currently selected paragraph.
+                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, 0, ref pf);
 
-                // check if alignment has been set yet
+                // Check if alignment has been set yet.
                 if ((PFM.STARTINDENT & pf.dwMask) != 0)
                 {
                     selIndent = pf.dxStartIndent;
@@ -1129,8 +1133,8 @@ namespace System.Windows.Forms
                     dxStartIndent = Pixel2Twip(value, true)
                 };
 
-                // set the format for our current paragraph or selection
-                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Set the format for our current paragraph or selection.
+                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, 0, ref pf);
             }
         }
 
@@ -1231,10 +1235,10 @@ namespace System.Windows.Forms
                     cbSize = (uint)sizeof(PARAFORMAT)
                 };
 
-                // get the format for our currently selected paragraph
-                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Get the format for our currently selected paragraph.
+                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, 0, ref pf);
 
-                // check if alignment has been set yet
+                // Check if alignment has been set yet.
                 if ((PFM.RIGHTINDENT & pf.dwMask) != 0)
                 {
                     selRightIndent = pf.dxRightIndent;
@@ -1246,7 +1250,10 @@ namespace System.Windows.Forms
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidLowBoundArgumentEx, nameof(SelectionRightIndent), value, 0));
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        string.Format(SR.InvalidLowBoundArgumentEx, nameof(SelectionRightIndent), value, 0));
                 }
 
                 ForceHandleCreate();
@@ -1257,8 +1264,8 @@ namespace System.Windows.Forms
                     dxRightIndent = Pixel2Twip(value, true)
                 };
 
-                // set the format for our current paragraph or selection
-                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Set the format for our current paragraph or selection.
+                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, 0, ref pf);
             }
         }
 
@@ -1281,7 +1288,7 @@ namespace System.Windows.Forms
                 };
 
                 // get the format for our currently selected paragraph
-                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, IntPtr.Zero, ref pf);
+                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, 0, ref pf);
 
                 // check if alignment has been set yet
                 if ((PFM.TABSTOPS & pf.dwMask) != 0)
@@ -1311,7 +1318,7 @@ namespace System.Windows.Forms
 
                 // get the format for our currently selected paragraph because
                 // we need to get the number of tabstops to copy
-                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, IntPtr.Zero, ref pf);
+                User32.SendMessageW(this, (User32.WM)EM.GETPARAFORMAT, 0, ref pf);
 
                 pf.cTabCount = (short)((value is null) ? 0 : value.Length);
                 pf.dwMask = PFM.TABSTOPS;
@@ -1320,8 +1327,8 @@ namespace System.Windows.Forms
                     pf.rgxTabs[x] = Pixel2Twip(value[x], true);
                 }
 
-                // set the format for our current paragraph or selection
-                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, IntPtr.Zero, ref pf);
+                // Set the format for our current paragraph or selection.
+                User32.SendMessageW(this, (User32.WM)EM.SETPARAFORMAT, 0, ref pf);
             }
         }
 
@@ -1557,10 +1564,10 @@ namespace System.Windows.Forms
                 {
                     int numerator = 0;
                     int denominator = 0;
-                    User32.SendMessageW(this, (User32.WM)EM.GETZOOM, (IntPtr)(&numerator), ref denominator);
+                    User32.SendMessageW(this, (User32.WM)EM.GETZOOM, (nint)(&numerator), ref denominator);
                     if ((numerator != 0) && (denominator != 0))
                     {
-                        zoomMultiplier = ((float)numerator) / ((float)denominator);
+                        zoomMultiplier = numerator / ((float)denominator);
                     }
                     else
                     {
@@ -1579,7 +1586,10 @@ namespace System.Windows.Forms
             {
                 if (value <= 0.015625f || value >= 64.0f)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, string.Format(SR.InvalidExBoundArgument, nameof(ZoomFactor), value, 0.015625f, 64.0f));
+                    throw new ArgumentOutOfRangeException(
+                        nameof(value),
+                        value,
+                        string.Format(SR.InvalidExBoundArgument, nameof(ZoomFactor), value, 0.015625f, 64.0f));
                 }
 
                 if (value != zoomMultiplier)
@@ -1970,7 +1980,7 @@ namespace System.Windows.Forms
             fixed (char* pText = str)
             {
                 ft.lpstrText = pText;
-                position = (int)User32.SendMessageW(this, (User32.WM)EM.FINDTEXT, (IntPtr)findOptions, ref ft);
+                position = (int)User32.SendMessageW(this, (User32.WM)EM.FINDTEXT, (nint)findOptions, ref ft);
             }
 
             // if we didn't find anything, or we don't have to select what was found,
@@ -2013,7 +2023,7 @@ namespace System.Windows.Forms
                     chrg.cpMax = foundCursor;
                 }
 
-                User32.SendMessageW(this, (User32.WM)EM.EXSETSEL, IntPtr.Zero, ref chrg);
+                User32.SendMessageW(this, (User32.WM)EM.EXSETSEL, 0, ref chrg);
                 User32.SendMessageW(this, (User32.WM)User32.EM.SCROLLCARET);
             }
 
@@ -2143,7 +2153,7 @@ namespace System.Windows.Forms
 
                     // go get the text in this range, if we didn't get any text then punt
                     int len;
-                    len = (int)User32.SendMessageW(this, (User32.WM)EM.GETTEXTRANGE, IntPtr.Zero, ref txrg);
+                    len = (int)User32.SendMessageW(this, (User32.WM)EM.GETTEXTRANGE, 0, ref txrg);
                     if (len == 0)
                     {
                         chrg.cpMax = chrg.cpMin = -1; // Hit end of control without finding what we wanted
@@ -2236,7 +2246,8 @@ namespace System.Windows.Forms
             {
                 cbSize = (uint)sizeof(CHARFORMAT2W)
             };
-            User32.SendMessageW(this, (User32.WM)EM.GETCHARFORMAT, (IntPtr)(fSelection ? SCF.SELECTION : SCF.DEFAULT), ref cf);
+
+            User32.SendMessageW(this, (User32.WM)EM.GETCHARFORMAT, (nint)(fSelection ? SCF.SELECTION : SCF.DEFAULT), ref cf);
             return cf;
         }
 
@@ -2320,7 +2331,7 @@ namespace System.Windows.Forms
         public override int GetCharIndexFromPosition(Point pt)
         {
             var wpt = new Point(pt.X, pt.Y);
-            int index = (int)User32.SendMessageW(this, (User32.WM)User32.EM.CHARFROMPOS, IntPtr.Zero, ref wpt);
+            int index = (int)User32.SendMessageW(this, (User32.WM)User32.EM.CHARFROMPOS, 0, ref wpt);
 
             string t = Text;
             // EM_CHARFROMPOS will return an invalid number if the last character in the RichEdit
@@ -2836,7 +2847,7 @@ namespace System.Windows.Forms
                 }
 
                 // set the format information
-                return User32.SendMessageW(this, (User32.WM)EM.SETCHARFORMAT, (IntPtr)SCF.SELECTION, ref cf) != IntPtr.Zero;
+                return User32.SendMessageW(this, (User32.WM)EM.SETCHARFORMAT, (nint)SCF.SELECTION, ref cf) != 0;
             }
 
             return false;
@@ -2844,7 +2855,7 @@ namespace System.Windows.Forms
 
         private bool SetCharFormat(SCF charRange, CHARFORMAT2W cf)
         {
-            return User32.SendMessageW(this, (User32.WM)EM.SETCHARFORMAT, (IntPtr)charRange, ref cf) != IntPtr.Zero;
+            return User32.SendMessageW(this, (User32.WM)EM.SETCHARFORMAT, (nint)charRange, ref cf) != 0;
         }
 
         private unsafe void SetCharFormatFont(bool selectionOnly, Font value)
@@ -2891,7 +2902,7 @@ namespace System.Windows.Forms
             User32.SendMessageW(
                 this,
                 (User32.WM)EM.SETCHARFORMAT,
-                (IntPtr)(selectionOnly ? SCF.SELECTION : SCF.ALL),
+                (nint)(selectionOnly ? SCF.SELECTION : SCF.ALL),
                 ref charFormat);
         }
 
@@ -2929,7 +2940,7 @@ namespace System.Windows.Forms
                 }
 
                 // WM_SETTEXT is allowed even if we have protected text
-                User32.SendMessageW(this, User32.WM.SETTEXT, IntPtr.Zero, string.Empty);
+                User32.SendMessageW(this, User32.WM.SETTEXT, 0, string.Empty);
                 return;
             }
 
@@ -2965,7 +2976,7 @@ namespace System.Windows.Forms
             if ((flags & SF.F_SELECTION) == 0)
             {
                 var cr = new CHARRANGE();
-                User32.SendMessageW(this, (User32.WM)EM.EXSETSEL, IntPtr.Zero, ref cr);
+                User32.SendMessageW(this, (User32.WM)EM.EXSETSEL, 0, ref cr);
             }
 
             try
@@ -3025,7 +3036,7 @@ namespace System.Windows.Forms
                 User32.SendMessageW(this, (User32.WM)EM.EXLIMITTEXT, IntPtr.Zero, (IntPtr)int.MaxValue);
 
                 // go get the text for the control
-                User32.SendMessageW(this, (User32.WM)EM.STREAMIN, (IntPtr)flags, ref es);
+                User32.SendMessageW(this, (User32.WM)EM.STREAMIN, (nint)flags, ref es);
                 GC.KeepAlive(callback);
 
                 UpdateMaxLength();
@@ -3131,7 +3142,7 @@ namespace System.Windows.Forms
                 es.pfnCallback = Marshal.GetFunctionPointerForDelegate(callback);
 
                 // Get Text
-                User32.SendMessageW(this, (User32.WM)EM.STREAMOUT, (IntPtr)flags, ref es);
+                User32.SendMessageW(this, (User32.WM)EM.STREAMOUT, (nint)flags, ref es);
                 GC.KeepAlive(callback);
 
                 // check to make sure things went well
@@ -3354,7 +3365,7 @@ namespace System.Windows.Forms
             }
 
             txrg.lpstrText = unmanagedBuffer;
-            int len = (int)User32.SendMessageW(this, (User32.WM)EM.GETTEXTRANGE, IntPtr.Zero, ref txrg);
+            int len = (int)User32.SendMessageW(this, (User32.WM)EM.GETTEXTRANGE, 0, ref txrg);
             Debug.Assert(len != 0, "CHARRANGE from RichTextBox was bad! - impossible?");
             charBuffer.PutCoTaskMem(unmanagedBuffer);
             if (txrg.lpstrText != IntPtr.Zero)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -270,13 +270,7 @@ namespace System.Windows.Forms
             set { richTextBoxFlags[callOnContentsResizedSection] = value ? 1 : 0; }
         }
 
-        internal override bool CanRaiseTextChangedEvent
-        {
-            get
-            {
-                return !SuppressTextChangedEvent;
-            }
-        }
+        internal override bool CanRaiseTextChangedEvent => !SuppressTextChangedEvent;
 
         /// <summary>
         ///  Whether or not there are actions that can be Redone on the RichTextBox control.
@@ -284,18 +278,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [SRDescription(nameof(SR.RichTextBoxCanRedoDescr))]
-        public bool CanRedo
-        {
-            get
-            {
-                if (IsHandleCreated)
-                {
-                    return unchecked((int)(long)User32.SendMessageW(this, (User32.WM)EM.CANREDO)) != 0;
-                }
-
-                return false;
-            }
-        }
+        public bool CanRedo => IsHandleCreated && (int)User32.SendMessageW(this, (User32.WM)EM.CANREDO) != 0;
 
         protected override CreateParams CreateParams
         {
@@ -602,10 +585,10 @@ namespace System.Windows.Forms
             {
                 if (!CanRedo)
                 {
-                    return "";
+                    return string.Empty;
                 }
 
-                int n = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)EM.GETREDONAME));
+                int n = (int)User32.SendMessageW(this, (User32.WM)EM.GETREDONAME);
                 return GetEditorActionName(n);
             }
         }
@@ -1369,7 +1352,7 @@ namespace System.Windows.Forms
                 ForceHandleCreate();
                 if (SelectionLength > 0)
                 {
-                    int n = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)EM.SELECTIONTYPE));
+                    int n = (int)User32.SendMessageW(this, (User32.WM)EM.SELECTIONTYPE);
                     return (RichTextBoxSelectionTypes)n;
                 }
                 else
@@ -1496,7 +1479,7 @@ namespace System.Windows.Forms
                     codepage = 1200u /* CP_UNICODE */
                 };
 
-                return unchecked((int)(long)User32.SendMessageW(this, (User32.WM)EM.GETTEXTLENGTHEX, (IntPtr)(&gtl)));
+                return (int)User32.SendMessageW(this, (User32.WM)EM.GETTEXTLENGTHEX, (IntPtr)(&gtl));
             }
         }
 
@@ -1520,7 +1503,7 @@ namespace System.Windows.Forms
                     return "";
                 }
 
-                int n = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)EM.GETUNDONAME));
+                int n = (int)User32.SendMessageW(this, (User32.WM)EM.GETUNDONAME);
                 return GetEditorActionName(n);
             }
         }
@@ -1714,9 +1697,7 @@ namespace System.Windows.Forms
         ///  given clipboard format.
         /// </summary>
         public bool CanPaste(DataFormats.Format clipFormat)
-        {
-            return unchecked((int)(long)User32.SendMessageW(this, (User32.WM)EM.CANPASTE, (IntPtr)clipFormat.Id)) != 0;
-        }
+            => (int)User32.SendMessageW(this, (User32.WM)EM.CANPASTE, clipFormat.Id) != 0;
 
         //DrawToBitmap doesn't work for this control, so we should hide it.  We'll
         //still call base so that this has a chance to work if it can.
@@ -2368,9 +2349,7 @@ namespace System.Windows.Forms
         ///  return 1 and not 0.
         /// </summary>
         public override int GetLineFromCharIndex(int index)
-        {
-            return unchecked((int)(long)User32.SendMessageW(this, (User32.WM)EM.EXLINEFROMCHAR, IntPtr.Zero, (IntPtr)index));
-        }
+            => (int)User32.SendMessageW(this, (User32.WM)EM.EXLINEFROMCHAR, 0, index);
 
         /// <summary>
         ///  Returns the location of the character at the given index.
@@ -3178,7 +3157,7 @@ namespace System.Windows.Forms
             }
 
             GETTEXTLENGTHEX* pGtl = &gtl;
-            int expectedLength = PARAM.ToInt(User32.SendMessageW(Handle, (User32.WM)User32.EM.GETTEXTLENGTHEX, (IntPtr)pGtl));
+            int expectedLength = (int)User32.SendMessageW(Handle, (User32.WM)User32.EM.GETTEXTLENGTHEX, (nint)pGtl);
             if (expectedLength == (int)HRESULT.E_INVALIDARG)
                 throw new Win32Exception(expectedLength);
 
@@ -3199,7 +3178,7 @@ namespace System.Windows.Forms
             GETTEXTEX* pGt = &gt;
             fixed (char* pText = text)
             {
-                int actualLength = PARAM.ToInt(User32.SendMessageW(Handle, (User32.WM)User32.EM.GETTEXTEX, (IntPtr)pGt, (IntPtr)pText));
+                int actualLength = (int)User32.SendMessageW(Handle, (User32.WM)User32.EM.GETTEXTEX, (nint)pGt, (nint)pText);
 
                 // The default behaviour of EM_GETTEXTEX is to normalise line endings to '\r'
                 // (see: GT_DEFAULT, https://docs.microsoft.com/windows/win32/api/richedit/ns-richedit-gettextex#members),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -194,8 +194,8 @@ namespace System.Windows.Forms
                     User32.SendMessageW(
                         this,
                         (User32.WM)EM.SETOPTIONS,
-                        (IntPtr)(value ? ECOOP.OR : ECOOP.XOR),
-                        (IntPtr)ECO.AUTOWORDSELECTION);
+                        (nint)(value ? ECOOP.OR : ECOOP.XOR),
+                        (nint)ECO.AUTOWORDSELECTION);
                 }
             }
         }
@@ -531,7 +531,7 @@ namespace System.Windows.Forms
                     languageOption = value;
                     if (IsHandleCreated)
                     {
-                        User32.SendMessageW(this, (User32.WM)EM.SETLANGOPTIONS, IntPtr.Zero, (IntPtr)value);
+                        User32.SendMessageW(this, (User32.WM)EM.SETLANGOPTIONS, 0, (nint)value);
                     }
                 }
             }
@@ -644,7 +644,7 @@ namespace System.Windows.Forms
                     else if (IsHandleCreated)
                     {
                         using var hDC = new Gdi32.CreateDcScope("DISPLAY", null, null, IntPtr.Zero, informationOnly: true);
-                        User32.SendMessageW(this, (User32.WM)EM.SETTARGETDEVICE, (IntPtr)hDC, (IntPtr)Pixel2Twip(value, true));
+                        User32.SendMessageW(this, (User32.WM)EM.SETTARGETDEVICE, hDC, Pixel2Twip(value, true));
                     }
                 }
             }
@@ -1382,8 +1382,8 @@ namespace System.Windows.Forms
                         User32.SendMessageW(
                             this,
                             (User32.WM)EM.SETOPTIONS,
-                            (IntPtr)(value ? ECOOP.OR : ECOOP.XOR),
-                            (IntPtr)ECO.SELECTIONBAR);
+                            (nint)(value ? ECOOP.OR : ECOOP.XOR),
+                            (nint)ECO.SELECTIONBAR);
                     }
                 }
             }
@@ -1479,7 +1479,7 @@ namespace System.Windows.Forms
                     codepage = 1200u /* CP_UNICODE */
                 };
 
-                return (int)User32.SendMessageW(this, (User32.WM)EM.GETTEXTLENGTHEX, (IntPtr)(&gtl));
+                return (int)User32.SendMessageW(this, (User32.WM)EM.GETTEXTLENGTHEX, (nint)(&gtl));
             }
         }
 
@@ -2367,7 +2367,7 @@ namespace System.Windows.Forms
             }
 
             var pt = new Point();
-            User32.SendMessageW(this, (User32.WM)User32.EM.POSFROMCHAR, (IntPtr)(&pt), (IntPtr)index);
+            User32.SendMessageW(this, (User32.WM)User32.EM.POSFROMCHAR, (nint)(&pt), index);
             return pt;
         }
 
@@ -2445,7 +2445,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)EM.SETBKGNDCOLOR, IntPtr.Zero, PARAM.FromColor(BackColor));
+                User32.SendMessageW(this, (User32.WM)EM.SETBKGNDCOLOR, 0, BackColor.ToWin32());
             }
 
             base.OnBackColorChanged(e);
@@ -2523,8 +2523,8 @@ namespace System.Windows.Forms
             User32.SendMessageW(
                 this,
                 (User32.WM)EM.SETEVENTMASK,
-                IntPtr.Zero,
-                (IntPtr)(ENM.PROTECTED | ENM.SELCHANGE |
+                0,
+                (nint)(ENM.PROTECTED | ENM.SELCHANGE |
                          ENM.DROPFILES | ENM.REQUESTRESIZE |
                          ENM.IMECHANGE | ENM.CHANGE |
                          ENM.UPDATE | ENM.SCROLL |
@@ -2535,7 +2535,7 @@ namespace System.Windows.Forms
             rightMargin = 0;
             RightMargin = rm;
 
-            User32.SendMessageW(this, (User32.WM)EM.AUTOURLDETECT, DetectUrls ? (IntPtr)1 : IntPtr.Zero, IntPtr.Zero);
+            User32.SendMessageW(this, (User32.WM)EM.AUTOURLDETECT, DetectUrls ? 1 : 0, 0);
             if (selectionBackColorToSetOnHandleCreated != Color.Empty)
             {
                 SelectionBackColor = selectionBackColorToSetOnHandleCreated;
@@ -2544,7 +2544,7 @@ namespace System.Windows.Forms
             // Initialize colors before initializing RTF, otherwise CFE_AUTOCOLOR will be in effect
             // and our text will all be Color.WindowText.
             AutoWordSelection = AutoWordSelection;
-            User32.SendMessageW(this, (User32.WM)EM.SETBKGNDCOLOR, IntPtr.Zero, PARAM.FromColor(BackColor));
+            User32.SendMessageW(this, (User32.WM)EM.SETBKGNDCOLOR, 0, BackColor.ToWin32());
             InternalSetForeColor(ForeColor);
 
             // base sets the Text property.  It's important to do this *after* setting EM_AUTOUrlDETECT.
@@ -2789,7 +2789,7 @@ namespace System.Windows.Forms
 
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)EM.SETZOOM, (IntPtr)numerator, (IntPtr)denominator);
+                User32.SendMessageW(this, (User32.WM)EM.SETZOOM, numerator, denominator);
             }
 
             if (numerator != 0)
@@ -3012,7 +3012,7 @@ namespace System.Windows.Forms
 
                 // gives us TextBox compatible behavior, programatic text change shouldn't
                 // be limited...
-                User32.SendMessageW(this, (User32.WM)EM.EXLIMITTEXT, IntPtr.Zero, (IntPtr)int.MaxValue);
+                User32.SendMessageW(this, (User32.WM)EM.EXLIMITTEXT, 0, int.MaxValue);
 
                 // go get the text for the control
                 User32.SendMessageW(this, (User32.WM)EM.STREAMIN, (nint)flags, ref es);
@@ -3034,7 +3034,7 @@ namespace System.Windows.Forms
                 }
 
                 // set the modify tag on the control
-                User32.SendMessageW(this, (User32.WM)User32.EM.SETMODIFY, (IntPtr)(-1));
+                User32.SendMessageW(this, (User32.WM)User32.EM.SETMODIFY, -1);
 
                 // EM_GETLINECOUNT will cause the RichTextBox to recalculate its line indexes
                 User32.SendMessageW(this, (User32.WM)User32.EM.GETLINECOUNT);
@@ -3228,7 +3228,7 @@ namespace System.Windows.Forms
                         Marshal.QueryInterface(punk, ref iidRichEditOleCallback, out IntPtr pRichEditOleCallback);
                         try
                         {
-                            User32.SendMessageW(this, (User32.WM)EM.SETOLECALLBACK, IntPtr.Zero, pRichEditOleCallback);
+                            User32.SendMessageW(this, (User32.WM)EM.SETOLECALLBACK, 0, pRichEditOleCallback);
                         }
                         finally
                         {
@@ -3253,7 +3253,7 @@ namespace System.Windows.Forms
             {
                 if (BackColor.IsSystemColor)
                 {
-                    User32.SendMessageW(this, (User32.WM)EM.SETBKGNDCOLOR, IntPtr.Zero, PARAM.FromColor(BackColor));
+                    User32.SendMessageW(this, (User32.WM)EM.SETBKGNDCOLOR, 0, BackColor.ToWin32());
                 }
 
                 if (ForeColor.IsSystemColor)
@@ -3360,7 +3360,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                User32.SendMessageW(this, (User32.WM)EM.EXLIMITTEXT, IntPtr.Zero, (IntPtr)MaxLength);
+                User32.SendMessageW(this, (User32.WM)EM.EXLIMITTEXT, 0, (IntPtr)MaxLength);
             }
         }
 
@@ -3590,7 +3590,7 @@ namespace System.Windows.Forms
             if (ImeMode == ImeMode.Hangul || ImeMode == ImeMode.HangulFull)
             {
                 // Is the IME CompositionWindow open?
-                ICM compMode = unchecked((ICM)(long)User32.SendMessageW(this, (User32.WM)EM.GETIMECOMPMODE));
+                ICM compMode = (ICM)User32.SendMessageW(this, (User32.WM)EM.GETIMECOMPMODE);
                 if (compMode != ICM.NOTOPEN)
                 {
                     int textLength = User32.GetWindowTextLengthW(new HandleRef(this, Handle));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
@@ -1261,7 +1261,7 @@ namespace System.Windows.Forms
                     this,
                     User32.WM.HSCROLL,
                     PARAM.FromLowHigh((RightToLeft == RightToLeft.Yes) ? (int)User32.SBH.RIGHT : (int)User32.SBH.LEFT, 0),
-                    IntPtr.Zero);
+                    0);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -469,7 +469,7 @@ namespace System.Windows.Forms
                         User32.GetWindowRect(this, ref r);
                         if ((r.left <= p.X && p.X < r.right && r.top <= p.Y && p.Y < r.bottom) || User32.GetCapture() == Handle)
                         {
-                            User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (IntPtr)User32.HT.CLIENT);
+                            User32.SendMessageW(this, User32.WM.SETCURSOR, Handle, (nint)User32.HT.CLIENT);
                         }
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -383,7 +383,7 @@ namespace System.Windows.Forms
 
                     if (IsHandleCreated)
                     {
-                        User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.ADJUSTRECT, IntPtr.Zero, ref rect);
+                        User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.ADJUSTRECT, 0, ref rect);
                     }
                 }
 
@@ -1156,7 +1156,7 @@ namespace System.Windows.Forms
                 CreateHandle();
             }
 
-            User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.GETITEMRECT, (IntPtr)index, ref rect);
+            User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.GETITEMRECT, index, ref rect);
             return Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
         }
 
@@ -2203,7 +2203,7 @@ namespace System.Windows.Forms
 
         private void SetState(State state, bool value) => _tabControlState[(int)state] = value;
 
-        private unsafe IntPtr SendMessage(ComCtl32.TCM msg, IntPtr wParam, TabPage tabPage)
+        private unsafe nint SendMessage(ComCtl32.TCM msg, nint wParam, TabPage tabPage)
         {
             var tcitem = new ComCtl32.TCITEMW();
             string text = tabPage.Text;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -646,7 +646,7 @@ namespace System.Windows.Forms
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [SRDescription(nameof(SR.TabBaseRowCountDescr))]
         public int RowCount
-            => unchecked((int)(long)User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.GETROWCOUNT));
+            => (int)User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.GETROWCOUNT);
 
         /// <summary>
         ///  The index of the currently selected tab in the strip, if there
@@ -660,15 +660,7 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.selectedIndexDescr))]
         public int SelectedIndex
         {
-            get
-            {
-                if (IsHandleCreated)
-                {
-                    return unchecked((int)(long)User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.GETCURSEL));
-                }
-
-                return _selectedIndex;
-            }
+            get => IsHandleCreated ? (int)User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.GETCURSEL) : _selectedIndex;
             set
             {
                 if (value < -1)
@@ -699,7 +691,7 @@ namespace System.Windows.Forms
                             }
                         }
 
-                        User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.SETCURSEL, (IntPtr)value);
+                        User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.SETCURSEL, value);
 
                         if (!GetState(State.FromCreateHandles) && !GetState(State.SelectFirstControl))
                         {
@@ -768,10 +760,7 @@ namespace System.Windows.Forms
         [RefreshProperties(RefreshProperties.Repaint)]
         public TabSizeMode SizeMode
         {
-            get
-            {
-                return _sizeMode;
-            }
+            get => _sizeMode;
             set
             {
                 if (_sizeMode == value)
@@ -2181,7 +2170,7 @@ namespace System.Windows.Forms
                             break;
                         case (int)TTN.GETDISPINFOW:
                             // Setting the max width has the added benefit of enabling Multiline tool tips
-                            User32.SendMessageW(nmhdr->hwndFrom, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                            User32.SendMessageW(nmhdr->hwndFrom, (User32.WM)TTM.SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
                             WmNeedText(ref m);
                             m.Result = (IntPtr)1;
                             return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -357,7 +357,7 @@ namespace System.Windows.Forms
                         if (PasswordChar != value)
                         {
                             // Set the password mode.
-                            SendMessageW(this, (WM)EM.SETPASSWORDCHAR, (IntPtr)value);
+                            SendMessageW(this, (WM)EM.SETPASSWORDCHAR, (nint)value);
 
                             // Disable IME if setting the control to password mode.
                             VerifyImeRestrictedModeChanged();
@@ -613,7 +613,7 @@ namespace System.Windows.Forms
             {
                 if (!useSystemPasswordChar)
                 {
-                    SendMessageW(this, (WM)EM.SETPASSWORDCHAR, (IntPtr)passwordChar);
+                    SendMessageW(this, (WM)EM.SETPASSWORDCHAR, (nint)passwordChar);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -347,7 +347,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                SendMessageW(_owningTextBoxBase, (WM)EM.SETSEL, (IntPtr)start, (IntPtr)end);
+                SendMessageW(_owningTextBoxBase, (WM)EM.SETSEL, start, end);
             }
 
             private RECT GetFormattingRectangle()
@@ -356,7 +356,7 @@ namespace System.Windows.Forms
 
                 // Send an EM_GETRECT message to find out the bounding rectangle.
                 RECT rectangle = new RECT();
-                SendMessageW(_owningTextBoxBase, (WM)EM.GETRECT, (IntPtr)0, ref rectangle);
+                SendMessageW(_owningTextBoxBase, (WM)EM.GETRECT, 0, ref rectangle);
                 return rectangle;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -143,20 +143,18 @@ namespace System.Windows.Forms
 
             public override Rectangle BoundingRectangle
                 => _owningTextBoxBase.IsHandleCreated
-                    ? (Rectangle)GetFormattingRectangle()
+                    ? GetFormattingRectangle()
                     : Rectangle.Empty;
 
             public override int FirstVisibleLine
                 => _owningTextBoxBase.IsHandleCreated
-                    ? (int)(long)SendMessageW(_owningTextBoxBase, (WM)EM.GETFIRSTVISIBLELINE)
+                    ? (int)SendMessageW(_owningTextBoxBase, (WM)EM.GETFIRSTVISIBLELINE)
                     : -1;
 
             public override bool IsMultiline => _owningTextBoxBase.Multiline;
 
             public override bool IsReadingRTL
-                => _owningTextBoxBase.IsHandleCreated
-                    ? WindowExStyle.HasFlag(WS_EX.RTLREADING)
-                    : false;
+                => _owningTextBoxBase.IsHandleCreated && WindowExStyle.HasFlag(WS_EX.RTLREADING);
 
             public override bool IsReadOnly => _owningTextBoxBase.ReadOnly;
 
@@ -169,14 +167,14 @@ namespace System.Windows.Forms
                         return false;
                     }
 
-                    ES extendedStyle = (ES)(long)GetWindowLong(_owningTextBoxBase, GWL.STYLE);
+                    ES extendedStyle = (ES)GetWindowLong(_owningTextBoxBase, GWL.STYLE);
                     return extendedStyle.HasFlag(ES.AUTOHSCROLL) || extendedStyle.HasFlag(ES.AUTOVSCROLL);
                 }
             }
 
             public override int LinesCount
                 => _owningTextBoxBase.IsHandleCreated
-                    ? (int)(long)SendMessageW(_owningTextBoxBase, (WM)EM.GETLINECOUNT)
+                    ? (int)SendMessageW(_owningTextBoxBase, (WM)EM.GETLINECOUNT)
                     : -1;
 
             public override int LinesPerPage
@@ -216,7 +214,7 @@ namespace System.Windows.Forms
 
             public override int TextLength
                 => _owningTextBoxBase.IsHandleCreated
-                    ? (int)(long)SendMessageW(_owningTextBoxBase, WM.GETTEXTLENGTH)
+                    ? (int)SendMessageW(_owningTextBoxBase, WM.GETTEXTLENGTH)
                     : -1;
 
             public override WS_EX WindowExStyle
@@ -241,7 +239,7 @@ namespace System.Windows.Forms
 
             public override int GetLineIndex(int line)
                 => _owningTextBoxBase.IsHandleCreated
-                    ? (int)(long)SendMessageW(_owningTextBoxBase, (WM)EM.LINEINDEX, (IntPtr)line)
+                    ? (int)SendMessageW(_owningTextBoxBase, (WM)EM.LINEINDEX, line)
                     : -1;
 
             public override Point GetPositionFromChar(int charIndex)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -324,7 +324,7 @@ namespace System.Windows.Forms
             public override bool LineScroll(int charactersHorizontal, int linesVertical)
                 // Sends an EM_LINESCROLL message to scroll it horizontally and/or vertically.
                 => _owningTextBoxBase.IsHandleCreated
-                    && SendMessageW(_owningTextBoxBase, (WM)EM.LINESCROLL, (IntPtr)charactersHorizontal, (IntPtr)linesVertical) != IntPtr.Zero;
+                    && SendMessageW(_owningTextBoxBase, (WM)EM.LINESCROLL, charactersHorizontal, linesVertical) != 0;
 
             public override void SetSelection(int start, int end)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -948,7 +948,7 @@ namespace System.Windows.Forms
             {
                 start = 0;
                 int startResult = 0;
-                User32.SendMessageW(this, (WM)EM.GETSEL, (IntPtr)(&startResult), ref end);
+                User32.SendMessageW(this, (WM)EM.GETSEL, (nint)(&startResult), ref end);
                 start = startResult;
 
                 //Here, we return the max of either 0 or the # returned by
@@ -1064,18 +1064,19 @@ namespace System.Windows.Forms
 
             if (clearUndo)
             {
-                SendMessageW(this, (WM)EM.REPLACESEL, IntPtr.Zero, text);
+                SendMessageW(this, (WM)EM.REPLACESEL, 0, text);
+
                 // For consistency with Text, we clear the modified flag
                 SendMessageW(this, (WM)EM.SETMODIFY);
                 ClearUndo();
             }
             else
             {
-                SendMessageW(this, (WM)EM.REPLACESEL, /*undoable*/ (IntPtr)(-1), text);
+                SendMessageW(this, (WM)EM.REPLACESEL, -1, text);
             }
 
             // Re-enable user input.
-            SendMessageW(this, (WM)EM.LIMITTEXT, (IntPtr)maxLength);
+            SendMessageW(this, (WM)EM.LIMITTEXT, maxLength);
         }
 
         /// <summary>
@@ -1725,7 +1726,7 @@ namespace System.Windows.Forms
             IntPtr editOlePtr = IntPtr.Zero;
             try
             {
-                if (SendMessageW(this, (WM)Richedit.EM.GETOLEINTERFACE, IntPtr.Zero, ref editOlePtr) != IntPtr.Zero)
+                if (SendMessageW(this, (WM)Richedit.EM.GETOLEINTERFACE, 0, ref editOlePtr) != 0)
                 {
                     IntPtr iTextDocument = IntPtr.Zero;
                     Guid iiTextDocumentGuid = typeof(Richedit.ITextDocument).GUID;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -418,21 +418,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [SRDescription(nameof(SR.TextBoxCanUndoDescr))]
-        public bool CanUndo
-        {
-            get
-            {
-                if (IsHandleCreated)
-                {
-                    bool b;
-                    b = unchecked((int)(long)SendMessageW(this, (WM)EM.CANUNDO)) != 0;
-
-                    return b;
-                }
-
-                return false;
-            }
-        }
+        public bool CanUndo => IsHandleCreated && (int)SendMessageW(this, (WM)EM.CANUNDO) != 0;
 
         /// <summary>
         ///  Returns the parameters needed to create the handle. Inheriting classes
@@ -733,7 +719,7 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-                    bool curState = (0 != unchecked((int)(long)SendMessageW(this, (WM)EM.GETMODIFY)));
+                    bool curState = (int)SendMessageW(this, (WM)EM.GETMODIFY) != 0;
                     if (textBoxFlags[modified] != curState)
                     {
                         // Raise ModifiedChanged event.  See WmReflectCommand for more info.
@@ -1634,7 +1620,7 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual int GetCharIndexFromPosition(Point pt)
         {
-            int index = (int)(long)User32.SendMessageW(this, (WM)EM.CHARFROMPOS, IntPtr.Zero, PARAM.FromLowHigh(pt.X, pt.Y));
+            int index = (int)User32.SendMessageW(this, (WM)EM.CHARFROMPOS, 0, PARAM.FromLowHigh(pt.X, pt.Y));
             index = PARAM.LOWORD(index);
 
             if (index < 0)
@@ -1664,10 +1650,7 @@ namespace System.Windows.Forms
         ///  you pass the index of a overflowed character, GetLineFromCharIndex would
         ///  return 1 and not 0.
         /// </summary>
-        public virtual int GetLineFromCharIndex(int index)
-        {
-            return (int)(long)SendMessageW(this, (WM)EM.LINEFROMCHAR, (IntPtr)index);
-        }
+        public virtual int GetLineFromCharIndex(int index) => (int)SendMessageW(this, (WM)EM.LINEFROMCHAR, index);
 
         /// <summary>
         ///  Returns the location of the character at the given index.
@@ -1679,7 +1662,7 @@ namespace System.Windows.Forms
                 return Point.Empty;
             }
 
-            int i = (int)(long)SendMessageW(this, (WM)EM.POSFROMCHAR, (IntPtr)index);
+            int i = (int)SendMessageW(this, (WM)EM.POSFROMCHAR, index);
             return new Point(PARAM.SignedLOWORD(i), PARAM.SignedHIWORD(i));
         }
 
@@ -1693,16 +1676,13 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException(nameof(lineNumber), lineNumber, string.Format(SR.InvalidArgument, nameof(lineNumber), lineNumber));
             }
 
-            return unchecked((int)(long)SendMessageW(this, (WM)EM.LINEINDEX, (IntPtr)lineNumber));
+            return (int)SendMessageW(this, (WM)EM.LINEINDEX, lineNumber);
         }
 
         /// <summary>
         ///  Returns the index of the first character of the line where the caret is.
         /// </summary>
-        public int GetFirstCharIndexOfCurrentLine()
-        {
-            return unchecked((int)(long)SendMessageW(this, (WM)EM.LINEINDEX, (IntPtr)(-1)));
-        }
+        public int GetFirstCharIndexOfCurrentLine() => (int)SendMessageW(this, (WM)EM.LINEINDEX, -1);
 
         /// <summary>
         ///  Ensures that the caret is visible in the TextBox window, by scrolling the
@@ -1753,7 +1733,7 @@ namespace System.Windows.Forms
                             textRange.ScrollIntoView(0);   // 0 ==> tomEnd
 
                             // 2. Get the first visible line.
-                            int firstVisibleLine = unchecked((int)(long)SendMessageW(this, (WM)EM.GETFIRSTVISIBLELINE));
+                            int firstVisibleLine = (int)SendMessageW(this, (WM)EM.GETFIRSTVISIBLELINE);
 
                             // 3. If the first visible line is smaller than the start of the selection, we are done;
                             if (firstVisibleLine <= selStartLine)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1444,7 +1444,7 @@ namespace System.Windows.Forms
             UpdateMaxLength();
             if (textBoxFlags[modified])
             {
-                SendMessageW(this, (WM)EM.SETMODIFY, PARAM.FromBool(true));
+                SendMessageW(this, (WM)EM.SETMODIFY, (nint)BOOL.TRUE);
             }
 
             if (textBoxFlags[scrollToCaretOnHandleCreated])
@@ -1828,7 +1828,7 @@ namespace System.Windows.Forms
             {
                 AdjustSelectionStartAndEnd(start, length, out int s, out int e, textLen);
 
-                SendMessageW(this, (WM)EM.SETSEL, (IntPtr)s, (IntPtr)e);
+                SendMessageW(this, (WM)EM.SETSEL, s, e);
 
                 AccessibilityObject?.RaiseAutomationEvent(UiaCore.UIA.Text_TextSelectionChangedEventId);
             }
@@ -1942,7 +1942,7 @@ namespace System.Windows.Forms
             {
                 textBoxFlags[setSelectionOnHandleCreated] = false;
                 AdjustSelectionStartAndEnd(selectionStart, selectionLength, out int start, out int end, -1);
-                SendMessageW(this, (WM)EM.SETSEL, (IntPtr)start, (IntPtr)end);
+                SendMessageW(this, (WM)EM.SETSEL, start, end);
             }
         }
 
@@ -2071,7 +2071,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                SendMessageW(this, (WM)EM.LIMITTEXT, (IntPtr)maxLength);
+                SendMessageW(this, (WM)EM.LIMITTEXT, maxLength);
             }
         }
 
@@ -2113,7 +2113,7 @@ namespace System.Windows.Forms
             base.WndProc(ref m);
             if (!textBoxFlags[multiline])
             {
-                SendMessageW(this, (WM)EM.SETMARGINS, (IntPtr)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
+                SendMessageW(this, (WM)EM.SETMARGINS, (nint)(EC.LEFTMARGIN | EC.RIGHTMARGIN));
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2913,8 +2913,8 @@ namespace System.Windows.Forms
             User32.SendMessageW(
                 this,
                 User32.WM.PRINT,
-                (IntPtr)imageHdc.HDC,
-                (IntPtr)(User32.PRF.CHILDREN | User32.PRF.CLIENT | User32.PRF.ERASEBKGND | User32.PRF.NONCLIENT));
+                imageHdc.HDC,
+                (nint)(User32.PRF.CHILDREN | User32.PRF.CLIENT | User32.PRF.ERASEBKGND | User32.PRF.NONCLIENT));
 
             // Now BLT the result to the destination bitmap.
             Gdi32.BitBlt(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -2198,7 +2198,7 @@ namespace System.Windows.Forms
                         // We're activating - notify the previous guy that we're activating.
                         HandleRef activeHwndHandleRef = ToolStripManager.ModalMenuFilter.ActiveHwnd;
 
-                        User32.SendMessageW(activeHwndHandleRef.Handle, User32.WM.NCACTIVATE, (IntPtr)1, (IntPtr)(-1));
+                        User32.SendMessageW(activeHwndHandleRef.Handle, User32.WM.NCACTIVATE, 1, -1);
                         User32.RedrawWindow(
                             activeHwndHandleRef,
                             null,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -2198,7 +2198,7 @@ namespace System.Windows.Forms
                         // We're activating - notify the previous guy that we're activating.
                         HandleRef activeHwndHandleRef = ToolStripManager.ModalMenuFilter.ActiveHwnd;
 
-                        User32.SendMessageW(activeHwndHandleRef.Handle, User32.WM.NCACTIVATE, 1, -1);
+                        User32.SendMessageW(activeHwndHandleRef.Handle, User32.WM.NCACTIVATE, (nint)BOOL.TRUE, -1);
                         User32.RedrawWindow(
                             activeHwndHandleRef,
                             null,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -452,7 +452,7 @@ namespace System.Windows.Forms
                     {
                         // If the title is null/empty, the icon won't display.
                         string title = !string.IsNullOrEmpty(_toolTipTitle) ? _toolTipTitle : " ";
-                        User32.SendMessageW(this, (User32.WM)TTM.SETTITLEW, (IntPtr)_toolTipIcon, title);
+                        User32.SendMessageW(this, (User32.WM)TTM.SETTITLEW, (nint)_toolTipIcon, title);
 
                         // Tooltip need to be updated to reflect the changes in the icon because
                         // this operation directly affects the size of the tooltip.
@@ -482,7 +482,7 @@ namespace System.Windows.Forms
                     _toolTipTitle = value;
                     if (GetHandleCreated())
                     {
-                        User32.SendMessageW(this, (User32.WM)TTM.SETTITLEW, (IntPtr)_toolTipIcon, _toolTipTitle);
+                        User32.SendMessageW(this, (User32.WM)TTM.SETTITLEW, (nint)_toolTipIcon, _toolTipTitle);
 
                         // Tooltip need to be updated to reflect the changes in the title text because
                         // this operation directly affects the size of the tooltip.
@@ -805,7 +805,7 @@ namespace System.Windows.Forms
             {
                 // If the title is null/empty, the icon won't display.
                 string title = !string.IsNullOrEmpty(_toolTipTitle) ? _toolTipTitle : " ";
-                User32.SendMessageW(this, (User32.WM)TTM.SETTITLEW, (IntPtr)_toolTipIcon, title);
+                User32.SendMessageW(this, (User32.WM)TTM.SETTITLEW, (nint)_toolTipIcon, title);
             }
         }
 
@@ -991,25 +991,22 @@ namespace System.Windows.Forms
             return control.GetToolInfoWrapper(flags, caption, this);
         }
 
-        private ToolInfoWrapper<IWin32WindowAdapter> GetWinTOOLINFO(IWin32Window hWnd)
+        private ToolInfoWrapper<IWin32WindowAdapter> GetWinTOOLINFO(IWin32Window window)
         {
             TTF flags = TTF.TRANSPARENT | TTF.SUBCLASS;
 
             // RightToLeft reading order
             if (TopLevelControl?.RightToLeft == RightToLeft.Yes)
             {
-                bool isWindowMirrored = ((unchecked((int)(long)User32.GetWindowLong(
-                    new HandleRef(this, Control.GetSafeHandle(hWnd)), User32.GWL.STYLE)) & (int)User32.WS_EX.LAYOUTRTL) == (int)User32.WS_EX.LAYOUTRTL);
-
                 // Indicates that the ToolTip text will be displayed in the opposite direction
                 // to the text in the parent window.
-                if (!isWindowMirrored)
+                if (!window.GetExtendedStyle().HasFlag(User32.WS_EX.LAYOUTRTL))
                 {
                     flags |= TTF.RTLREADING;
                 }
             }
 
-            return new ToolInfoWrapper<IWin32WindowAdapter>(new IWin32WindowAdapter(hWnd), flags);
+            return new ToolInfoWrapper<IWin32WindowAdapter>(new IWin32WindowAdapter(window), flags);
         }
 
         /// <summary>
@@ -2111,7 +2108,7 @@ namespace System.Windows.Forms
             if (IsBalloon)
             {
                 // Get the text display rectangle
-                User32.SendMessageW(this, (User32.WM)TTM.ADJUSTRECT, PARAM.FromBool(true), ref rect);
+                User32.SendMessageW(this, (User32.WM)TTM.ADJUSTRECT, (nint)BOOL.TRUE, ref rect);
                 if (rect.Size.Height > currentTooltipSize.Height)
                 {
                     currentTooltipSize.Height = rect.Size.Height;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -193,7 +193,7 @@ namespace System.Windows.Forms
                 _backColor = value;
                 if (GetHandleCreated())
                 {
-                    User32.SendMessageW(this, (User32.WM)TTM.SETTIPBKCOLOR, PARAM.FromColor(_backColor));
+                    User32.SendMessageW(this, (User32.WM)TTM.SETTIPBKCOLOR, _backColor.ToWin32());
                 }
             }
         }
@@ -262,7 +262,7 @@ namespace System.Windows.Forms
                 _foreColor = value;
                 if (GetHandleCreated())
                 {
-                    User32.SendMessageW(this, (User32.WM)TTM.SETTIPTEXTCOLOR, PARAM.FromColor(_foreColor));
+                    User32.SendMessageW(this, (User32.WM)TTM.SETTIPTEXTCOLOR, _foreColor.ToWin32());
                 }
             }
         }
@@ -750,7 +750,7 @@ namespace System.Windows.Forms
             }
 
             // Setting the max width has the added benefit of enabling multiline tool tips.
-            User32.SendMessageW(this, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+            User32.SendMessageW(this, (User32.WM)TTM.SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
 
             if (_auto)
             {
@@ -793,12 +793,12 @@ namespace System.Windows.Forms
 
             if (BackColor != SystemColors.Info)
             {
-                User32.SendMessageW(this, (User32.WM)TTM.SETTIPBKCOLOR, PARAM.FromColor(BackColor));
+                User32.SendMessageW(this, (User32.WM)TTM.SETTIPBKCOLOR, BackColor.ToWin32());
             }
 
             if (ForeColor != SystemColors.InfoText)
             {
-                User32.SendMessageW(this, (User32.WM)TTM.SETTIPTEXTCOLOR, PARAM.FromColor(ForeColor));
+                User32.SendMessageW(this, (User32.WM)TTM.SETTIPTEXTCOLOR, ForeColor.ToWin32());
             }
 
             if (_toolTipIcon > 0 || !string.IsNullOrEmpty(_toolTipTitle))
@@ -1186,7 +1186,7 @@ namespace System.Windows.Forms
 
             if (GetHandleCreated() && time >= 0)
             {
-                User32.SendMessageW(this, (User32.WM)TTM.SETDELAYTIME, (IntPtr)type, (IntPtr)time);
+                User32.SendMessageW(this, (User32.WM)TTM.SETDELAYTIME, (nint)type, time);
                 if (type == TTDT.AUTOPOP && time != InfiniteDelay)
                 {
                     IsPersistent = false;
@@ -1751,7 +1751,7 @@ namespace System.Windows.Forms
             try
             {
                 _trackPosition = true;
-                User32.SendMessageW(this, (User32.WM)TTM.TRACKPOSITION, IntPtr.Zero, PARAM.FromLowHigh(pointX, pointY));
+                User32.SendMessageW(this, (User32.WM)TTM.TRACKPOSITION, 0, PARAM.FromLowHigh(pointX, pointY));
             }
             finally
             {
@@ -2125,7 +2125,7 @@ namespace System.Windows.Forms
                 int maxwidth = (IsBalloon)
                     ? Math.Min(currentTooltipSize.Width - 2 * BalloonOffsetX, screen.WorkingArea.Width)
                     : Math.Min(currentTooltipSize.Width, screen.WorkingArea.Width);
-                User32.SendMessageW(this, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)maxwidth);
+                User32.SendMessageW(this, (User32.WM)TTM.SETMAXTIPWIDTH, 0, maxwidth);
             }
 
             if (e.Cancel)
@@ -2279,7 +2279,7 @@ namespace System.Windows.Forms
             if ((tipInfo.TipType & TipInfo.Type.Auto) != 0 || (tipInfo.TipType & TipInfo.Type.SemiAbsolute) != 0)
             {
                 Screen screen = Screen.FromPoint(Cursor.Position);
-                User32.SendMessageW(this, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)screen.WorkingArea.Width);
+                User32.SendMessageW(this, (User32.WM)TTM.SETMAXTIPWIDTH, 0, screen.WorkingArea.Width);
             }
 
             // For non-auto tips (those shown through the show(.) methods, we need to

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -968,7 +968,7 @@ namespace System.Windows.Forms
                 return _delayTimes[(int)type];
             }
 
-            return (int)(long)User32.SendMessageW(this, (User32.WM)TTM.GETDELAYTIME, (IntPtr)type);
+            return (int)User32.SendMessageW(this, (User32.WM)TTM.GETDELAYTIME, (nint)type);
         }
 
         internal bool GetHandleCreated() => _window is not null && _window.Handle != IntPtr.Zero;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -7,7 +7,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
-using System.Globalization;
 using System.Windows.Forms.Layout;
 using static Interop;
 using static Interop.ComCtl32;
@@ -280,7 +279,7 @@ namespace System.Windows.Forms
                 _largeChange = value;
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, (User32.WM)TBM.SETPAGESIZE, IntPtr.Zero, (IntPtr)value);
+                    User32.SendMessageW(this, (User32.WM)TBM.SETPAGESIZE, 0, value);
                 }
             }
         }
@@ -425,7 +424,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            User32.SendMessageW(this, (User32.WM)TBM.SETRANGEMAX, PARAM.FromBool(true), (IntPtr)_maximum);
+            User32.SendMessageW(this, (User32.WM)TBM.SETRANGEMAX, (nint)BOOL.TRUE, _maximum);
             Invalidate();
         }
 
@@ -483,7 +482,7 @@ namespace System.Windows.Forms
                 _smallChange = value;
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, (User32.WM)TBM.SETLINESIZE, IntPtr.Zero, (IntPtr)value);
+                    User32.SendMessageW(this, (User32.WM)TBM.SETLINESIZE, 0, value);
                 }
             }
         }
@@ -559,7 +558,7 @@ namespace System.Windows.Forms
                 _tickFrequency = value;
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, (User32.WM)TBM.SETTICFREQ, (IntPtr)value);
+                    User32.SendMessageW(this, (User32.WM)TBM.SETTICFREQ, value);
                     Invalidate();
                 }
             }
@@ -759,7 +758,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                _value = PARAM.ToInt(User32.SendMessageW(this, (User32.WM)TBM.GETPOS));
+                _value = (int)User32.SendMessageW(this, (User32.WM)TBM.GETPOS);
 
                 // See SetTrackBarValue() for a description of why we sometimes reflect the trackbar value
                 if (_orientation == Orientation.Vertical)
@@ -807,11 +806,11 @@ namespace System.Windows.Forms
                 return;
             }
 
-            User32.SendMessageW(this, (User32.WM)TBM.SETRANGEMIN, PARAM.FromBool(false), (IntPtr)_minimum);
-            User32.SendMessageW(this, (User32.WM)TBM.SETRANGEMAX, PARAM.FromBool(false), (IntPtr)_maximum);
-            User32.SendMessageW(this, (User32.WM)TBM.SETTICFREQ, (IntPtr)_tickFrequency);
-            User32.SendMessageW(this, (User32.WM)TBM.SETPAGESIZE, IntPtr.Zero, (IntPtr)_largeChange);
-            User32.SendMessageW(this, (User32.WM)TBM.SETLINESIZE, IntPtr.Zero, (IntPtr)_smallChange);
+            User32.SendMessageW(this, (User32.WM)TBM.SETRANGEMIN, (nint)BOOL.FALSE, _minimum);
+            User32.SendMessageW(this, (User32.WM)TBM.SETRANGEMAX, (nint)BOOL.FALSE, _maximum);
+            User32.SendMessageW(this, (User32.WM)TBM.SETTICFREQ, _tickFrequency);
+            User32.SendMessageW(this, (User32.WM)TBM.SETPAGESIZE, 0, _largeChange);
+            User32.SendMessageW(this, (User32.WM)TBM.SETLINESIZE, 0, _smallChange);
             SetTrackBarPosition();
             AdjustSize();
         }
@@ -990,10 +989,10 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, (User32.WM)TBM.SETRANGEMIN, PARAM.FromBool(false), (IntPtr)_minimum);
+                    User32.SendMessageW(this, (User32.WM)TBM.SETRANGEMIN, (nint)BOOL.FALSE, _minimum);
 
                     // We must repaint the trackbar after changing the range.
-                    User32.SendMessageW(this, (User32.WM)TBM.SETRANGEMAX, PARAM.FromBool(true), (IntPtr)_maximum);
+                    User32.SendMessageW(this, (User32.WM)TBM.SETRANGEMAX, (nint)BOOL.TRUE, _maximum);
 
                     Invalidate();
                 }
@@ -1038,15 +1037,11 @@ namespace System.Windows.Forms
                     reflectedValue = Minimum + Maximum - _value;
                 }
 
-                User32.SendMessageW(this, (User32.WM)TBM.SETPOS, PARAM.FromBool(true), (IntPtr)reflectedValue);
+                User32.SendMessageW(this, (User32.WM)TBM.SETPOS, (nint)BOOL.TRUE, reflectedValue);
             }
         }
 
-        public override string ToString()
-        {
-            string s = base.ToString();
-            return s + ", Minimum: " + Minimum.ToString(CultureInfo.CurrentCulture) + ", Maximum: " + Maximum.ToString(CultureInfo.CurrentCulture) + ", Value: " + _value;
-        }
+        public override string ToString() => $"{base.ToString()}, Minimum: {Minimum}, Maximum: {Maximum}, Value: {_value}";
 
         protected override void WndProc(ref Message m)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -349,7 +349,7 @@ namespace System.Windows.Forms
                         stateMask = TVIS.STATEIMAGEMASK
                     };
 
-                    User32.SendMessageW(tv, (User32.WM)TVM.GETITEMW, IntPtr.Zero, ref item);
+                    User32.SendMessageW(tv, (User32.WM)TVM.GETITEMW, 0, ref item);
                     Debug.Assert(
                         !tv.CheckBoxes || (((int)item.state >> SHIFTVAL) > 1) == CheckedInternal,
                         $"isChecked on node '{Name}' did not match the state in TVM_GETITEM.");
@@ -738,7 +738,6 @@ namespace System.Windows.Forms
             {
                 // TVGN_NEXTVISIBLE can only be sent if the specified node is visible.
                 // So before sending, we check if this node is visible. If not, we find the first visible parent.
-                //
                 TreeView tv = TreeView;
                 if (tv is null || tv.IsDisposed)
                 {
@@ -749,7 +748,7 @@ namespace System.Windows.Forms
 
                 if (node is not null)
                 {
-                    IntPtr next = User32.SendMessageW(tv, (User32.WM)TVM.GETNEXTITEM, (IntPtr)TVGN.NEXTVISIBLE, node.Handle);
+                    IntPtr next = User32.SendMessageW(tv, (User32.WM)TVM.GETNEXTITEM, (nint)TVGN.NEXTVISIBLE, node.Handle);
                     if (next != IntPtr.Zero)
                     {
                         return tv.NodeFromHandle(next);
@@ -897,7 +896,6 @@ namespace System.Windows.Forms
             {
                 // TVGN_PREVIOUSVISIBLE can only be sent if the specified node is visible.
                 // So before sending, we check if this node is visible. If not, we find the first visible parent.
-                //
                 TreeNode node = FirstVisibleParent;
                 TreeView tv = TreeView;
 
@@ -908,7 +906,7 @@ namespace System.Windows.Forms
                         return null;
                     }
 
-                    IntPtr prev = User32.SendMessageW(tv, (User32.WM)TVM.GETNEXTITEM, (IntPtr)TVGN.PREVIOUSVISIBLE, node.Handle);
+                    IntPtr prev = User32.SendMessageW(tv, (User32.WM)TVM.GETNEXTITEM, (nint)TVGN.PREVIOUSVISIBLE, node.Handle);
                     if (prev != IntPtr.Zero)
                     {
                         return tv.NodeFromHandle(prev);
@@ -1354,7 +1352,7 @@ namespace System.Windows.Forms
                     tv.Focus();
                 }
 
-                User32.SendMessageW(tv, (User32.WM)TVM.EDITLABELW, (IntPtr)0, _handle);
+                User32.SendMessageW(tv, (User32.WM)TVM.EDITLABELW, 0, _handle);
             }
         }
 
@@ -1547,7 +1545,7 @@ namespace System.Windows.Forms
                 tv.OnBeforeCollapse(e);
                 if (!e.Cancel)
                 {
-                    User32.SendMessageW(tv, (User32.WM)TVM.EXPAND, (IntPtr)TVE.COLLAPSE, (IntPtr)Handle);
+                    User32.SendMessageW(tv, (User32.WM)TVM.EXPAND, (nint)TVE.COLLAPSE, Handle);
                     tv.OnAfterCollapse(new TreeViewEventArgs(this));
                 }
             }
@@ -1735,7 +1733,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            User32.SendMessageW(tv, (User32.WM)TVM.ENSUREVISIBLE, IntPtr.Zero, Handle);
+            User32.SendMessageW(tv, (User32.WM)TVM.ENSUREVISIBLE, 0, Handle);
         }
 
         /// <summary>
@@ -1753,7 +1751,7 @@ namespace System.Windows.Forms
             ResetExpandedState(tv);
             if (!IsExpanded)
             {
-                User32.SendMessageW(tv, (User32.WM)TVM.EXPAND, (IntPtr)TVE.EXPAND, Handle);
+                User32.SendMessageW(tv, (User32.WM)TVM.EXPAND, (nint)TVE.EXPAND, Handle);
             }
 
             expandOnRealization = false;
@@ -1962,7 +1960,7 @@ namespace System.Windows.Forms
                 {
                     // Currently editing.
                     editing = true;
-                    User32.SendMessageW(tv, (User32.WM)TVM.ENDEDITLABELNOW, PARAM.FromBool(false));
+                    User32.SendMessageW(tv, (User32.WM)TVM.ENDEDITLABELNOW, (nint)BOOL.FALSE);
                 }
 
                 _handle = User32.SendMessageW(tv, (User32.WM)TVM.INSERTITEMW, 0, ref tvis);
@@ -1987,7 +1985,7 @@ namespace System.Windows.Forms
                     // and this is the FIRST NODE to get added..
                     // This is Comctl quirk where it just doesn't draw
                     // the first node after a Clear( ) if Scrollable == false.
-                    User32.SendMessageW(tv, User32.WM.SETREDRAW, PARAM.FromBool(true));
+                    User32.SendMessageW(tv, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
                     nodesCleared = false;
                 }
             }
@@ -2062,7 +2060,7 @@ namespace System.Windows.Forms
             {
                 if (notify && tv.IsHandleCreated)
                 {
-                    User32.SendMessageW(tv, (User32.WM)TVM.DELETEITEM, IntPtr.Zero, _handle);
+                    User32.SendMessageW(tv, (User32.WM)TVM.DELETEITEM, 0, _handle);
                 }
 
                 treeView._nodeTable.Remove(_handle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -76,19 +76,19 @@ namespace System.Windows.Forms
                     throw new ArgumentException(string.Format(SR.TreeNodeBoundToAnotherTreeView), nameof(value));
                 }
 
-                if (tv.nodeTable.ContainsKey(value.Handle) && value.index != index)
+                if (tv._nodeTable.ContainsKey(value.Handle) && value.index != index)
                 {
                     throw new ArgumentException(string.Format(SR.OnlyOneControl, value.Text), nameof(value));
                 }
 
-                if (tv.nodeTable.ContainsKey(value.Handle)
+                if (tv._nodeTable.ContainsKey(value.Handle)
                     && value.Handle == actual.Handle
                     && value.index == index)
                 {
                     return;
                 }
 
-                tv.nodeTable.Remove(actual.handle);
+                tv._nodeTable.Remove(actual._handle);
                 value.parent = owner;
                 value.index = index;
                 owner.children[index] = value;
@@ -363,7 +363,7 @@ namespace System.Windows.Forms
                 throw new ArgumentNullException(nameof(node));
             }
 
-            if (node.handle != IntPtr.Zero)
+            if (node._handle != IntPtr.Zero)
             {
                 throw new ArgumentException(string.Format(SR.OnlyOneControl, node.Text), nameof(node));
             }
@@ -524,7 +524,7 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual void Insert(int index, TreeNode node)
         {
-            if (node.handle != IntPtr.Zero)
+            if (node._handle != IntPtr.Zero)
             {
                 throw new ArgumentException(string.Format(SR.OnlyOneControl, node.Text), nameof(node));
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -781,12 +781,11 @@ namespace System.Windows.Forms
                 }
                 else if (IsHandleCreated)
                 {
-                    return unchecked((int)(long)User32.SendMessageW(this, (User32.WM)TVM.GETINDENT));
+                    return (int)User32.SendMessageW(this, (User32.WM)TVM.GETINDENT);
                 }
 
                 return DefaultTreeViewIndent;
             }
-
             set
             {
                 if (indent != value)
@@ -805,7 +804,7 @@ namespace System.Windows.Forms
                     if (IsHandleCreated)
                     {
                         User32.SendMessageW(this, (User32.WM)TVM.SETINDENT, (IntPtr)value);
-                        indent = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)TVM.GETINDENT));
+                        indent = (int)User32.SendMessageW(this, (User32.WM)TVM.GETINDENT);
                     }
                 }
             }
@@ -827,7 +826,7 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    return unchecked((int)(long)User32.SendMessageW(this, (User32.WM)TVM.GETITEMHEIGHT));
+                    return (int)User32.SendMessageW(this, (User32.WM)TVM.GETITEMHEIGHT);
                 }
                 else
                 {
@@ -839,7 +838,6 @@ namespace System.Windows.Forms
                     return FontHeight + 3;
                 }
             }
-
             set
             {
                 if (itemHeight != value)
@@ -870,8 +868,8 @@ namespace System.Windows.Forms
                             }
                         }
 
-                        User32.SendMessageW(this, (User32.WM)TVM.SETITEMHEIGHT, (IntPtr)value);
-                        itemHeight = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)TVM.GETITEMHEIGHT));
+                        User32.SendMessageW(this, (User32.WM)TVM.SETITEMHEIGHT, value);
+                        itemHeight = (int)User32.SendMessageW(this, (User32.WM)TVM.GETITEMHEIGHT);
                     }
                 }
             }
@@ -917,7 +915,7 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-                    int intColor = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)TVM.GETLINECOLOR));
+                    int intColor = (int)User32.SendMessageW(this, (User32.WM)TVM.GETLINECOLOR);
                     return ColorTranslator.FromWin32(intColor);
                 }
 
@@ -1433,18 +1431,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [SRDescription(nameof(SR.TreeViewVisibleCountDescr))]
-        public int VisibleCount
-        {
-            get
-            {
-                if (IsHandleCreated)
-                {
-                    return unchecked((int)(long)User32.SendMessageW(this, (User32.WM)TVM.GETVISIBLECOUNT));
-                }
-
-                return 0;
-            }
-        }
+        public int VisibleCount => IsHandleCreated ? (int)User32.SendMessageW(this, (User32.WM)TVM.GETVISIBLECOUNT) : 0;
 
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.TreeViewBeforeEditDescr))]
@@ -1961,7 +1948,7 @@ namespace System.Windows.Forms
 
             base.OnHandleCreated(e);
 
-            int version = unchecked((int)(long)User32.SendMessageW(this, (User32.WM)CCM.GETVERSION));
+            int version = (int)User32.SendMessageW(this, (User32.WM)CCM.GETVERSION);
             if (version < 5)
             {
                 User32.SendMessageW(this, (User32.WM)CCM.SETVERSION, (IntPtr)5);
@@ -3238,7 +3225,7 @@ namespace System.Windows.Forms
                     {
                         case TTN.GETDISPINFOW:
                             // Setting the max width has the added benefit of enabling multiline tool tips
-                            User32.SendMessageW(nmhdr->hwndFrom, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+                            User32.SendMessageW(nmhdr->hwndFrom, (User32.WM)TTM.SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
                             WmNeedText(ref m);
                             m.Result = (IntPtr)1;
                             return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -206,12 +206,12 @@ namespace System.Windows.Forms
                 base.BackColor = value;
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, (User32.WM)TVM.SETBKCOLOR, IntPtr.Zero, PARAM.FromColor(BackColor));
+                    User32.SendMessageW(this, (User32.WM)TVM.SETBKCOLOR, 0, BackColor.ToWin32());
 
                     // This is to get around a problem in the comctl control where the lines
                     // connecting nodes don't get the new BackColor.  This messages forces
                     // reconstruction of the line bitmaps without changing anything else.
-                    User32.SendMessageW(this, (User32.WM)TVM.SETINDENT, (IntPtr)Indent);
+                    User32.SendMessageW(this, (User32.WM)TVM.SETINDENT, Indent);
                 }
             }
         }
@@ -462,7 +462,7 @@ namespace System.Windows.Forms
                 base.ForeColor = value;
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, (User32.WM)TVM.SETTEXTCOLOR, IntPtr.Zero, PARAM.FromColor(ForeColor));
+                    User32.SendMessageW(this, (User32.WM)TVM.SETTEXTCOLOR, 0, ForeColor.ToWin32());
                 }
             }
         }
@@ -660,11 +660,9 @@ namespace System.Windows.Forms
                     AttachImageListHandlers();
 
                     // Update TreeView's images
-                    //
                     if (IsHandleCreated)
                     {
-                        User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, IntPtr.Zero,
-                                    value is null ? IntPtr.Zero : value.Handle);
+                        User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, 0, value is null ? 0 : value.Handle);
                         if (StateImageList is not null && StateImageList.Images.Count > 0 && internalStateImageList is not null)
                         {
                             SetStateImageList(internalStateImageList.Handle);
@@ -803,7 +801,7 @@ namespace System.Windows.Forms
                     indent = value;
                     if (IsHandleCreated)
                     {
-                        User32.SendMessageW(this, (User32.WM)TVM.SETINDENT, (IntPtr)value);
+                        User32.SendMessageW(this, (User32.WM)TVM.SETINDENT, value);
                         indent = (int)User32.SendMessageW(this, (User32.WM)TVM.GETINDENT);
                     }
                 }
@@ -928,7 +926,7 @@ namespace System.Windows.Forms
                     lineColor = value;
                     if (IsHandleCreated)
                     {
-                        User32.SendMessageW(this, (User32.WM)TVM.SETLINECOLOR, IntPtr.Zero, PARAM.FromColor(lineColor));
+                        User32.SendMessageW(this, (User32.WM)TVM.SETLINECOLOR, 0, lineColor.ToWin32());
                     }
                 }
             }
@@ -1173,7 +1171,7 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-                    IntPtr hItem = User32.SendMessageW(this, (User32.WM)TVM.GETNEXTITEM, (IntPtr)TVGN.CARET);
+                    IntPtr hItem = User32.SendMessageW(this, (User32.WM)TVM.GETNEXTITEM, (nint)TVGN.CARET);
                     if (hItem == IntPtr.Zero)
                     {
                         return null;
@@ -1199,8 +1197,8 @@ namespace System.Windows.Forms
                     // to inform the handle that the selected node has been added to the TreeView.
                     Debug.Assert(selectedNode is null || selectedNode.TreeView != this, "handle is created, but we're still caching selectedNode");
 
-                    IntPtr hnode = (value is null ? IntPtr.Zero : value.Handle);
-                    User32.SendMessageW(this, (User32.WM)TVM.SELECTITEM, (IntPtr)TVGN.CARET, hnode);
+                    nint hnode = (value is null ? 0 : value.Handle);
+                    User32.SendMessageW(this, (User32.WM)TVM.SELECTITEM, (nint)TVGN.CARET, hnode);
                     selectedNode = null;
                 }
                 else
@@ -1395,7 +1393,7 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-                    IntPtr hitem = User32.SendMessageW(this, (User32.WM)TVM.GETNEXTITEM, (IntPtr)TVGN.FIRSTVISIBLE);
+                    IntPtr hitem = User32.SendMessageW(this, (User32.WM)TVM.GETNEXTITEM, (nint)TVGN.FIRSTVISIBLE);
                     return (hitem == IntPtr.Zero ? null : NodeFromHandle(hitem));
                 }
 
@@ -1410,8 +1408,8 @@ namespace System.Windows.Forms
                     // to inform the handle that the selected node has been added to the TreeView.
                     Debug.Assert(topNode is null || topNode.TreeView != this, "handle is created, but we're still caching selectedNode");
 
-                    IntPtr hnode = (value is null ? IntPtr.Zero : value.Handle);
-                    User32.SendMessageW(this, (User32.WM)TVM.SELECTITEM, (IntPtr)TVGN.FIRSTVISIBLE, hnode);
+                    nint hnode = (value is null ? 0 : value.Handle);
+                    User32.SendMessageW(this, (User32.WM)TVM.SELECTITEM, (nint)TVGN.FIRSTVISIBLE, hnode);
                     topNode = null;
                 }
                 else
@@ -1689,14 +1687,14 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-                    User32.SendMessageW(this, User32.WM.SETREDRAW, PARAM.FromBool(false));
+                    User32.SendMessageW(this, User32.WM.SETREDRAW, (nint)BOOL.FALSE);
                     if (delayed)
                     {
-                        User32.PostMessageW(this, User32.WM.SETREDRAW, (IntPtr)1, IntPtr.Zero);
+                        User32.PostMessageW(this, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
                     }
                     else
                     {
-                        User32.SendMessageW(this, User32.WM.SETREDRAW, PARAM.FromBool(true));
+                        User32.SendMessageW(this, User32.WM.SETREDRAW, (nint)BOOL.TRUE);
                     }
                 }
             }
@@ -1712,7 +1710,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            User32.SendMessageW(toolTip, (User32.WM)TTM.SETMAXTIPWIDTH, IntPtr.Zero, (IntPtr)SystemInformation.MaxWindowTrackSize.Width);
+            User32.SendMessageW(toolTip, (User32.WM)TTM.SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
             User32.SendMessageW(this, (User32.WM)TVM.SETTOOLTIPS, toolTip.Handle);
             controlToolTipText = toolTip.GetToolTip(this);
         }
@@ -1791,7 +1789,7 @@ namespace System.Windows.Forms
             if (IsHandleCreated)
             {
                 IntPtr handle = (ImageList is null) ? IntPtr.Zero : ImageList.Handle;
-                User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, IntPtr.Zero, handle);
+                User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, 0, handle);
             }
         }
 
@@ -1951,7 +1949,7 @@ namespace System.Windows.Forms
             int version = (int)User32.SendMessageW(this, (User32.WM)CCM.GETVERSION);
             if (version < 5)
             {
-                User32.SendMessageW(this, (User32.WM)CCM.SETVERSION, (IntPtr)5);
+                User32.SendMessageW(this, (User32.WM)CCM.SETVERSION, 5);
             }
 
             // Workaround for problem in TreeView where it doesn't recognize the TVS_CHECKBOXES
@@ -1961,40 +1959,40 @@ namespace System.Windows.Forms
             // This seems to make the Treeview happy.
             if (CheckBoxes)
             {
-                int style = PARAM.ToInt(User32.GetWindowLong(this, User32.GWL.STYLE));
+                int style = (int)User32.GetWindowLong(this, User32.GWL.STYLE);
                 style |= (int)TVS.CHECKBOXES;
-                User32.SetWindowLong(this, User32.GWL.STYLE, (IntPtr)style);
+                User32.SetWindowLong(this, User32.GWL.STYLE, style);
             }
 
             if (ShowNodeToolTips && !DesignMode)
             {
-                int style = PARAM.ToInt(User32.GetWindowLong(this, User32.GWL.STYLE));
+                int style = (int)User32.GetWindowLong(this, User32.GWL.STYLE);
                 style |= (int)TVS.INFOTIP;
-                User32.SetWindowLong(this, User32.GWL.STYLE, (IntPtr)style);
+                User32.SetWindowLong(this, User32.GWL.STYLE, style);
             }
 
             Color c = BackColor;
             if (c != SystemColors.Window)
             {
-                User32.SendMessageW(this, (User32.WM)TVM.SETBKCOLOR, IntPtr.Zero, PARAM.FromColor(c));
+                User32.SendMessageW(this, (User32.WM)TVM.SETBKCOLOR, 0, c.ToWin32());
             }
 
             c = ForeColor;
 
             if (c != SystemColors.WindowText)
             {
-                User32.SendMessageW(this, (User32.WM)TVM.SETTEXTCOLOR, IntPtr.Zero, PARAM.FromColor(c));
+                User32.SendMessageW(this, (User32.WM)TVM.SETTEXTCOLOR, 0, c.ToWin32());
             }
 
             // Put the linecolor into the native control only if set.
             if (lineColor != Color.Empty)
             {
-                User32.SendMessageW(this, (User32.WM)TVM.SETLINECOLOR, IntPtr.Zero, PARAM.FromColor(lineColor));
+                User32.SendMessageW(this, (User32.WM)TVM.SETLINECOLOR, 0, lineColor.ToWin32());
             }
 
             if (imageList is not null)
             {
-                User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, IntPtr.Zero, imageList.Handle);
+                User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, 0, imageList.Handle);
             }
 
             if (stateImageList is not null)
@@ -2004,12 +2002,12 @@ namespace System.Windows.Forms
 
             if (indent != -1)
             {
-                User32.SendMessageW(this, (User32.WM)TVM.SETINDENT, (IntPtr)indent);
+                User32.SendMessageW(this, (User32.WM)TVM.SETINDENT, indent);
             }
 
             if (itemHeight != -1)
             {
-                User32.SendMessageW(this, (User32.WM)TVM.SETITEMHEIGHT, (IntPtr)ItemHeight);
+                User32.SendMessageW(this, (User32.WM)TVM.SETITEMHEIGHT, ItemHeight);
             }
 
             // Essentially we are setting the width to be infinite so that the
@@ -2074,7 +2072,7 @@ namespace System.Windows.Forms
                 }
 
                 newImageList.Images.AddRange(images);
-                User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE, newImageList.Handle);
+                User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (nint)TVSIL.STATE, newImageList.Handle);
 
                 if (internalStateImageList is not null)
                 {
@@ -2089,7 +2087,7 @@ namespace System.Windows.Forms
         {
             // In certain cases (TREEVIEWSTATE_checkBoxes) e.g., the Native TreeView leaks the imagelist
             // even if set by us. To prevent any leaks, we always destroy what was there after setting a new list.
-            IntPtr handleOld = User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE, handle);
+            IntPtr handleOld = User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (nint)TVSIL.STATE, handle);
             if ((handleOld != IntPtr.Zero) && (handleOld != handle))
             {
                 ComCtl32.ImageList.Destroy(new HandleRef(this, handleOld));
@@ -2100,13 +2098,13 @@ namespace System.Windows.Forms
         // We must destroy it explicitly.
         private void DestroyNativeStateImageList(bool reset)
         {
-            IntPtr handle = User32.SendMessageW(this, (User32.WM)TVM.GETIMAGELIST, (IntPtr)TVSIL.STATE);
+            IntPtr handle = User32.SendMessageW(this, (User32.WM)TVM.GETIMAGELIST, (nint)TVSIL.STATE);
             if (handle != IntPtr.Zero)
             {
                 ComCtl32.ImageList.Destroy(new HandleRef(this, handle));
                 if (reset)
                 {
-                    User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (IntPtr)TVSIL.STATE);
+                    User32.SendMessageW(this, (User32.WM)TVM.SETIMAGELIST, (nint)TVSIL.STATE);
                 }
             }
         }
@@ -2694,7 +2692,7 @@ namespace System.Windows.Forms
             // If the user shows the ContextMenu bu overriding the WndProc( ), then the treeview
             // goes into the weird state where the high-light gets locked to the node on which the ContextMenu was shown.
             // So we need to get the native TREEVIEW out of this weird state.
-            User32.SendMessageW(this, (User32.WM)TVM.SELECTITEM, (IntPtr)TVGN.DROPHILITE);
+            User32.SendMessageW(this, (User32.WM)TVM.SELECTITEM, (nint)TVGN.DROPHILITE);
 
             // Windows TreeView pushes its own message loop in WM_xBUTTONDOWN, so fire the
             // event before calling defWndProc or else it won't get fired until the button
@@ -3077,7 +3075,7 @@ namespace System.Windows.Forms
                             else
                             {
                                 treeViewState[TREEVIEWSTATE_showTreeViewContextMenu] = true;
-                                User32.SendMessageW(this, User32.WM.CONTEXTMENU, Handle, (IntPtr)User32.GetMessagePos());
+                                User32.SendMessageW(this, User32.WM.CONTEXTMENU, Handle, (nint)User32.GetMessagePos());
                             }
 
                             m.Result = (IntPtr)1;
@@ -3135,7 +3133,7 @@ namespace System.Windows.Forms
             ContextMenuStrip strip = sender as ContextMenuStrip;
             // Unhook the Event.
             strip.Closing -= new ToolStripDropDownClosingEventHandler(ContextMenuStripClosing);
-            User32.SendMessageW(this, (User32.WM)TVM.SELECTITEM, (IntPtr)TVGN.DROPHILITE);
+            User32.SendMessageW(this, (User32.WM)TVM.SELECTITEM, (nint)TVGN.DROPHILITE);
         }
 
         private void UnhookNodes()
@@ -3402,7 +3400,7 @@ namespace System.Windows.Forms
                     downButton = MouseButtons.Right;
                     break;
                 case (int)User32.WM.SYSCOLORCHANGE:
-                    User32.SendMessageW(this, (User32.WM)TVM.SETINDENT, (IntPtr)Indent);
+                    User32.SendMessageW(this, (User32.WM)TVM.SETINDENT, Indent);
                     base.WndProc(ref m);
                     break;
                 case (int)User32.WM.SETFOCUS:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Win32WindowExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Win32WindowExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    internal static class Win32WindowExtensions
+    {
+        public static User32.WS_EX GetExtendedStyle(this IWin32Window window)
+        {
+            User32.WS_EX style = (User32.WS_EX)User32.GetWindowLong(Control.GetSafeHandle(window), User32.GWL.EXSTYLE);
+            GC.KeepAlive(window);
+            return style;
+        }
+
+        public static User32.WS GetStyle(this IWin32Window window)
+        {
+            User32.WS style = (User32.WS)User32.GetWindowLong(Control.GetSafeHandle(window), User32.GWL.STYLE);
+            GC.KeepAlive(window);
+            return style;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Win32WindowExtensions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Win32WindowExtensions.cs
@@ -14,12 +14,5 @@ namespace System.Windows.Forms
             GC.KeepAlive(window);
             return style;
         }
-
-        public static User32.WS GetStyle(this IWin32Window window)
-        {
-            User32.WS style = (User32.WS)User32.GetWindowLong(Control.GetSafeHandle(window), User32.GWL.STYLE);
-            GC.KeepAlive(window);
-            return style;
-        }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiMonthCalendarTests/MauiMonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiMonthCalendarTests/MauiMonthCalendarTests.cs
@@ -113,7 +113,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
                 stSelEnd = date,
             };
 
-            SendMessageW(wrapper.Calendar.Handle, WM.REFLECT | WM.NOTIFY, IntPtr.Zero, ref lParam);
+            SendMessageW(wrapper.Calendar.Handle, WM.REFLECT | WM.NOTIFY, 0, ref lParam);
 
             return new ScenarioResult(true);
         }

--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiRichTextBoxTests/MauiRichTextBoxTests.cs
@@ -178,7 +178,7 @@ This is a custom link\v #link3#\v0  which is followed by hidden text.\par
                 dwEffects = Richedit.CFE.LINK,
             };
 
-            SendMessageW(_control, (WM)Richedit.EM.SETCHARFORMAT, (IntPtr)Richedit.SCF.SELECTION, ref format);
+            SendMessageW(_control, (WM)Richedit.EM.SETCHARFORMAT, (nint)Richedit.SCF.SELECTION, ref format);
 
             _control.Select(0, 0);
         }
@@ -190,7 +190,7 @@ This is a custom link\v #link3#\v0  which is followed by hidden text.\par
 
             try
             {
-                if (SendMessageW(_control, (WM)Richedit.EM.GETOLEINTERFACE, IntPtr.Zero, ref pOleInterface) != IntPtr.Zero && pOleInterface != IntPtr.Zero)
+                if (SendMessageW(_control, (WM)Richedit.EM.GETOLEINTERFACE, 0, ref pOleInterface) != 0 && pOleInterface != IntPtr.Zero)
                 {
                     // This increments the RCW reference count, further casts do not increment it. It is important
                     // to capture the initial reference to the RCW so we can release it even if casts fail.

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/RichTextBoxes.cs
@@ -44,7 +44,7 @@ This is a custom link\v #data#\v0  with hidden text after the link.\par
                 dwEffects = Interop.Richedit.CFE.LINK,
             };
 
-            Interop.User32.SendMessageW(control, (Interop.User32.WM)Interop.Richedit.EM.SETCHARFORMAT, (IntPtr)Interop.Richedit.SCF.SELECTION, ref format);
+            Interop.User32.SendMessageW(control, (Interop.User32.WM)Interop.Richedit.EM.SETCHARFORMAT, (nint)Interop.Richedit.SCF.SELECTION, ref format);
 
             control.Select(0, 0);
         }

--- a/src/System.Windows.Forms/tests/TestUtilities/ControlExtensions.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/ControlExtensions.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Forms
             EmfScope emf,
             User32.PRF prf = User32.PRF.CHILDREN | User32.PRF.CLIENT)
         {
-            User32.SendMessageW(control.Handle, User32.WM.PRINT, (IntPtr)emf.HDC, (IntPtr)prf);
+            User32.SendMessageW(control.Handle, User32.WM.PRINT, (IntPtr)emf.HDC, (nint)prf);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/TestUtilities/SystemEventsHelper.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/SystemEventsHelper.cs
@@ -13,9 +13,11 @@ namespace System
     {
         private static IntPtr GetHWnd()
         {
-            // locate the hwnd used by SystemEvents in this domain
-            FieldInfo windowClassNameField = typeof(SystemEvents).GetField("s_className", BindingFlags.Static | BindingFlags.NonPublic) ??  // runtime
-                                             typeof(SystemEvents).GetField("className", BindingFlags.Static | BindingFlags.NonPublic);      // desktop
+            // Locate the hwnd used by SystemEvents in this domain.
+            FieldInfo windowClassNameField =
+                typeof(SystemEvents).GetField("s_className", BindingFlags.Static | BindingFlags.NonPublic)   // runtime
+                ?? typeof(SystemEvents).GetField("className", BindingFlags.Static | BindingFlags.NonPublic); // desktop
+
             Assert.NotNull(windowClassNameField);
             string windowClassName = windowClassNameField.GetValue(null) as string;
             Assert.NotNull(windowClassName);
@@ -29,11 +31,11 @@ namespace System
             IntPtr window = GetHWnd();
 
             WM msg;
-            IntPtr wParam;
+            nint wParam;
             if (category == UserPreferenceCategory.Color)
             {
                 msg = WM.SYSCOLORCHANGE;
-                wParam = IntPtr.Zero;
+                wParam = 0;
             }
             else
             {
@@ -41,39 +43,39 @@ namespace System
 
                 if (category == UserPreferenceCategory.Accessibility)
                 {
-                    wParam = (IntPtr)SPI.SETHIGHCONTRAST;
+                    wParam = (nint)SPI.SETHIGHCONTRAST;
                 }
                 else if (category == UserPreferenceCategory.Desktop)
                 {
-                    wParam = (IntPtr)SPI.SETDESKWALLPAPER;
+                    wParam = (nint)SPI.SETDESKWALLPAPER;
                 }
                 else if (category == UserPreferenceCategory.Icon)
                 {
-                    wParam = (IntPtr)SPI.ICONHORIZONTALSPACING;
+                    wParam = (nint)SPI.ICONHORIZONTALSPACING;
                 }
                 else if (category == UserPreferenceCategory.Mouse)
                 {
-                    wParam = (IntPtr)SPI.SETDOUBLECLICKTIME;
+                    wParam = (nint)SPI.SETDOUBLECLICKTIME;
                 }
                 else if (category == UserPreferenceCategory.Keyboard)
                 {
-                    wParam = (IntPtr)SPI.SETKEYBOARDDELAY;
+                    wParam = (nint)SPI.SETKEYBOARDDELAY;
                 }
                 else if (category == UserPreferenceCategory.Menu)
                 {
-                    wParam = (IntPtr)SPI.SETMENUDROPALIGNMENT;
+                    wParam = (nint)SPI.SETMENUDROPALIGNMENT;
                 }
                 else if (category == UserPreferenceCategory.Power)
                 {
-                    wParam = (IntPtr)SPI.SETLOWPOWERACTIVE;
+                    wParam = (nint)SPI.SETLOWPOWERACTIVE;
                 }
                 else if (category == UserPreferenceCategory.Screensaver)
                 {
-                    wParam = (IntPtr)SPI.SETMENUDROPALIGNMENT;
+                    wParam = (nint)SPI.SETMENUDROPALIGNMENT;
                 }
                 else if (category == UserPreferenceCategory.Window)
                 {
-                    wParam = (IntPtr)SPI.SETMENUDROPALIGNMENT;
+                    wParam = (nint)SPI.SETMENUDROPALIGNMENT;
                 }
                 else
                 {
@@ -82,7 +84,7 @@ namespace System
             }
 
             // Call with reflect to immediately send the message.
-            SendMessageW(window, msg | WM.REFLECT, wParam, IntPtr.Zero);
+            SendMessageW(window, msg | WM.REFLECT, wParam);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeaderTests.cs
@@ -223,7 +223,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
             listView.Columns[columnIndex].DisplayIndex = value;
             var result = new int[3];
-            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNORDERARRAY, (IntPtr)3, ref result[0]));
+            Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNORDERARRAY, 3, ref result[0]));
             Assert.Equal(expectedDisplayIndices, result);
         }
 
@@ -449,7 +449,7 @@ namespace System.Windows.Forms.Tests
             {
                 mask = ComCtl32.LVCF.IMAGE
             };
-            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, (IntPtr)0, ref column));
+            Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, 0, ref column));
             Assert.Equal(0, column.iImage);
         }
 
@@ -479,7 +479,7 @@ namespace System.Windows.Forms.Tests
                 mask = ComCtl32.LVCF.IMAGE | ComCtl32.LVCF.FMT,
                 fmt = ComCtl32.LVCFMT.IMAGE
             };
-            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, (IntPtr)0, ref column));
+            Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, 0, ref column));
             Assert.Equal(expected, column.iImage);
         }
 
@@ -669,7 +669,7 @@ namespace System.Windows.Forms.Tests
             {
                 mask = ComCtl32.LVCF.IMAGE
             };
-            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, (IntPtr)0, ref column));
+            Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, 0, ref column));
             Assert.Equal(0, column.iImage);
         }
 
@@ -701,7 +701,7 @@ namespace System.Windows.Forms.Tests
                 mask = ComCtl32.LVCF.IMAGE | ComCtl32.LVCF.FMT,
                 fmt = ComCtl32.LVCFMT.IMAGE
             };
-            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, (IntPtr)0, ref column));
+            Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, 0, ref column));
             Assert.Equal(expected, column.iImage);
         }
 
@@ -1017,7 +1017,7 @@ namespace System.Windows.Forms.Tests
                 pszText = buffer,
                 cchTextMax = 256
             };
-            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, (IntPtr)0, ref column));
+            Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, 0, ref column));
             Assert.Equal(expected, new string(column.pszText));
         }
 
@@ -1206,7 +1206,7 @@ namespace System.Windows.Forms.Tests
             {
                 mask = ComCtl32.LVCF.FMT
             };
-            Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, (IntPtr)columnIndex, ref column));
+            Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNW, columnIndex, ref column));
             Assert.Equal(expected, (int)column.fmt);
         }
 
@@ -1364,7 +1364,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
             header.Width = value;
-            Assert.Equal((IntPtr)value, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNWIDTH, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(value, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNWIDTH));
         }
 
         [WinFormsTheory]
@@ -1382,7 +1382,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
             header.Width = value;
-            Assert.True(User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNWIDTH, IntPtr.Zero, IntPtr.Zero).ToInt32() > 0);
+            Assert.True(User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETCOLUMNWIDTH) > 0);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
@@ -264,7 +264,7 @@ namespace System.Windows.Forms.Tests
 
             itemAccessibleObject.ScrollIntoView();
 
-            int actual = unchecked((int)(long)User32.SendMessageW(comboBox, (User32.WM)User32.CB.GETTOPINDEX));
+            int actual = (int)User32.SendMessageW(comboBox, (User32.WM)User32.CB.GETTOPINDEX);
 
             Assert.Equal(0, actual); // ScrollIntoView didn't scroll to the tested item because the combobox is disabled
         }
@@ -354,7 +354,7 @@ namespace System.Windows.Forms.Tests
 
             itemAccessibleObject.ScrollIntoView();
 
-            int actual = unchecked((int)(long)User32.SendMessageW(comboBox, (User32.WM)User32.CB.GETTOPINDEX));
+            int actual = (int)User32.SendMessageW(comboBox, (User32.WM)User32.CB.GETTOPINDEX);
 
             Assert.Equal(expected, actual);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxUiaTextProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxUiaTextProviderTests.cs
@@ -1089,7 +1089,7 @@ namespace System.Windows.Forms.Tests
             comboBox.CreateControl();
             ComboBox.ComboBoxUiaTextProvider provider = new ComboBox.ComboBoxUiaTextProvider(comboBox);
 
-            var actualValue = (int)(long)SendMessageW(comboBox.TestAccessor().Dynamic._childEdit, (WM)EM.GETFIRSTVISIBLELINE);
+            int actualValue = (int)SendMessageW((IHandle)comboBox.TestAccessor().Dynamic._childEdit, (WM)EM.GETFIRSTVISIBLELINE);
 
             Assert.Equal(actualValue, provider.FirstVisibleLine);
         }
@@ -1103,7 +1103,7 @@ namespace System.Windows.Forms.Tests
             comboBox.CreateControl();
             ComboBox.ComboBoxUiaTextProvider provider = new ComboBox.ComboBoxUiaTextProvider(comboBox);
 
-            var actualValue = (int)(long)SendMessageW(comboBox.TestAccessor().Dynamic._childEdit, (WM)EM.GETLINECOUNT);
+            int actualValue = (int)SendMessageW((IHandle)comboBox.TestAccessor().Dynamic._childEdit, (WM)EM.GETLINECOUNT);
 
             Assert.Equal(actualValue, provider.LinesCount);
         }
@@ -1129,7 +1129,7 @@ namespace System.Windows.Forms.Tests
             comboBox.SelectedIndex = 0;
             ComboBox.ComboBoxUiaTextProvider provider = new ComboBox.ComboBoxUiaTextProvider(comboBox);
 
-            int expectedLine = (int)(long)SendMessageW(comboBox.TestAccessor().Dynamic._childEdit, (WM)EM.LINEFROMCHAR, (IntPtr)charIndex);
+            int expectedLine = (int)SendMessageW((IHandle)comboBox.TestAccessor().Dynamic._childEdit, (WM)EM.LINEFROMCHAR, charIndex);
             int actualLine = provider.GetLineFromCharIndex(charIndex);
 
             Assert.Equal(expectedLine, actualLine);
@@ -1150,7 +1150,7 @@ namespace System.Windows.Forms.Tests
             comboBox.SelectedIndex = 0;
             ComboBox.ComboBoxUiaTextProvider provider = new ComboBox.ComboBoxUiaTextProvider(comboBox);
 
-            var expectedValue = SendMessageW(comboBox.TestAccessor().Dynamic._childEdit, (WM)EM.LINESCROLL, (IntPtr)0, (IntPtr)newLine) != IntPtr.Zero;
+            bool expectedValue = SendMessageW((IHandle)comboBox.TestAccessor().Dynamic._childEdit, (WM)EM.LINESCROLL, 0, newLine) != 0;
 
             Assert.Equal(expectedValue, provider.LineScroll(0, newLine));
             Assert.True(comboBox.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CommonDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CommonDialogTests.cs
@@ -232,7 +232,7 @@ namespace System.Windows.Forms.Tests
         public void OwnerWndProc_HelpMessage_CallsHelpRequest()
         {
             using var dialog = new SubCommonDialog();
-            FieldInfo field = typeof(CommonDialog).GetField("s_helpMsg", BindingFlags.NonPublic | BindingFlags.Static);
+            FieldInfo field = typeof(CommonDialog).GetField("s_helpMessage", BindingFlags.NonPublic | BindingFlags.Static);
             Assert.NotNull(field);
 
             int callCount = 0;
@@ -252,7 +252,7 @@ namespace System.Windows.Forms.Tests
         public void OwnerWndProc_NonHelpMessage_DoesNotCallHelpRequest()
         {
             using var dialog = new SubCommonDialog();
-            FieldInfo field = typeof(CommonDialog).GetField("s_helpMsg", BindingFlags.NonPublic | BindingFlags.Static);
+            FieldInfo field = typeof(CommonDialog).GetField("s_helpMessage", BindingFlags.NonPublic | BindingFlags.Static);
             Assert.NotNull(field);
 
             int callCount = 0;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/COM2PictureConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComponentModel/Com2Interop/COM2PictureConverterTests.cs
@@ -79,7 +79,7 @@ namespace System.Windows.Forms.Tests.ComponentModel.Com2Interop
             }
             finally
             {
-                Gdi32.DeleteObject(hBitmap);
+                Gdi32.DeleteObject((Gdi32.HGDIOBJ)hBitmap);
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
@@ -10535,7 +10535,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new SubControl();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            User32.SendMessageW(control.Handle, User32.WM.UPDATEUISTATE, (IntPtr)wParam, IntPtr.Zero);
+            User32.SendMessageW(control.Handle, User32.WM.UPDATEUISTATE, wParam);
             Assert.Equal(expected, control.ShowFocusCues);
         }
 
@@ -10594,7 +10594,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new SubControl();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            User32.SendMessageW(control.Handle, User32.WM.UPDATEUISTATE, (IntPtr)wParam, IntPtr.Zero);
+            User32.SendMessageW(control.Handle, User32.WM.UPDATEUISTATE, wParam);
             Assert.Equal(expected, control.ShowKeyboardCues);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePickerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePickerTests.cs
@@ -213,7 +213,7 @@ namespace System.Windows.Forms.Tests
                 // An empty SYSTEMTIME has year, month and day as 0, but DateTime can't have these parameters.
                 // So an empty SYSTEMTIME is incorrect in this case.
                 SYSTEMTIME systemTime = new SYSTEMTIME();
-                DateTime dateTime = DateTimePicker.SysTimeToDateTime(systemTime);
+                DateTime dateTime = systemTime;
                 Assert.Equal(DateTime.MinValue, dateTime);
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/DpiMessageHelper.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/DpiMessageHelper.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms.Tests.Dpi
         public static void TriggerDpiMessage(User32.WM message, Control control, int newDpi)
         {
             double factor = newDpi / DpiHelper.LogicalDpi;
-            IntPtr wParam = PARAM.FromLowHigh(newDpi, newDpi);
+            nint wParam = PARAM.FromLowHigh(newDpi, newDpi);
 
             _ = message switch
             {
@@ -21,7 +21,7 @@ namespace System.Windows.Forms.Tests.Dpi
                 _ => throw new NotImplementedException()
             };
 
-            IntPtr SendWmDpiChangedMessage()
+            nint SendWmDpiChangedMessage()
             {
                 RECT suggestedRect = new(0,
                     0,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -197,14 +197,14 @@ namespace System.Windows.Forms.Tests
             using var form = new Form();
             Assert.True(form.Handle != IntPtr.Zero);
 
-            IntPtr hSmallIcon = User32.SendMessageW(form, User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            IntPtr hSmallIcon = User32.SendMessageW(form, User32.WM.GETICON, (nint)User32.ICON.SMALL, 0);
             Assert.True(hSmallIcon != IntPtr.Zero);
 
-            IntPtr hLargeIcon = User32.SendMessageW(form, User32.WM.GETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+            IntPtr hLargeIcon = User32.SendMessageW(form, User32.WM.GETICON, (nint)User32.ICON.BIG, 0);
             Assert.True(hLargeIcon != IntPtr.Zero);
 
             // normal form doesn't have WS_EX.DLGMODALFRAME set, and show icon
-            User32.WS_EX extendedStyle = unchecked((User32.WS_EX)(long)User32.GetWindowLong(form, User32.GWL.EXSTYLE));
+            User32.WS_EX extendedStyle = (User32.WS_EX)User32.GetWindowLong(form, User32.GWL.EXSTYLE);
             Assert.False(extendedStyle.HasFlag(User32.WS_EX.DLGMODALFRAME));
         }
 
@@ -985,8 +985,8 @@ namespace System.Windows.Forms.Tests
 
             form.ShowIcon = showIcon;
 
-            IntPtr hSmallIcon = User32.SendMessageW(form, User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
-            IntPtr hLargeIcon = User32.SendMessageW(form, User32.WM.GETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+            IntPtr hSmallIcon = User32.SendMessageW(form, User32.WM.GETICON, (nint)User32.ICON.SMALL, 0);
+            IntPtr hLargeIcon = User32.SendMessageW(form, User32.WM.GETICON, (nint)User32.ICON.BIG, 0);
             Assert.Equal(expectedIconNull, hSmallIcon == IntPtr.Zero);
             Assert.Equal(expectedIconNull, hLargeIcon == IntPtr.Zero);
         }
@@ -1186,23 +1186,23 @@ namespace System.Windows.Forms.Tests
             control.Show();
 
             control.ShowIcon = false;
-            IntPtr hSmallIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            IntPtr hSmallIcon = User32.SendMessageW(control, User32.WM.GETICON, (nint)User32.ICON.SMALL, 0);
             Assert.True(hSmallIcon == IntPtr.Zero);
-            IntPtr hLargeIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+            IntPtr hLargeIcon = User32.SendMessageW(control, User32.WM.GETICON, (nint)User32.ICON.BIG, 0);
             Assert.True(hLargeIcon == IntPtr.Zero);
 
             control.WindowState = FormWindowState.Maximized;
             control.ShowIcon = false;
-            hSmallIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            hSmallIcon = User32.SendMessageW(control, User32.WM.GETICON, (nint)User32.ICON.SMALL, 0);
             Assert.True(hSmallIcon == IntPtr.Zero);
-            hLargeIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+            hLargeIcon = User32.SendMessageW(control, User32.WM.GETICON, (nint)User32.ICON.BIG, 0);
             Assert.True(hLargeIcon == IntPtr.Zero);
             Assert.True(!menuStrip.Items[0].Visible);
 
             control.ShowIcon = true;
-            hSmallIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.SMALL, IntPtr.Zero);
+            hSmallIcon = User32.SendMessageW(control, User32.WM.GETICON, (nint)User32.ICON.SMALL, 0);
             Assert.True(hSmallIcon != IntPtr.Zero);
-            hLargeIcon = User32.SendMessageW(control, User32.WM.GETICON, (IntPtr)User32.ICON.BIG, IntPtr.Zero);
+            hLargeIcon = User32.SendMessageW(control, User32.WM.GETICON, (nint)User32.ICON.BIG, 0);
             Assert.True(hLargeIcon != IntPtr.Zero);
             Assert.True(menuStrip.Items[0].Visible);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBox.ObjectCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBox.ObjectCollectionTests.cs
@@ -341,12 +341,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set middle.
@@ -358,12 +358,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set last.
@@ -375,12 +375,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
 
             // Set same.
@@ -392,12 +392,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
         }
 
@@ -430,12 +430,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set middle.
@@ -447,12 +447,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set last.
@@ -464,12 +464,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
 
             // Set same.
@@ -481,12 +481,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
         }
 #endif
@@ -517,12 +517,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set middle.
@@ -534,12 +534,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set last.
@@ -551,12 +551,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
 
             // Set same.
@@ -568,12 +568,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
         }
 
@@ -606,12 +606,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set middle.
@@ -623,12 +623,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set last.
@@ -640,12 +640,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
 
             // Set same.
@@ -657,12 +657,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
         }
 
@@ -1483,8 +1483,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -1496,10 +1496,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Add same.
@@ -1511,12 +1511,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Add another.
@@ -1528,14 +1528,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -1562,8 +1562,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -1575,10 +1575,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Add same.
@@ -1590,12 +1590,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Add another.
@@ -1607,14 +1607,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -1644,8 +1644,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -1657,10 +1657,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add same.
@@ -1672,12 +1672,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -1689,14 +1689,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -1726,8 +1726,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -1739,10 +1739,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add same.
@@ -1754,12 +1754,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -1771,14 +1771,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -2146,7 +2146,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(3);
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -2160,14 +2160,14 @@ namespace System.Windows.Forms.Tests
             collection.Add(3);
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -2331,14 +2331,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Add empty.
@@ -2350,14 +2350,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -2383,14 +2383,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Add empty.
@@ -2402,14 +2402,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -2438,14 +2438,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Add empty.
@@ -2457,14 +2457,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -2493,14 +2493,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Add empty.
@@ -2512,14 +2512,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -2839,7 +2839,7 @@ namespace System.Windows.Forms.Tests
             collection.AddRange(new object[] { 2, 1, 1, 3 });
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -2850,14 +2850,14 @@ namespace System.Windows.Forms.Tests
             collection.AddRange(new object[] { 2, 1, 1, 3 });
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -3008,14 +3008,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Add empty.
@@ -3029,14 +3029,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -3065,14 +3065,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Add empty.
@@ -3086,14 +3086,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -3125,14 +3125,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Add empty.
@@ -3146,14 +3146,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -3185,14 +3185,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Add empty.
@@ -3206,14 +3206,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -3576,7 +3576,7 @@ namespace System.Windows.Forms.Tests
             collection.AddRange(otherCollection);
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -3590,14 +3590,14 @@ namespace System.Windows.Forms.Tests
             collection.AddRange(otherCollection);
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -3794,7 +3794,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
 
             // Call again.
             collection.Clear();
@@ -3806,7 +3806,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -3831,7 +3831,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
 
             // Call again.
             collection.Clear();
@@ -3843,7 +3843,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -3869,7 +3869,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
 
             // Call again.
             collection.Clear();
@@ -3881,7 +3881,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -3907,7 +3907,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
 
             // Call again.
             collection.Clear();
@@ -3919,7 +3919,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -4288,8 +4288,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -4301,10 +4301,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert same.
@@ -4316,12 +4316,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -4333,14 +4333,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -4367,8 +4367,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -4380,10 +4380,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert same.
@@ -4395,12 +4395,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -4412,14 +4412,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -4449,8 +4449,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -4462,10 +4462,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Insert same.
@@ -4477,12 +4477,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Insert end.
@@ -4494,14 +4494,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -4531,8 +4531,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -4544,10 +4544,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Insert same.
@@ -4559,12 +4559,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Insert end.
@@ -4576,14 +4576,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -4943,7 +4943,7 @@ namespace System.Windows.Forms.Tests
             collection.Insert(3, 3);
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -4957,14 +4957,14 @@ namespace System.Windows.Forms.Tests
             collection.Insert(3, 3);
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -5229,10 +5229,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove again.
@@ -5244,10 +5244,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -5259,8 +5259,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Remove first.
@@ -5272,7 +5272,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -5304,10 +5304,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove again.
@@ -5320,10 +5320,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -5336,8 +5336,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Remove first.
@@ -5349,7 +5349,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -5381,10 +5381,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove again.
@@ -5396,10 +5396,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -5411,8 +5411,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Remove first.
@@ -5424,7 +5424,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -5459,10 +5459,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove again.
@@ -5475,10 +5475,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -5491,8 +5491,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Remove first.
@@ -5504,7 +5504,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -6142,10 +6142,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -6157,8 +6157,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Remove first.
@@ -6170,7 +6170,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -6202,10 +6202,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -6218,8 +6218,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Remove first.
@@ -6231,7 +6231,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -6263,10 +6263,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -6278,8 +6278,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Remove first.
@@ -6291,7 +6291,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -6326,10 +6326,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -6342,8 +6342,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Remove first.
@@ -6355,7 +6355,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -7096,12 +7096,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set middle.
@@ -7113,12 +7113,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set last.
@@ -7130,12 +7130,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
 
             // Set same.
@@ -7147,12 +7147,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
         }
 
@@ -7187,12 +7187,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set middle.
@@ -7204,12 +7204,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set last.
@@ -7221,12 +7221,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
 
             // Set same.
@@ -7238,12 +7238,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
         }
 #endif
@@ -7276,12 +7276,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set middle.
@@ -7293,12 +7293,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set last.
@@ -7310,12 +7310,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
 
             // Set same.
@@ -7327,12 +7327,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
         }
 
@@ -7367,12 +7367,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set middle.
@@ -7384,12 +7384,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Set last.
@@ -7401,12 +7401,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
 
             // Set same.
@@ -7418,12 +7418,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("4", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("5", new string(textBuffer));
         }
 
@@ -8244,8 +8244,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -8257,10 +8257,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Add same.
@@ -8272,12 +8272,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Add another.
@@ -8289,14 +8289,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -8323,8 +8323,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -8336,10 +8336,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Add same.
@@ -8351,12 +8351,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Add another.
@@ -8368,14 +8368,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -8405,8 +8405,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -8418,10 +8418,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add same.
@@ -8433,12 +8433,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -8450,14 +8450,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -8487,8 +8487,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -8500,10 +8500,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add same.
@@ -8515,12 +8515,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Add another.
@@ -8532,14 +8532,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -8907,7 +8907,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(3);
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -8921,14 +8921,14 @@ namespace System.Windows.Forms.Tests
             collection.Add(3);
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -9078,7 +9078,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
 
             // Call again.
             collection.Clear();
@@ -9090,7 +9090,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -9115,7 +9115,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
 
             // Call again.
             collection.Clear();
@@ -9127,7 +9127,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -9153,7 +9153,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
 
             // Call again.
             collection.Clear();
@@ -9165,7 +9165,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -9191,7 +9191,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
 
             // Call again.
             collection.Clear();
@@ -9203,7 +9203,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -9572,8 +9572,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -9585,10 +9585,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert same.
@@ -9600,12 +9600,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -9617,14 +9617,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -9651,8 +9651,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -9664,10 +9664,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert same.
@@ -9679,12 +9679,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -9696,14 +9696,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -9733,8 +9733,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -9746,10 +9746,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Insert same.
@@ -9761,12 +9761,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Insert end.
@@ -9778,14 +9778,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -9815,8 +9815,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Insert end.
@@ -9828,10 +9828,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Insert same.
@@ -9843,12 +9843,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(3, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Insert end.
@@ -9860,14 +9860,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -10227,7 +10227,7 @@ namespace System.Windows.Forms.Tests
             collection.Insert(3, 3);
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -10241,14 +10241,14 @@ namespace System.Windows.Forms.Tests
             collection.Insert(3, 3);
             char* textBuffer = stackalloc char[256];
 
-            Assert.Equal((IntPtr)4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(4, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)2, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 2, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)3, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 3, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
         }
 
@@ -10513,10 +10513,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove again.
@@ -10528,10 +10528,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -10543,8 +10543,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Remove first.
@@ -10556,7 +10556,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -10588,10 +10588,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove again.
@@ -10604,10 +10604,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -10620,8 +10620,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Remove first.
@@ -10633,7 +10633,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -10665,10 +10665,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove again.
@@ -10680,10 +10680,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -10695,8 +10695,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Remove first.
@@ -10708,7 +10708,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -10743,10 +10743,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove again.
@@ -10759,10 +10759,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -10775,8 +10775,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Remove first.
@@ -10788,7 +10788,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -11426,10 +11426,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -11441,8 +11441,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Remove first.
@@ -11454,7 +11454,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -11486,10 +11486,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -11502,8 +11502,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("2", new string(textBuffer));
 
             // Remove first.
@@ -11515,7 +11515,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -11547,10 +11547,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -11562,8 +11562,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Remove first.
@@ -11575,7 +11575,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]
@@ -11610,10 +11610,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(2, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)1, (IntPtr)textBuffer);
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 1, (nint)textBuffer);
             Assert.Equal("3", new string(textBuffer));
 
             // Remove last.
@@ -11626,8 +11626,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
-            SendMessageW(owner.Handle, (WM)LB.GETTEXT, (IntPtr)0, (IntPtr)textBuffer);
+            Assert.Equal(1, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            SendMessageW(owner.Handle, (WM)LB.GETTEXT, 0, (nint)textBuffer);
             Assert.Equal("1", new string(textBuffer));
 
             // Remove first.
@@ -11639,7 +11639,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
-            Assert.Equal((IntPtr)0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
+            Assert.Equal(0, SendMessageW(owner.Handle, (WM)LB.GETCOUNT));
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -773,7 +773,7 @@ namespace System.Windows.Forms.Tests
             control.ColumnWidth = 123;
 
             RECT rc = default;
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)LB.GETITEMRECT, (IntPtr)0, ref rc));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)LB.GETITEMRECT, 0, ref rc));
             Assert.Equal(123, ((Rectangle)rc).Width);
         }
 
@@ -1466,10 +1466,10 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Assert.Equal(0, control.HorizontalExtent);
-            Assert.Equal((IntPtr)0, SendMessageW(control.Handle, (WM)LB.GETHORIZONTALEXTENT));
+            Assert.Equal(0, SendMessageW(control.Handle, (WM)LB.GETHORIZONTALEXTENT));
 
             control.HorizontalExtent = 10;
-            Assert.Equal((IntPtr)expected, SendMessageW(control.Handle, (WM)LB.GETHORIZONTALEXTENT));
+            Assert.Equal(expected, SendMessageW(control.Handle, (WM)LB.GETHORIZONTALEXTENT));
         }
 
         public static IEnumerable<object[]> HorizontalScrollbar_Set_TestData()
@@ -2633,15 +2633,15 @@ namespace System.Windows.Forms.Tests
             // Select last.
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.SelectedIndex = 1;
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
 
             // Select first.
             control.SelectedIndex = 0;
-            Assert.Equal((IntPtr)0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
 
             // Clear selection.
             control.SelectedIndex = -1;
-            Assert.Equal((IntPtr)(-1), SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(-1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
         }
 
         [WinFormsTheory]
@@ -2660,21 +2660,21 @@ namespace System.Windows.Forms.Tests
             // Select last.
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.SelectedIndex = 1;
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
             Span<int> buffer = stackalloc int[5];
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, (IntPtr)buffer.Length, ref buffer[0]));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, buffer.Length, ref buffer[0]));
             Assert.Equal(new int[] { 1, 0, 0, 0, 0 }, buffer.ToArray());
 
             // Select first.
             control.SelectedIndex = 0;
-            Assert.Equal((IntPtr)0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
-            Assert.Equal((IntPtr)2, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, (IntPtr)buffer.Length, ref buffer[0]));
+            Assert.Equal(0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(2, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, buffer.Length, ref buffer[0]));
             Assert.Equal(new int[] { 0, 1, 0, 0, 0 }, buffer.ToArray());
 
             // Clear selection.
             control.SelectedIndex = -1;
-            Assert.Equal((IntPtr)0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
-            Assert.Equal((IntPtr)0, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, (IntPtr)buffer.Length, ref buffer[0]));
+            Assert.Equal(0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(0, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, buffer.Length, ref buffer[0]));
             Assert.Equal(new int[] { 0, 1, 0, 0, 0 }, buffer.ToArray());
         }
 
@@ -3146,19 +3146,19 @@ namespace System.Windows.Forms.Tests
             // Select last.
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.SelectedItem = "item2";
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
 
             // Select invalid.
             control.SelectedItem = "NoSuchItem";
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
 
             // Select first.
             control.SelectedItem = "item1";
-            Assert.Equal((IntPtr)0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
 
             // Clear selection.
             control.SelectedItem = null;
-            Assert.Equal((IntPtr)(-1), SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(-1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
         }
 
         [WinFormsTheory]
@@ -3177,28 +3177,28 @@ namespace System.Windows.Forms.Tests
             // Select last.
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.SelectedItem = "item2";
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
             Span<int> buffer = stackalloc int[5];
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, (IntPtr)buffer.Length, ref buffer[0]));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, buffer.Length, ref buffer[0]));
             Assert.Equal(new int[] { 1, 0, 0, 0, 0 }, buffer.ToArray());
 
             // Select invalid.
             control.SelectedItem = "NoSuchItem";
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
             buffer = stackalloc int[5];
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, (IntPtr)buffer.Length, ref buffer[0]));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, buffer.Length, ref buffer[0]));
             Assert.Equal(new int[] { 1, 0, 0, 0, 0 }, buffer.ToArray());
 
             // Select first.
             control.SelectedItem = "item1";
-            Assert.Equal((IntPtr)0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
-            Assert.Equal((IntPtr)2, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, (IntPtr)buffer.Length, ref buffer[0]));
+            Assert.Equal(0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(2, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, buffer.Length, ref buffer[0]));
             Assert.Equal(new int[] { 0, 1, 0, 0, 0 }, buffer.ToArray());
 
             // Clear selection.
             control.SelectedItem = null;
-            Assert.Equal((IntPtr)0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
-            Assert.Equal((IntPtr)0, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, (IntPtr)buffer.Length, ref buffer[0]));
+            Assert.Equal(0, SendMessageW(control.Handle, (WM)LB.GETCURSEL));
+            Assert.Equal(0, SendMessageW(control.Handle, (WM)LB.GETSELITEMS, buffer.Length, ref buffer[0]));
             Assert.Equal(new int[] { 0, 1, 0, 0, 0 }, buffer.ToArray());
         }
 
@@ -4434,7 +4434,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.TopIndex = 1;
-            Assert.Equal((IntPtr)0, SendMessageW(control.Handle, (WM)LB.GETTOPINDEX));
+            Assert.Equal(0, SendMessageW(control.Handle, (WM)LB.GETTOPINDEX));
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -1805,7 +1805,7 @@ namespace System.Windows.Forms.Tests
             };
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(expected, SendMessageW(control.Handle, (WM)LB.GETITEMHEIGHT) == (IntPtr)25);
+            Assert.Equal(expected, SendMessageW(control.Handle, (WM)LB.GETITEMHEIGHT) == 25);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -270,7 +270,7 @@ namespace System.Windows.Forms.Tests
                 Assert.True(list.IsHandleCreated);
 
                 RECT groupRect = new RECT();
-                User32.SendMessageW(list, (User32.WM)ComCtl32.LVM.GETGROUPRECT, (IntPtr)list.Groups.IndexOf(listGroup), ref groupRect);
+                User32.SendMessageW(list, (User32.WM)ComCtl32.LVM.GETGROUPRECT, list.Groups.IndexOf(listGroup), ref groupRect);
 
                 int actualWidth = group1AccObj.Bounds.Width;
                 int expectedWidth = groupRect.Width;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -201,8 +201,8 @@ namespace System.Windows.Forms.Tests
                     groupImageList.Images.Add(new Bitmap(10, 10));
                     groupImageList.Images.Add(new Bitmap(20, 20));
                     listView.GroupImageList = groupImageList;
-                    Assert.Equal(groupImageList.Handle,
-                        User32.SendMessageW(listView.Handle, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, groupImageList.Handle));
+                    Assert.Equal((nint)groupImageList.Handle,
+                        User32.SendMessageW(listView.Handle, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.GROUPHEADER, groupImageList.Handle));
 
                     var group = new ListViewGroup();
                     listView.Groups.Add(group);
@@ -210,14 +210,14 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.TitleImageIndex = value.Index;
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
                     var lvgroup = new LVGROUPW
                     {
                         cbSize = (uint)sizeof(LVGROUPW),
                         mask = LVGF.TITLEIMAGE | LVGF.GROUPID,
                     };
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 0, ref lvgroup));
                     Assert.Equal(value.Expected, lvgroup.iTitleImage);
                     Assert.True(lvgroup.iGroupId >= 0);
                 }
@@ -341,8 +341,8 @@ namespace System.Windows.Forms.Tests
                     using var groupImageList = new ImageList();
                     groupImageList.Images.Add(value.Key, new Bitmap(10, 10));
                     listView.GroupImageList = groupImageList;
-                    Assert.Equal(groupImageList.Handle,
-                        User32.SendMessageW(listView.Handle, (User32.WM)LVM.SETIMAGELIST, (IntPtr)LVSIL.GROUPHEADER, groupImageList.Handle));
+                    Assert.Equal((nint)groupImageList.Handle,
+                        User32.SendMessageW(listView.Handle, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.GROUPHEADER, groupImageList.Handle));
 
                     var group = new ListViewGroup();
                     listView.Groups.Add(group);
@@ -350,14 +350,14 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.TitleImageKey = value.Key;
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
                     var lvgroup = new LVGROUPW
                     {
                         cbSize = (uint)sizeof(LVGROUPW),
                         mask = LVGF.TITLEIMAGE | LVGF.GROUPID
                     };
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 0, ref lvgroup));
                     Assert.Equal(value.ExpectedIndex, lvgroup.iTitleImage);
                     Assert.True(lvgroup.iGroupId >= 0);
                 }
@@ -470,6 +470,9 @@ namespace System.Windows.Forms.Tests
             // Run this from another thread as we call Application.EnableVisualStyles.
             using RemoteInvokeHandle invokerHandle = RemoteExecutor.Invoke(() =>
             {
+                // This needs to be initialized out of the loop.
+                char* buffer = stackalloc char[256];
+
                 foreach (object[] data in Property_TypeString_GetGroupInfo_TestData())
                 {
                     string value = (string)data[0];
@@ -484,8 +487,8 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.Subtitle = value;
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
-                    char* buffer = stackalloc char[256];
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+
                     var lvgroup = new LVGROUPW
                     {
                         cbSize = (uint)sizeof(LVGROUPW),
@@ -494,7 +497,7 @@ namespace System.Windows.Forms.Tests
                         cchSubtitle = 256
                     };
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 0, ref lvgroup));
                     Assert.Equal(expected, new string(lvgroup.pszSubtitle));
                     Assert.True(lvgroup.iGroupId >= 0);
                 }
@@ -595,7 +598,7 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.Footer = value;
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
                     char* buffer = stackalloc char[256];
                     var lvgroup = new LVGROUPW
                     {
@@ -605,7 +608,7 @@ namespace System.Windows.Forms.Tests
                         cchFooter = 256
                     };
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 0, ref lvgroup));
                     Assert.Equal(expected, new string(lvgroup.pszFooter));
                     Assert.True(lvgroup.iGroupId >= 0);
                     Assert.Equal(LVGA.HEADER_LEFT | LVGA.FOOTER_LEFT, lvgroup.uAlign);
@@ -739,7 +742,7 @@ namespace System.Windows.Forms.Tests
                 Assert.NotEqual(IntPtr.Zero, listView.Handle);
                 group1.FooterAlignment = value;
 
-                Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
                 char* buffer = stackalloc char[256];
                 var lvgroup = new LVGROUPW
                 {
@@ -749,7 +752,7 @@ namespace System.Windows.Forms.Tests
                     cchFooter = 256
                 };
 
-                Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 0, ref lvgroup));
                 Assert.Equal(footer, new string(lvgroup.pszFooter));
                 Assert.True(lvgroup.iGroupId >= 0);
                 Assert.Equal(expectedAlign, (int)lvgroup.uAlign);
@@ -855,7 +858,7 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.Header = value;
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
                     char* buffer = stackalloc char[256];
                     var lvgroup = new LVGROUPW
                     {
@@ -865,7 +868,7 @@ namespace System.Windows.Forms.Tests
                         cchHeader = 256
                     };
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 0, ref lvgroup));
                     Assert.Equal(expected, new string(lvgroup.pszHeader));
                     Assert.True(lvgroup.iGroupId >= 0);
                     Assert.Equal(LVGA.HEADER_LEFT | LVGA.FOOTER_LEFT, lvgroup.uAlign);
@@ -989,7 +992,7 @@ namespace System.Windows.Forms.Tests
                 Assert.NotEqual(IntPtr.Zero, listView.Handle);
                 group1.HeaderAlignment = value;
 
-                Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
                 char* buffer = stackalloc char[256];
                 var lvgroup = new LVGROUPW
                 {
@@ -999,7 +1002,7 @@ namespace System.Windows.Forms.Tests
                     cchHeader = 256
                 };
 
-                Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 0, ref lvgroup));
                 Assert.Equal(header, new string(lvgroup.pszHeader));
                 Assert.True(lvgroup.iGroupId >= 0);
                 Assert.Equal(expectedAlign, (int)lvgroup.uAlign);
@@ -1112,7 +1115,7 @@ namespace System.Windows.Forms.Tests
                     group.CollapsedState = (ListViewGroupCollapsedState)data[0];
                     ListViewGroupCollapsedState expectedCollapsedState = (ListViewGroupCollapsedState)data[1];
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
                     var lvgroup = new LVGROUPW
                     {
                         cbSize = (uint)sizeof(LVGROUPW),
@@ -1120,7 +1123,7 @@ namespace System.Windows.Forms.Tests
                         stateMask = LVGS.COLLAPSIBLE | LVGS.COLLAPSED
                     };
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 0, ref lvgroup));
                     Assert.True(lvgroup.iGroupId >= 0);
                     Assert.Equal(expectedCollapsedState, group.CollapsedState);
                     if (expectedCollapsedState == ListViewGroupCollapsedState.Default)
@@ -1243,6 +1246,9 @@ namespace System.Windows.Forms.Tests
             // Run this from another thread as we call Application.EnableVisualStyles.
             using RemoteInvokeHandle invokerHandle = RemoteExecutor.Invoke(() =>
             {
+                // This needs to be outside the loop.
+                char* buffer = stackalloc char[256];
+
                 foreach (object[] data in Property_TypeString_GetGroupInfo_TestData())
                 {
                     string value = (string)data[0];
@@ -1257,8 +1263,7 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.TaskLink = value;
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
-                    char* buffer = stackalloc char[256];
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
                     var lvgroup = new LVGROUPW
                     {
                         cbSize = (uint)sizeof(LVGROUPW),
@@ -1267,13 +1272,13 @@ namespace System.Windows.Forms.Tests
                         cchTask = 256
                     };
 
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 0, ref lvgroup));
                     Assert.Equal(expected, new string(lvgroup.pszTask));
                     Assert.True(lvgroup.iGroupId >= 0);
                 }
             });
 
-            // verify the remote process succeeded
+            // Verify the remote process succeeded.
             Assert.Equal(0, invokerHandle.ExitCode);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -210,7 +210,7 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.TitleImageIndex = value.Index;
 
-                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
                     var lvgroup = new LVGROUPW
                     {
                         cbSize = (uint)sizeof(LVGROUPW),
@@ -350,7 +350,7 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.TitleImageKey = value.Key;
 
-                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
                     var lvgroup = new LVGROUPW
                     {
                         cbSize = (uint)sizeof(LVGROUPW),
@@ -487,7 +487,7 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.Subtitle = value;
 
-                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
 
                     var lvgroup = new LVGROUPW
                     {
@@ -598,7 +598,7 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.Footer = value;
 
-                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
                     char* buffer = stackalloc char[256];
                     var lvgroup = new LVGROUPW
                     {
@@ -742,7 +742,7 @@ namespace System.Windows.Forms.Tests
                 Assert.NotEqual(IntPtr.Zero, listView.Handle);
                 group1.FooterAlignment = value;
 
-                Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+                Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
                 char* buffer = stackalloc char[256];
                 var lvgroup = new LVGROUPW
                 {
@@ -858,7 +858,7 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.Header = value;
 
-                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
                     char* buffer = stackalloc char[256];
                     var lvgroup = new LVGROUPW
                     {
@@ -992,7 +992,7 @@ namespace System.Windows.Forms.Tests
                 Assert.NotEqual(IntPtr.Zero, listView.Handle);
                 group1.HeaderAlignment = value;
 
-                Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+                Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
                 char* buffer = stackalloc char[256];
                 var lvgroup = new LVGROUPW
                 {
@@ -1115,7 +1115,7 @@ namespace System.Windows.Forms.Tests
                     group.CollapsedState = (ListViewGroupCollapsedState)data[0];
                     ListViewGroupCollapsedState expectedCollapsedState = (ListViewGroupCollapsedState)data[1];
 
-                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
                     var lvgroup = new LVGROUPW
                     {
                         cbSize = (uint)sizeof(LVGROUPW),
@@ -1263,7 +1263,7 @@ namespace System.Windows.Forms.Tests
                     Assert.NotEqual(IntPtr.Zero, listView.Handle);
                     group.TaskLink = value;
 
-                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
                     var lvgroup = new LVGROUPW
                     {
                         cbSize = (uint)sizeof(LVGROUPW),

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
@@ -101,11 +101,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
 
                 // Set true.
                 control.InsertionMark.AppearsAfterItem = true;
@@ -113,11 +113,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000001, (uint)insertMark.dwFlags);
                 Assert.Equal(0, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
 
                 // Set false.
                 control.InsertionMark.AppearsAfterItem = false;
@@ -125,11 +125,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(0, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
             }).Dispose();
         }
 
@@ -152,11 +152,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
 
                 // Set true.
                 control.InsertionMark.AppearsAfterItem = true;
@@ -164,11 +164,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000001, (uint)insertMark.dwFlags);
                 Assert.Equal(0, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
 
                 // Set false.
                 control.InsertionMark.AppearsAfterItem = false;
@@ -176,11 +176,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(0, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
             }).Dispose();
         }
 
@@ -377,11 +377,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(00, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
 
                 // Set different.
                 control.InsertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
@@ -389,11 +389,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(00, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
             }).Dispose();
         }
 
@@ -474,11 +474,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
 
                 // Set negative one.
                 Assert.NotEqual(IntPtr.Zero, control.Handle);
@@ -487,11 +487,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
 
                 // Set different.
                 control.InsertionMark.Index = index;
@@ -499,11 +499,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(index, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
             }, indexParam.ToString()).Dispose();
         }
 
@@ -529,11 +529,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
 
                 // Set negative one.
                 Assert.NotEqual(IntPtr.Zero, control.Handle);
@@ -542,11 +542,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
 
                 // Set different.
                 control.InsertionMark.Index = index;
@@ -554,11 +554,11 @@ namespace System.Windows.Forms.Tests
                 {
                     cbSize = (uint)sizeof(ComCtl32.LVINSERTMARK)
                 };
-                Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, IntPtr.Zero, ref insertMark));
+                Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARK, 0, ref insertMark));
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(index, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, IntPtr.Zero, IntPtr.Zero));
+                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
             }, indexParam.ToString()).Dispose();
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
@@ -105,7 +105,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
 
                 // Set true.
                 control.InsertionMark.AppearsAfterItem = true;
@@ -117,7 +117,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000001, (uint)insertMark.dwFlags);
                 Assert.Equal(0, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
 
                 // Set false.
                 control.InsertionMark.AppearsAfterItem = false;
@@ -129,7 +129,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(0, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
             }).Dispose();
         }
 
@@ -156,7 +156,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
 
                 // Set true.
                 control.InsertionMark.AppearsAfterItem = true;
@@ -168,7 +168,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000001, (uint)insertMark.dwFlags);
                 Assert.Equal(0, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
 
                 // Set false.
                 control.InsertionMark.AppearsAfterItem = false;
@@ -180,7 +180,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(0, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
             }).Dispose();
         }
 
@@ -381,7 +381,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(00, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(00, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
 
                 // Set different.
                 control.InsertionMark.Color = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
@@ -393,7 +393,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
             }).Dispose();
         }
 
@@ -478,7 +478,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
 
                 // Set negative one.
                 Assert.NotEqual(IntPtr.Zero, control.Handle);
@@ -491,7 +491,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
 
                 // Set different.
                 control.InsertionMark.Index = index;
@@ -503,7 +503,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(index, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
             }, indexParam.ToString()).Dispose();
         }
 
@@ -533,7 +533,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
 
                 // Set negative one.
                 Assert.NotEqual(IntPtr.Zero, control.Handle);
@@ -546,7 +546,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(-1, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
 
                 // Set different.
                 control.InsertionMark.Index = index;
@@ -558,7 +558,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(0x80000000, (uint)insertMark.dwFlags);
                 Assert.Equal(index, insertMark.iItem);
                 Assert.Equal(0u, insertMark.dwReserved);
-                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR, 0, 0));
+                Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.LVM.GETINSERTMARKCOLOR));
             }, indexParam.ToString()).Dispose();
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -516,7 +516,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.BackColor = Color.FromArgb(0xFF, 0x12, 0x34, 0x56);
-            Assert.Equal((IntPtr)0x563412, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETBKCOLOR));
+            Assert.Equal(0x563412, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETBKCOLOR));
         }
 
         [WinFormsFact]
@@ -1378,7 +1378,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.ForeColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78);
-            Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETTEXTCOLOR));
+            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETTEXTCOLOR));
         }
 
         [WinFormsFact]
@@ -1848,7 +1848,7 @@ namespace System.Windows.Forms.Tests
                 BackColor = Color.FromArgb(0xFF, 0x12, 0x34, 0x56)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)0x563412, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETBKCOLOR));
+            Assert.Equal(0x563412, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETBKCOLOR));
         }
 
         [WinFormsFact]
@@ -1859,7 +1859,7 @@ namespace System.Windows.Forms.Tests
                 ForeColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETTEXTCOLOR));
+            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETTEXTCOLOR));
         }
 
         [WinFormsTheory]
@@ -1870,7 +1870,7 @@ namespace System.Windows.Forms.Tests
             {
                 ShowGroups = showGroups
             };
-            Assert.Equal((IntPtr)0, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(0, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
         }
 
         public static IEnumerable<object[]> Handle_GetWithGroups_TestData()
@@ -1901,6 +1901,9 @@ namespace System.Windows.Forms.Tests
             // Run this from another thread as we call Application.EnableVisualStyles.
             using RemoteInvokeHandle invokerHandle = RemoteExecutor.Invoke(() =>
             {
+                char* headerBuffer = stackalloc char[256];
+                char* footerBuffer = stackalloc char[256];
+
                 foreach (object[] data in Handle_GetWithGroups_TestData())
                 {
                     bool showGroups = (bool)data[0];
@@ -1929,9 +1932,8 @@ namespace System.Windows.Forms.Tests
                     listView.Groups.Add(group1);
                     listView.Groups.Add(group2);
 
-                    Assert.Equal((IntPtr)2, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
-                    char* headerBuffer = stackalloc char[256];
-                    char* footerBuffer = stackalloc char[256];
+                    Assert.Equal(2, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+
                     var lvgroup1 = new LVGROUPW
                     {
                         cbSize = (uint)sizeof(LVGROUPW),
@@ -1941,7 +1943,7 @@ namespace System.Windows.Forms.Tests
                         pszFooter = footerBuffer,
                         cchFooter = 256,
                     };
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)0, ref lvgroup1));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 0, ref lvgroup1));
                     Assert.Equal("ListViewGroup", new string(lvgroup1.pszHeader));
                     Assert.Empty(new string(lvgroup1.pszFooter));
                     Assert.True(lvgroup1.iGroupId >= 0);
@@ -1956,7 +1958,7 @@ namespace System.Windows.Forms.Tests
                         pszFooter = footerBuffer,
                         cchFooter = 256,
                     };
-                    Assert.Equal((IntPtr)1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, (IntPtr)1, ref lvgroup2));
+                    Assert.Equal(1, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPINFOBYINDEX, 1, ref lvgroup2));
                     Assert.Equal(expectedHeaderText, new string(lvgroup2.pszHeader));
                     Assert.Equal(expectedFooterText, new string(lvgroup2.pszFooter));
                     Assert.True(lvgroup2.iGroupId > 0);
@@ -1975,7 +1977,7 @@ namespace System.Windows.Forms.Tests
             using var control = new ListView();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
 
-            IntPtr expected = IntPtr.Size == 8 ? (IntPtr)0xFFFFFFFF : (IntPtr)(-1);
+            nint expected = unchecked((nint)0xFFFFFFFF);
             Assert.Equal(expected, User32.SendMessageW(control.Handle, (User32.WM)LVM.GETTEXTBKCOLOR));
         }
 
@@ -1985,7 +1987,7 @@ namespace System.Windows.Forms.Tests
             using var control = new ListView();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             int version = Application.UseVisualStyles ? 6 : 5;
-            Assert.Equal((IntPtr)version, User32.SendMessageW(control.Handle, (User32.WM)CCM.GETVERSION));
+            Assert.Equal(version, User32.SendMessageW(control.Handle, (User32.WM)CCM.GETVERSION));
         }
 
         public static IEnumerable<object[]> Handle_CustomGetVersion_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -1870,7 +1870,7 @@ namespace System.Windows.Forms.Tests
             {
                 ShowGroups = showGroups
             };
-            Assert.Equal(0, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, 0, 0));
+            Assert.Equal(0, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
         }
 
         public static IEnumerable<object[]> Handle_GetWithGroups_TestData()
@@ -1932,7 +1932,7 @@ namespace System.Windows.Forms.Tests
                     listView.Groups.Add(group1);
                     listView.Groups.Add(group2);
 
-                    Assert.Equal(2, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT, IntPtr.Zero, IntPtr.Zero));
+                    Assert.Equal(2, User32.SendMessageW(listView.Handle, (User32.WM)LVM.GETGROUPCOUNT));
 
                     var lvgroup1 = new LVGROUPW
                     {
@@ -4483,7 +4483,7 @@ namespace System.Windows.Forms.Tests
             uint keyCode = (uint)Keys.Space;
             uint lParam = (0x00000001 | keyCode << 16);
 
-            User32.SendMessageW(control, User32.WM.KEYDOWN, (IntPtr)keyCode, (IntPtr)lParam);
+            User32.SendMessageW(control, User32.WM.KEYDOWN, (nint)keyCode, (nint)lParam);
             Assert.Equal(selectItems ? 2 : 0, control.SelectedItems.Count);
             Assert.Equal(!checkItem && selectItems && focusItem, item2.Checked);
         }
@@ -4515,7 +4515,7 @@ namespace System.Windows.Forms.Tests
             uint lParam = (0x00000001 | keyCode << 16);
 
             // If control doesn't have selected items none will be focused.
-            User32.SendMessageW(control, User32.WM.KEYDOWN, (IntPtr)keyCode, (IntPtr)lParam);
+            User32.SendMessageW(control, User32.WM.KEYDOWN, (nint)keyCode, (nint)lParam);
             Assert.Empty(control.SelectedIndices);
             Assert.Null(control.FocusedItem);
             Assert.Null(control.FocusedGroup);
@@ -4559,7 +4559,7 @@ namespace System.Windows.Forms.Tests
                 uint keyCode = (uint)(key_s == "Keys.Down" ? Keys.Down : Keys.Up);
                 uint lParam = (0x00000001 | keyCode << 16);
 
-                User32.SendMessageW(control, User32.WM.KEYDOWN, (IntPtr)keyCode, (IntPtr)lParam);
+                User32.SendMessageW(control, User32.WM.KEYDOWN, (nint)keyCode, (nint)lParam);
                 Assert.False(control.GroupsEnabled);
                 Assert.True(control.Items.Count > 0);
                 int expectedGroupIndex = int.Parse(expectedGroupIndex_s);
@@ -4604,7 +4604,7 @@ namespace System.Windows.Forms.Tests
             uint lParam = (0x00000001 | keyCode << 16);
 
             // Actually ListView in VirtualMode can't have Groups
-            User32.SendMessageW(control, User32.WM.KEYDOWN, (IntPtr)keyCode, (IntPtr)lParam);
+            User32.SendMessageW(control, User32.WM.KEYDOWN, (nint)keyCode, (nint)lParam);
             Assert.Null(control.FocusedGroup);
         }
 
@@ -4646,7 +4646,7 @@ namespace System.Windows.Forms.Tests
             uint lParam = (0x00000001 | keyCode << 16);
 
             // Actually ListView in VirtualMode doesn't check items here
-            User32.SendMessageW(control, User32.WM.KEYDOWN, (IntPtr)keyCode, (IntPtr)lParam);
+            User32.SendMessageW(control, User32.WM.KEYDOWN, (nint)keyCode, (nint)lParam);
             Assert.False(item2.Checked);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObjectTests.cs
@@ -47,7 +47,7 @@ namespace System.Windows.Forms.Tests
             using MonthCalendar control = new MonthCalendar();
 
             control.CreateControl();
-            User32.SendMessageW(control, (User32.WM)MCM.SETCURRENTVIEW, IntPtr.Zero, (IntPtr)view);
+            User32.SendMessageW(control, (User32.WM)MCM.SETCURRENTVIEW, 0, view);
             CalendarBodyAccessibleObject accessibleObject = CreateCalendarBodyAccessibleObject(control);
 
             Assert.Equal(expected, accessibleObject.ColumnCount);
@@ -73,7 +73,7 @@ namespace System.Windows.Forms.Tests
             using MonthCalendar control = new MonthCalendar();
 
             control.CreateControl();
-            User32.SendMessageW(control, (User32.WM)MCM.SETCURRENTVIEW, IntPtr.Zero, (IntPtr)view);
+            User32.SendMessageW(control, (User32.WM)MCM.SETCURRENTVIEW, 0, view);
             CalendarBodyAccessibleObject accessibleObject = CreateCalendarBodyAccessibleObject(control);
 
             Assert.Null(accessibleObject.GetColumnHeaders());
@@ -139,7 +139,7 @@ namespace System.Windows.Forms.Tests
             control.SelectionStart = new DateTime(2021, 1, 1);
 
             control.CreateControl();
-            User32.SendMessageW(control, (User32.WM)MCM.SETCURRENTVIEW, IntPtr.Zero, (IntPtr)view);
+            User32.SendMessageW(control, (User32.WM)MCM.SETCURRENTVIEW, 0, (nint)view);
             MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
             LinkedListNode<CalendarAccessibleObject> calendarNode = controlAccessibleObject.CalendarsAccessibleObjects.First;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarCellAccessibleObjectTests.cs
@@ -144,7 +144,7 @@ namespace System.Windows.Forms.Tests
             control.SelectionStart = new DateTime(2021, 6, 16); // Set a date to have a stable test case
 
             control.CreateControl();
-            User32.SendMessageW(control, (User32.WM)MCM.SETCURRENTVIEW, default, (IntPtr)view);
+            User32.SendMessageW(control, (User32.WM)MCM.SETCURRENTVIEW, 0, view);
 
             CalendarCellAccessibleObject cellAccessibleObject = CreateCalendarCellAccessibleObject(control, 0, 2, 2);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
@@ -1028,7 +1028,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Span<Kernel32.SYSTEMTIME> range = stackalloc Kernel32.SYSTEMTIME[2];
-            Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETSELRANGE, IntPtr.Zero, ref range[0]));
+            Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETSELRANGE, 0, ref range[0]));
             Assert.Equal(2019, range[0].wYear);
             Assert.Equal(1, range[0].wMonth);
             Assert.Equal(30, range[0].wDay);
@@ -1055,7 +1055,7 @@ namespace System.Windows.Forms.Tests
                 MaxSelectionCount = 10
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)10, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETMAXSELCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(10, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETMAXSELCOUNT, 0, 0));
         }
 
         [WinFormsFact]
@@ -1067,7 +1067,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Kernel32.SYSTEMTIME date = default;
-            Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETTODAY, IntPtr.Zero, ref date));
+            Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETTODAY, 0, ref date));
             Assert.Equal(2019, date.wYear);
             Assert.Equal(1, date.wMonth);
             Assert.Equal(30, date.wDay);
@@ -1086,7 +1086,7 @@ namespace System.Windows.Forms.Tests
                 ForeColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (IntPtr)ComCtl32.MCSC.TEXT, IntPtr.Zero));
+            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TEXT, 0));
         }
 
         [WinFormsFact]
@@ -1097,7 +1097,7 @@ namespace System.Windows.Forms.Tests
                 BackColor = Color.FromArgb(0xFF, 0x12, 0x34, 0x56)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)0x563412, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (IntPtr)ComCtl32.MCSC.MONTHBK, IntPtr.Zero));
+            Assert.Equal(0x563412, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.MONTHBK, 0));
         }
 
         [WinFormsFact]
@@ -1108,7 +1108,7 @@ namespace System.Windows.Forms.Tests
                 TitleBackColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (IntPtr)ComCtl32.MCSC.TITLEBK, IntPtr.Zero));
+            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TITLEBK, 0));
         }
 
         [WinFormsFact]
@@ -1119,7 +1119,7 @@ namespace System.Windows.Forms.Tests
                 TitleForeColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (IntPtr)ComCtl32.MCSC.TITLETEXT, IntPtr.Zero));
+            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TITLETEXT, 0));
         }
 
         [WinFormsFact]
@@ -1130,7 +1130,7 @@ namespace System.Windows.Forms.Tests
                 TrailingForeColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (IntPtr)ComCtl32.MCSC.TRAILINGTEXT, IntPtr.Zero));
+            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TRAILINGTEXT, 0));
         }
 
         [WinFormsFact]
@@ -1147,7 +1147,7 @@ namespace System.Windows.Forms.Tests
                 expected -= 7;
             }
 
-            Assert.Equal((IntPtr)expected, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETFIRSTDAYOFWEEK, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(expected, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETFIRSTDAYOFWEEK));
         }
 
         [WinFormsFact]
@@ -1158,7 +1158,7 @@ namespace System.Windows.Forms.Tests
                 FirstDayOfWeek = Day.Tuesday
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)0x10001, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETFIRSTDAYOFWEEK, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(0x10001, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETFIRSTDAYOFWEEK));
         }
 
         [WinFormsFact]
@@ -1171,7 +1171,7 @@ namespace System.Windows.Forms.Tests
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             Span<Kernel32.SYSTEMTIME> range = stackalloc Kernel32.SYSTEMTIME[2];
-            Assert.Equal((IntPtr)3, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETRANGE, IntPtr.Zero, ref range[0]));
+            Assert.Equal(3, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETRANGE, 0, ref range[0]));
             Assert.Equal(2019, range[0].wYear);
             Assert.Equal(1, range[0].wMonth);
             Assert.Equal(2, range[0].wDay);
@@ -1198,7 +1198,7 @@ namespace System.Windows.Forms.Tests
                 ScrollChange = 10
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)10, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETMONTHDELTA, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(10, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETMONTHDELTA));
         }
 
         public static IEnumerable<object[]> ImeMode_Set_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
@@ -1055,7 +1055,7 @@ namespace System.Windows.Forms.Tests
                 MaxSelectionCount = 10
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(10, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETMAXSELCOUNT, 0, 0));
+            Assert.Equal(10, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETMAXSELCOUNT));
         }
 
         [WinFormsFact]
@@ -1086,7 +1086,7 @@ namespace System.Windows.Forms.Tests
                 ForeColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TEXT, 0));
+            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TEXT));
         }
 
         [WinFormsFact]
@@ -1097,7 +1097,7 @@ namespace System.Windows.Forms.Tests
                 BackColor = Color.FromArgb(0xFF, 0x12, 0x34, 0x56)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(0x563412, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.MONTHBK, 0));
+            Assert.Equal(0x563412, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.MONTHBK));
         }
 
         [WinFormsFact]
@@ -1108,7 +1108,7 @@ namespace System.Windows.Forms.Tests
                 TitleBackColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TITLEBK, 0));
+            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TITLEBK));
         }
 
         [WinFormsFact]
@@ -1119,7 +1119,7 @@ namespace System.Windows.Forms.Tests
                 TitleForeColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TITLETEXT, 0));
+            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TITLETEXT));
         }
 
         [WinFormsFact]
@@ -1130,7 +1130,7 @@ namespace System.Windows.Forms.Tests
                 TrailingForeColor = Color.FromArgb(0x12, 0x34, 0x56, 0x78)
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TRAILINGTEXT, 0));
+            Assert.Equal(0x785634, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.MCM.GETCOLOR, (nint)ComCtl32.MCSC.TRAILINGTEXT));
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -661,7 +661,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.AutoWordSelection = value;
-            Assert.Equal((IntPtr)expected, SendMessageW(control.Handle, (WM)Richedit.EM.GETOPTIONS));
+            Assert.Equal(expected, SendMessageW(control.Handle, (WM)Richedit.EM.GETOPTIONS));
         }
 
         public static IEnumerable<object[]> BackColor_Set_TestData()
@@ -1209,7 +1209,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.DetectUrls = value;
-            Assert.Equal((IntPtr)expected, SendMessageW(control.Handle, (WM)Richedit.EM.GETAUTOURLDETECT));
+            Assert.Equal(expected, SendMessageW(control.Handle, (WM)Richedit.EM.GETAUTOURLDETECT));
         }
 
         [WinFormsTheory]
@@ -1622,13 +1622,13 @@ namespace System.Windows.Forms.Tests
                 dwMask = (CFM)int.MaxValue
             };
 
-            IntPtr result;
+            nint result;
 
             using (var font = new Font(familyName, emSize, style, unit, gdiCharSet))
             {
                 control.Font = font;
-                result = SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (IntPtr)SCF.ALL, ref format);
-                Assert.NotEqual(IntPtr.Zero, result);
+                result = SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (nint)SCF.ALL, ref format);
+                Assert.NotEqual(0, result);
                 Assert.Equal(familyName, format.FaceName.ToString());
                 Assert.Equal(expectedYHeight, format.yHeight);
                 Assert.Equal(CFE.AUTOBACKCOLOR | CFE.AUTOCOLOR | (CFE)expectedEffects, format.dwEffects);
@@ -1644,8 +1644,8 @@ namespace System.Windows.Forms.Tests
                 dwMask = (CFM)int.MaxValue
             };
 
-            result = SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (IntPtr)SCF.ALL, ref format1);
-            Assert.NotEqual(IntPtr.Zero, result);
+            result = SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (nint)SCF.ALL, ref format1);
+            Assert.NotEqual(0, result);
             Assert.Equal(Control.DefaultFont.Name, format1.FaceName.ToString());
             Assert.Equal((int)(Control.DefaultFont.SizeInPoints * 20), (int)format1.yHeight);
             Assert.True(format1.dwEffects.HasFlag(CFE.AUTOBACKCOLOR));
@@ -1770,7 +1770,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(CHARFORMAT2W)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (IntPtr)SCF.ALL, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (nint)SCF.ALL, ref format));
             Assert.Equal(0x785634, format.crTextColor);
         }
 
@@ -1785,7 +1785,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(CHARFORMAT2W)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (IntPtr)SCF.ALL, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (nint)SCF.ALL, ref format));
             Assert.Equal(0x785634, format.crTextColor);
 
             // Set different.
@@ -1794,7 +1794,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(CHARFORMAT2W)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (IntPtr)SCF.ALL, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (nint)SCF.ALL, ref format));
             Assert.Equal(0x907856, format.crTextColor);
         }
 
@@ -2068,7 +2068,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.MaxLength = value;
-            Assert.Equal((IntPtr)expected, SendMessageW(control.Handle, (WM)User32.EM.GETLIMITTEXT));
+            Assert.Equal(expected, SendMessageW(control.Handle, (WM)User32.EM.GETLIMITTEXT));
         }
 
         [WinFormsFact]
@@ -3802,7 +3802,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(PARAFORMAT)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(expected, (int)format.wAlignment);
         }
 
@@ -3997,7 +3997,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(CHARFORMAT2W)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(0x785634, format.crBackColor);
         }
 
@@ -4259,7 +4259,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(PARAFORMAT)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(expectedOffset, (int)format.dxOffset);
             Assert.Equal(expected, (int)format.wNumbering);
         }
@@ -4453,7 +4453,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(CHARFORMAT2W)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(900, format.yOffset);
         }
 
@@ -4642,7 +4642,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(CHARFORMAT2W)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(0x785634, format.crTextColor);
         }
 
@@ -4957,7 +4957,7 @@ namespace System.Windows.Forms.Tests
                 cbSize = (uint)sizeof(CHARFORMAT2W),
                 dwMask = (CFM)int.MaxValue
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal("Arial", format.FaceName.ToString());
             Assert.Equal(expectedYHeight, (int)format.yHeight);
             Assert.Equal(CFE.AUTOBACKCOLOR | CFE.AUTOCOLOR | (CFE)expectedEffects, format.dwEffects);
@@ -5177,7 +5177,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(PARAFORMAT)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(expected, format.dxOffset);
         }
 
@@ -5368,7 +5368,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(PARAFORMAT)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(expected, format.dxStartIndent);
         }
 
@@ -5766,7 +5766,7 @@ namespace System.Windows.Forms.Tests
                 cbSize = (uint)sizeof(CHARFORMAT2W),
                 dwMask = CFM.PROTECTED
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETCHARFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(value, (format.dwEffects & CFE.PROTECTED) != 0);
         }
 
@@ -5952,7 +5952,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(PARAFORMAT)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(expected, format.dxRightIndent);
         }
 
@@ -6399,7 +6399,7 @@ namespace System.Windows.Forms.Tests
             {
                 cbSize = (uint)sizeof(PARAFORMAT)
             };
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(3, format.cTabCount);
             Assert.Equal(15, format.rgxTabs[0]);
             Assert.Equal(30, format.rgxTabs[1]);
@@ -6407,7 +6407,7 @@ namespace System.Windows.Forms.Tests
 
             // Set null or empty.
             control.SelectionTabs = nullOrEmptyValue;
-            Assert.NotEqual(IntPtr.Zero, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (IntPtr)SCF.SELECTION, ref format));
+            Assert.NotEqual(0, SendMessageW(control.Handle, (WM)Richedit.EM.GETPARAFORMAT, (nint)SCF.SELECTION, ref format));
             Assert.Equal(0, format.cTabCount);
         }
 
@@ -6676,7 +6676,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.ShowSelectionMargin = value;
-            Assert.Equal((IntPtr)expected, SendMessageW(control.Handle, (WM)Richedit.EM.GETOPTIONS));
+            Assert.Equal(expected, SendMessageW(control.Handle, (WM)Richedit.EM.GETOPTIONS));
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -585,7 +585,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_SETOPTIONS.
-            SendMessageW(control.Handle, (WM)Richedit.EM.SETOPTIONS, (IntPtr)ECOOP.OR, (IntPtr)ECO.AUTOWORDSELECTION);
+            SendMessageW(control.Handle, (WM)Richedit.EM.SETOPTIONS, (nint)ECOOP.OR, (nint)ECO.AUTOWORDSELECTION);
             Assert.False(control.AutoWordSelection);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
@@ -1132,7 +1132,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_AUTOURLDETECT.
-            SendMessageW(control.Handle, (WM)Richedit.EM.AUTOURLDETECT, IntPtr.Zero);
+            SendMessageW(control.Handle, (WM)Richedit.EM.AUTOURLDETECT, 0);
             Assert.True(control.DetectUrls);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
@@ -1951,7 +1951,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_LIMITTEXT.
-            SendMessageW(control.Handle, (WM)User32.EM.LIMITTEXT, IntPtr.Zero, (IntPtr)1);
+            SendMessageW(control.Handle, (WM)User32.EM.LIMITTEXT, 0, 1);
             Assert.Equal(0x7FFFFFFF, control.MaxLength);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
@@ -1959,7 +1959,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_EXLIMITTEXT.
-            SendMessageW(control.Handle, (WM)Richedit.EM.EXLIMITTEXT, IntPtr.Zero, (IntPtr)2);
+            SendMessageW(control.Handle, (WM)Richedit.EM.EXLIMITTEXT, 0, 2);
             Assert.Equal(0x7FFFFFFF, control.MaxLength);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
@@ -5570,7 +5570,7 @@ namespace System.Windows.Forms.Tests
             control.SelectionLength = value;
             int selectionStart = 0;
             int selectionEnd = 0;
-            IntPtr result = SendMessageW(control.Handle, (WM)User32.EM.GETSEL, (IntPtr)(&selectionStart), (IntPtr)(&selectionEnd));
+            IntPtr result = SendMessageW(control.Handle, (WM)User32.EM.GETSEL, (nint)(&selectionStart), (nint)(&selectionEnd));
             Assert.Equal(1, PARAM.LOWORD(result));
             Assert.Equal(expected, PARAM.HIWORD(result));
             Assert.Equal(1, selectionStart);
@@ -6160,7 +6160,7 @@ namespace System.Windows.Forms.Tests
             control.SelectionStart = value;
             int selectionStart = 0;
             int selectionEnd = 0;
-            IntPtr result = SendMessageW(control.Handle, (WM)User32.EM.GETSEL, (IntPtr)(&selectionStart), (IntPtr)(&selectionEnd));
+            IntPtr result = SendMessageW(control.Handle, (WM)User32.EM.GETSEL, (nint)(&selectionStart), (nint)(&selectionEnd));
             Assert.Equal(expectedSelectionStart, PARAM.LOWORD(result));
             Assert.Equal(expectedEnd, PARAM.HIWORD(result));
             Assert.Equal(expectedSelectionStart, selectionStart);
@@ -6600,7 +6600,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_SETOPTIONS.
-            SendMessageW(control.Handle, (WM)Richedit.EM.SETOPTIONS, (IntPtr)ECOOP.OR, (IntPtr)ECO.SELECTIONBAR);
+            SendMessageW(control.Handle, (WM)Richedit.EM.SETOPTIONS, (nint)ECOOP.OR, (nint)ECO.SELECTIONBAR);
             Assert.False(control.ShowSelectionMargin);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
@@ -7746,7 +7746,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_SETZOOM.
-            SendMessageW(control.Handle, (WM)Richedit.EM.SETZOOM, (IntPtr)2, (IntPtr)10);
+            SendMessageW(control.Handle, (WM)Richedit.EM.SETZOOM, 2, 10);
             Assert.Equal(0.2f, control.ZoomFactor);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.ControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.ControlCollectionTests.cs
@@ -769,7 +769,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(page1);
             collection.Add(page2);
             collection.Add(page3);
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -779,7 +779,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -787,7 +787,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -795,7 +795,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -837,7 +837,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(page1);
             collection.Add(page2);
             collection.Add(page3);
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -847,7 +847,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -855,7 +855,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -863,7 +863,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1477,7 +1477,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
             collection.Remove(page2);
-            Assert.Equal((IntPtr)2, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(2, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -1487,7 +1487,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1495,7 +1495,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1535,7 +1535,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
             collection.Remove(page2);
-            Assert.Equal((IntPtr)2, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(2, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -1545,7 +1545,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1553,7 +1553,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
@@ -768,7 +768,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(page1);
             collection.Add(page2);
             collection.Add(page3);
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -778,7 +778,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -786,7 +786,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -794,7 +794,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -836,7 +836,7 @@ namespace System.Windows.Forms.Tests
             collection.Add(page1);
             collection.Add(page2);
             collection.Add(page3);
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -846,7 +846,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -854,7 +854,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -862,7 +862,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1516,7 +1516,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
             collection.Clear();
-            Assert.Equal((IntPtr)0, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(0, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
         }
 
         [WinFormsFact]
@@ -2764,7 +2764,7 @@ namespace System.Windows.Forms.Tests
             collection.Insert(0, page3);
             collection.Insert(0, page2);
             collection.Insert(0, page1);
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -2774,7 +2774,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -2782,7 +2782,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -2790,7 +2790,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -2832,7 +2832,7 @@ namespace System.Windows.Forms.Tests
             collection.Insert(0, page3);
             collection.Insert(0, page2);
             collection.Insert(0, page1);
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -2842,7 +2842,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -2850,7 +2850,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -2858,7 +2858,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3497,7 +3497,7 @@ namespace System.Windows.Forms.Tests
                 ImageIndex = 1
             };
             collection[1] = value;
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -3507,7 +3507,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3515,7 +3515,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3523,7 +3523,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3567,7 +3567,7 @@ namespace System.Windows.Forms.Tests
                 ImageIndex = 1
             };
             collection[1] = value;
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -3577,7 +3577,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3585,7 +3585,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3593,7 +3593,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -4520,7 +4520,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
             collection.Remove(page2);
-            Assert.Equal((IntPtr)2, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(2, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -4530,7 +4530,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -4538,7 +4538,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -4578,7 +4578,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
             collection.Remove(page2);
-            Assert.Equal((IntPtr)2, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(2, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -4588,7 +4588,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -4596,7 +4596,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -1015,7 +1015,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new TabControl();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(IntPtr.Zero, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST));
         }
 
         [WinFormsFact]
@@ -1027,7 +1027,7 @@ namespace System.Windows.Forms.Tests
                 ImageList = imageList
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(imageList.Handle, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal((nint)imageList.Handle, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST));
         }
 
         [WinFormsFact]
@@ -1035,7 +1035,7 @@ namespace System.Windows.Forms.Tests
         {
             using var control = new TabControl();
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal(IntPtr.Zero, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
         }
 
         [WinFormsTheory]
@@ -1057,7 +1057,7 @@ namespace System.Windows.Forms.Tests
             control.TabPages.Add(page2);
             control.TabPages.Add(page3);
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)3, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -1067,7 +1067,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1075,7 +1075,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1083,7 +1083,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1302,11 +1302,11 @@ namespace System.Windows.Forms.Tests
             using var imageList = new ImageList();
             control.ImageList = imageList;
             Assert.True(imageList.HandleCreated);
-            Assert.Equal(imageList.Handle, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal((nint)imageList.Handle, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST));
 
             // Set null.
             control.ImageList = null;
-            Assert.Equal(IntPtr.Zero, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST));
         }
 
         [WinFormsFact]
@@ -1423,7 +1423,7 @@ namespace System.Windows.Forms.Tests
             imageList1.ImageSize = new Size(1, 2);
             Assert.Equal(1, recreateCallCount1);
             Assert.Same(imageList1, control.ImageList);
-            Assert.Equal(imageList1.Handle, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal((nint)imageList1.Handle, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1434,7 +1434,7 @@ namespace System.Windows.Forms.Tests
             imageList1.ImageSize = new Size(2, 3);
             Assert.Equal(2, recreateCallCount1);
             Assert.Same(imageList2, control.ImageList);
-            Assert.Equal(imageList2.Handle, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal((nint)imageList2.Handle, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETIMAGELIST));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -4923,7 +4923,7 @@ namespace System.Windows.Forms.Tests
             control.TabPages.Add(page3);
 
             control.RecreateHandle();
-            Assert.Equal((IntPtr)3, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -4933,7 +4933,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -4941,7 +4941,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -4949,7 +4949,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -5180,7 +5180,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.RemoveAll();
-            Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
@@ -1386,7 +1386,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
 
             page2.ImageIndex = imageIndex;
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -1396,7 +1396,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1404,7 +1404,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1412,7 +1412,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(imageIndex, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1453,7 +1453,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
 
             page2.ImageIndex = imageIndex;
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -1463,7 +1463,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1471,7 +1471,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1479,7 +1479,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(imageIndex, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1761,7 +1761,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
 
             page2.ImageKey = "ImageKey";
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -1771,7 +1771,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1779,7 +1779,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1787,7 +1787,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1825,7 +1825,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
 
             page2.ImageKey = "ImageKey";
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -1835,7 +1835,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1843,7 +1843,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -1851,7 +1851,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3017,7 +3017,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
 
             page2.Text = text;
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -3027,7 +3027,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3035,7 +3035,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3043,7 +3043,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3084,7 +3084,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
 
             page2.Text = text;
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -3094,7 +3094,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3102,7 +3102,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3110,7 +3110,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3390,7 +3390,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
 
             page2.ToolTipText = "ToolTipText";
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -3400,7 +3400,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3408,7 +3408,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3416,7 +3416,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3454,7 +3454,7 @@ namespace System.Windows.Forms.Tests
             Assert.NotEqual(IntPtr.Zero, owner.Handle);
 
             page2.ToolTipText = "ToolTipText";
-            Assert.Equal((IntPtr)3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(3, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMCOUNT));
 
             char* buffer = stackalloc char[256];
             ComCtl32.TCITEMW item = default;
@@ -3464,7 +3464,7 @@ namespace System.Windows.Forms.Tests
             item.mask = (ComCtl32.TCIF)uint.MaxValue;
 
             // Get item 0.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 0, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3472,7 +3472,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, item.iImage);
 
             // Get item 1.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)1, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 1, ref item));
             Assert.Equal(ComCtl32.TCIS.BUTTONPRESSED, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);
@@ -3480,7 +3480,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, item.iImage);
 
             // Get item 2.
-            Assert.Equal((IntPtr)1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, (IntPtr)2, ref item));
+            Assert.Equal(1, User32.SendMessageW(owner.Handle, (User32.WM)ComCtl32.TCM.GETITEMW, 2, ref item));
             Assert.Equal((ComCtl32.TCIS)0, item.dwState);
             Assert.Equal(IntPtr.Zero, item.lParam);
             Assert.Equal(int.MaxValue, item.cchTextMax);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -132,7 +132,7 @@ namespace System.Windows.Forms.Tests
             TreeNodeCollection collection = treeView.Nodes;
             collection.Add("Node 1");
             collection[0] = new TreeNode("New node 1");
-            Assert.Equal(1, treeView.nodeTable.Count);
+            Assert.Equal(1, treeView._nodeTable.Count);
             Assert.Equal(1, collection.Count);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeTests.cs
@@ -675,7 +675,7 @@ namespace System.Windows.Forms.Tests
                 stateMask = TVIS.STATEIMAGEMASK,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, IntPtr.Zero, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal((TVIS)expectedValue, item.state);
         }
 
@@ -943,7 +943,7 @@ namespace System.Windows.Forms.Tests
                 stateMask = TVIS.STATEIMAGEMASK,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, IntPtr.Zero, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal((TVIS)expectedValue, item.state);
         }
 
@@ -1216,7 +1216,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.IMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal(expected, item.iImage);
         }
 
@@ -1243,7 +1243,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.IMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal(expected, item.iImage);
         }
 
@@ -1274,7 +1274,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.IMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal(expected, item.iImage);
         }
 
@@ -1489,7 +1489,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.IMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref column));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref column));
             Assert.Equal(0, column.iImage);
         }
 
@@ -1519,7 +1519,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.IMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref column));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref column));
             Assert.Equal(expected, column.iImage);
         }
 
@@ -1551,7 +1551,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.IMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref column));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref column));
             Assert.Equal(expected, column.iImage);
         }
 
@@ -3198,7 +3198,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.IMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal(expected, item.iSelectedImage);
         }
 
@@ -3227,7 +3227,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.SELECTEDIMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal(expected, item.iSelectedImage);
         }
 
@@ -3258,7 +3258,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.SELECTEDIMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal(expected, item.iSelectedImage);
         }
 
@@ -3473,7 +3473,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.SELECTEDIMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref column));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref column));
             Assert.Equal(0, column.iSelectedImage);
         }
 
@@ -3503,7 +3503,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.SELECTEDIMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref column));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref column));
             Assert.Equal(expected, column.iSelectedImage);
         }
 
@@ -3535,7 +3535,7 @@ namespace System.Windows.Forms.Tests
                 mask = TVIF.HANDLE | TVIF.SELECTEDIMAGE,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref column));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref column));
             Assert.Equal(expected, column.iSelectedImage);
         }
 
@@ -3863,7 +3863,7 @@ namespace System.Windows.Forms.Tests
                 stateMask = TVIS.STATEIMAGEMASK,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal((TVIS)expected, item.state);
         }
 
@@ -3893,7 +3893,7 @@ namespace System.Windows.Forms.Tests
                 stateMask = TVIS.STATEIMAGEMASK,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal((TVIS)expected, item.state);
         }
 
@@ -3925,7 +3925,7 @@ namespace System.Windows.Forms.Tests
                 stateMask = TVIS.STATEIMAGEMASK,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal((TVIS)expected, item.state);
         }
 
@@ -4226,7 +4226,7 @@ namespace System.Windows.Forms.Tests
                 stateMask = TVIS.STATEIMAGEMASK,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref column));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref column));
             Assert.Equal((TVIS)0, column.state);
         }
 
@@ -4264,7 +4264,7 @@ namespace System.Windows.Forms.Tests
                 stateMask = TVIS.STATEIMAGEMASK,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref column));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref column));
             Assert.Equal((TVIS)expected, column.state);
         }
 
@@ -4304,7 +4304,7 @@ namespace System.Windows.Forms.Tests
                 stateMask = TVIS.STATEIMAGEMASK,
                 hItem = node.Handle
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref column));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref column));
             Assert.Equal((TVIS)expected, column.state);
         }
 
@@ -4462,7 +4462,7 @@ namespace System.Windows.Forms.Tests
                 cchTextMax = 256,
                 pszText = (IntPtr)textBuffer
             };
-            Assert.Equal((IntPtr)1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, (IntPtr)0, ref item));
+            Assert.Equal(1, SendMessageW(control.Handle, (WM)TVM.GETITEMW, 0, ref item));
             Assert.Equal(expected, new string((char*)item.pszText));
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -1680,7 +1680,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             int version = Application.UseVisualStyles ? 6 : 5;
-            Assert.Equal((IntPtr)version, User32.SendMessageW(control.Handle, (User32.WM)CCM.GETVERSION));
+            Assert.Equal(version, User32.SendMessageW(control.Handle, (User32.WM)CCM.GETVERSION));
         }
 
         public static IEnumerable<object[]> Handle_CustomGetVersion_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -1271,7 +1271,7 @@ namespace System.Windows.Forms.Tests
             };
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)expected, User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETMODIFY, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(expected, User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETMODIFY));
         }
 
         [WinFormsTheory]
@@ -1750,7 +1750,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.MaxLength = value;
-            Assert.Equal((IntPtr)expected, User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETLIMITTEXT, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(expected, User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETLIMITTEXT));
         }
 
         [WinFormsFact]
@@ -1866,7 +1866,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             control.Modified = value;
-            Assert.Equal((IntPtr)expected, User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETMODIFY, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(expected, User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETMODIFY));
         }
 
         [WinFormsFact]
@@ -2374,7 +2374,7 @@ namespace System.Windows.Forms.Tests
             control.ReadOnly = value;
 
             User32.ES style = (User32.ES)User32.GetWindowLong(control.Handle, User32.GWL.STYLE);
-            Assert.Equal(value, (style & User32.ES.READONLY) != 0);
+            Assert.Equal(value, style.HasFlag(User32.ES.READONLY));
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -1641,7 +1641,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_LIMITTEXT.
-            User32.SendMessageW(control.Handle, (User32.WM)User32.EM.LIMITTEXT, IntPtr.Zero, (IntPtr)1);
+            User32.SendMessageW(control.Handle, (User32.WM)User32.EM.LIMITTEXT, 0, 1);
             Assert.Equal(0x7FFF, control.MaxLength);
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
@@ -1788,7 +1788,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_SETMODIFY.
-            User32.SendMessageW(control.Handle, (User32.WM)User32.EM.SETMODIFY, (IntPtr)1, IntPtr.Zero);
+            User32.SendMessageW(control.Handle, (User32.WM)User32.EM.SETMODIFY, (nint)BOOL.TRUE);
             Assert.Equal(0, modifiedChangedCallCount);
 
             Assert.True(control.Modified);
@@ -2290,7 +2290,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
 
             // Call EM_SETREADONLY.
-            User32.SendMessageW(control.Handle, (User32.WM)User32.EM.SETREADONLY, (IntPtr)1, IntPtr.Zero);
+            User32.SendMessageW(control.Handle, (User32.WM)User32.EM.SETREADONLY, (nint)BOOL.TRUE);
             Assert.Equal(0, readOnlyChangedCallCount);
 
             Assert.False(control.ReadOnly);
@@ -2883,7 +2883,7 @@ namespace System.Windows.Forms.Tests
             control.SelectionLength = value;
             int selectionStart = 0;
             int selectionEnd = 0;
-            IntPtr result = User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETSEL, (IntPtr)(&selectionStart), (IntPtr)(&selectionEnd));
+            nint result = User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETSEL, (nint)(&selectionStart), (nint)(&selectionEnd));
             Assert.Equal(1, PARAM.LOWORD(result));
             Assert.Equal(expected, PARAM.HIWORD(result));
             Assert.Equal(1, selectionStart);
@@ -3056,7 +3056,7 @@ namespace System.Windows.Forms.Tests
             control.SelectionStart = value;
             int selectionStart = 0;
             int selectionEnd = 0;
-            IntPtr result = User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETSEL, (IntPtr)(&selectionStart), (IntPtr)(&selectionEnd));
+            nint result = User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETSEL, (nint)(&selectionStart), (nint)(&selectionEnd));
             Assert.Equal(expectedSelectionStart, PARAM.LOWORD(result));
             Assert.Equal(expectedEnd, PARAM.HIWORD(result));
             Assert.Equal(expectedSelectionStart, selectionStart);
@@ -4239,7 +4239,7 @@ namespace System.Windows.Forms.Tests
             control.CreateHandle();
             int selectionStart = 0;
             int selectionEnd = 0;
-            IntPtr result = User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETSEL, (IntPtr)(&selectionStart), (IntPtr)(&selectionEnd));
+            nint result = User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETSEL, (nint)(&selectionStart), (nint)(&selectionEnd));
             Assert.Equal(1, PARAM.LOWORD(result));
             Assert.Equal(3, PARAM.HIWORD(result));
             Assert.Equal(1, selectionStart);
@@ -6493,7 +6493,7 @@ namespace System.Windows.Forms.Tests
             control.Select(start, length);
             int selectionStart = 0;
             int selectionEnd = 0;
-            IntPtr result = User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETSEL, (IntPtr)(&selectionStart), (IntPtr)(&selectionEnd));
+            nint result = User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETSEL, (nint)(&selectionStart), (nint)(&selectionEnd));
             Assert.Equal(expectedSelectionStart, PARAM.LOWORD(result));
             Assert.Equal(expectedEnd, PARAM.HIWORD(result));
             Assert.Equal(expectedSelectionStart, selectionStart);
@@ -6625,7 +6625,7 @@ namespace System.Windows.Forms.Tests
             control.SelectAll();
             int selectionStart = 0;
             int selectionEnd = 0;
-            IntPtr result = User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETSEL, (IntPtr)(&selectionStart), (IntPtr)(&selectionEnd));
+            nint result = User32.SendMessageW(control.Handle, (User32.WM)User32.EM.GETSEL, (nint)(&selectionStart), (nint)(&selectionEnd));
             Assert.Equal(0, PARAM.LOWORD(result));
             Assert.Equal(4, PARAM.HIWORD(result));
             Assert.Equal(0, selectionStart);
@@ -7828,7 +7828,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(!multiline, control.IsHandleCreated);
                 Assert.Equal(0, textChangedCallCount);
                 control.CreateControl();
-                IntPtr result = SendMessageW(control.Handle, (WM)EM.GETMARGINS);
+                nint result = SendMessageW(control.Handle, (WM)EM.GETMARGINS);
                 Assert.Equal(expectedMargin, PARAM.HIWORD(result));
                 Assert.Equal(expectedMargin, PARAM.LOWORD(result));
             }

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -4,7 +4,6 @@
 
 using System.ComponentModel;
 using System.Drawing;
-using System.Runtime.InteropServices;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
@@ -387,14 +386,12 @@ namespace System.Windows.Forms.Tests
                 PlaceholderText = "Enter your name"
             };
 
-            HandleRef refHandle = new HandleRef(tb, tb.Handle);
-
-            //Cover the Placeholder draw code path
-            User32.SendMessageW(refHandle, User32.WM.PAINT, PARAM.FromBool(false));
+            // Cover the Placeholder draw code path
+            User32.SendMessageW(tb, User32.WM.PAINT, (nint)BOOL.FALSE);
             tb.TextAlign = HorizontalAlignment.Center;
-            User32.SendMessageW(refHandle, User32.WM.PAINT, PARAM.FromBool(false));
+            User32.SendMessageW(tb, User32.WM.PAINT, (nint)BOOL.FALSE);
             tb.TextAlign = HorizontalAlignment.Right;
-            User32.SendMessageW(refHandle, User32.WM.PAINT, PARAM.FromBool(false));
+            User32.SendMessageW(tb, User32.WM.PAINT, (nint)BOOL.FALSE);
 
             Assert.False(string.IsNullOrEmpty(tb.PlaceholderText));
         }
@@ -408,14 +405,12 @@ namespace System.Windows.Forms.Tests
                 RightToLeft = RightToLeft.Yes
             };
 
-            HandleRef refHandle = new HandleRef(tb, tb.Handle);
-
             //Cover the Placeholder draw code path in RightToLeft scenario
-            User32.SendMessageW(refHandle, User32.WM.PAINT, PARAM.FromBool(false));
+            User32.SendMessageW(tb, User32.WM.PAINT, (nint)BOOL.FALSE);
             tb.TextAlign = HorizontalAlignment.Center;
-            User32.SendMessageW(refHandle, User32.WM.PAINT, PARAM.FromBool(false));
+            User32.SendMessageW(tb, User32.WM.PAINT, (nint)BOOL.FALSE);
             tb.TextAlign = HorizontalAlignment.Right;
-            User32.SendMessageW(refHandle, User32.WM.PAINT, PARAM.FromBool(false));
+            User32.SendMessageW(tb, User32.WM.PAINT, (nint)BOOL.FALSE);
 
             Assert.False(string.IsNullOrEmpty(tb.PlaceholderText));
         }

--- a/src/System.Windows.Forms/tests/UnitTests/TrackBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TrackBarTests.cs
@@ -781,7 +781,7 @@ namespace System.Windows.Forms.Tests
                 Maximum = 11
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)11, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(11, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX));
         }
 
         [WinFormsFact]
@@ -792,7 +792,7 @@ namespace System.Windows.Forms.Tests
                 Minimum = 11
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)11, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(11, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN));
         }
 
         [WinFormsTheory]
@@ -811,7 +811,7 @@ namespace System.Windows.Forms.Tests
                 RightToLeftLayout = rightToLeftLayout
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)expected, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
+            Assert.Equal(expected, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
         }
 
         [WinFormsFact]
@@ -823,7 +823,7 @@ namespace System.Windows.Forms.Tests
                 Value = 5
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
+            Assert.Equal(5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
         }
 
         [WinFormsFact]
@@ -834,7 +834,7 @@ namespace System.Windows.Forms.Tests
                 LargeChange = 11
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)11, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPAGESIZE, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(11, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPAGESIZE));
         }
 
         [WinFormsFact]
@@ -845,7 +845,7 @@ namespace System.Windows.Forms.Tests
                 SmallChange = 11
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            Assert.Equal((IntPtr)11, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETLINESIZE, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(11, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETLINESIZE));
         }
 
         public static IEnumerable<object[]> Handle_GetSize_TestData()
@@ -1014,7 +1014,7 @@ namespace System.Windows.Forms.Tests
 
             control.LargeChange = value;
             Assert.Equal(value, control.LargeChange);
-            Assert.Equal((IntPtr)value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPAGESIZE, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPAGESIZE));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1023,7 +1023,7 @@ namespace System.Windows.Forms.Tests
             // Set same.
             control.LargeChange = value;
             Assert.Equal(value, control.LargeChange);
-            Assert.Equal((IntPtr)value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPAGESIZE, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPAGESIZE));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1088,9 +1088,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, control.Value);
             Assert.Equal(5, control.LargeChange);
             Assert.Equal(1, control.SmallChange);
-            Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN));
+            Assert.Equal(value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX));
+            Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1103,9 +1103,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, control.Value);
             Assert.Equal(5, control.LargeChange);
             Assert.Equal(1, control.SmallChange);
-            Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN));
+            Assert.Equal(value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX));
+            Assert.Equal(0, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1151,9 +1151,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(5, control.Value);
             Assert.Equal(5, control.LargeChange);
             Assert.Equal(1, control.SmallChange);
-            Assert.Equal((IntPtr)5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN));
+            Assert.Equal(5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX));
+            Assert.Equal(5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1227,9 +1227,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(5, control.Value);
             Assert.Equal(5, control.LargeChange);
             Assert.Equal(1, control.SmallChange);
-            Assert.Equal((IntPtr)value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)10, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN));
+            Assert.Equal(10, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX));
+            Assert.Equal(5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1241,9 +1241,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, control.Minimum);
             Assert.Equal(5, control.Value);
             Assert.Equal(5, control.LargeChange);
-            Assert.Equal((IntPtr)value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)10, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN));
+            Assert.Equal(10, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX));
+            Assert.Equal(5, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1289,9 +1289,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(12, control.Value);
             Assert.Equal(5, control.LargeChange);
             Assert.Equal(1, control.SmallChange);
-            Assert.Equal((IntPtr)12, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)12, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)12, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(12, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN));
+            Assert.Equal(12, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX));
+            Assert.Equal(12, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(1, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1748,7 +1748,7 @@ namespace System.Windows.Forms.Tests
 
             control.SmallChange = value;
             Assert.Equal(value, control.SmallChange);
-            Assert.Equal((IntPtr)value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETLINESIZE, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETLINESIZE));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -1757,7 +1757,7 @@ namespace System.Windows.Forms.Tests
             // Set same.
             control.SmallChange = value;
             Assert.Equal(value, control.SmallChange);
-            Assert.Equal((IntPtr)value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETLINESIZE, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(value, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETLINESIZE));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -2133,7 +2133,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, control.Value);
             Assert.Equal(5, control.LargeChange);
             Assert.Equal(1, control.SmallChange);
-            Assert.Equal((IntPtr)expectedPos, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(expectedPos, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -2146,7 +2146,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value, control.Value);
             Assert.Equal(5, control.LargeChange);
             Assert.Equal(1, control.SmallChange);
-            Assert.Equal((IntPtr)expectedPos, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(expectedPos, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
@@ -3100,9 +3100,9 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedMinimum, control.Minimum);
             Assert.Equal(expectedMaximum, control.Maximum);
             Assert.Equal(expectedValue, control.Value);
-            Assert.Equal((IntPtr)expectedMinimum, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)expectedMaximum, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX, IntPtr.Zero, IntPtr.Zero));
-            Assert.Equal((IntPtr)expectedValue, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS, IntPtr.Zero, IntPtr.Zero));
+            Assert.Equal(expectedMinimum, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMIN));
+            Assert.Equal(expectedMaximum, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETRANGEMAX));
+            Assert.Equal(expectedValue, User32.SendMessageW(control.Handle, (User32.WM)ComCtl32.TBM.GETPOS));
             Assert.True(control.IsHandleCreated);
             Assert.Equal(expectedInvalidatedCallCount, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);


### PR DESCRIPTION
We still had a number of potential and actual overflow scenarios. In order to make this more resilient, move SendMessage, PostMessage, and Get/SetWindowLong from IntPtr to nint.

This also makes things slightly faster as we aren't creating IntPtr structs and invoking the cast methods on it.

Note that IntPtr implicitly converts to nint. I've removed most of the actual IntPtr usages. I've also removed most of the HandleRef overloads and vetted the callers to do the right thing in regards to avoiding finalizer issues.

There is more we can do here, but this is a big first step.

Also clean up DateTimePicker and move SYSTEMTIME converters to SYSTEMTIME.

I did some style cleanup, but not exhaustively. I'll fix anything I changed if you catch anything I messed up.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5791)