### PR TITLE
Update template to include *.user file while creating new applications.

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
@@ -102,16 +102,19 @@
   ],
   "sources": [
     {
+      "exclude": [ "**/[Bb]in/**", "**/[Oo]bj/**", ".template.config/**/*", "**/*.filelist", "**/*.lock.json" ],
       "condition": "Framework == \"netcoreapp3.1\"",
       "source": "./netcoreapp3.1",
       "target": "./"
     },
     {
+      "exclude": [ "**/[Bb]in/**", "**/[Oo]bj/**", ".template.config/**/*", "**/*.filelist", "**/*.lock.json" ],
       "condition": "Framework == \"net5.0\"",
       "source": "./net5.0",
       "target": "./"
     },
     {
+      "exclude": [ "**/[Bb]in/**", "**/[Oo]bj/**", ".template.config/**/*", "**/*.filelist", "**/*.lock.json" ],
       "condition": "Framework == \"net6.0\"",
       "source": "./net6.0",
       "target": "./"

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/template.json
@@ -102,16 +102,19 @@
   ],
   "sources": [
     {
+      "exclude": [ "**/[Bb]in/**", "**/[Oo]bj/**", ".template.config/**/*", "**/*.filelist", "**/*.lock.json" ],
       "condition": "Framework == \"netcoreapp3.1\"",
       "source": "./netcoreapp3.1",
       "target": "./"
     },
     {
+      "exclude": [ "**/[Bb]in/**", "**/[Oo]bj/**", ".template.config/**/*", "**/*.filelist", "**/*.lock.json" ],
       "condition": "Framework == \"net5.0\"",
       "source": "./net5.0",
       "target": "./"
     },
     {
+      "exclude": [ "**/[Bb]in/**", "**/[Oo]bj/**", ".template.config/**/*", "**/*.filelist", "**/*.lock.json" ],
       "condition": "Framework == \"net6.0\"",
       "source": "./net6.0",
       "target": "./"

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
@@ -102,16 +102,19 @@
   ],
   "sources": [
     {
+      "exclude": [ "**/[Bb]in/**", "**/[Oo]bj/**", ".template.config/**/*", "**/*.filelist", "**/*.lock.json" ],
       "condition": "Framework == \"netcoreapp3.1\"",
       "source": "./netcoreapp3.1",
       "target": "./"
     },
     {
+      "exclude": [ "**/[Bb]in/**", "**/[Oo]bj/**", ".template.config/**/*", "**/*.filelist", "**/*.lock.json" ],
       "condition": "Framework == \"net5.0\"",
       "source": "./net5.0",
       "target": "./"
     },
     {
+      "exclude": [ "**/[Bb]in/**", "**/[Oo]bj/**", ".template.config/**/*", "**/*.filelist", "**/*.lock.json" ],
       "condition": "Framework == \"net6.0\"",
       "source": "./net6.0",
       "target": "./"


### PR DESCRIPTION
Fixes dotnet/winforms-designer#3724

By default *.user files are excluded/removed by the template engine. Template owners need to override this with `exclude` flag and remove the *.user files form exclusion list.

Related #5547 

Related #3510
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5848)