### PR TITLE
Fixing switching focus between ToolStrips where TabStop=true with Shift-Tab

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6841,4 +6841,13 @@ Stack trace where the illegal operation occurred was:
   <data name="ListViewCannotAddGroupsToVirtualListView" xml:space="preserve">
     <value>You cannot add groups to the ListView groups collection when the ListView is in virtual mode.</value>
   </data>
+  <data name="ParentPropertyNotSetInGetNextControl" xml:space="preserve">
+    <value>{0} property should be set for {1}.</value>
+  </data>
+  <data name="ControlsPropertyNotSetInGetNextControl" xml:space="preserve">
+    <value>{0} property should be set for {1}.</value>
+  </data>
+  <data name="ControlsCollectionShouldNotBeEmptyInGetNextControl" xml:space="preserve">
+    <value>{0} collection shouldn't be empty for {1}.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">Velikost ovládacího prvku, pokud by obrazovka byla nekonečně velká.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">Seznam musí být rozhraní IBindingList pro metodu AddNew.</target>
@@ -7534,6 +7544,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">Určuje, zda podokno má mít ohraničení.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">Die Größe des Steuerelements, wenn die Bildschirmgröße unendlich wäre.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">Die Liste muss eine IBindingList für AddNew sein.</target>
@@ -7534,6 +7544,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">Zeigt an, ob der Bereich einen Rahmen haben soll.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">Tamaño del control si la pantalla fuese más grande.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">La lista debe ser IBindingList para AddNew.</target>
@@ -7534,6 +7544,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">Indica si el panel debe tener un borde.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">Le taille du contrôle si l'écran était sans limites.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">La liste doit être un IBindingList pour AddNew.</target>
@@ -7534,6 +7544,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">Indique si le panneau doit avoir une bordure.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">Le dimensioni che avrebbe il controllo se lo schermo non avesse limiti di larghezza.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">L'elenco deve essere un elemento IBindingList per AddNew.</target>
@@ -7534,6 +7544,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">Indica se il riquadro deve avere un bordo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">スクリーンが最大のときのコントロールのサイズです。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">AddNew を実行するには、一覧に IBindingList を指定しなければなりません。</target>
@@ -7534,6 +7544,11 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">パネルに境界線を設定するかどうかを示します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">화면 크기에 제한이 없는 경우 컨트롤의 크기입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">해당 목록은 AddNew 대상 IBindingList여야 합니다.</target>
@@ -7534,6 +7544,11 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">패널에 테두리를 표시할지 여부를 나타냅니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">Rozmiary formantu przy założeniu, że ekran jest nieskończenie wielki.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">Lista musi być parametrem IBindingList dla parametru AddNew.</target>
@@ -7534,6 +7544,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">Wskazuje, czy panel ma mieć obramowanie.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">O tamanho do controle se a tela fosse muito grande.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">A lista deve ser uma IBindingList para AddNew.</target>
@@ -7534,6 +7544,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">Indica se o painel deve ter uma borda.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">Размеры данного элемента управления при бесконечном размере экрана.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">Данный список должен быть IBindingList для AddNew.</target>
@@ -7535,6 +7545,11 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">Показывает, должны ли у панели быть границы.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">Ekran sonsuz büyüklükte olsaydı denetimin boyutu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">AddNew için listenin IbindingList olması gerekir.</target>
@@ -7534,6 +7544,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">Bölmenin kenarlığı olup olmayacağını gösterir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">屏幕为无限大时控件的大小。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">列表必须为 IBindingList 才能执行 AddNew。</target>
@@ -7534,6 +7544,11 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">指示面板是否应具有边框。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -2062,6 +2062,16 @@
         <target state="translated">如果螢幕無限大時的控制項大小。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ControlsCollectionShouldNotBeEmptyInGetNextControl">
