### PR TITLE
Switch to 1ES servicing pools for release/6.0

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -16,8 +16,8 @@ stages:
         enableRichCodeNavigation: true
         richCodeNavigationEnvironment: 'production'
         pool:
-          name: NetCorePublic-Pool
-          queue: BuildPool.Windows.10.Amd64.VS2019.Open
+          name: NetCore1ESPool-Svc-Public
+          demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
 
         steps:
         - checkout: self

--- a/eng/pipelines/build.yml
+++ b/eng/pipelines/build.yml
@@ -14,11 +14,11 @@ jobs:
     timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        name: NetCorePublic-Pool
-        queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+        name: NetCore1ESPool-Svc-Public
+        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
       ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        name: NetCoreInternal-Pool
-        queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre
     strategy:
       matrix:
         ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Tracking issue: https://github.com/dotnet/core-eng/issues/14276

We have a deadline to migrate away from our build pools and to the 1ES pools by Sep 30. This accomplishes that for the release/6.0 branch.

## Proposed changes

- Switch to 1ES servicing pools.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- N/A

## Regression? 

- No

## Risk

- N/A

<!-- end TELL-MODE -->