+        <source>{0} collection shouldn't be empty for {1}.</source>
+        <target state="new">{0} collection shouldn't be empty for {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ControlsPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CurrencyManagerCantAddNew">
         <source>The list must be an IBindingList to AddNew.</source>
         <target state="translated">清單必須是 AddNew 的 IBindingList。</target>
@@ -7534,6 +7544,11 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="PanelBorderStyleDescr">
         <source>Indicates whether the panel should have a border.</source>
         <target state="translated">表示面板是否要有框線。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ParentPropertyNotSetInGetNextControl">
+        <source>{0} property should be set for {1}.</source>
+        <target state="new">{0} property should be set for {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="PictureBoxBorderStyleDescr">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6034,46 +6034,69 @@ namespace System.Windows.Forms
             }
             else
             {
-                if (ctl != this)
+                ControlCollection children = GetControlCollection(ctl);
+
+                if (children is not null && children.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
+                {
+                    Control found = ctl.GetFirstChildControlInTabOrder(forward: false);
+                    if (found is not null)
+                    {
+                        return found;
+                    }
+                }
+
+                // Cycle through the controls in reverse z-order looking for the next lowest tab index.  We must
+                // start with the same tab index as ctl, because there can be dups.
+                while (ctl != this)
                 {
                     int targetIndex = ctl._tabIndex;
                     bool hitCtl = false;
                     Control found = null;
-                    Control p = ctl._parent;
+                    Control parent = ctl._parent;
 
-                    // Cycle through the controls in reverse z-order looking for the next lowest tab index.  We must
-                    // start with the same tab index as ctl, because there can be dups.
-                    int parentControlCount = 0;
-
-                    ControlCollection parentControls = (ControlCollection)p.Properties.GetObject(s_controlsCollectionProperty);
-
-                    if (parentControls is not null)
+                    if (parent is null)
                     {
-                        parentControlCount = parentControls.Count;
+                        throw new InvalidOperationException(
+                            string.Format(SR.ParentPropertyNotSetInGetNextControl, nameof(Control.Parent), ctl));
                     }
 
-                    for (int c = parentControlCount - 1; c >= 0; c--)
+                    ControlCollection siblings = GetControlCollection(parent);
+
+                    if (siblings is null)
                     {
-                        // The logic for this is a bit lengthy, so I have broken it into separate
-                        // clauses:
+                        throw new InvalidOperationException(
+                            string.Format(SR.ControlsPropertyNotSetInGetNextControl, nameof(Control.Controls), parent));
+                    }
+
+                    int siblingCount = siblings.Count;
+
+                    if (siblingCount == 0)
+                    {
+                        throw new InvalidOperationException(
+                           string.Format(SR.ControlsCollectionShouldNotBeEmptyInGetNextControl, nameof(Control.Controls), parent));
+                    }
+
+                    for (int c = siblingCount - 1; c >= 0; c--)
+                    {
+                        Control sibling = siblings[c];
 
                         // We are not interested in ourself.
-                        if (parentControls[c] != ctl)
+                        if (sibling != ctl)
                         {
                             // We are interested in controls with <= tab indexes to ctl.  We must include those
                             // controls with equal indexes to account for duplicate indexes.
-                            if (parentControls[c]._tabIndex <= targetIndex)
+                            if (sibling._tabIndex <= targetIndex)
                             {
                                 // Check to see if this control replaces the "best match" we've already
                                 // found.
-                                if (found is null || found._tabIndex < parentControls[c]._tabIndex)
+                                if (found is null || found._tabIndex < sibling._tabIndex)
                                 {
                                     // Finally, check to make sure that if this tab index is the same as ctl,
                                     // that we've already encountered ctl in the z-order.  If it isn't the same,
                                     // than we're more than happy with it.
-                                    if (parentControls[c]._tabIndex != targetIndex || hitCtl)
+                                    if (sibling._tabIndex != targetIndex || hitCtl)
                                     {
-                                        found = parentControls[c];
+                                        found = sibling;
                                     }
                                 }
                             }
@@ -6086,44 +6109,19 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    // If we were unable to find a control we should return the control's parent.  However, if that parent is us, return
-                    // NULL.
                     if (found is not null)
                     {
-                        ctl = found;
+                        return found;
                     }
-                    else
-                    {
-                        if (p == this)
-                        {
-                            return null;
-                        }
-                        else
-                        {
-                            return p;
-                        }
-                    }
-                }
 
-                // We found a control.  Walk into this control to find the proper sub control within it to select.
-                ControlCollection ctlControls = (ControlCollection)ctl.Properties.GetObject(s_controlsCollectionProperty);
-
-                while (ctlControls is not null && ctlControls.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
-                {
-                    Control found = ctl.GetFirstChildControlInTabOrder(/*forward=*/false);
-                    if (found is not null)
-                    {
-                        ctl = found;
-                        ctlControls = (ControlCollection)ctl.Properties.GetObject(s_controlsCollectionProperty);
-                    }
-                    else
-                    {
-                        break;
-                    }
+                    ctl = ctl._parent;
                 }
             }
 
             return ctl == this ? null : ctl;
+
+            ControlCollection GetControlCollection(Control control)
+               => (ControlCollection)control.Properties.GetObject(s_controlsCollectionProperty);
         }
 
         /// <summary>
@@ -9948,7 +9946,7 @@ namespace System.Windows.Forms
                 UiaCore.UiaReturnRawElementProvider(handle, 0, 0, null);
             }
 
-            if (IsAccessibilityObjectCreated && OsVersion.IsWindows8OrGreater)
+            if (OsVersion.IsWindows8OrGreater && IsAccessibilityObjectCreated)
             {
                 UiaCore.UiaDisconnectProvider(AccessibilityObject);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2254,7 +2254,7 @@ namespace System.Windows.Forms
                 case ArrowDirection.Right:
                     return GetNextItemHorizontal(start, forward: true);
                 case ArrowDirection.Left:
-                    bool forward = LastKeyData == Keys.Tab;
+                    bool forward = LastKeyData == Keys.Tab || TabStop;
                     return GetNextItemHorizontal(start, forward);
                 case ArrowDirection.Down:
                     return GetNextItemVertical(start, down: true);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
@@ -721,6 +721,259 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void Control_GetNextItem_Buttons_CycleForwardExpected(RightToLeft rightToLeft)
+        {
+            using SubControl control = new() { RightToLeft = rightToLeft };
+            using Button button1 = new();
+            using Button button2 = new();
+            using Button button3 = new();
+            control.Controls.AddRange(new Button[] { button1, button2, button3});
+            Control nextControl1 = control.GetNextControl(button1, forward: true);
+            Control nextControl2 = control.GetNextControl(button2, forward: true);
+            Control nextControl3 = control.GetNextControl(button3, forward: true);
+
+            Assert.Equal(button2, nextControl1);
+            Assert.Equal(button3, nextControl2);
+            Assert.Null(nextControl3);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void Control_GetNextItem_Buttons_CycleBackwardExpected(RightToLeft rightToLeft)
+        {
+            using SubControl control = new() { RightToLeft = rightToLeft };
+            using Button button1 = new();
+            using Button button2 = new();
+            using Button button3 = new();
+            control.Controls.AddRange(new Button[] { button1, button2, button3 });
+            Control previousControl1 = control.GetNextControl(button1, forward: false);
+            Control previousControl2 = control.GetNextControl(button2, forward: false);
+            Control previousControl3 = control.GetNextControl(button3, forward: false);
+
+            Assert.Null(previousControl1);
+            Assert.Equal(button1, previousControl2);
+            Assert.Equal(button2, previousControl3);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void Control_GetNextSelectableControl_Buttons_CycleForwardExpected(RightToLeft rightToLeft)
+        {
+            using SubControl control = new() { RightToLeft = rightToLeft };
+            using Button button1 = new();
+            using Button button2 = new();
+            using Button button3 = new();
+            control.Controls.AddRange(new Button[] { button1, button2, button3 });
+            Control nextControl1 = control.GetNextSelectableControl(button1, forward: true, tabStopOnly: true, nested: true, wrap: true);
+            Control nextControl2 = control.GetNextSelectableControl(button2, forward: true, tabStopOnly: true, nested: true, wrap: true);
+            Control nextControl3 = control.GetNextSelectableControl(button3, forward: true, tabStopOnly: true, nested: true, wrap: true);
+            Control nextControl4 = control.GetNextSelectableControl(button1, forward: true, tabStopOnly: true, nested: true, wrap: true);
+
+            Assert.Equal(button2, nextControl1);
+            Assert.Equal(button3, nextControl2);
+            Assert.Equal(button1, nextControl3);
+            Assert.Equal(button2, nextControl4);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void Control_GetNextSelectableControl_Buttons_CycleBackwardExpected(RightToLeft rightToLeft)
+        {
+            using SubControl control = new() { RightToLeft = rightToLeft };
+            using Button button1 = new();
+            using Button button2 = new();
+            using Button button3 = new();
+            control.Controls.AddRange(new Button[] { button1, button2, button3 });
+            Control previousControl1 = control.GetNextSelectableControl(button1, forward: false, tabStopOnly: true, nested: true, wrap: true);
+            Control previousControl2 = control.GetNextSelectableControl(button3, forward: false, tabStopOnly: true, nested: true, wrap: true);
+            Control previousControl3 = control.GetNextSelectableControl(button2, forward: false, tabStopOnly: true, nested: true, wrap: true);
+            Control previousControl4 = control.GetNextSelectableControl(button1, forward: false, tabStopOnly: true, nested: true, wrap: true);
+
+            Assert.Equal(button3, previousControl1);
+            Assert.Equal(button2, previousControl2);
+            Assert.Equal(button1, previousControl3);
+            Assert.Equal(button3, previousControl4);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void Control_GetNextSelectableControl_MultipleComplexControls_CycleBackwardExpected(RightToLeft rightToLeft)
+        {
+            using SubControl control = new() { RightToLeft = rightToLeft };
+            using TableLayoutPanel table = new() { Dock = DockStyle.Fill, ColumnCount = 3 };
+            table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            control.Controls.Add(table);
+            using FlowLayoutPanel panelRadioButtons = new()
+            {
+                Dock = DockStyle.Fill,
+                FlowDirection = FlowDirection.TopDown
+            };
+
+            table.Controls.Add(panelRadioButtons, column: 0, row: 0);
+            using RadioButton radioButton1 = new() { Checked = true };
+            panelRadioButtons.Controls.Add(radioButton1);
+            using RadioButton radioButton2 = new() { Checked = false };
+            panelRadioButtons.Controls.Add(radioButton2);
+            using FlowLayoutPanel panelCheckBoxes = new()
+            {
+                Dock = DockStyle.Fill,
+                FlowDirection = FlowDirection.TopDown
+            };
+
+            table.Controls.Add(panelCheckBoxes, column: 1, row: 0);
+            using CheckBox checkBox1 = new() { Checked = true };
+            panelCheckBoxes.Controls.Add(checkBox1);
+            using CheckBox checkBox2 = new() { Checked = true };
+            panelCheckBoxes.Controls.Add(checkBox2);
+            using FlowLayoutPanel panelButtons = new()
+            {
+                Dock = DockStyle.Fill,
+                FlowDirection = FlowDirection.TopDown
+            };
+
+            table.Controls.Add(panelButtons, column: 2, row: 0);
+            using Button button1 = new();
+            panelButtons.Controls.Add(button1);
+            using Button button2 = new();
+            panelButtons.Controls.Add(button2);
+            Control previousControl1 = control.GetNextSelectableControl(button2, forward: false, tabStopOnly: true, nested: true, wrap: true);
+            Control previousControl2 = control.GetNextSelectableControl(button1, forward: false, tabStopOnly: true, nested: true, wrap: true);
+            Control previousControl3 = control.GetNextSelectableControl(checkBox2, forward: false, tabStopOnly: true, nested: true, wrap: true);
+            Control previousControl4 = control.GetNextSelectableControl(checkBox1, forward: false, tabStopOnly: true, nested: true, wrap: true);
+            Control previousControl5 = control.GetNextSelectableControl(radioButton1, forward: false, tabStopOnly: true, nested: true, wrap: true);
+            Control previousControl6 = control.GetNextSelectableControl(button2, forward: false, tabStopOnly: true, nested: true, wrap: true);
+
+            Assert.Equal(button1, previousControl1);
+            Assert.Equal(checkBox2, previousControl2);
+            Assert.Equal(checkBox1, previousControl3);
+            Assert.Equal(radioButton1, previousControl4);
+            Assert.Equal(button2, previousControl5);
+            Assert.Equal(button1, previousControl6);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void Control_SelectNextControl_ToolStrips_CycleForwardExpected(RightToLeft rightToLeft)
+        {
+            using Form form = new() { RightToLeft = rightToLeft, };
+            using ToolStrip toolStrip1 = new() { TabStop = true, };
+            using ToolStrip toolStrip2 = new() { TabStop = true, };
+            toolStrip1.CreateControl();
+            toolStrip2.CreateControl();
+            form.CreateControl();
+            using ToolStripButton toolStrip1_Button1 = new();
+            using ToolStripTextBox toolStrip1_TextBox1 = new();
+            using ToolStripComboBox toolStrip1_ComboBox1 = new();
+            using ToolStripSplitButton toolStrip1_SplitButton1 = new();
+            toolStrip1.Items.AddRange(new ToolStripItem[]
+            {
+                toolStrip1_Button1, toolStrip1_TextBox1, toolStrip1_ComboBox1, toolStrip1_SplitButton1
+            });
+
+            using ToolStripComboBox toolStrip2_ComboBox1 = new();
+            using ToolStripSplitButton toolStrip2_SplitButton1 = new();
+            using ToolStripLabel toolStrip2_Label1 = new();
+            using ToolStripSplitButton toolStrip2_DropDownButton1 = new();
+            using ToolStripComboBox toolStrip2_ComboBox2 = new();
+            toolStrip2.Items.AddRange(new ToolStripItem[]
+            {
+                toolStrip2_ComboBox1,
+                toolStrip2_SplitButton1,
+                toolStrip2_Label1,
+                toolStrip2_DropDownButton1,
+                toolStrip2_ComboBox2
+            });
+
+            form.Controls.AddRange(new ToolStrip[] { toolStrip1, toolStrip2 });
+            toolStrip1.ParentInternal.Visible = true;
+            toolStrip2.ParentInternal.Visible = true;
+            toolStrip1_ComboBox1.ParentInternal.Visible = true;
+            toolStrip1_TextBox1.ParentInternal.Visible = true;
+            toolStrip1_ComboBox1.ComboBox.AssignParent(toolStrip1);
+            toolStrip1_TextBox1.Control.AssignParent(toolStrip1);
+
+            var result = form.SelectNextControl(toolStrip1_ComboBox1.ComboBox, forward: true, tabStopOnly: true, nested: true, wrap: true);
+            Assert.True(result);
+            Assert.True(toolStrip2_ComboBox1.Focused);
+            Assert.True(toolStrip2.Items[0].Selected);
+
+            result = form.SelectNextControl(toolStrip1_TextBox1.Control, forward: true, tabStopOnly: true, nested: true, wrap: true);
+            Assert.True(result);
+            Assert.True(toolStrip2_ComboBox1.Focused);
+            Assert.True(toolStrip2.Items[0].Selected);
+
+            Assert.True(form.IsHandleCreated);
+            Assert.True(toolStrip1.IsHandleCreated);
+            Assert.True(toolStrip2.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void Control_SelectNextControl_ToolStrips_CycleBackwardExpected(RightToLeft rightToLeft)
+        {
+            using Form form = new() { RightToLeft = rightToLeft };
+            using ToolStrip toolStrip1 = new() { TabStop = true };
+            using ToolStrip toolStrip2 = new() { TabStop = true };
+            toolStrip1.CreateControl();
+            toolStrip2.CreateControl();
+            form.CreateControl();
+            using ToolStripButton toolStrip1_Button1 = new();
+            using ToolStripLabel toolStrip1_Label1 = new();
+            using ToolStripTextBox toolStrip1_TextBox1 = new();
+            using ToolStripSplitButton toolStrip1_SplitButton1 = new();
+            toolStrip1.Items.AddRange(new ToolStripItem[]
+            {
+                toolStrip1_Button1, toolStrip1_Label1, toolStrip1_TextBox1, toolStrip1_SplitButton1
+            });
+
+            using ToolStripComboBox toolStrip2_ComboBox1 = new();
+            using ToolStripSplitButton toolStrip2_SplitButton1 = new();
+            using ToolStripLabel toolStrip2_Label1 = new();
+            using ToolStripSplitButton toolStrip2_DropDownButton1 = new();
+            using ToolStripComboBox toolStrip2_ComboBox2 = new();
+            toolStrip2.Items.AddRange(new ToolStripItem[]
+            {
+                toolStrip2_ComboBox1,
+                toolStrip2_SplitButton1,
+                toolStrip2_Label1,
+                toolStrip2_DropDownButton1,
+                toolStrip2_ComboBox2
+            });
+
+            form.Controls.AddRange(new ToolStrip[] { toolStrip1, toolStrip2 });
+            toolStrip1.ParentInternal.Visible = true;
+            toolStrip2.ParentInternal.Visible = true;
+            toolStrip2_ComboBox1.ParentInternal.Visible = true;
+            toolStrip2_ComboBox2.ParentInternal.Visible = true;
+            toolStrip2_ComboBox1.ComboBox.AssignParent(toolStrip2);
+            toolStrip2_ComboBox2.ComboBox.AssignParent(toolStrip2);
+
+            var result = form.SelectNextControl(toolStrip2_ComboBox2.ComboBox, forward: false, tabStopOnly: true, nested: true, wrap: true);
+            Assert.True(result);
+            Assert.True(toolStrip1.Focused);
+            Assert.True(toolStrip1.Items[0].Selected);
+
+            result = form.SelectNextControl(toolStrip2_ComboBox1.ComboBox, forward: false, tabStopOnly: true, nested: true, wrap: true);
+            Assert.True(result);
+            Assert.True(toolStrip1.Focused);
+            Assert.True(toolStrip1.Items[0].Selected);
+
+            Assert.True(form.IsHandleCreated);
+            Assert.True(toolStrip1.IsHandleCreated);
+            Assert.True(toolStrip2.IsHandleCreated);
+        }
+
         private class SubControl : Control
         {
             public SubControl() : base()
@@ -742,6 +995,9 @@ namespace System.Windows.Forms.Tests
             public SubControl(Control parent, string text, int left, int top, int width, int height) : base(parent, text, left, top, width, height)
             {
             }
+
+            public Control GetNextSelectableControl(Control ctl, bool forward, bool tabStopOnly, bool nested, bool wrap)
+                => this.TestAccessor().Dynamic.GetNextSelectableControl(ctl, forward, tabStopOnly, nested, wrap);
 
             public new bool CanEnableIme => base.CanEnableIme;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -4799,6 +4799,26 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(RightToLeft.No)]
         [InlineData(RightToLeft.Yes)]
+        public void ToolStrip_GetNextItem_CyclesForwardExpected(RightToLeft rightToLeft)
+        {
+            using ToolStrip toolStrip = new() { RightToLeft = rightToLeft, TabStop = false };
+            using ToolStripButton toolStripButton1 = new();
+            using ToolStripButton toolStripButton2 = new();
+            using ToolStripButton toolStripButton3 = new();
+            toolStrip.Items.AddRange(new ToolStripItem[] { toolStripButton1, toolStripButton2, toolStripButton3 });
+            ToolStripItem nextToolStripItem1 = toolStrip.GetNextItem(toolStripButton1, ArrowDirection.Right);
+            ToolStripItem nextToolStripItem2 = toolStrip.GetNextItem(toolStripButton2, ArrowDirection.Right);
+            ToolStripItem nextToolStripItem3 = toolStrip.GetNextItem(toolStripButton3, ArrowDirection.Right);
+
+            Assert.Equal(toolStripButton2, nextToolStripItem1);
+            Assert.Equal(toolStripButton3, nextToolStripItem2);
+            Assert.Equal(toolStripButton1, nextToolStripItem3);
+            Assert.False(toolStrip.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
         public void ToolStrip_GetNextItem_ReturnsBackwardItem(RightToLeft rightToLeft)
         {
             using ToolStrip toolStrip = new()
@@ -4814,6 +4834,27 @@ namespace System.Windows.Forms.Tests
             ToolStripItem actual = toolStrip.GetNextItem(toolStrip.Items[0], ArrowDirection.Left);
 
             Assert.Equal(toolStripButton3, actual);
+            Assert.False(toolStrip.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void ToolStrip_GetNextItem_CyclesBackwardExpected(RightToLeft rightToLeft)
+        {
+            using ToolStrip toolStrip = new() { RightToLeft = rightToLeft, TabStop = false };
+            using ToolStripButton toolStripButton1 = new();
+            using ToolStripButton toolStripButton2 = new();
+            using ToolStripButton toolStripButton3 = new();
+            toolStrip.Items.AddRange(new ToolStripItem[] { toolStripButton1, toolStripButton2, toolStripButton3 });
+            toolStrip.TestAccessor().Dynamic.LastKeyData = Keys.Shift | Keys.Tab;
+            ToolStripItem previousToolStripItem1 = toolStrip.GetNextItem(toolStripButton1, ArrowDirection.Left);
+            ToolStripItem previousToolStripItem2 = toolStrip.GetNextItem(toolStripButton3, ArrowDirection.Left);
+            ToolStripItem previousToolStripItem3 = toolStrip.GetNextItem(toolStripButton2, ArrowDirection.Left);
+
+            Assert.Equal(toolStripButton3, previousToolStripItem1);
+            Assert.Equal(toolStripButton2, previousToolStripItem2);
+            Assert.Equal(toolStripButton1, previousToolStripItem3);
             Assert.False(toolStrip.IsHandleCreated);
         }
 


### PR DESCRIPTION
Fixes #5795

## Proposed changes

- Extracted moving focus backward to separate method with special treatment for ToolStrip, because it's not a simple control, but control with children controls and they should be parsed in a `while` cycle
- Changed `forward` condition at the `GetNextItem` method at the `ToolStrip` class because it is called after moving focus to the ToolStrip, but when `TabStop` is true the first item should be always focused
- Added unit test for checking focus cycling

## Customer Impact

- Before the fix (focus was trapped at the last ToolStrip item while pressing `Shift`+`Tab`):
![shiftTabNotWorking](https://user-images.githubusercontent.com/87859299/134381259-94979eae-2232-4a84-a9a8-5c25ad10e628.gif)

- After the fix (focus isn't trapped at the last ToolStrip item while pressing `Shift`+`Tab`):
![shiftTabWorking](https://user-images.githubusercontent.com/87859299/134379122-84de599d-f9cb-4999-b75d-fecfe7d24f3e.gif)

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit test
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
Microsoft Windows [Version 10.0.19043.1237]
.NET SDK 7.0.0-alpha.1.21471.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5842)