### PR TITLE
Update Message to avoid common casting errors

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.FilterListBox.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.FilterListBox.cs
@@ -46,15 +46,16 @@ namespace System.ComponentModel.Design
 
             protected override void WndProc(ref Message m)
             {
-                switch ((User32.WM)m.Msg)
+                switch (m._Msg)
                 {
                     case User32.WM.KEYDOWN:
                         _lastKeyDown = m;
 
-                        // the first thing the ime does on a key it cares about is send a VK_PROCESSKEY, so we use that to sling focus to the grid.
-                        if (unchecked((int)(long)m.WParam) == VK_PROCESSKEY)
+                        // The first thing the ime does on a key it cares about is send a VK_PROCESSKEY, so we use
+                        // that to sling focus to the grid.
+                        if (m._WParam == VK_PROCESSKEY)
                         {
-                            if (PropertyGrid != null)
+                            if (PropertyGrid is not null)
                             {
                                 PropertyGrid.Focus();
                                 User32.SetFocus(new HandleRef(PropertyGrid, PropertyGrid.Handle));
@@ -67,8 +68,8 @@ namespace System.ComponentModel.Design
 
                             if (PropertyGrid.Focused || PropertyGrid.ContainsFocus)
                             {
-                                // recreate the keystroke to the newly activated window
-                                User32.SendMessageW(User32.GetFocus(), User32.WM.KEYDOWN, _lastKeyDown.WParam, _lastKeyDown.LParam);
+                                // Recreate the keystroke to the newly activated window.
+                                User32.SendMessageW(User32.GetFocus(), User32.WM.KEYDOWN, _lastKeyDown._WParam, _lastKeyDown._LParam);
                             }
                         }
 
@@ -96,8 +97,8 @@ namespace System.ComponentModel.Design
                         if (PropertyGrid.Focused || PropertyGrid.ContainsFocus)
                         {
                             IntPtr hWnd = User32.GetFocus();
-                            User32.SendMessageW(hWnd, User32.WM.KEYDOWN, _lastKeyDown.WParam, _lastKeyDown.LParam);
-                            User32.SendMessageW(hWnd, User32.WM.CHAR, m.WParam, m.LParam);
+                            User32.SendMessageW(hWnd, User32.WM.KEYDOWN, _lastKeyDown._WParam, _lastKeyDown._LParam);
+                            User32.SendMessageW(hWnd, User32.WM.CHAR, m._WParam, m._LParam);
                             return;
                         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -630,30 +630,28 @@ namespace System.ComponentModel.Design
 
                 protected override void WndProc(ref Message m)
                 {
-                    if (m.Msg == (int)User32.WM.ACTIVATE)
+                    if (m._Msg == User32.WM.ACTIVATE
+                        && Visible
+                        && (User32.WA)PARAM.LOWORD(m._WParam) == User32.WA.INACTIVE
+                        && !OwnsWindow(m._LParam))
                     {
-                        if (Visible && PARAM.LOWORD(m.WParam) == (int)User32.WA.INACTIVE)
+                        Visible = false;
+                        if (m._LParam == 0)
                         {
-                            if (!OwnsWindow(m.LParam))
+                            // We 're switching process, also dismiss the parent.
+                            Control toplevel = _parentControl.TopLevelControl;
+                            if (toplevel is ToolStripDropDown dropDown)
                             {
-                                Visible = false;
-                                if (m.LParam == IntPtr.Zero)
-                                { //we 're switching process, also dismiss the parent
-                                    Control toplevel = _parentControl.TopLevelControl;
-                                    if (toplevel is ToolStripDropDown dropDown)
-                                    {
-                                        // if it's a toolstrip dropdown let it know that we have a specific close reason.
-                                        dropDown.Close();
-                                    }
-                                    else if (toplevel != null)
-                                    {
-                                        toplevel.Visible = false;
-                                    }
-                                }
-
-                                return;
+                                // If it's a toolstrip dropdown let it know that we have a specific close reason.
+                                dropDown.Close();
+                            }
+                            else if (toplevel is not null)
+                            {
+                                toplevel.Visible = false;
                             }
                         }
+
+                        return;
                     }
 
                     base.WndProc(ref m);

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
@@ -1078,9 +1078,9 @@ namespace System.ComponentModel.Design
 
         private void WmActivate(ref Message m)
         {
-            if (unchecked((int)(long)m.WParam) == (int)User32.WA.INACTIVE)
+            if ((User32.WA)m._WParam == User32.WA.INACTIVE)
             {
-                IntPtr hwndActivating = m.LParam;
+                IntPtr hwndActivating = m._LParam;
                 if (WindowOwnsWindow(Handle, hwndActivating))
                 {
                     Debug.WriteLineIf(DesignerActionUI.DropDownVisibilityDebug.TraceVerbose, "[DesignerActionUI WmActivate] setting cancel close true because WindowsOwnWindow");

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.Selector.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ObjectSelectorEditor.Selector.cs
@@ -198,10 +198,10 @@ namespace System.ComponentModel.Design
 
             protected unsafe override void WndProc(ref Message m)
             {
-                switch ((User32.WM)m.Msg)
+                switch (m._Msg)
                 {
                     case User32.WM.GETDLGCODE:
-                        m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTALLKEYS);
+                        m._Result = m._Result | (int)User32.DLGC.WANTALLKEYS;
                         return;
                     case User32.WM.MOUSEMOVE:
                         if (clickSeen)
@@ -211,7 +211,7 @@ namespace System.ComponentModel.Design
 
                         break;
                     case User32.WM.REFLECT_NOTIFY:
-                        User32.NMHDR* nmtv = (User32.NMHDR*)m.LParam;
+                        User32.NMHDR* nmtv = (User32.NMHDR*)m._LParam;
                         if (nmtv->code == (int)ComCtl32.NM.CLICK)
                         {
                             clickSeen = true;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.MouseHook.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.MouseHook.cs
@@ -88,7 +88,7 @@ namespace System.Windows.Forms.Design.Behavior
                     }
                 }
 
-                private unsafe IntPtr MouseHookProc(User32.HC nCode, IntPtr wparam, IntPtr lparam)
+                private unsafe nint MouseHookProc(User32.HC nCode, nint wparam, nint lparam)
                 {
                     if (_isHooked && nCode == User32.HC.ACTION && lparam != IntPtr.Zero)
                     {
@@ -96,9 +96,9 @@ namespace System.Windows.Forms.Design.Behavior
 
                         try
                         {
-                            if (ProcessMouseMessage(mhs->hWnd, unchecked((int)(long)wparam), mhs->pt.X, mhs->pt.Y))
+                            if (ProcessMouseMessage(mhs->hWnd, (User32.WM)wparam, mhs->pt.X, mhs->pt.Y))
                             {
-                                return (IntPtr)1;
+                                return 1;
                             }
                         }
                         catch (Exception ex)
@@ -122,7 +122,7 @@ namespace System.Windows.Forms.Design.Behavior
                     }
 
                     Debug.Assert(_isHooked, "How did we get here when we are disposed?");
-                    return User32.CallNextHookEx(new HandleRef(this, _mouseHookHandle), nCode, wparam, lparam);
+                    return User32.CallNextHookEx(_mouseHookHandle, nCode, wparam, lparam);
                 }
 
                 private void UnhookMouse()
@@ -139,7 +139,7 @@ namespace System.Windows.Forms.Design.Behavior
                     }
                 }
 
-                private bool ProcessMouseMessage(IntPtr hWnd, int msg, int x, int y)
+                private bool ProcessMouseMessage(IntPtr hWnd, User32.WM msg, int x, int y)
                 {
                     if (_processingMessage)
                     {
@@ -176,7 +176,7 @@ namespace System.Windows.Forms.Design.Behavior
                                 _processingMessage = true;
                                 var pt = new Point(x, y);
                                 adornerWindow.PointToClient(pt);
-                                Message m = Message.Create(hWnd, msg, (IntPtr)0, PARAM.FromLowHigh(pt.Y, pt.X));
+                                Message m = Message.Create(hWnd, msg, 0, PARAM.FromLowHigh(pt.Y, pt.X));
 
                                 // No one knows why we get an extra click here from VS. As a workaround, we check the TimeStamp and discard it.
                                 if (m.Msg == (int)User32.WM.LBUTTONDOWN)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.cs
@@ -329,9 +329,7 @@ namespace System.Windows.Forms.Design.Behavior
                         }
 
                     case User32.WM.NCHITTEST:
-                        Point pt = new Point(
-                            (short)PARAM.LOWORD(m.LParam),
-                            (short)PARAM.HIWORD(m.LParam));
+                        Point pt = PARAM.ToPoint(m._LParam);
 
                         var pt1 = new Point();
                         pt1 = PointToClient(pt1);
@@ -339,11 +337,11 @@ namespace System.Windows.Forms.Design.Behavior
 
                         if (_behaviorService.PropagateHitTest(pt) && !ProcessingDrag)
                         {
-                            m.Result = (IntPtr)User32.HT.TRANSPARENT;
+                            m._Result = (nint)User32.HT.TRANSPARENT;
                         }
                         else
                         {
-                            m.Result = (IntPtr)User32.HT.CLIENT;
+                            m._Result = (nint)User32.HT.CLIENT;
                         }
 
                         break;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -829,15 +829,15 @@ namespace System.Windows.Forms.Design.Behavior
 
         private void TestHook_SetText(ref Message m, string text)
         {
-            if (m.LParam == IntPtr.Zero)
+            if (m._LParam == 0)
             {
-                m.Result = (IntPtr)((text.Length + 1) * Marshal.SystemDefaultCharSize);
+                m._Result = (text.Length + 1) * sizeof(char);
                 return;
             }
 
-            if (unchecked((int)(long)m.WParam) < text.Length + 1)
+            if (m._WParam < text.Length + 1)
             {
-                m.Result = (IntPtr)(-1);
+                m._Result = -1;
                 return;
             }
 
@@ -846,20 +846,12 @@ namespace System.Windows.Forms.Design.Behavior
             byte[] nullBytes;
             byte[] bytes;
 
-            if (Marshal.SystemDefaultCharSize == 1)
-            {
-                bytes = Text.Encoding.Default.GetBytes(text);
-                nullBytes = Text.Encoding.Default.GetBytes(nullChar);
-            }
-            else
-            {
-                bytes = Text.Encoding.Unicode.GetBytes(text);
-                nullBytes = Text.Encoding.Unicode.GetBytes(nullChar);
-            }
+            bytes = Text.Encoding.Unicode.GetBytes(text);
+            nullBytes = Text.Encoding.Unicode.GetBytes(nullChar);
 
-            Marshal.Copy(bytes, 0, m.LParam, bytes.Length);
-            Marshal.Copy(nullBytes, 0, unchecked((IntPtr)((long)m.LParam + bytes.Length)), nullBytes.Length);
-            m.Result = (IntPtr)((bytes.Length + nullBytes.Length) / Marshal.SystemDefaultCharSize);
+            Marshal.Copy(bytes, 0, m._LParam, bytes.Length);
+            Marshal.Copy(nullBytes, 0, m._LParam + bytes.Length, nullBytes.Length);
+            m._Result = (bytes.Length + nullBytes.Length) / sizeof(char);
         }
 
         private void TestHook_GetAllSnapLines(ref Message m)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ChildSubClass.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.ChildSubClass.cs
@@ -39,14 +39,14 @@ namespace System.Windows.Forms.Design
                     return;
                 }
 
-                if (m.Msg == (int)User32.WM.DESTROY)
+                if (m._Msg == User32.WM.DESTROY)
                 {
                     _designer.RemoveSubclassedWindow(m.HWnd);
                 }
 
-                if (m.Msg == (int)User32.WM.PARENTNOTIFY && PARAM.LOWORD(m.WParam) == (short)User32.WM.CREATE)
+                if (m._Msg == User32.WM.PARENTNOTIFY && (User32.WM)PARAM.LOWORD(m._WParam) == User32.WM.CREATE)
                 {
-                    _designer.HookChildHandles(m.LParam); // they will get removed from the collection just above
+                    _designer.HookChildHandles(m._LParam); // they will get removed from the collection just above
                 }
 
                 // We want these messages to go through the designer's WndProc method, and we want people to be able

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -426,7 +426,7 @@ namespace System.Windows.Forms.Design
         ///  want to block it from getting to Windows itself because it causes other messages to be generated.
         /// </summary>
         protected void BaseWndProc(ref Message m)
-            => m.Result = User32.DefWindowProcW(m.HWnd, (User32.WM)m.Msg, m.WParam, m.LParam);
+            => m._Result = User32.DefWindowProcW(m.HWnd, m._Msg, m._WParam, m._LParam);
 
         /// <summary>
         ///  Determines if the this designer can be parented to the specified designer -- generally this means if the
@@ -1738,10 +1738,10 @@ namespace System.Windows.Forms.Design
             IMouseHandler mouseHandler = null;
 
             // We look at WM_NCHITTEST to determine if the mouse is in a live region of the control
-            if (m.Msg == (int)User32.WM.NCHITTEST && !_inHitTest)
+            if (m._Msg == User32.WM.NCHITTEST && !_inHitTest)
             {
                 _inHitTest = true;
-                Point pt = new Point((short)PARAM.LOWORD(m.LParam), (short)PARAM.HIWORD(m.LParam));
+                Point pt = PARAM.ToPoint(m._LParam);
                 try
                 {
                     _liveRegion = GetHitTest(pt);
@@ -1759,14 +1759,14 @@ namespace System.Windows.Forms.Design
             }
 
             // Check to see if the mouse is in a live region of the control and that the context key is not being fired
-            bool isContextKey = (m.Msg == (int)User32.WM.CONTEXTMENU);
-            if (_liveRegion && (IsMouseMessage(m.Msg) || isContextKey))
+            bool isContextKey = m._Msg == User32.WM.CONTEXTMENU;
+            if (_liveRegion && (IsMouseMessage(m._Msg) || isContextKey))
             {
                 // The ActiveX DataGrid control brings up a context menu on right mouse down when it is in edit mode.
                 // And, when we generate a WM_CONTEXTMENU message later, it calls DefWndProc() which by default calls
                 // the parent (formdesigner). The FormDesigner then brings up the AxHost context menu. This code
                 // causes recursive WM_CONTEXTMENU messages to be ignored till we return from the live region message.
-                if (m.Msg == (int)User32.WM.CONTEXTMENU)
+                if (m._Msg == User32.WM.CONTEXTMENU)
                 {
                     Debug.Assert(!s_inContextMenu, "Recursively hitting live region for context menu!!!");
                     s_inContextMenu = true;
@@ -1778,12 +1778,12 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (m.Msg == (int)User32.WM.CONTEXTMENU)
+                    if (m._Msg == User32.WM.CONTEXTMENU)
                     {
                         s_inContextMenu = false;
                     }
 
-                    if (m.Msg == (int)User32.WM.LBUTTONUP)
+                    if (m._Msg == User32.WM.LBUTTONUP)
                     {
                         // terminate the drag. TabControl loses shortcut menu options after adding ActiveX control.
                         OnMouseDragEnd(true);
@@ -1794,15 +1794,15 @@ namespace System.Windows.Forms.Design
             }
 
             // Get the x and y coordinates of the mouse message
-            int x = 0, y = 0;
+            Point location = default;
 
             // Look for a mouse handler.
             // CONSIDER - I really don't like this one bit. We need a
             //          : centralized handler so we can do a global override for the tab order
             //          : UI, but the designer is a natural fit for an object oriented UI.
-            if ((m.Msg >= (int)User32.WM.MOUSEFIRST && m.Msg <= (int)User32.WM.MOUSELAST)
-                || (m.Msg >= (int)User32.WM.NCMOUSEMOVE && m.Msg <= (int)User32.WM.NCMBUTTONDBLCLK)
-                || m.Msg == (int)User32.WM.SETCURSOR)
+            if ((m._Msg >= User32.WM.MOUSEFIRST && m._Msg <= User32.WM.MOUSELAST)
+                || (m._Msg >= User32.WM.NCMOUSEMOVE && m._Msg <= User32.WM.NCMBUTTONDBLCLK)
+                || m._Msg == User32.WM.SETCURSOR)
             {
                 _eventService ??= GetService<IEventHandlerService>();
 
@@ -1812,28 +1812,20 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (m.Msg >= (int)User32.WM.MOUSEFIRST && m.Msg <= (int)User32.WM.MOUSELAST)
+            if (m._Msg >= User32.WM.MOUSEFIRST && m._Msg <= User32.WM.MOUSELAST)
             {
-                Point pt = new()
-                {
-                    X = PARAM.SignedLOWORD(m.LParam),
-                    Y = PARAM.SignedHIWORD(m.LParam)
-                };
-
-                User32.MapWindowPoints(m.HWnd, IntPtr.Zero, &pt, 1);
-                x = pt.X;
-                y = pt.Y;
+                location = PARAM.ToPoint(m._LParam);
+                User32.MapWindowPoints(m.HWnd, IntPtr.Zero, &location, 1);
             }
-            else if (m.Msg >= (int)User32.WM.NCMOUSEMOVE && m.Msg <= (int)User32.WM.NCMBUTTONDBLCLK)
+            else if (m._Msg >= User32.WM.NCMOUSEMOVE && m._Msg <= User32.WM.NCMBUTTONDBLCLK)
             {
-                x = PARAM.SignedLOWORD(m.LParam);
-                y = PARAM.SignedHIWORD(m.LParam);
+                location = PARAM.ToPoint(m._LParam);
             }
 
             // This is implemented on the base designer for UI activation support.  We call it so that we can support
             // UI activation.
             MouseButtons button = MouseButtons.None;
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.CREATE:
                     DefWndProc(ref m);
@@ -1849,7 +1841,7 @@ namespace System.Windows.Forms.Design
 
                 case User32.WM.GETOBJECT:
                     // See "How to Handle WM_GETOBJECT" in MSDN
-                    if (unchecked((int)(long)m.LParam) == User32.OBJID.CLIENT)
+                    if (m._LParam == User32.OBJID.CLIENT)
                     {
                         Guid IID_IAccessible = new Guid(NativeMethods.uuid_IAccessible);
                         // Get an Lresult for the accessibility Object for this control
@@ -1858,7 +1850,7 @@ namespace System.Windows.Forms.Design
                         if (iacc is null)
                         {
                             // Accessibility is not supported on this control
-                            m.Result = (IntPtr)0;
+                            m._Result = 0;
                         }
                         else
                         {
@@ -1866,7 +1858,7 @@ namespace System.Windows.Forms.Design
                             punkAcc = Marshal.GetIUnknownForObject(iacc);
                             try
                             {
-                                m.Result = Oleacc.LresultFromObject(ref IID_IAccessible, m.WParam, punkAcc);
+                                m._Result = Oleacc.LresultFromObject(ref IID_IAccessible, m._WParam, punkAcc);
                             }
                             finally
                             {
@@ -1875,7 +1867,8 @@ namespace System.Windows.Forms.Design
                         }
                     }
                     else
-                    {  // m.lparam != OBJID_CLIENT, so do default message processing
+                    {
+                        // m.lparam != OBJID_CLIENT, so do default message processing.
                         DefWndProc(ref m);
                     }
 
@@ -1893,7 +1886,7 @@ namespace System.Windows.Forms.Design
                     // We intentionally eat these messages.
                     break;
                 case User32.WM.MOUSEHOVER:
-                    if (mouseHandler != null)
+                    if (mouseHandler is not null)
                     {
                         mouseHandler.OnMouseHover(Component);
                     }
@@ -1911,7 +1904,7 @@ namespace System.Windows.Forms.Design
                 case User32.WM.LBUTTONDBLCLK:
                 case User32.WM.NCRBUTTONDBLCLK:
                 case User32.WM.RBUTTONDBLCLK:
-                    if ((m.Msg == (int)User32.WM.NCRBUTTONDBLCLK || m.Msg == (int)User32.WM.RBUTTONDBLCLK))
+                    if (m._Msg == User32.WM.NCRBUTTONDBLCLK || m._Msg == User32.WM.RBUTTONDBLCLK)
                     {
                         button = MouseButtons.Right;
                     }
@@ -1924,7 +1917,7 @@ namespace System.Windows.Forms.Design
                     {
                         // We handle doubleclick messages, and we also process our own simulated double clicks for
                         // controls that don't specify CS_WANTDBLCLKS.
-                        if (mouseHandler != null)
+                        if (mouseHandler is not null)
                         {
                             mouseHandler.OnMouseDoubleClick(Component);
                         }
@@ -1939,7 +1932,7 @@ namespace System.Windows.Forms.Design
                 case User32.WM.LBUTTONDOWN:
                 case User32.WM.NCRBUTTONDOWN:
                 case User32.WM.RBUTTONDOWN:
-                    if ((m.Msg == (int)User32.WM.NCRBUTTONDOWN || m.Msg == (int)User32.WM.RBUTTONDOWN))
+                    if (m._Msg == User32.WM.NCRBUTTONDOWN || m._Msg == User32.WM.RBUTTONDOWN)
                     {
                         button = MouseButtons.Right;
                     }
@@ -1953,9 +1946,9 @@ namespace System.Windows.Forms.Design
                     User32.SendMessageW(Control.Handle, User32.WM.SETFOCUS);
 
                     // We simulate doubleclick for things that don't...
-                    if (button == MouseButtons.Left && IsDoubleClick(x, y))
+                    if (button == MouseButtons.Left && IsDoubleClick(location.X, location.Y))
                     {
-                        if (mouseHandler != null)
+                        if (mouseHandler is not null)
                         {
                             mouseHandler.OnMouseDoubleClick(Component);
                         }
@@ -1984,17 +1977,17 @@ namespace System.Windows.Forms.Design
 
                         if (_toolPassThrough)
                         {
-                            User32.SendMessageW(Control.Parent.Handle, (User32.WM)m.Msg, m.WParam, GetParentPointFromLparam(m.LParam));
+                            User32.SendMessageW(Control.Parent, m._Msg, m._WParam, GetParentPointFromLparam(m._LParam));
                             return;
                         }
 
                         if (mouseHandler != null)
                         {
-                            mouseHandler.OnMouseDown(Component, button, x, y);
+                            mouseHandler.OnMouseDown(Component, button, location.X, location.Y);
                         }
                         else if (button == MouseButtons.Left)
                         {
-                            OnMouseDragBegin(x, y);
+                            OnMouseDragBegin(location.X, location.Y);
                         }
                         else if (button == MouseButtons.Right)
                         {
@@ -2003,19 +1996,19 @@ namespace System.Windows.Forms.Design
                                 SelectionTypes.Primary);
                         }
 
-                        _lastMoveScreenX = x;
-                        _lastMoveScreenY = y;
+                        _lastMoveScreenX = location.X;
+                        _lastMoveScreenY = location.Y;
                     }
 
                     break;
 
                 case User32.WM.NCMOUSEMOVE:
                 case User32.WM.MOUSEMOVE:
-                    if ((unchecked((User32.MK)(long)m.WParam) & User32.MK.LBUTTON) != 0)
+                    if (((User32.MK)m._WParam).HasFlag(User32.MK.LBUTTON))
                     {
                         button = MouseButtons.Left;
                     }
-                    else if ((unchecked((User32.MK)(long)m.WParam) & User32.MK.RBUTTON) != 0)
+                    else if (((User32.MK)m._WParam).HasFlag(User32.MK.RBUTTON))
                     {
                         button = MouseButtons.Right;
                         _toolPassThrough = false;
@@ -2025,34 +2018,34 @@ namespace System.Windows.Forms.Design
                         _toolPassThrough = false;
                     }
 
-                    if (_lastMoveScreenX != x || _lastMoveScreenY != y)
+                    if (_lastMoveScreenX != location.X || _lastMoveScreenY != location.Y)
                     {
                         if (_toolPassThrough)
                         {
                             User32.SendMessageW(
                                 Control.Parent.Handle,
-                                (User32.WM)m.Msg,
-                                m.WParam,
-                                GetParentPointFromLparam(m.LParam));
+                                m._Msg,
+                                m._WParam,
+                                GetParentPointFromLparam(m._LParam));
                             return;
                         }
 
-                        if (mouseHandler != null)
+                        if (mouseHandler is not null)
                         {
-                            mouseHandler.OnMouseMove(Component, x, y);
+                            mouseHandler.OnMouseMove(Component, location.X, location.Y);
                         }
                         else if (button == MouseButtons.Left)
                         {
-                            OnMouseDragMove(x, y);
+                            OnMouseDragMove(location.X, location.Y);
                         }
                     }
 
-                    _lastMoveScreenX = x;
-                    _lastMoveScreenY = y;
+                    _lastMoveScreenX = location.X;
+                    _lastMoveScreenY = location.Y;
 
                     // We eat WM_NCMOUSEMOVE messages, since we don't want the non-client area/ of design time
                     // controls to repaint on mouse move.
-                    if (m.Msg == (int)User32.WM.MOUSEMOVE)
+                    if (m._Msg == User32.WM.MOUSEMOVE)
                     {
                         BaseWndProc(ref m);
                     }
@@ -2063,12 +2056,12 @@ namespace System.Windows.Forms.Design
                 case User32.WM.NCRBUTTONUP:
                 case User32.WM.RBUTTONUP:
                     // This is implemented on the base designer for UI activation support.
-                    button = m.Msg == (int)User32.WM.NCRBUTTONUP || m.Msg == (int)User32.WM.RBUTTONUP
+                    button = m._Msg == User32.WM.NCRBUTTONUP || m._Msg == User32.WM.RBUTTONUP
                         ? MouseButtons.Right
                         : MouseButtons.Left;
 
                     // And terminate the drag.
-                    if (mouseHandler != null)
+                    if (mouseHandler is not null)
                     {
                         mouseHandler.OnMouseUp(Component, button);
                     }
@@ -2078,9 +2071,9 @@ namespace System.Windows.Forms.Design
                         {
                             User32.SendMessageW(
                                 Control.Parent.Handle,
-                                (User32.WM)m.Msg,
-                                m.WParam,
-                                GetParentPointFromLparam(m.LParam));
+                                m._Msg,
+                                m._WParam,
+                                GetParentPointFromLparam(m._LParam));
                             _toolPassThrough = false;
                             return;
                         }
@@ -2097,7 +2090,7 @@ namespace System.Windows.Forms.Design
                     break;
                 case User32.WM.PRINTCLIENT:
                     {
-                        using Graphics g = Graphics.FromHdc(m.WParam);
+                        using Graphics g = Graphics.FromHdc(m._WParam);
                         using PaintEventArgs e = new PaintEventArgs(g, Control.ClientRectangle);
                         DefWndProc(ref m);
                         OnPaintAdornments(e);
@@ -2266,32 +2259,29 @@ namespace System.Windows.Forms.Design
                     // We handle this in addition to a right mouse button. Why?  Because we often eat the right mouse
                     // button, so it may never generate a WM_CONTEXTMENU.  However, the system may generate one in
                     // response to an F-10.
-                    x = PARAM.SignedLOWORD(m.LParam);
-                    y = PARAM.SignedHIWORD(m.LParam);
+                    location = PARAM.ToPoint(m._LParam);
 
-                    bool handled = GetService<ToolStripKeyboardHandlingService>()?.OnContextMenu(x, y) ?? false;
+                    bool handled = GetService<ToolStripKeyboardHandlingService>()?.OnContextMenu(location.X, location.Y) ?? false;
 
                     if (!handled)
                     {
-                        if (x == -1 && y == -1)
+                        if (location.X == -1 && location.Y == -1)
                         {
-                            // for shift-F10
-                            Point p = Cursor.Position;
-                            x = p.X;
-                            y = p.Y;
+                            // For shift-F10.
+                            location = Cursor.Position;
                         }
 
-                        OnContextMenu(x, y);
+                        OnContextMenu(location.X, location.Y);
                     }
 
                     break;
                 default:
-                    if (m.Msg == (int)User32.RegisteredMessage.WM_MOUSEENTER)
+                    if (m._Msg == User32.RegisteredMessage.WM_MOUSEENTER)
                     {
                         OnMouseEnter();
                         BaseWndProc(ref m);
                     }
-                    else if (m.Msg < (int)User32.WM.KEYFIRST || m.Msg > (int)User32.WM.KEYLAST)
+                    else if (m._Msg < User32.WM.KEYFIRST || m._Msg > User32.WM.KEYLAST)
                     {
                         // We eat all key handling to the control.  Controls generally should not be getting focus
                         // anyway, so this shouldn't happen. However, we want to prevent this as much as possible.
@@ -2380,14 +2370,14 @@ namespace System.Windows.Forms.Design
 
         private IOverlayService OverlayService => _overlayService ??= GetService<IOverlayService>();
 
-        private bool IsMouseMessage(int msg)
+        private bool IsMouseMessage(User32.WM msg)
         {
-            if (msg >= (int)User32.WM.MOUSEFIRST && msg <= (int)User32.WM.MOUSELAST)
+            if (msg >= User32.WM.MOUSEFIRST && msg <= User32.WM.MOUSELAST)
             {
                 return true;
             }
 
-            switch ((User32.WM)msg)
+            switch (msg)
             {
                 // WM messages not covered by the above block
                 case User32.WM.MOUSEHOVER:
@@ -2462,9 +2452,9 @@ namespace System.Windows.Forms.Design
             }
         }
 
-        private int GetParentPointFromLparam(IntPtr lParam)
+        private nint GetParentPointFromLparam(nint lParam)
         {
-            Point pt = new Point(PARAM.SignedLOWORD(lParam), PARAM.SignedHIWORD(lParam));
+            Point pt = PARAM.ToPoint(lParam);
             pt = Control.PointToScreen(pt);
             pt = Control.Parent.PointToClient(pt);
             return PARAM.ToInt(pt.X, pt.Y);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
@@ -105,8 +105,8 @@ namespace System.Windows.Forms.Design
         {
             if (_designer != null && _designer.IsHandleCreated)
             {
-                User32.SendMessageW(_designer.Handle, User32.WM.NCACTIVATE, PARAM.FromBool(focus));
-                User32.RedrawWindow(_designer.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
+                User32.SendMessageW(_designer.Handle, User32.WM.NCACTIVATE, (nint)focus.ToBOOL());
+                User32.RedrawWindow(_designer.Handle, flags: User32.RDW.FRAME);
             }
         }
 
@@ -207,7 +207,7 @@ namespace System.Windows.Forms.Design
                     if (!_designerRegion._messageMouseWheelProcessed)
                     {
                         _designerRegion._messageMouseWheelProcessed = true;
-                        User32.SendMessageW(_designerRegion.Handle, User32.WM.MOUSEWHEEL, m.WParam, m.LParam);
+                        User32.SendMessageW(_designerRegion.Handle, User32.WM.MOUSEWHEEL, m._WParam, m._LParam);
                         return;
                     }
 
@@ -216,8 +216,8 @@ namespace System.Windows.Forms.Design
                 case User32.WM.KEYDOWN:
                     User32.SBV wScrollNotify = 0;
                     User32.WM msg = User32.WM.NULL;
-                    int keycode = unchecked((int)(long)m.WParam) & 0xFFFF;
-                    switch ((Keys)keycode)
+                    Keys keycode = (Keys)(m._WParam & 0xFFFF);
+                    switch (keycode)
                     {
                         case Keys.Up:
                             wScrollNotify = User32.SBV.LINEUP;
@@ -262,7 +262,7 @@ namespace System.Windows.Forms.Design
 
                     break;
                 case User32.WM.CONTEXTMENU:
-                    User32.SendMessageW(_designer.Handle, (User32.WM)m.Msg, m.WParam, m.LParam);
+                    User32.SendMessageW(_designer.Handle, m._Msg, m._WParam, m._LParam);
                     return;
             }
 
@@ -562,14 +562,14 @@ namespace System.Windows.Forms.Design
             protected override void WndProc(ref Message m)
             {
                 base.WndProc(ref m);
-                if (m.Msg == (int)User32.WM.PARENTNOTIFY && PARAM.LOWORD(m.WParam) == (short)User32.WM.CREATE)
+                if (m._Msg == User32.WM.PARENTNOTIFY && (User32.WM)PARAM.LOWORD(m._WParam) == User32.WM.CREATE)
                 {
                     if (_overlayList != null)
                     {
                         bool ourWindow = false;
                         foreach (Control c in _overlayList)
                         {
-                            if (c.IsHandleCreated && m.LParam == c.Handle)
+                            if (c.IsHandleCreated && m._LParam == c.Handle)
                             {
                                 ourWindow = true;
                                 break;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
@@ -1209,7 +1209,7 @@ namespace System.Windows.Forms.Design
             if (control is not null && control.IsHandleCreated)
             {
                 User32.SendMessageW(control.Handle, User32.WM.NCACTIVATE, (nint)BOOL.FALSE);
-                User32.RedrawWindow(control.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
+                User32.RedrawWindow(control.Handle, flags: User32.RDW.FRAME);
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormDocumentDesigner.cs
@@ -380,7 +380,7 @@ namespace System.Windows.Forms.Design
             if (control != null && control.IsHandleCreated)
             {
                 User32.SendMessageW(control.Handle, User32.WM.NCACTIVATE, (nint)BOOL.TRUE);
-                User32.RedrawWindow(control.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
+                User32.RedrawWindow(control.Handle, flags: User32.RDW.FRAME);
             }
         }
 
@@ -393,7 +393,7 @@ namespace System.Windows.Forms.Design
             if (control != null && control.IsHandleCreated)
             {
                 User32.SendMessageW(control.Handle, User32.WM.NCACTIVATE, (nint)BOOL.FALSE);
-                User32.RedrawWindow(control.Handle, null, IntPtr.Zero, User32.RDW.FRAME);
+                User32.RedrawWindow(control.Handle, flags: User32.RDW.FRAME);
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/GroupBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/GroupBoxDesigner.cs
@@ -109,16 +109,13 @@ namespace System.Windows.Forms.Design
             switch (m.Msg)
             {
                 case (int)User32.WM.NCHITTEST:
-                    // The group box always fires HTTRANSPARENT, which
-                    // causes the message to go to our parent.  We want
-                    // the group box's designer to get these messages, however,
-                    // so change this.
-                    //
+                    // The group box always fires HTTRANSPARENT, which causes the message to go to our parent.  We want
+                    // the group box's designer to get these messages, however, so change this.
                     base.WndProc(ref m);
 
-                    if (unchecked((int)(long)m.Result) == (int)User32.HT.TRANSPARENT)
+                    if (m._Result == (int)User32.HT.TRANSPARENT)
                     {
-                        m.Result = (IntPtr)User32.HT.CLIENT;
+                        m._Result = (nint)User32.HT.CLIENT;
                     }
 
                     break;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ListViewDesigner.cs
@@ -135,7 +135,7 @@ namespace System.Windows.Forms.Design
             {
                 case (int)User32.WM.NOTIFY:
                 case (int)User32.WM.REFLECT_NOTIFY:
-                    User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+                    User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
                     if (nmhdr->code == (int)ComCtl32.HDN.ENDTRACKW)
                     {
                         // Re-codegen if the columns have been resized

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PbrsForward.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PbrsForward.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -121,22 +121,22 @@ namespace System.Windows.Forms.Design
                     {
                         foreach (BufferedKey bk in bufferedChars)
                         {
-                            if (bk.KeyChar.Msg == (int)User32.WM.CHAR)
+                            if (bk.KeyChar._Msg == User32.WM.CHAR)
                             {
-                                if (bk.KeyDown.Msg != 0)
+                                if (bk.KeyDown._Msg != 0)
                                 {
-                                    User32.SendMessageW(hWnd, User32.WM.KEYDOWN, bk.KeyDown.WParam, bk.KeyDown.LParam);
+                                    User32.SendMessageW(hWnd, User32.WM.KEYDOWN, bk.KeyDown._WParam, bk.KeyDown._LParam);
                                 }
 
-                                User32.SendMessageW(hWnd, User32.WM.CHAR, bk.KeyChar.WParam, bk.KeyChar.LParam);
-                                if (bk.KeyUp.Msg != 0)
+                                User32.SendMessageW(hWnd, User32.WM.CHAR, bk.KeyChar._WParam, bk.KeyChar._LParam);
+                                if (bk.KeyUp._Msg != 0)
                                 {
-                                    User32.SendMessageW(hWnd, User32.WM.KEYUP, bk.KeyUp.WParam, bk.KeyUp.LParam);
+                                    User32.SendMessageW(hWnd, User32.WM.KEYUP, bk.KeyUp._WParam, bk.KeyUp._LParam);
                                 }
                             }
                             else
                             {
-                                User32.SendMessageW(hWnd, (User32.WM)bk.KeyChar.Msg, bk.KeyChar.WParam, bk.KeyChar.LParam);
+                                User32.SendMessageW(hWnd, bk.KeyChar._Msg, bk.KeyChar._WParam, bk.KeyChar._LParam);
                             }
                         }
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
@@ -283,10 +283,10 @@ namespace System.Windows.Forms.Design
             /// </summary>
             protected override void WndProc(ref Message m)
             {
-                switch ((User32.WM)m.Msg)
+                switch (m._Msg)
                 {
                     case User32.WM.NCHITTEST:
-                        m.Result = (IntPtr)User32.HT.TRANSPARENT;
+                        m._Result = (nint)User32.HT.TRANSPARENT;
                         break;
                     default:
                         base.WndProc(ref m);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -2547,10 +2547,7 @@ namespace System.Windows.Forms.Design
             switch ((User32.WM)m.Msg)
             {
                 case User32.WM.CONTEXTMENU:
-                    int x = PARAM.SignedLOWORD(m.LParam);
-                    int y = PARAM.SignedHIWORD(m.LParam);
-                    bool inBounds = GetHitTest(new Point(x, y));
-                    if (inBounds)
+                    if (GetHitTest(PARAM.ToPoint(m._LParam)))
                     {
                         return;
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
@@ -1580,14 +1580,14 @@ namespace System.Windows.Forms.Design
             /// </summary>
             protected override void WndProc(ref Message m)
             {
-                switch ((User32.WM)m.Msg)
+                switch (m._Msg)
                 {
                     case User32.WM.KILLFOCUS:
                         base.WndProc(ref m);
-                        IntPtr focussedWindow = m.WParam;
-                        if (!IsParentWindow(focussedWindow))
+                        IntPtr focusedWindow = m._WParam;
+                        if (!IsParentWindow(focusedWindow))
                         {
-                            owner.Commit(false, false);
+                            owner.Commit(enterKeyPressed: false, tabKeyPressed: false);
                         }
 
                         break;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateBrushScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.CreateBrushScope.cs
@@ -48,7 +48,7 @@ internal static partial class Interop
                 if (!HBrush.IsNull)
                 {
                     // Note that this is a no-op if the original brush was a system brush
-                    DeleteObject(HBrush);
+                    DeleteObject((HGDIOBJ)HBrush);
                 }
 
 #if DEBUG

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.DeleteObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.DeleteObject.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
     internal static partial class Gdi32
     {
         [DllImport(Libraries.Gdi32, ExactSpelling = true)]
-        private static extern BOOL DeleteObject(IntPtr hObject);
+        private static extern BOOL DeleteObject(nint hObject);
 
         public static BOOL DeleteObject(HGDIOBJ hObject) => DeleteObject(hObject.Handle);
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.HBRUSH.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.HBRUSH.cs
@@ -8,16 +8,16 @@ internal static partial class Interop
     {
         public readonly struct HBRUSH
         {
-            public IntPtr Handle { get; }
+            public nint Handle { get; }
 
-            public HBRUSH(IntPtr handle) => Handle = handle;
+            public HBRUSH(nint handle) => Handle = handle;
 
-            public bool IsNull => Handle == IntPtr.Zero;
+            public bool IsNull => Handle == 0;
 
-            public static explicit operator IntPtr(HBRUSH hbrush) => hbrush.Handle;
-            public static explicit operator HBRUSH(IntPtr hbrush) => new HBRUSH(hbrush);
-            public static implicit operator HGDIOBJ(HBRUSH hbrush) => new HGDIOBJ(hbrush.Handle);
-            public static explicit operator HBRUSH(HGDIOBJ hbrush) => new HBRUSH(hbrush.Handle);
+            public static implicit operator nint(HBRUSH hbrush) => hbrush.Handle;
+            public static explicit operator HBRUSH(nint hbrush) => new(hbrush);
+            public static implicit operator HGDIOBJ(HBRUSH hbrush) => new(hbrush.Handle);
+            public static explicit operator HBRUSH(HGDIOBJ hbrush) => new(hbrush.Handle);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.HGDIOBJ.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Gdi32/Interop.HGDIOBJ.cs
@@ -8,14 +8,14 @@ internal static partial class Interop
     {
         public struct HGDIOBJ
         {
-            public IntPtr Handle { get; }
+            public nint Handle { get; }
 
-            public HGDIOBJ(IntPtr handle) => Handle = handle;
+            public HGDIOBJ(nint handle) => Handle = handle;
 
-            public bool IsNull => Handle == IntPtr.Zero;
+            public bool IsNull => Handle == 0;
 
-            public static explicit operator IntPtr(HGDIOBJ hgdiobj) => hgdiobj.Handle;
-            public static explicit operator HGDIOBJ(IntPtr hgdiobj) => new HGDIOBJ(hgdiobj);
+            public static explicit operator nint(HGDIOBJ hgdiobj) => hgdiobj.Handle;
+            public static explicit operator HGDIOBJ(nint hgdiobj) => new(hgdiobj);
 
             public static bool operator ==(HGDIOBJ value1, HGDIOBJ value2) => value1.Handle == value2.Handle;
             public static bool operator !=(HGDIOBJ value1, HGDIOBJ value2) => value1.Handle != value2.Handle;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Interop.PARAM.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+
 internal partial class Interop
 {
     /// <summary>
@@ -9,8 +11,7 @@ internal partial class Interop
     /// </summary>
     internal static class PARAM
     {
-        public static nint FromLowHigh(int low, int high)
-            => (nint)ToInt(low, high);
+        public static nint FromLowHigh(int low, int high) => ToInt(low, high);
 
         public static nint FromLowHighUnsigned(int low, int high)
             // Convert the int to an uint before converting it to a pointer type,
@@ -29,13 +30,13 @@ internal partial class Interop
             => n & 0xffff;
 
         public static int LOWORD(nint n)
-            => LOWORD(unchecked((int)n));
+            => LOWORD((int)n);
 
         public static int HIWORD(nint n)
-            => HIWORD(unchecked((int)n));
+            => HIWORD((int)n);
 
         public static int SignedHIWORD(nint n)
-            => SignedHIWORD(unchecked((int)n));
+            => SignedHIWORD((int)n);
 
         public static int SignedLOWORD(nint n)
             => SignedLOWORD(unchecked((int)n));
@@ -58,5 +59,17 @@ internal partial class Interop
         ///  Hard casts to <see langword="uint" /> without bounds checks.
         /// </summary>
         public static uint ToUInt(nint param) => (uint)param;
+
+        /// <summary>
+        ///  Packs a <see cref="Point"/> into a PARAM.
+        /// </summary>
+        public static nint FromPoint(Point point)
+            => PARAM.FromLowHigh(point.X, point.Y);
+
+        /// <summary>
+        ///  Unpacks a <see cref="Point"/> from a PARAM.
+        /// </summary>
+        public static Point ToPoint(nint param)
+            => new(SignedLOWORD(param), SignedHIWORD(param));
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Oleacc/Interop.LresultFromObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Oleacc/Interop.LresultFromObject.cs
@@ -9,11 +9,11 @@ internal static partial class Interop
     internal static partial class Oleacc
     {
         [DllImport(Libraries.Oleacc, ExactSpelling = true)]
-        public static extern IntPtr LresultFromObject(ref Guid refiid, IntPtr wParam, IntPtr pAcc);
+        public static extern nint LresultFromObject(ref Guid refiid, nint wParam, IntPtr pAcc);
 
-        public static IntPtr LresultFromObject(ref Guid refiid, IntPtr wParam, HandleRef pAcc)
+        public static nint LresultFromObject(ref Guid refiid, nint wParam, HandleRef pAcc)
         {
-            IntPtr result = LresultFromObject(ref refiid, wParam, pAcc.Handle);
+            nint result = LresultFromObject(ref refiid, wParam, pAcc.Handle);
             GC.KeepAlive(pAcc.Wrapper);
             return result;
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UiaReturnRawElementProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UiaReturnRawElementProvider.cs
@@ -9,12 +9,12 @@ internal partial class Interop
     internal static partial class UiaCore
     {
         [DllImport(Libraries.UiaCore, CharSet = CharSet.Unicode)]
-        public static extern IntPtr UiaReturnRawElementProvider(IntPtr hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple el);
+        public static extern nint UiaReturnRawElementProvider(IntPtr hwnd, nint wParam, nint lParam, IRawElementProviderSimple el);
 
-        public static IntPtr UiaReturnRawElementProvider(HandleRef hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple el)
+        public static nint UiaReturnRawElementProvider(IHandle hwnd, nint wParam, nint lParam, IRawElementProviderSimple el)
         {
-            IntPtr result = UiaReturnRawElementProvider(hwnd.Handle, wParam, lParam, el);
-            GC.KeepAlive(hwnd.Wrapper);
+            nint result = UiaReturnRawElementProvider(hwnd.Handle, wParam, lParam, el);
+            GC.KeepAlive(hwnd);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CallNextHookEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CallNextHookEx.cs
@@ -9,13 +9,6 @@ internal static partial class Interop
     internal static partial class User32
     {
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr CallNextHookEx(IntPtr hhook, User32.HC nCode, IntPtr wparam, IntPtr lparam);
-
-        public static IntPtr CallNextHookEx(HandleRef hhook, User32.HC nCode, IntPtr wparam, IntPtr lparam)
-        {
-            IntPtr result = CallNextHookEx(hhook.Handle, nCode, wparam, lparam);
-            GC.KeepAlive(hhook.Wrapper);
-            return result;
-        }
+        public static extern nint CallNextHookEx(IntPtr hhook, User32.HC nCode, nint wparam, nint lparam);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CallWindowProcW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CallWindowProcW.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
             IntPtr wndProc,
             IntPtr hWnd,
             WM msg,
-            IntPtr wParam,
-            IntPtr lParam);
+            nint wParam,
+            nint lParam);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.HOOKPROC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.HOOKPROC.cs
@@ -6,6 +6,6 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        public delegate IntPtr HOOKPROC(User32.HC nCode, IntPtr wParam, IntPtr lParam);
+        public delegate nint HOOKPROC(HC nCode, nint wParam, nint lParam);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MSG.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MSG.cs
@@ -15,16 +15,16 @@ internal static partial class Interop
         {
             public IntPtr hwnd;
             public WM message;
-            public IntPtr wParam;
-            public IntPtr lParam;
+            public nint wParam;
+            public nint lParam;
             public uint time;
             public Point pt;
 
             public static implicit operator Message(MSG msg)
-                => new Message { HWnd = msg.hwnd, Msg = (int)msg.message, WParam = msg.wParam, LParam = msg.lParam };
+                => new Message { HWnd = msg.hwnd, Msg = (int)msg.message, _WParam = msg.wParam, _LParam = msg.lParam };
 
             public static implicit operator MSG(Message message)
-                => new MSG { hwnd = message.HWnd, message = (WM)message.Msg, wParam = message.WParam, lParam = message.LParam };
+                => new MSG { hwnd = message.HWnd, message = message._Msg, wParam = message._WParam, lParam = message._LParam };
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.RDW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.RDW.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        /// <summary>
+        ///  <see cref="RedrawWindow(IntPtr, RECT*, Gdi32.HRGN, RDW)"/> flags.
+        /// </summary>
+        [Flags]
+        public enum RDW : uint
+        {
+            INVALIDATE = 0x0001,
+            INTERNALPAINT = 0x0002,
+            ERASE = 0x0004,
+            VALIDATE = 0x0008,
+            NOINTERNALPAINT = 0x0010,
+            NOERASE = 0x0020,
+            NOCHILDREN = 0x0040,
+            ALLCHILDREN = 0x0080,
+            UPDATENOW = 0x0100,
+            ERASENOW = 0x0200,
+            FRAME = 0x0400,
+            NOFRAME = 0x0800,
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.RedrawWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.RedrawWindow.cs
@@ -8,37 +8,14 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        /// <summary>
-        ///  <see cref="RedrawWindow(IntPtr, RECT*, IntPtr, RDW)"/> flags.
-        /// </summary>
-        [Flags]
-        public enum RDW : uint
-        {
-            INVALIDATE = 0x0001,
-            INTERNALPAINT = 0x0002,
-            ERASE = 0x0004,
-            VALIDATE = 0x0008,
-            NOINTERNALPAINT = 0x0010,
-            NOERASE = 0x0020,
-            NOCHILDREN = 0x0040,
-            ALLCHILDREN = 0x0080,
-            UPDATENOW = 0x0100,
-            ERASENOW = 0x0200,
-            FRAME = 0x0400,
-            NOFRAME = 0x0800,
-        }
-
         [DllImport(Libraries.User32, ExactSpelling = true)]
-        public unsafe static extern BOOL RedrawWindow(IntPtr hWnd, RECT* lprcUpdate, IntPtr hrgnUpdate, RDW flags);
+        public unsafe static extern BOOL RedrawWindow(IntPtr hWnd, RECT* lprcUpdate = default, Gdi32.HRGN hrgnUpdate = default, RDW flags = default);
 
-        public unsafe static BOOL RedrawWindow(HandleRef hWnd, RECT* lprcUpdate, IntPtr hrgnUpdate, RDW flags)
+        public unsafe static BOOL RedrawWindow(IHandle hWnd, RECT* lprcUpdate = default, Gdi32.HRGN hrgnUpdate = default, RDW flags = default)
         {
             BOOL result = RedrawWindow(hWnd.Handle, lprcUpdate, hrgnUpdate, flags);
-            GC.KeepAlive(hWnd.Wrapper);
+            GC.KeepAlive(hWnd);
             return result;
         }
-
-        public unsafe static BOOL RedrawWindow(HandleRef hWnd, RECT* lprcUpdate, Gdi32.HRGN hrgnUpdate, RDW flags)
-            => RedrawWindow(hWnd, lprcUpdate, hrgnUpdate.Handle, flags);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowPos.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowPos.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
             int y = 0,
             int cx = 0,
             int cy = 0,
-            SWP flags = (SWP)0);
+            SWP flags = default);
 
         public static BOOL SetWindowPos(
             HandleRef hWnd,
@@ -31,7 +31,7 @@ internal static partial class Interop
             int y = 0,
             int cx = 0,
             int cy = 0,
-            SWP flags = (SWP)0)
+            SWP flags = default)
         {
             BOOL result = SetWindowPos(hWnd.Handle, hWndInsertAfter, x, y, cx, cy, flags);
             GC.KeepAlive(hWnd.Wrapper);
@@ -39,17 +39,16 @@ internal static partial class Interop
         }
 
         public static BOOL SetWindowPos(
-            HandleRef hWnd,
-            HandleRef hWndInsertAfter,
+            IHandle hWnd,
+            IntPtr hWndInsertAfter,
             int x = 0,
             int y = 0,
             int cx = 0,
             int cy = 0,
-            SWP flags = (SWP)0)
+            SWP flags = default)
         {
-            BOOL result = SetWindowPos(hWnd.Handle, hWndInsertAfter.Handle, x, y, cx, cy, flags);
-            GC.KeepAlive(hWnd.Wrapper);
-            GC.KeepAlive(hWndInsertAfter.Wrapper);
+            BOOL result = SetWindowPos(hWnd.Handle, hWndInsertAfter, x, y, cx, cy, flags);
+            GC.KeepAlive(hWnd);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/MessageDecoder.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/MessageDecoder.cs
@@ -319,8 +319,7 @@ namespace System.Windows.Forms
                 lDescription = Parenthesize(MsgToString((User32.WM)PARAM.LOWORD(wparam)));
             }
 
-            return @$"msg=0x{(uint)msg:x}{id} hwnd=0x{(long)hWnd:x)} wparam
-                =0x{wparam:x} lparam=0x{lparam:x}{lDescription} result=0x{result:x}";
+            return $@"msg=0x{(uint)msg:x}{id} hwnd=0x{(long)hWnd:x} wparam=0x{wparam:x} lparam=0x{lparam:x}{lDescription} result=0x{result:x}";
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/MessageDecoder.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/MessageDecoder.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using static Interop;
-using static Interop.User32;
 
 namespace System.Windows.Forms
 {
@@ -17,859 +16,311 @@ namespace System.Windows.Forms
         ///  Returns the symbolic name of the msg value, or null if it isn't one of the
         ///  existing constants.
         /// </summary>
-        private static string? MsgToString(int msg)
+        private static string? MsgToString(User32.WM msg)
         {
-            string? text;
-            switch (msg)
+            string? text = msg switch
             {
-                case (int)WM.NULL:
-                    text = "WM_NULL";
-                    break;
-                case (int)WM.CREATE:
-                    text = "WM_CREATE";
-                    break;
-                case (int)WM.DESTROY:
-                    text = "WM_DESTROY";
-                    break;
-                case (int)WM.MOVE:
-                    text = "WM_MOVE";
-                    break;
-                case (int)WM.SIZE:
-                    text = "WM_SIZE";
-                    break;
-                case (int)WM.ACTIVATE:
-                    text = "WM_ACTIVATE";
-                    break;
-                case (int)WM.SETFOCUS:
-                    text = "WM_SETFOCUS";
-                    break;
-                case (int)WM.KILLFOCUS:
-                    text = "WM_KILLFOCUS";
-                    break;
-                case (int)WM.ENABLE:
-                    text = "WM_ENABLE";
-                    break;
-                case (int)WM.SETREDRAW:
-                    text = "WM_SETREDRAW";
-                    break;
-                case (int)WM.SETTEXT:
-                    text = "WM_SETTEXT";
-                    break;
-                case (int)WM.GETTEXT:
-                    text = "WM_GETTEXT";
-                    break;
-                case (int)WM.GETTEXTLENGTH:
-                    text = "WM_GETTEXTLENGTH";
-                    break;
-                case (int)WM.PAINT:
-                    text = "WM_PAINT";
-                    break;
-                case (int)WM.CLOSE:
-                    text = "WM_CLOSE";
-                    break;
-                case (int)WM.QUERYENDSESSION:
-                    text = "WM_QUERYENDSESSION";
-                    break;
-                case (int)WM.QUIT:
-                    text = "WM_QUIT";
-                    break;
-                case (int)WM.QUERYOPEN:
-                    text = "WM_QUERYOPEN";
-                    break;
-                case (int)WM.ERASEBKGND:
-                    text = "WM_ERASEBKGND";
-                    break;
-                case (int)WM.SYSCOLORCHANGE:
-                    text = "WM_SYSCOLORCHANGE";
-                    break;
-                case (int)WM.ENDSESSION:
-                    text = "WM_ENDSESSION";
-                    break;
-                case (int)WM.SHOWWINDOW:
-                    text = "WM_SHOWWINDOW";
-                    break;
-                case (int)WM.WININICHANGE:
-                    text = "WM_WININICHANGE";
-                    break;
-                case (int)WM.DEVMODECHANGE:
-                    text = "WM_DEVMODECHANGE";
-                    break;
-                case (int)WM.ACTIVATEAPP:
-                    text = "WM_ACTIVATEAPP";
-                    break;
-                case (int)WM.FONTCHANGE:
-                    text = "WM_FONTCHANGE";
-                    break;
-                case (int)WM.TIMECHANGE:
-                    text = "WM_TIMECHANGE";
-                    break;
-                case (int)WM.CANCELMODE:
-                    text = "WM_CANCELMODE";
-                    break;
-                case (int)WM.SETCURSOR:
-                    text = "WM_SETCURSOR";
-                    break;
-                case (int)WM.MOUSEACTIVATE:
-                    text = "WM_MOUSEACTIVATE";
-                    break;
-                case (int)WM.CHILDACTIVATE:
-                    text = "WM_CHILDACTIVATE";
-                    break;
-                case (int)WM.QUEUESYNC:
-                    text = "WM_QUEUESYNC";
-                    break;
-                case (int)WM.GETMINMAXINFO:
-                    text = "WM_GETMINMAXINFO";
-                    break;
-                case (int)WM.PAINTICON:
-                    text = "WM_PAINTICON";
-                    break;
-                case (int)WM.ICONERASEBKGND:
-                    text = "WM_ICONERASEBKGND";
-                    break;
-                case (int)WM.NEXTDLGCTL:
-                    text = "WM_NEXTDLGCTL";
-                    break;
-                case (int)WM.SPOOLERSTATUS:
-                    text = "WM_SPOOLERSTATUS";
-                    break;
-                case (int)WM.DRAWITEM:
-                    text = "WM_DRAWITEM";
-                    break;
-                case (int)WM.MEASUREITEM:
-                    text = "WM_MEASUREITEM";
-                    break;
-                case (int)WM.DELETEITEM:
-                    text = "WM_DELETEITEM";
-                    break;
-                case (int)WM.VKEYTOITEM:
-                    text = "WM_VKEYTOITEM";
-                    break;
-                case (int)WM.CHARTOITEM:
-                    text = "WM_CHARTOITEM";
-                    break;
-                case (int)WM.SETFONT:
-                    text = "WM_SETFONT";
-                    break;
-                case (int)WM.GETFONT:
-                    text = "WM_GETFONT";
-                    break;
-                case (int)WM.SETHOTKEY:
-                    text = "WM_SETHOTKEY";
-                    break;
-                case (int)WM.GETHOTKEY:
-                    text = "WM_GETHOTKEY";
-                    break;
-                case (int)WM.QUERYDRAGICON:
-                    text = "WM_QUERYDRAGICON";
-                    break;
-                case (int)WM.COMPAREITEM:
-                    text = "WM_COMPAREITEM";
-                    break;
-                case (int)WM.GETOBJECT:
-                    text = "WM_GETOBJECT";
-                    break;
-                case (int)WM.COMPACTING:
-                    text = "WM_COMPACTING";
-                    break;
-                case (int)WM.COMMNOTIFY:
-                    text = "WM_COMMNOTIFY";
-                    break;
-                case (int)WM.WINDOWPOSCHANGING:
-                    text = "WM_WINDOWPOSCHANGING";
-                    break;
-                case (int)WM.WINDOWPOSCHANGED:
-                    text = "WM_WINDOWPOSCHANGED";
-                    break;
-                case (int)WM.POWER:
-                    text = "WM_POWER";
-                    break;
-                case (int)WM.COPYDATA:
-                    text = "WM_COPYDATA";
-                    break;
-                case (int)WM.CANCELJOURNAL:
-                    text = "WM_CANCELJOURNAL";
-                    break;
-                case (int)WM.NOTIFY:
-                    text = "WM_NOTIFY";
-                    break;
-                case (int)WM.INPUTLANGCHANGEREQUEST:
-                    text = "WM_INPUTLANGCHANGEREQUEST";
-                    break;
-                case (int)WM.INPUTLANGCHANGE:
-                    text = "WM_INPUTLANGCHANGE";
-                    break;
-                case (int)WM.TCARD:
-                    text = "WM_TCARD";
-                    break;
-                case (int)WM.HELP:
-                    text = "WM_HELP";
-                    break;
-                case (int)WM.USERCHANGED:
-                    text = "WM_USERCHANGED";
-                    break;
-                case (int)WM.NOTIFYFORMAT:
-                    text = "WM_NOTIFYFORMAT";
-                    break;
-                case (int)WM.CONTEXTMENU:
-                    text = "WM_CONTEXTMENU";
-                    break;
-                case (int)WM.STYLECHANGING:
-                    text = "WM_STYLECHANGING";
-                    break;
-                case (int)WM.STYLECHANGED:
-                    text = "WM_STYLECHANGED";
-                    break;
-                case (int)WM.DISPLAYCHANGE:
-                    text = "WM_DISPLAYCHANGE";
-                    break;
-                case (int)WM.GETICON:
-                    text = "WM_GETICON";
-                    break;
-                case (int)WM.SETICON:
-                    text = "WM_SETICON";
-                    break;
-                case (int)WM.NCCREATE:
-                    text = "WM_NCCREATE";
-                    break;
-                case (int)WM.NCDESTROY:
-                    text = "WM_NCDESTROY";
-                    break;
-                case (int)WM.NCCALCSIZE:
-                    text = "WM_NCCALCSIZE";
-                    break;
-                case (int)WM.NCHITTEST:
-                    text = "WM_NCHITTEST";
-                    break;
-                case (int)WM.NCPAINT:
-                    text = "WM_NCPAINT";
-                    break;
-                case (int)WM.NCACTIVATE:
-                    text = "WM_NCACTIVATE";
-                    break;
-                case (int)WM.GETDLGCODE:
-                    text = "WM_GETDLGCODE";
-                    break;
-                case (int)WM.NCMOUSEMOVE:
-                    text = "WM_NCMOUSEMOVE";
-                    break;
-                case (int)WM.NCLBUTTONDOWN:
-                    text = "WM_NCLBUTTONDOWN";
-                    break;
-                case (int)WM.NCLBUTTONUP:
-                    text = "WM_NCLBUTTONUP";
-                    break;
-                case (int)WM.NCLBUTTONDBLCLK:
-                    text = "WM_NCLBUTTONDBLCLK";
-                    break;
-                case (int)WM.NCRBUTTONDOWN:
-                    text = "WM_NCRBUTTONDOWN";
-                    break;
-                case (int)WM.NCRBUTTONUP:
-                    text = "WM_NCRBUTTONUP";
-                    break;
-                case (int)WM.NCRBUTTONDBLCLK:
-                    text = "WM_NCRBUTTONDBLCLK";
-                    break;
-                case (int)WM.NCMBUTTONDOWN:
-                    text = "WM_NCMBUTTONDOWN";
-                    break;
-                case (int)WM.NCMBUTTONUP:
-                    text = "WM_NCMBUTTONUP";
-                    break;
-                case (int)WM.NCMBUTTONDBLCLK:
-                    text = "WM_NCMBUTTONDBLCLK";
-                    break;
-                case (int)WM.KEYDOWN:
-                    text = "WM_KEYDOWN";
-                    break;
-                case (int)WM.KEYUP:
-                    text = "WM_KEYUP";
-                    break;
-                case (int)WM.CHAR:
-                    text = "WM_CHAR";
-                    break;
-                case (int)WM.DEADCHAR:
-                    text = "WM_DEADCHAR";
-                    break;
-                case (int)WM.SYSKEYDOWN:
-                    text = "WM_SYSKEYDOWN";
-                    break;
-                case (int)WM.SYSKEYUP:
-                    text = "WM_SYSKEYUP";
-                    break;
-                case (int)WM.SYSCHAR:
-                    text = "WM_SYSCHAR";
-                    break;
-                case (int)WM.SYSDEADCHAR:
-                    text = "WM_SYSDEADCHAR";
-                    break;
-                case (int)WM.KEYLAST:
-                    text = "WM_KEYLAST";
-                    break;
-                case (int)WM.IME_STARTCOMPOSITION:
-                    text = "WM_IME_STARTCOMPOSITION";
-                    break;
-                case (int)WM.IME_ENDCOMPOSITION:
-                    text = "WM_IME_ENDCOMPOSITION";
-                    break;
-                case (int)WM.IME_COMPOSITION:
-                    text = "WM_IME_COMPOSITION";
-                    break;
-                case (int)WM.INITDIALOG:
-                    text = "WM_INITDIALOG";
-                    break;
-                case (int)WM.COMMAND:
-                    text = "WM_COMMAND";
-                    break;
-                case (int)WM.SYSCOMMAND:
-                    text = "WM_SYSCOMMAND";
-                    break;
-                case (int)WM.TIMER:
-                    text = "WM_TIMER";
-                    break;
-                case (int)WM.HSCROLL:
-                    text = "WM_HSCROLL";
-                    break;
-                case (int)WM.VSCROLL:
-                    text = "WM_VSCROLL";
-                    break;
-                case (int)WM.INITMENU:
-                    text = "WM_INITMENU";
-                    break;
-                case (int)WM.INITMENUPOPUP:
-                    text = "WM_INITMENUPOPUP";
-                    break;
-                case (int)WM.MENUSELECT:
-                    text = "WM_MENUSELECT";
-                    break;
-                case (int)WM.MENUCHAR:
-                    text = "WM_MENUCHAR";
-                    break;
-                case (int)WM.ENTERIDLE:
-                    text = "WM_ENTERIDLE";
-                    break;
-                case (int)WM.CTLCOLORMSGBOX:
-                    text = "WM_CTLCOLORMSGBOX";
-                    break;
-                case (int)WM.CTLCOLOREDIT:
-                    text = "WM_CTLCOLOREDIT";
-                    break;
-                case (int)WM.CTLCOLORLISTBOX:
-                    text = "WM_CTLCOLORLISTBOX";
-                    break;
-                case (int)WM.CTLCOLORBTN:
-                    text = "WM_CTLCOLORBTN";
-                    break;
-                case (int)WM.CTLCOLORDLG:
-                    text = "WM_CTLCOLORDLG";
-                    break;
-                case (int)WM.CTLCOLORSCROLLBAR:
-                    text = "WM_CTLCOLORSCROLLBAR";
-                    break;
-                case (int)WM.CTLCOLORSTATIC:
-                    text = "WM_CTLCOLORSTATIC";
-                    break;
-                case (int)WM.MOUSEMOVE:
-                    text = "WM_MOUSEMOVE";
-                    break;
-                case (int)WM.LBUTTONDOWN:
-                    text = "WM_LBUTTONDOWN";
-                    break;
-                case (int)WM.LBUTTONUP:
-                    text = "WM_LBUTTONUP";
-                    break;
-                case (int)WM.LBUTTONDBLCLK:
-                    text = "WM_LBUTTONDBLCLK";
-                    break;
-                case (int)WM.RBUTTONDOWN:
-                    text = "WM_RBUTTONDOWN";
-                    break;
-                case (int)WM.RBUTTONUP:
-                    text = "WM_RBUTTONUP";
-                    break;
-                case (int)WM.RBUTTONDBLCLK:
-                    text = "WM_RBUTTONDBLCLK";
-                    break;
-                case (int)WM.MBUTTONDOWN:
-                    text = "WM_MBUTTONDOWN";
-                    break;
-                case (int)WM.MBUTTONUP:
-                    text = "WM_MBUTTONUP";
-                    break;
-                case (int)WM.MBUTTONDBLCLK:
-                    text = "WM_MBUTTONDBLCLK";
-                    break;
-                case (int)WM.MOUSEWHEEL:
-                    text = "WM_MOUSEWHEEL";
-                    break;
-                case (int)WM.PARENTNOTIFY:
-                    text = "WM_PARENTNOTIFY";
-                    break;
-                case (int)WM.ENTERMENULOOP:
-                    text = "WM_ENTERMENULOOP";
-                    break;
-                case (int)WM.EXITMENULOOP:
-                    text = "WM_EXITMENULOOP";
-                    break;
-                case (int)WM.NEXTMENU:
-                    text = "WM_NEXTMENU";
-                    break;
-                case (int)WM.SIZING:
-                    text = "WM_SIZING";
-                    break;
-                case (int)WM.CAPTURECHANGED:
-                    text = "WM_CAPTURECHANGED";
-                    break;
-                case (int)WM.MOVING:
-                    text = "WM_MOVING";
-                    break;
-                case (int)WM.POWERBROADCAST:
-                    text = "WM_POWERBROADCAST";
-                    break;
-                case (int)WM.DEVICECHANGE:
-                    text = "WM_DEVICECHANGE";
-                    break;
-                case (int)WM.IME_SETCONTEXT:
-                    text = "WM_IME_SETCONTEXT";
-                    break;
-                case (int)WM.IME_NOTIFY:
-                    text = "WM_IME_NOTIFY";
-                    break;
-                case (int)WM.IME_CONTROL:
-                    text = "WM_IME_CONTROL";
-                    break;
-                case (int)WM.IME_COMPOSITIONFULL:
-                    text = "WM_IME_COMPOSITIONFULL";
-                    break;
-                case (int)WM.IME_SELECT:
-                    text = "WM_IME_SELECT";
-                    break;
-                case (int)WM.IME_CHAR:
-                    text = "WM_IME_CHAR";
-                    break;
-                case (int)WM.IME_KEYDOWN:
-                    text = "WM_IME_KEYDOWN";
-                    break;
-                case (int)WM.IME_KEYUP:
-                    text = "WM_IME_KEYUP";
-                    break;
-                case (int)WM.MDICREATE:
-                    text = "WM_MDICREATE";
-                    break;
-                case (int)WM.MDIDESTROY:
-                    text = "WM_MDIDESTROY";
-                    break;
-                case (int)WM.MDIACTIVATE:
-                    text = "WM_MDIACTIVATE";
-                    break;
-                case (int)WM.MDIRESTORE:
-                    text = "WM_MDIRESTORE";
-                    break;
-                case (int)WM.MDINEXT:
-                    text = "WM_MDINEXT";
-                    break;
-                case (int)WM.MDIMAXIMIZE:
-                    text = "WM_MDIMAXIMIZE";
-                    break;
-                case (int)WM.MDITILE:
-                    text = "WM_MDITILE";
-                    break;
-                case (int)WM.MDICASCADE:
-                    text = "WM_MDICASCADE";
-                    break;
-                case (int)WM.MDIICONARRANGE:
-                    text = "WM_MDIICONARRANGE";
-                    break;
-                case (int)WM.MDIGETACTIVE:
-                    text = "WM_MDIGETACTIVE";
-                    break;
-                case (int)WM.MDISETMENU:
-                    text = "WM_MDISETMENU";
-                    break;
-                case (int)WM.ENTERSIZEMOVE:
-                    text = "WM_ENTERSIZEMOVE";
-                    break;
-                case (int)WM.EXITSIZEMOVE:
-                    text = "WM_EXITSIZEMOVE";
-                    break;
-                case (int)WM.DROPFILES:
-                    text = "WM_DROPFILES";
-                    break;
-                case (int)WM.MDIREFRESHMENU:
-                    text = "WM_MDIREFRESHMENU";
-                    break;
-                case (int)WM.MOUSEHOVER:
-                    text = "WM_MOUSEHOVER";
-                    break;
-                case (int)WM.MOUSELEAVE:
-                    text = "WM_MOUSELEAVE";
-                    break;
-                case (int)WM.CUT:
-                    text = "WM_CUT";
-                    break;
-                case (int)WM.COPY:
-                    text = "WM_COPY";
-                    break;
-                case (int)WM.PASTE:
-                    text = "WM_PASTE";
-                    break;
-                case (int)WM.CLEAR:
-                    text = "WM_CLEAR";
-                    break;
-                case (int)WM.UNDO:
-                    text = "WM_UNDO";
-                    break;
-                case (int)WM.RENDERFORMAT:
-                    text = "WM_RENDERFORMAT";
-                    break;
-                case (int)WM.RENDERALLFORMATS:
-                    text = "WM_RENDERALLFORMATS";
-                    break;
-                case (int)WM.DESTROYCLIPBOARD:
-                    text = "WM_DESTROYCLIPBOARD";
-                    break;
-                case (int)WM.DRAWCLIPBOARD:
-                    text = "WM_DRAWCLIPBOARD";
-                    break;
-                case (int)WM.PAINTCLIPBOARD:
-                    text = "WM_PAINTCLIPBOARD";
-                    break;
-                case (int)WM.VSCROLLCLIPBOARD:
-                    text = "WM_VSCROLLCLIPBOARD";
-                    break;
-                case (int)WM.SIZECLIPBOARD:
-                    text = "WM_SIZECLIPBOARD";
-                    break;
-                case (int)WM.ASKCBFORMATNAME:
-                    text = "WM_ASKCBFORMATNAME";
-                    break;
-                case (int)WM.CHANGECBCHAIN:
-                    text = "WM_CHANGECBCHAIN";
-                    break;
-                case (int)WM.HSCROLLCLIPBOARD:
-                    text = "WM_HSCROLLCLIPBOARD";
-                    break;
-                case (int)WM.QUERYNEWPALETTE:
-                    text = "WM_QUERYNEWPALETTE";
-                    break;
-                case (int)WM.PALETTEISCHANGING:
-                    text = "WM_PALETTEISCHANGING";
-                    break;
-                case (int)WM.PALETTECHANGED:
-                    text = "WM_PALETTECHANGED";
-                    break;
-                case (int)WM.HOTKEY:
-                    text = "WM_HOTKEY";
-                    break;
-                case (int)WM.PRINT:
-                    text = "WM_PRINT";
-                    break;
-                case (int)WM.PRINTCLIENT:
-                    text = "WM_PRINTCLIENT";
-                    break;
-                case (int)WM.HANDHELDFIRST:
-                    text = "WM_HANDHELDFIRST";
-                    break;
-                case (int)WM.HANDHELDLAST:
-                    text = "WM_HANDHELDLAST";
-                    break;
-                case (int)WM.AFXFIRST:
-                    text = "WM_AFXFIRST";
-                    break;
-                case (int)WM.AFXLAST:
-                    text = "WM_AFXLAST";
-                    break;
-                case (int)WM.PENWINFIRST:
-                    text = "WM_PENWINFIRST";
-                    break;
-                case (int)WM.PENWINLAST:
-                    text = "WM_PENWINLAST";
-                    break;
-                case (int)WM.APP:
-                    text = "WM_APP";
-                    break;
-                case (int)WM.USER:
-                    text = "WM_USER";
-                    break;
-                case (int)WM.CTLCOLOR:
-                    text = "WM_CTLCOLOR";
-                    break;
-
+                User32.WM.NULL => "WM_NULL",
+                User32.WM.CREATE => "WM_CREATE",
+                User32.WM.DESTROY => "WM_DESTROY",
+                User32.WM.MOVE => "WM_MOVE",
+                User32.WM.SIZE => "WM_SIZE",
+                User32.WM.ACTIVATE => "WM_ACTIVATE",
+                User32.WM.SETFOCUS => "WM_SETFOCUS",
+                User32.WM.KILLFOCUS => "WM_KILLFOCUS",
+                User32.WM.ENABLE => "WM_ENABLE",
+                User32.WM.SETREDRAW => "WM_SETREDRAW",
+                User32.WM.SETTEXT => "WM_SETTEXT",
+                User32.WM.GETTEXT => "WM_GETTEXT",
+                User32.WM.GETTEXTLENGTH => "WM_GETTEXTLENGTH",
+                User32.WM.PAINT => "WM_PAINT",
+                User32.WM.CLOSE => "WM_CLOSE",
+                User32.WM.QUERYENDSESSION => "WM_QUERYENDSESSION",
+                User32.WM.QUIT => "WM_QUIT",
+                User32.WM.QUERYOPEN => "WM_QUERYOPEN",
+                User32.WM.ERASEBKGND => "WM_ERASEBKGND",
+                User32.WM.SYSCOLORCHANGE => "WM_SYSCOLORCHANGE",
+                User32.WM.ENDSESSION => "WM_ENDSESSION",
+                User32.WM.SHOWWINDOW => "WM_SHOWWINDOW",
+                User32.WM.WININICHANGE => "WM_WININICHANGE",
+                User32.WM.DEVMODECHANGE => "WM_DEVMODECHANGE",
+                User32.WM.ACTIVATEAPP => "WM_ACTIVATEAPP",
+                User32.WM.FONTCHANGE => "WM_FONTCHANGE",
+                User32.WM.TIMECHANGE => "WM_TIMECHANGE",
+                User32.WM.CANCELMODE => "WM_CANCELMODE",
+                User32.WM.SETCURSOR => "WM_SETCURSOR",
+                User32.WM.MOUSEACTIVATE => "WM_MOUSEACTIVATE",
+                User32.WM.CHILDACTIVATE => "WM_CHILDACTIVATE",
+                User32.WM.QUEUESYNC => "WM_QUEUESYNC",
+                User32.WM.GETMINMAXINFO => "WM_GETMINMAXINFO",
+                User32.WM.PAINTICON => "WM_PAINTICON",
+                User32.WM.ICONERASEBKGND => "WM_ICONERASEBKGND",
+                User32.WM.NEXTDLGCTL => "WM_NEXTDLGCTL",
+                User32.WM.SPOOLERSTATUS => "WM_SPOOLERSTATUS",
+                User32.WM.DRAWITEM => "WM_DRAWITEM",
+                User32.WM.MEASUREITEM => "WM_MEASUREITEM",
+                User32.WM.DELETEITEM => "WM_DELETEITEM",
+                User32.WM.VKEYTOITEM => "WM_VKEYTOITEM",
+                User32.WM.CHARTOITEM => "WM_CHARTOITEM",
+                User32.WM.SETFONT => "WM_SETFONT",
+                User32.WM.GETFONT => "WM_GETFONT",
+                User32.WM.SETHOTKEY => "WM_SETHOTKEY",
+                User32.WM.GETHOTKEY => "WM_GETHOTKEY",
+                User32.WM.QUERYDRAGICON => "WM_QUERYDRAGICON",
+                User32.WM.COMPAREITEM => "WM_COMPAREITEM",
+                User32.WM.GETOBJECT => "WM_GETOBJECT",
+                User32.WM.COMPACTING => "WM_COMPACTING",
+                User32.WM.COMMNOTIFY => "WM_COMMNOTIFY",
+                User32.WM.WINDOWPOSCHANGING => "WM_WINDOWPOSCHANGING",
+                User32.WM.WINDOWPOSCHANGED => "WM_WINDOWPOSCHANGED",
+                User32.WM.POWER => "WM_POWER",
+                User32.WM.COPYDATA => "WM_COPYDATA",
+                User32.WM.CANCELJOURNAL => "WM_CANCELJOURNAL",
+                User32.WM.NOTIFY => "WM_NOTIFY",
+                User32.WM.INPUTLANGCHANGEREQUEST => "WM_INPUTLANGCHANGEREQUEST",
+                User32.WM.INPUTLANGCHANGE => "WM_INPUTLANGCHANGE",
+                User32.WM.TCARD => "WM_TCARD",
+                User32.WM.HELP => "WM_HELP",
+                User32.WM.USERCHANGED => "WM_USERCHANGED",
+                User32.WM.NOTIFYFORMAT => "WM_NOTIFYFORMAT",
+                User32.WM.CONTEXTMENU => "WM_CONTEXTMENU",
+                User32.WM.STYLECHANGING => "WM_STYLECHANGING",
+                User32.WM.STYLECHANGED => "WM_STYLECHANGED",
+                User32.WM.DISPLAYCHANGE => "WM_DISPLAYCHANGE",
+                User32.WM.GETICON => "WM_GETICON",
+                User32.WM.SETICON => "WM_SETICON",
+                User32.WM.NCCREATE => "WM_NCCREATE",
+                User32.WM.NCDESTROY => "WM_NCDESTROY",
+                User32.WM.NCCALCSIZE => "WM_NCCALCSIZE",
+                User32.WM.NCHITTEST => "WM_NCHITTEST",
+                User32.WM.NCPAINT => "WM_NCPAINT",
+                User32.WM.NCACTIVATE => "WM_NCACTIVATE",
+                User32.WM.GETDLGCODE => "WM_GETDLGCODE",
+                User32.WM.NCMOUSEMOVE => "WM_NCMOUSEMOVE",
+                User32.WM.NCLBUTTONDOWN => "WM_NCLBUTTONDOWN",
+                User32.WM.NCLBUTTONUP => "WM_NCLBUTTONUP",
+                User32.WM.NCLBUTTONDBLCLK => "WM_NCLBUTTONDBLCLK",
+                User32.WM.NCRBUTTONDOWN => "WM_NCRBUTTONDOWN",
+                User32.WM.NCRBUTTONUP => "WM_NCRBUTTONUP",
+                User32.WM.NCRBUTTONDBLCLK => "WM_NCRBUTTONDBLCLK",
+                User32.WM.NCMBUTTONDOWN => "WM_NCMBUTTONDOWN",
+                User32.WM.NCMBUTTONUP => "WM_NCMBUTTONUP",
+                User32.WM.NCMBUTTONDBLCLK => "WM_NCMBUTTONDBLCLK",
+                User32.WM.KEYDOWN => "WM_KEYDOWN",
+                User32.WM.KEYUP => "WM_KEYUP",
+                User32.WM.CHAR => "WM_CHAR",
+                User32.WM.DEADCHAR => "WM_DEADCHAR",
+                User32.WM.SYSKEYDOWN => "WM_SYSKEYDOWN",
+                User32.WM.SYSKEYUP => "WM_SYSKEYUP",
+                User32.WM.SYSCHAR => "WM_SYSCHAR",
+                User32.WM.SYSDEADCHAR => "WM_SYSDEADCHAR",
+                User32.WM.KEYLAST => "WM_KEYLAST",
+                User32.WM.IME_STARTCOMPOSITION => "WM_IME_STARTCOMPOSITION",
+                User32.WM.IME_ENDCOMPOSITION => "WM_IME_ENDCOMPOSITION",
+                User32.WM.IME_COMPOSITION => "WM_IME_COMPOSITION",
+                User32.WM.INITDIALOG => "WM_INITDIALOG",
+                User32.WM.COMMAND => "WM_COMMAND",
+                User32.WM.SYSCOMMAND => "WM_SYSCOMMAND",
+                User32.WM.TIMER => "WM_TIMER",
+                User32.WM.HSCROLL => "WM_HSCROLL",
+                User32.WM.VSCROLL => "WM_VSCROLL",
+                User32.WM.INITMENU => "WM_INITMENU",
+                User32.WM.INITMENUPOPUP => "WM_INITMENUPOPUP",
+                User32.WM.MENUSELECT => "WM_MENUSELECT",
+                User32.WM.MENUCHAR => "WM_MENUCHAR",
+                User32.WM.ENTERIDLE => "WM_ENTERIDLE",
+                User32.WM.CTLCOLORMSGBOX => "WM_CTLCOLORMSGBOX",
+                User32.WM.CTLCOLOREDIT => "WM_CTLCOLOREDIT",
+                User32.WM.CTLCOLORLISTBOX => "WM_CTLCOLORLISTBOX",
+                User32.WM.CTLCOLORBTN => "WM_CTLCOLORBTN",
+                User32.WM.CTLCOLORDLG => "WM_CTLCOLORDLG",
+                User32.WM.CTLCOLORSCROLLBAR => "WM_CTLCOLORSCROLLBAR",
+                User32.WM.CTLCOLORSTATIC => "WM_CTLCOLORSTATIC",
+                User32.WM.MOUSEMOVE => "WM_MOUSEMOVE",
+                User32.WM.LBUTTONDOWN => "WM_LBUTTONDOWN",
+                User32.WM.LBUTTONUP => "WM_LBUTTONUP",
+                User32.WM.LBUTTONDBLCLK => "WM_LBUTTONDBLCLK",
+                User32.WM.RBUTTONDOWN => "WM_RBUTTONDOWN",
+                User32.WM.RBUTTONUP => "WM_RBUTTONUP",
+                User32.WM.RBUTTONDBLCLK => "WM_RBUTTONDBLCLK",
+                User32.WM.MBUTTONDOWN => "WM_MBUTTONDOWN",
+                User32.WM.MBUTTONUP => "WM_MBUTTONUP",
+                User32.WM.MBUTTONDBLCLK => "WM_MBUTTONDBLCLK",
+                User32.WM.MOUSEWHEEL => "WM_MOUSEWHEEL",
+                User32.WM.PARENTNOTIFY => "WM_PARENTNOTIFY",
+                User32.WM.ENTERMENULOOP => "WM_ENTERMENULOOP",
+                User32.WM.EXITMENULOOP => "WM_EXITMENULOOP",
+                User32.WM.NEXTMENU => "WM_NEXTMENU",
+                User32.WM.SIZING => "WM_SIZING",
+                User32.WM.CAPTURECHANGED => "WM_CAPTURECHANGED",
+                User32.WM.MOVING => "WM_MOVING",
+                User32.WM.POWERBROADCAST => "WM_POWERBROADCAST",
+                User32.WM.DEVICECHANGE => "WM_DEVICECHANGE",
+                User32.WM.IME_SETCONTEXT => "WM_IME_SETCONTEXT",
+                User32.WM.IME_NOTIFY => "WM_IME_NOTIFY",
+                User32.WM.IME_CONTROL => "WM_IME_CONTROL",
+                User32.WM.IME_COMPOSITIONFULL => "WM_IME_COMPOSITIONFULL",
+                User32.WM.IME_SELECT => "WM_IME_SELECT",
+                User32.WM.IME_CHAR => "WM_IME_CHAR",
+                User32.WM.IME_KEYDOWN => "WM_IME_KEYDOWN",
+                User32.WM.IME_KEYUP => "WM_IME_KEYUP",
+                User32.WM.MDICREATE => "WM_MDICREATE",
+                User32.WM.MDIDESTROY => "WM_MDIDESTROY",
+                User32.WM.MDIACTIVATE => "WM_MDIACTIVATE",
+                User32.WM.MDIRESTORE => "WM_MDIRESTORE",
+                User32.WM.MDINEXT => "WM_MDINEXT",
+                User32.WM.MDIMAXIMIZE => "WM_MDIMAXIMIZE",
+                User32.WM.MDITILE => "WM_MDITILE",
+                User32.WM.MDICASCADE => "WM_MDICASCADE",
+                User32.WM.MDIICONARRANGE => "WM_MDIICONARRANGE",
+                User32.WM.MDIGETACTIVE => "WM_MDIGETACTIVE",
+                User32.WM.MDISETMENU => "WM_MDISETMENU",
+                User32.WM.ENTERSIZEMOVE => "WM_ENTERSIZEMOVE",
+                User32.WM.EXITSIZEMOVE => "WM_EXITSIZEMOVE",
+                User32.WM.DROPFILES => "WM_DROPFILES",
+                User32.WM.MDIREFRESHMENU => "WM_MDIREFRESHMENU",
+                User32.WM.MOUSEHOVER => "WM_MOUSEHOVER",
+                User32.WM.MOUSELEAVE => "WM_MOUSELEAVE",
+                User32.WM.CUT => "WM_CUT",
+                User32.WM.COPY => "WM_COPY",
+                User32.WM.PASTE => "WM_PASTE",
+                User32.WM.CLEAR => "WM_CLEAR",
+                User32.WM.UNDO => "WM_UNDO",
+                User32.WM.RENDERFORMAT => "WM_RENDERFORMAT",
+                User32.WM.RENDERALLFORMATS => "WM_RENDERALLFORMATS",
+                User32.WM.DESTROYCLIPBOARD => "WM_DESTROYCLIPBOARD",
+                User32.WM.DRAWCLIPBOARD => "WM_DRAWCLIPBOARD",
+                User32.WM.PAINTCLIPBOARD => "WM_PAINTCLIPBOARD",
+                User32.WM.VSCROLLCLIPBOARD => "WM_VSCROLLCLIPBOARD",
+                User32.WM.SIZECLIPBOARD => "WM_SIZECLIPBOARD",
+                User32.WM.ASKCBFORMATNAME => "WM_ASKCBFORMATNAME",
+                User32.WM.CHANGECBCHAIN => "WM_CHANGECBCHAIN",
+                User32.WM.HSCROLLCLIPBOARD => "WM_HSCROLLCLIPBOARD",
+                User32.WM.QUERYNEWPALETTE => "WM_QUERYNEWPALETTE",
+                User32.WM.PALETTEISCHANGING => "WM_PALETTEISCHANGING",
+                User32.WM.PALETTECHANGED => "WM_PALETTECHANGED",
+                User32.WM.HOTKEY => "WM_HOTKEY",
+                User32.WM.PRINT => "WM_PRINT",
+                User32.WM.PRINTCLIENT => "WM_PRINTCLIENT",
+                User32.WM.HANDHELDFIRST => "WM_HANDHELDFIRST",
+                User32.WM.HANDHELDLAST => "WM_HANDHELDLAST",
+                User32.WM.AFXFIRST => "WM_AFXFIRST",
+                User32.WM.AFXLAST => "WM_AFXLAST",
+                User32.WM.PENWINFIRST => "WM_PENWINFIRST",
+                User32.WM.PENWINLAST => "WM_PENWINLAST",
+                User32.WM.APP => "WM_APP",
+                User32.WM.USER => "WM_USER",
+                User32.WM.CTLCOLOR => "WM_CTLCOLOR",
                 // RichEdit messages
-                case (int)User32.EM.GETLIMITTEXT:
-                    text = "EM_GETLIMITTEXT";
-                    break;
-                case (int)User32.EM.POSFROMCHAR:
-                    text = "EM_POSFROMCHAR";
-                    break;
-                case (int)User32.EM.CHARFROMPOS:
-                    text = "EM_CHARFROMPOS";
-                    break;
-                case (int)User32.EM.SCROLLCARET:
-                    text = "EM_SCROLLCARET";
-                    break;
-                case (int)Richedit.EM.CANPASTE:
-                    text = "EM_CANPASTE";
-                    break;
-                case (int)Richedit.EM.DISPLAYBAND:
-                    text = "EM_DISPLAYBAND";
-                    break;
-                case (int)Richedit.EM.EXGETSEL:
-                    text = "EM_EXGETSEL";
-                    break;
-                case (int)Richedit.EM.EXLIMITTEXT:
-                    text = "EM_EXLIMITTEXT";
-                    break;
-                case (int)Richedit.EM.EXLINEFROMCHAR:
-                    text = "EM_EXLINEFROMCHAR";
-                    break;
-                case (int)Richedit.EM.EXSETSEL:
-                    text = "EM_EXSETSEL";
-                    break;
-                case (int)Richedit.EM.FINDTEXT:
-                    text = "EM_FINDTEXT";
-                    break;
-                case (int)Richedit.EM.FORMATRANGE:
-                    text = "EM_FORMATRANGE";
-                    break;
-                case (int)Richedit.EM.GETCHARFORMAT:
-                    text = "EM_GETCHARFORMAT";
-                    break;
-                case (int)Richedit.EM.GETEVENTMASK:
-                    text = "EM_GETEVENTMASK";
-                    break;
-                case (int)Richedit.EM.GETOLEINTERFACE:
-                    text = "EM_GETOLEINTERFACE";
-                    break;
-                case (int)Richedit.EM.GETPARAFORMAT:
-                    text = "EM_GETPARAFORMAT";
-                    break;
-                case (int)Richedit.EM.GETSELTEXT:
-                    text = "EM_GETSELTEXT";
-                    break;
-                case (int)Richedit.EM.HIDESELECTION:
-                    text = "EM_HIDESELECTION";
-                    break;
-                case (int)Richedit.EM.PASTESPECIAL:
-                    text = "EM_PASTESPECIAL";
-                    break;
-                case (int)Richedit.EM.REQUESTRESIZE:
-                    text = "EM_REQUESTRESIZE";
-                    break;
-                case (int)Richedit.EM.SELECTIONTYPE:
-                    text = "EM_SELECTIONTYPE";
-                    break;
-                case (int)Richedit.EM.SETBKGNDCOLOR:
-                    text = "EM_SETBKGNDCOLOR";
-                    break;
-                case (int)Richedit.EM.SETCHARFORMAT:
-                    text = "EM_SETCHARFORMAT";
-                    break;
-                case (int)Richedit.EM.SETEVENTMASK:
-                    text = "EM_SETEVENTMASK";
-                    break;
-                case (int)Richedit.EM.SETOLECALLBACK:
-                    text = "EM_SETOLECALLBACK";
-                    break;
-                case (int)Richedit.EM.SETPARAFORMAT:
-                    text = "EM_SETPARAFORMAT";
-                    break;
-                case (int)Richedit.EM.SETTARGETDEVICE:
-                    text = "EM_SETTARGETDEVICE";
-                    break;
-                case (int)Richedit.EM.STREAMIN:
-                    text = "EM_STREAMIN";
-                    break;
-                case (int)Richedit.EM.STREAMOUT:
-                    text = "EM_STREAMOUT";
-                    break;
-                case (int)Richedit.EM.GETTEXTRANGE:
-                    text = "EM_GETTEXTRANGE";
-                    break;
-                case (int)Richedit.EM.FINDWORDBREAK:
-                    text = "EM_FINDWORDBREAK";
-                    break;
-                case (int)Richedit.EM.SETOPTIONS:
-                    text = "EM_SETOPTIONS";
-                    break;
-                case (int)Richedit.EM.GETOPTIONS:
-                    text = "EM_GETOPTIONS";
-                    break;
-                case (int)Richedit.EM.FINDTEXTEX:
-                    text = "EM_FINDTEXTEX";
-                    break;
-                case (int)Richedit.EM.GETWORDBREAKPROCEX:
-                    text = "EM_GETWORDBREAKPROCEX";
-                    break;
-                case (int)Richedit.EM.SETWORDBREAKPROCEX:
-                    text = "EM_SETWORDBREAKPROCEX";
-                    break;
-
+                (User32.WM)User32.EM.GETLIMITTEXT => "EM_GETLIMITTEXT",
+                (User32.WM)User32.EM.POSFROMCHAR => "EM_POSFROMCHAR",
+                (User32.WM)User32.EM.CHARFROMPOS => "EM_CHARFROMPOS",
+                (User32.WM)User32.EM.SCROLLCARET => "EM_SCROLLCARET",
+                (User32.WM)Richedit.EM.CANPASTE => "EM_CANPASTE",
+                (User32.WM)Richedit.EM.DISPLAYBAND => "EM_DISPLAYBAND",
+                (User32.WM)Richedit.EM.EXGETSEL => "EM_EXGETSEL",
+                (User32.WM)Richedit.EM.EXLIMITTEXT => "EM_EXLIMITTEXT",
+                (User32.WM)Richedit.EM.EXLINEFROMCHAR => "EM_EXLINEFROMCHAR",
+                (User32.WM)Richedit.EM.EXSETSEL => "EM_EXSETSEL",
+                (User32.WM)Richedit.EM.FINDTEXT => "EM_FINDTEXT",
+                (User32.WM)Richedit.EM.FORMATRANGE => "EM_FORMATRANGE",
+                (User32.WM)Richedit.EM.GETCHARFORMAT => "EM_GETCHARFORMAT",
+                (User32.WM)Richedit.EM.GETEVENTMASK => "EM_GETEVENTMASK",
+                (User32.WM)Richedit.EM.GETOLEINTERFACE => "EM_GETOLEINTERFACE",
+                (User32.WM)Richedit.EM.GETPARAFORMAT => "EM_GETPARAFORMAT",
+                (User32.WM)Richedit.EM.GETSELTEXT => "EM_GETSELTEXT",
+                (User32.WM)Richedit.EM.HIDESELECTION => "EM_HIDESELECTION",
+                (User32.WM)Richedit.EM.PASTESPECIAL => "EM_PASTESPECIAL",
+                (User32.WM)Richedit.EM.REQUESTRESIZE => "EM_REQUESTRESIZE",
+                (User32.WM)Richedit.EM.SELECTIONTYPE => "EM_SELECTIONTYPE",
+                (User32.WM)Richedit.EM.SETBKGNDCOLOR => "EM_SETBKGNDCOLOR",
+                (User32.WM)Richedit.EM.SETCHARFORMAT => "EM_SETCHARFORMAT",
+                (User32.WM)Richedit.EM.SETEVENTMASK => "EM_SETEVENTMASK",
+                (User32.WM)Richedit.EM.SETOLECALLBACK => "EM_SETOLECALLBACK",
+                (User32.WM)Richedit.EM.SETPARAFORMAT => "EM_SETPARAFORMAT",
+                (User32.WM)Richedit.EM.SETTARGETDEVICE => "EM_SETTARGETDEVICE",
+                (User32.WM)Richedit.EM.STREAMIN => "EM_STREAMIN",
+                (User32.WM)Richedit.EM.STREAMOUT => "EM_STREAMOUT",
+                (User32.WM)Richedit.EM.GETTEXTRANGE => "EM_GETTEXTRANGE",
+                (User32.WM)Richedit.EM.FINDWORDBREAK => "EM_FINDWORDBREAK",
+                (User32.WM)Richedit.EM.SETOPTIONS => "EM_SETOPTIONS",
+                (User32.WM)Richedit.EM.GETOPTIONS => "EM_GETOPTIONS",
+                (User32.WM)Richedit.EM.FINDTEXTEX => "EM_FINDTEXTEX",
+                (User32.WM)Richedit.EM.GETWORDBREAKPROCEX => "EM_GETWORDBREAKPROCEX",
+                (User32.WM)Richedit.EM.SETWORDBREAKPROCEX => "EM_SETWORDBREAKPROCEX",
                 // Richedit v2.0 messages
-                case (int)Richedit.EM.SETUNDOLIMIT:
-                    text = "EM_SETUNDOLIMIT";
-                    break;
-                case (int)Richedit.EM.REDO:
-                    text = "EM_REDO";
-                    break;
-                case (int)Richedit.EM.CANREDO:
-                    text = "EM_CANREDO";
-                    break;
-                case (int)Richedit.EM.GETUNDONAME:
-                    text = "EM_GETUNDONAME";
-                    break;
-                case (int)Richedit.EM.GETREDONAME:
-                    text = "EM_GETREDONAME";
-                    break;
-                case (int)Richedit.EM.STOPGROUPTYPING:
-                    text = "EM_STOPGROUPTYPING";
-                    break;
-                case (int)Richedit.EM.SETTEXTMODE:
-                    text = "EM_SETTEXTMODE";
-                    break;
-                case (int)Richedit.EM.GETTEXTMODE:
-                    text = "EM_GETTEXTMODE";
-                    break;
-                case (int)Richedit.EM.AUTOURLDETECT:
-                    text = "EM_AUTOURLDETECT";
-                    break;
-                case (int)Richedit.EM.GETAUTOURLDETECT:
-                    text = "EM_GETAUTOURLDETECT";
-                    break;
-                case (int)Richedit.EM.SETPALETTE:
-                    text = "EM_SETPALETTE";
-                    break;
-                case (int)Richedit.EM.GETTEXTEX:
-                    text = "EM_GETTEXTEX";
-                    break;
-                case (int)Richedit.EM.GETTEXTLENGTHEX:
-                    text = "EM_GETTEXTLENGTHEX";
-                    break;
-
+                (User32.WM)Richedit.EM.SETUNDOLIMIT => "EM_SETUNDOLIMIT",
+                (User32.WM)Richedit.EM.REDO => "EM_REDO",
+                (User32.WM)Richedit.EM.CANREDO => "EM_CANREDO",
+                (User32.WM)Richedit.EM.GETUNDONAME => "EM_GETUNDONAME",
+                (User32.WM)Richedit.EM.GETREDONAME => "EM_GETREDONAME",
+                (User32.WM)Richedit.EM.STOPGROUPTYPING => "EM_STOPGROUPTYPING",
+                (User32.WM)Richedit.EM.SETTEXTMODE => "EM_SETTEXTMODE",
+                (User32.WM)Richedit.EM.GETTEXTMODE => "EM_GETTEXTMODE",
+                (User32.WM)Richedit.EM.AUTOURLDETECT => "EM_AUTOURLDETECT",
+                (User32.WM)Richedit.EM.GETAUTOURLDETECT => "EM_GETAUTOURLDETECT",
+                (User32.WM)Richedit.EM.SETPALETTE => "EM_SETPALETTE",
+                (User32.WM)Richedit.EM.GETTEXTEX => "EM_GETTEXTEX",
+                (User32.WM)Richedit.EM.GETTEXTLENGTHEX => "EM_GETTEXTLENGTHEX",
                 // Asia specific messages
-                case (int)Richedit.EM.SETPUNCTUATION:
-                    text = "EM_SETPUNCTUATION";
-                    break;
-                case (int)Richedit.EM.GETPUNCTUATION:
-                    text = "EM_GETPUNCTUATION";
-                    break;
-                case (int)Richedit.EM.SETWORDWRAPMODE:
-                    text = "EM_SETWORDWRAPMODE";
-                    break;
-                case (int)Richedit.EM.GETWORDWRAPMODE:
-                    text = "EM_GETWORDWRAPMODE";
-                    break;
-                case (int)Richedit.EM.SETIMECOLOR:
-                    text = "EM_SETIMECOLOR";
-                    break;
-                case (int)Richedit.EM.GETIMECOLOR:
-                    text = "EM_GETIMECOLOR";
-                    break;
-                case (int)Richedit.EM.SETIMEOPTIONS:
-                    text = "EM_SETIMEOPTIONS";
-                    break;
-                case (int)Richedit.EM.GETIMEOPTIONS:
-                    text = "EM_GETIMEOPTIONS";
-                    break;
-                case (int)Richedit.EM.CONVPOSITION:
-                    text = "EM_CONVPOSITION";
-                    break;
-                case (int)Richedit.EM.SETLANGOPTIONS:
-                    text = "EM_SETLANGOPTIONS";
-                    break;
-                case (int)Richedit.EM.GETLANGOPTIONS:
-                    text = "EM_GETLANGOPTIONS";
-                    break;
-                case (int)Richedit.EM.GETIMECOMPMODE:
-                    text = "EM_GETIMECOMPMODE";
-                    break;
-                case (int)Richedit.EM.FINDTEXTW:
-                    text = "EM_FINDTEXTW";
-                    break;
-                case (int)Richedit.EM.FINDTEXTEXW:
-                    text = "EM_FINDTEXTEXW";
-                    break;
-
+                (User32.WM)Richedit.EM.SETPUNCTUATION => "EM_SETPUNCTUATION",
+                (User32.WM)Richedit.EM.GETPUNCTUATION => "EM_GETPUNCTUATION",
+                (User32.WM)Richedit.EM.SETWORDWRAPMODE => "EM_SETWORDWRAPMODE",
+                (User32.WM)Richedit.EM.GETWORDWRAPMODE => "EM_GETWORDWRAPMODE",
+                (User32.WM)Richedit.EM.SETIMECOLOR => "EM_SETIMECOLOR",
+                (User32.WM)Richedit.EM.GETIMECOLOR => "EM_GETIMECOLOR",
+                (User32.WM)Richedit.EM.SETIMEOPTIONS => "EM_SETIMEOPTIONS",
+                (User32.WM)Richedit.EM.GETIMEOPTIONS => "EM_GETIMEOPTIONS",
+                (User32.WM)Richedit.EM.CONVPOSITION => "EM_CONVPOSITION",
+                (User32.WM)Richedit.EM.SETLANGOPTIONS => "EM_SETLANGOPTIONS",
+                (User32.WM)Richedit.EM.GETLANGOPTIONS => "EM_GETLANGOPTIONS",
+                (User32.WM)Richedit.EM.GETIMECOMPMODE => "EM_GETIMECOMPMODE",
+                (User32.WM)Richedit.EM.FINDTEXTW => "EM_FINDTEXTW",
+                (User32.WM)Richedit.EM.FINDTEXTEXW => "EM_FINDTEXTEXW",
                 // Rich Edit 3.0 Asia msgs
-                case (int)Richedit.EM.RECONVERSION:
-                    text = "EM_RECONVERSION";
-                    break;
-                case (int)Richedit.EM.SETIMEMODEBIAS:
-                    text = "EM_SETIMEMODEBIAS";
-                    break;
-                case (int)Richedit.EM.GETIMEMODEBIAS:
-                    text = "EM_GETIMEMODEBIAS";
-                    break;
-
+                (User32.WM)Richedit.EM.RECONVERSION => "EM_RECONVERSION",
+                (User32.WM)Richedit.EM.SETIMEMODEBIAS => "EM_SETIMEMODEBIAS",
+                (User32.WM)Richedit.EM.GETIMEMODEBIAS => "EM_GETIMEMODEBIAS",
                 // BiDi Specific messages
-                case (int)Richedit.EM.SETBIDIOPTIONS:
-                    text = "EM_SETBIDIOPTIONS";
-                    break;
-                case (int)Richedit.EM.GETBIDIOPTIONS:
-                    text = "EM_GETBIDIOPTIONS";
-                    break;
-                case (int)Richedit.EM.SETTYPOGRAPHYOPTIONS:
-                    text = "EM_SETTYPOGRAPHYOPTIONS";
-                    break;
-                case (int)Richedit.EM.GETTYPOGRAPHYOPTIONS:
-                    text = "EM_GETTYPOGRAPHYOPTIONS";
-                    break;
-
+                (User32.WM)Richedit.EM.SETBIDIOPTIONS => "EM_SETBIDIOPTIONS",
+                (User32.WM)Richedit.EM.GETBIDIOPTIONS => "EM_GETBIDIOPTIONS",
+                (User32.WM)Richedit.EM.SETTYPOGRAPHYOPTIONS => "EM_SETTYPOGRAPHYOPTIONS",
+                (User32.WM)Richedit.EM.GETTYPOGRAPHYOPTIONS => "EM_GETTYPOGRAPHYOPTIONS",
                 // Extended Edit style specific messages
-                case (int)Richedit.EM.SETEDITSTYLE:
-                    text = "EM_SETEDITSTYLE";
-                    break;
-                case (int)Richedit.EM.GETEDITSTYLE:
-                    text = "EM_GETEDITSTYLE";
-                    break;
+                (User32.WM)Richedit.EM.SETEDITSTYLE => "EM_SETEDITSTYLE",
+                (User32.WM)Richedit.EM.GETEDITSTYLE => "EM_GETEDITSTYLE",
+                _ => null,
+            };
 
-                default:
-                    text = null;
-                    break;
-            }
-
-            if (text is null && ((msg & (int)WM.REFLECT) == (int)WM.REFLECT))
+            if (text is null && ((msg & User32.WM.REFLECT) == User32.WM.REFLECT))
             {
-                string subtext = MsgToString(msg - (int)WM.REFLECT) ?? "???";
+                string subtext = MsgToString((User32.WM)(msg - User32.WM.REFLECT)) ?? "???";
 
-                text = "WM_REFLECT + " + subtext;
+                text = $"WM_REFLECT + {subtext}";
             }
 
             return text;
         }
 
-        private static string Parenthesize(string? input)
-        {
-            if (input is null)
-            {
-                return string.Empty;
-            }
-
-            return " (" + input + ")";
-        }
+        private static string Parenthesize(string? input) => input is null ? string.Empty : $" ({input})";
 
         public static string ToString(Message message)
         {
-            return ToString(message.HWnd, message.Msg, message.WParam, message.LParam, message.Result);
+            return ToString(message.HWnd, message._Msg, message._WParam, message._LParam, message._Result);
         }
 
-        public static string ToString(IntPtr hWnd, int msg, IntPtr wparam, IntPtr lparam, IntPtr result)
+        private static string ToString(IntPtr hWnd, User32.WM msg, nint wparam, nint lparam, nint result)
         {
             string id = Parenthesize(MsgToString(msg));
 
             string lDescription = string.Empty;
-            if (msg == (int)WM.PARENTNOTIFY)
+            if (msg == User32.WM.PARENTNOTIFY)
             {
-                lDescription = Parenthesize(MsgToString(PARAM.LOWORD(wparam)));
+                lDescription = Parenthesize(MsgToString((User32.WM)PARAM.LOWORD(wparam)));
             }
 
-            return
-                "msg=0x" + Convert.ToString(msg, 16) + id +
-                " hwnd=0x" + Convert.ToString((long)hWnd, 16) +
-                " wparam=0x" + Convert.ToString((long)wparam, 16) +
-                " lparam=0x" + Convert.ToString((long)lparam, 16) + lDescription +
-                " result=0x" + Convert.ToString((long)result, 16);
+            return @$"msg=0x{(uint)msg:x}{id} hwnd=0x{(long)hWnd:x)} wparam
+                =0x{wparam:x} lparam=0x{lparam:x}{lDescription} result=0x{result:x}";
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
@@ -16,25 +16,76 @@ namespace System.Windows.Forms
     public struct Message
     {
 #if DEBUG
-        private static readonly TraceSwitch s_allWinMessages = new TraceSwitch("AllWinMessages", "Output every received message");
+        private static readonly TraceSwitch s_allWinMessages = new("AllWinMessages", "Output every received message");
 #endif
+
+        // Using prefixed variants of the property names for easier diffing.
+#pragma warning disable IDE1006 // Naming Styles
+        internal nint _Result;
+        internal nint _LParam;
+        internal nint _WParam;
+        internal User32.WM _Msg;
+#pragma warning restore IDE1006 // Naming Styles
 
         public IntPtr HWnd { get; set; }
 
-        public int Msg { get; set; }
+        public int Msg
+        {
+            get => (int)_Msg;
+            set => _Msg = (User32.WM)value;
+        }
 
-        public IntPtr WParam { get; set; }
+        // It is particularly dangerous to cast to/from IntPtr on 64 bit platforms as casts are checked.
+        // Doing so leads to hard-to-find overflow exceptions. We've mitigated this historically by trying
+        // to first cast to long when casting out of IntPtr and first casting to int when casting into an
+        // IntPtr. That pattern, unfortunately, is difficult to audit and has negative performance implications,
+        // particularly on 32bit.
+        //
+        // Using the new nint/nuint types allows casting to follow with the default project settings, which
+        // is unchecked. Casting works just like casting between other intrinsic types (short, int, long, etc.).
+        //
+        // Marking it as obsolete in DEBUG to fail the build. In consuming projects you can skip this obsoletion
+        // by adding the property <NoWarn>$(NoWarn),WINFORMSDEV0001</NoWarn> to a property group in your project
+        // file (or adding the warning via the project properties pages).
+#if DEBUG
+        [Obsolete(
+            $"Casting to/from IntPtr is unsafe, use {nameof(_WParam)}.",
+            DiagnosticId = "WINFORMSDEV0001")]
+#endif
+        public IntPtr WParam
+        {
+            get => _WParam;
+            set => _WParam = value;
+        }
 
-        public IntPtr LParam { get; set; }
+#if DEBUG
+        [Obsolete(
+            $"Casting to/from IntPtr is unsafe, use {nameof(_LParam)}.",
+            DiagnosticId = "WINFORMSDEV0001")]
+#endif
+        public IntPtr LParam
+        {
+            get => _LParam;
+            set => _LParam = value;
+        }
 
-        public IntPtr Result { get; set; }
+#if DEBUG
+        [Obsolete(
+            $"Casting to/from IntPtr is unsafe, use {nameof(_Result)}.",
+            DiagnosticId = "WINFORMSDEV0001")]
+#endif
+        public IntPtr Result
+        {
+            get => _Result;
+            set => _Result = value;
+        }
 
         /// <summary>
         ///  Gets the <see cref='LParam'/> value, and converts the value to an object.
         /// </summary>
-        public object? GetLParam(Type cls) => Marshal.PtrToStructure(LParam, cls);
+        public object? GetLParam(Type cls) => Marshal.PtrToStructure(_LParam, cls);
 
-        internal static Message Create(IntPtr hWnd, User32.WM msg, IntPtr wparam, IntPtr lparam)
+        internal static Message Create(IntPtr hWnd, User32.WM msg, nint wparam, nint lparam)
             => Create(hWnd, (int)msg, wparam, lparam);
 
         public static Message Create(IntPtr hWnd, int msg, IntPtr wparam, IntPtr lparam)
@@ -43,9 +94,9 @@ namespace System.Windows.Forms
             {
                 HWnd = hWnd,
                 Msg = msg,
-                WParam = wparam,
-                LParam = lparam,
-                Result = IntPtr.Zero
+                _WParam = wparam,
+                _LParam = lparam,
+                _Result = IntPtr.Zero
             };
 
 #if DEBUG
@@ -59,16 +110,16 @@ namespace System.Windows.Forms
 
         public override bool Equals(object? o)
         {
-            if (!(o is Message m))
+            if (o is not Message m)
             {
                 return false;
             }
 
-            return HWnd == m.HWnd &&
-                   Msg == m.Msg &&
-                   WParam == m.WParam &&
-                   LParam == m.LParam &&
-                   Result == m.Result;
+            return HWnd == m.HWnd
+                && _Msg == m._Msg
+                && _WParam == m._WParam
+                && _LParam == m._LParam
+                && _Result == m._Result;
         }
 
         public static bool operator ==(Message a, Message b) => a.Equals(b);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ParkingWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ParkingWindow.cs
@@ -150,20 +150,20 @@ namespace System.Windows.Forms
 
             protected override void WndProc(ref Message m)
             {
-                if (m.Msg == (int)User32.WM.SHOWWINDOW)
+                if (m._Msg == User32.WM.SHOWWINDOW)
                     return;
 
                 base.WndProc(ref m);
-                switch (m.Msg)
+                switch (m._Msg)
                 {
-                    case (int)User32.WM.PARENTNOTIFY:
-                        if (PARAM.LOWORD(m.WParam) == (int)User32.WM.DESTROY)
+                    case User32.WM.PARENTNOTIFY:
+                        if ((User32.WM)PARAM.LOWORD(m._WParam) == User32.WM.DESTROY)
                         {
                             User32.PostMessageW(this, (User32.WM)WM_CHECKDESTROY);
                         }
 
                         break;
-                    case WM_CHECKDESTROY:
+                    case (User32.WM)WM_CHECKDESTROY:
                         CheckDestroy();
                         break;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -1285,9 +1285,9 @@ namespace System.Windows.Forms
                             if (f is IMessageModifyAndFilter)
                             {
                                 msg.hwnd = m.HWnd;
-                                msg.message = (User32.WM)m.Msg;
-                                msg.wParam = m.WParam;
-                                msg.lParam = m.LParam;
+                                msg.message = m._Msg;
+                                msg.wParam = m._WParam;
+                                msg.lParam = m._LParam;
                                 modified = true;
                             }
 
@@ -1384,8 +1384,8 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    msg.wParam = m.WParam;
-                    msg.lParam = m.LParam;
+                    msg.wParam = m._WParam;
+                    msg.lParam = m._LParam;
 
                     if (retValue)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -601,9 +601,7 @@ namespace System.Windows.Forms
                 SendThemeChangedRecursive(handle);
                 User32.RedrawWindow(
                     handle,
-                    null,
-                    IntPtr.Zero,
-                    User32.RDW.INVALIDATE | User32.RDW.FRAME | User32.RDW.ERASE | User32.RDW.ALLCHILDREN);
+                    flags: User32.RDW.INVALIDATE | User32.RDW.FRAME | User32.RDW.ERASE | User32.RDW.ALLCHILDREN);
             }
 
             return BOOL.TRUE;
@@ -679,9 +677,9 @@ namespace System.Windows.Forms
             if (modified)
             {
                 message.HWnd = msg.hwnd;
-                message.Msg = (int)msg.message;
-                message.WParam = msg.wParam;
-                message.LParam = msg.lParam;
+                message._Msg = msg.message;
+                message._WParam = msg.wParam;
+                message._LParam = msg.lParam;
             }
 
             return processed;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Button.cs
@@ -358,14 +358,9 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Provides some interesting information for the Button control in
-        ///  String form.
+        ///  Provides some interesting information for the Button control in String form.
         /// </summary>
-        public override string ToString()
-        {
-            string s = base.ToString();
-            return s + ", Text: " + Text;
-        }
+        public override string ToString() => $"{base.ToString()}, Text: {Text}";
 
         /// <summary>
         ///  The button's window procedure.  Inheriting classes can override this
@@ -374,10 +369,10 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void WndProc(ref Message m)
         {
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.REFLECT_COMMAND:
-                    if (PARAM.HIWORD(m.WParam) == (int)User32.BN.CLICKED)
+                    if ((User32.BN)PARAM.HIWORD(m._WParam) == User32.BN.CLICKED)
                     {
                         if (!ValidationCancelled)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -1289,14 +1289,14 @@ namespace System.Windows.Forms
 
         protected override void WndProc(ref Message m)
         {
-            switch (m.Msg)
+            switch (m._Msg)
             {
                 // We don't respect this because the code below eats BM_SETSTATE.
                 // So we just invoke the click.
-                case (int)User32.BM.CLICK:
-                    if (this is IButtonControl)
+                case (User32.WM)User32.BM.CLICK:
+                    if (this is IButtonControl control)
                     {
-                        ((IButtonControl)this).PerformClick();
+                        control.PerformClick();
                     }
                     else
                     {
@@ -1308,16 +1308,16 @@ namespace System.Windows.Forms
 
             if (OwnerDraw)
             {
-                switch (m.Msg)
+                switch (m._Msg)
                 {
-                    case (int)User32.BM.SETSTATE:
+                    case (User32.WM)User32.BM.SETSTATE:
                         // Ignore BM_SETSTATE - Windows gets confused and paints things,
                         // even though we are ownerdraw.
                         break;
 
-                    case (int)User32.WM.KILLFOCUS:
-                    case (int)User32.WM.CANCELMODE:
-                    case (int)User32.WM.CAPTURECHANGED:
+                    case User32.WM.KILLFOCUS:
+                    case User32.WM.CANCELMODE:
+                    case User32.WM.CAPTURECHANGED:
                         if (!GetFlag(FlagInButtonUp) && GetFlag(FlagMousePressed))
                         {
                             SetFlag(FlagMousePressed, false);
@@ -1332,9 +1332,9 @@ namespace System.Windows.Forms
                         base.WndProc(ref m);
                         break;
 
-                    case (int)User32.WM.LBUTTONUP:
-                    case (int)User32.WM.MBUTTONUP:
-                    case (int)User32.WM.RBUTTONUP:
+                    case User32.WM.LBUTTONUP:
+                    case User32.WM.MBUTTONUP:
+                    case User32.WM.RBUTTONUP:
                         try
                         {
                             SetFlag(FlagInButtonUp, true);
@@ -1354,10 +1354,10 @@ namespace System.Windows.Forms
             }
             else
             {
-                switch ((User32.WM)m.Msg)
+                switch (m._Msg)
                 {
                     case User32.WM.REFLECT_COMMAND:
-                        if (PARAM.HIWORD(m.WParam) == (int)User32.BN.CLICKED && !ValidationCancelled)
+                        if ((User32.BN)PARAM.HIWORD(m._WParam) == User32.BN.CLICKED && !ValidationCancelled)
                         {
                             OnClick(EventArgs.Empty);
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -937,21 +937,19 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  We need to get LBN_SELCHANGE notifications
+        ///  We need to get LBN_SELCHANGE notifications.
         /// </summary>
         protected override void WmReflectCommand(ref Message m)
         {
-            switch (PARAM.HIWORD(m.WParam))
+            switch ((User32.LBN)PARAM.HIWORD(m._WParam))
             {
-                case (int)LBN.SELCHANGE:
+                case User32.LBN.SELCHANGE:
                     LbnSelChange();
-                    // finally, fire the OnSelectionChange event.
                     base.WmReflectCommand(ref m);
                     break;
 
-                case (int)LBN.DBLCLK:
+                case User32.LBN.DBLCLK:
                     // We want double-clicks to change the checkstate on each click - just like the CheckBox control
-                    //
                     LbnSelChange();
                     base.WmReflectCommand(ref m);
                     break;
@@ -968,8 +966,8 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmReflectVKeyToItem(ref Message m)
         {
-            int keycode = PARAM.LOWORD(m.WParam);
-            switch ((Keys)keycode)
+            Keys keycode = (Keys)PARAM.LOWORD(m._WParam);
+            switch (keycode)
             {
                 case Keys.Up:
                 case Keys.Down:
@@ -986,7 +984,7 @@ namespace System.Windows.Forms
                     break;
             }
 
-            m.Result = NativeMethods.InvalidIntPtr;
+            m._Result = -1;
         }
 
         /// <summary>
@@ -996,39 +994,39 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void WndProc(ref Message m)
         {
-            switch ((WM)m.Msg)
+            switch (m._Msg)
             {
                 case WM.REFLECT_CHARTOITEM:
-                    m.Result = NativeMethods.InvalidIntPtr;
+                    m._Result = -1;
                     break;
                 case WM.REFLECT_VKEYTOITEM:
                     WmReflectVKeyToItem(ref m);
                     break;
                 default:
-                    if (m.Msg == (int)LBC_GETCHECKSTATE)
+                    if (m._Msg == LBC_GETCHECKSTATE)
                     {
-                        int item = unchecked((int)(long)m.WParam);
+                        int item = (int)m._WParam;
                         if (item < 0 || item >= Items.Count)
                         {
-                            m.Result = (IntPtr)LB_ERR;
+                            m._Result = LB_ERR;
                         }
                         else
                         {
-                            m.Result = (IntPtr)(GetItemChecked(item) ? LB_CHECKED : LB_UNCHECKED);
+                            m._Result = GetItemChecked(item) ? LB_CHECKED : LB_UNCHECKED;
                         }
                     }
-                    else if (m.Msg == (int)LBC_SETCHECKSTATE)
+                    else if (m._Msg == LBC_SETCHECKSTATE)
                     {
-                        int item = unchecked((int)(long)m.WParam);
-                        int state = unchecked((int)(long)m.LParam);
+                        int item = (int)m._WParam;
+                        int state = (int)m._LParam;
                         if (item < 0 || item >= Items.Count || (state != LB_CHECKED && state != LB_UNCHECKED))
                         {
-                            m.Result = IntPtr.Zero;
+                            m._Result = 0;
                         }
                         else
                         {
                             SetItemChecked(item, (state == LB_CHECKED));
-                            m.Result = (IntPtr)1;
+                            m._Result = 1;
                         }
                     }
                     else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
@@ -85,25 +85,23 @@ namespace System.Windows.Forms
 
             private void WmGetObject(ref Message m)
             {
-                if (m.LParam == (IntPtr)NativeMethods.UiaRootObjectId)
+                if (m._LParam == NativeMethods.UiaRootObjectId)
                 {
                     // If the requested object identifier is UiaRootObjectId,
                     // we should return an UI Automation provider using the UiaReturnRawElementProvider function.
-                    m.Result = UiaCore.UiaReturnRawElementProvider(
-                        new HandleRef(this, Handle),
-                        m.WParam,
-                        m.LParam,
+                    m._Result = UiaCore.UiaReturnRawElementProvider(
+                        this,
+                        m._WParam,
+                        m._LParam,
                         GetChildAccessibleObject(_childWindowType));
 
                     return;
                 }
 
                 // See "How to Handle WM_GETOBJECT" in MSDN
-                //
-                if (PARAM.ToInt(m.LParam) == OBJID.CLIENT)
+                if ((int)m._LParam == OBJID.CLIENT)
                 {
                     // Get the IAccessible GUID
-                    //
                     Guid IID_IAccessible = new Guid(NativeMethods.uuid_IAccessible);
 
                     // Get an Lresult for the accessibility Object for this control
@@ -114,7 +112,7 @@ namespace System.Windows.Forms
 
                         try
                         {
-                            m.Result = Oleacc.LresultFromObject(ref IID_IAccessible, m.WParam, new HandleRef(this, pUnknown));
+                            m._Result = Oleacc.LresultFromObject(ref IID_IAccessible, m._WParam, new HandleRef(this, pUnknown));
                         }
                         finally
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
@@ -359,7 +359,7 @@ namespace System.Windows.Forms
 
             private int GetCharIndexFromPosition(Point pt)
             {
-                int index = (int)User32.SendMessageW(_owningChildEdit, (WM)EM.CHARFROMPOS, 0, PARAM.FromLowHigh(pt.X, pt.Y));
+                int index = (int)User32.SendMessageW(_owningChildEdit, (WM)EM.CHARFROMPOS, 0, PARAM.FromPoint(pt));
                 index = PARAM.LOWORD(index);
 
                 if (index < 0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -338,7 +338,7 @@ namespace System.Windows.Forms
                                     target = realTarget;
                                 }
 
-                                lpmsg->lParam = PARAM.FromLowHigh(pt.X, pt.Y);
+                                lpmsg->lParam = PARAM.FromPoint(pt);
                             }
 
 #if DEBUG
@@ -2193,7 +2193,7 @@ namespace System.Windows.Forms
                     else
                     {
                         Message m = Message.Create(lpmsg->hwnd, lpmsg->message, lpmsg->wParam, lpmsg->lParam);
-                        Debug.WriteLine("AxSource: TranslateAccelerator : " + m.ToString());
+                        Debug.WriteLine($"AxSource: TranslateAccelerator : {m}");
                     }
                 }
 #endif // DEBUG
@@ -2221,9 +2221,9 @@ namespace System.Windows.Forms
                             case PreProcessControlState.MessageProcessed:
                                 // someone returned true from PreProcessMessage
                                 // no need to dispatch the message, its already been coped with.
-                                lpmsg->message = (User32.WM)msg.Msg;
-                                lpmsg->wParam = msg.WParam;
-                                lpmsg->lParam = msg.LParam;
+                                lpmsg->message = msg._Msg;
+                                lpmsg->wParam = msg._WParam;
+                                lpmsg->lParam = msg._LParam;
                                 return HRESULT.S_OK;
                             case PreProcessControlState.MessageNeeded:
                                 // Here we need to dispatch the message ourselves

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.Ime.cs
@@ -715,7 +715,7 @@ namespace System.Windows.Forms
             }
             else
             {
-                m.Result = IntPtr.Zero;
+                m._Result = 0;
             }
 
             Debug.Unindent();
@@ -739,7 +739,9 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmImeEndComposition(ref Message m)
         {
-            Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, "Inside WmImeEndComposition() - Disabling ImeWmCharToIgnore, this=" + this);
+            Debug.WriteLineIf(
+                CompModSwitches.ImeMode.Level >= TraceLevel.Info,
+                $"Inside WmImeEndComposition() - Disabling ImeWmCharToIgnore, this={this}");
             ImeWmCharsToIgnore = ImeCharsToIgnoreDisabled;
             DefWndProc(ref m);
         }
@@ -751,7 +753,7 @@ namespace System.Windows.Forms
         {
             if (ImeSupported && ImeModeConversion.InputLanguageTable != ImeModeConversion.UnsupportedTable && !IgnoreWmImeNotify)
             {
-                int wparam = PARAM.ToInt(m.WParam);
+                int wparam = PARAM.ToInt(m._WParam);
 
                 // The WM_IME_NOTIFY message is not consistent across the different IMEs, particularly the notification type
                 // we care about (IMN_SETCONVERSIONMODE & IMN_SETOPENSTATUS).
@@ -772,7 +774,9 @@ namespace System.Windows.Forms
 
                 if (wparam == (int)Imm32.IMN.SETCONVERSIONMODE || wparam == (int)Imm32.IMN.SETOPENSTATUS)
                 {
-                    Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, string.Format(CultureInfo.CurrentCulture, "Inside WmImeNotify(m.wparam=[{0}]), this={1}", m.WParam, this));
+                    Debug.WriteLineIf(
+                        CompModSwitches.ImeMode.Level >= TraceLevel.Info,
+                        $"Inside WmImeNotify(m.wparam=[{m._WParam}]), this={this}");
                     Debug.Indent();
 
                     // Synchronize internal properties with the IME context mode.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6217,14 +6217,12 @@ namespace System.Windows.Forms
             _requiredScaling |= (byte)((int)specified & RequiredScalingMask);
         }
 
-        // Sets the text and background colors of the DC, and returns the background HBRUSH.
-        // This gets called from some variation on WM_CTLCOLOR...
-        // Virtual because Scrollbar insists on being different.
-        //
-        // NOTE: this message may not have originally been sent to this HWND.
-        //
+        /// <summary>
+        ///  Sets the text and background colors of the DC, and returns the background HBRUSH.
+        /// </summary>
         internal virtual Gdi32.HBRUSH InitializeDCForWmCtlColor(Gdi32.HDC dc, User32.WM msg)
         {
+            // NOTE: this message may not have originally been sent to this HWND.
             if (!GetStyle(ControlStyles.UserPaint))
             {
                 Gdi32.SetTextColor(dc, ColorTranslator.ToWin32(ForeColor));
@@ -6266,7 +6264,7 @@ namespace System.Windows.Forms
                 if (invalidateChildren)
                 {
                     User32.RedrawWindow(
-                        new HandleRef(this, Handle),
+                        this,
                         null,
                         regionHandle,
                         User32.RDW.INVALIDATE | User32.RDW.ERASE | User32.RDW.ALLCHILDREN);
@@ -6307,10 +6305,8 @@ namespace System.Windows.Forms
                 if (invalidateChildren)
                 {
                     User32.RedrawWindow(
-                        new HandleRef(_window, Handle),
-                        null,
-                        IntPtr.Zero,
-                        User32.RDW.INVALIDATE | User32.RDW.ERASE | User32.RDW.ALLCHILDREN);
+                        _window,
+                        flags: User32.RDW.INVALIDATE | User32.RDW.ERASE | User32.RDW.ALLCHILDREN);
                 }
                 else
                 {
@@ -6355,9 +6351,9 @@ namespace System.Windows.Forms
                 if (invalidateChildren)
                 {
                     User32.RedrawWindow(
-                        new HandleRef(_window, Handle),
+                        _window,
                         &rcArea,
-                        IntPtr.Zero,
+                        default,
                         User32.RDW.INVALIDATE | User32.RDW.ERASE | User32.RDW.ALLCHILDREN);
                 }
                 else
@@ -6989,15 +6985,15 @@ namespace System.Windows.Forms
         /// </summary>
         private void MarshalStringToMessage(string value, ref Message m)
         {
-            if (m.LParam == IntPtr.Zero)
+            if (m._LParam == 0)
             {
-                m.Result = (IntPtr)((value.Length + 1) * sizeof(char));
+                m._Result = (value.Length + 1) * sizeof(char);
                 return;
             }
 
-            if (unchecked((int)(long)m.WParam) < value.Length + 1)
+            if ((int)m._WParam < value.Length + 1)
             {
-                m.Result = (IntPtr)(-1);
+                m._Result = -1;
                 return;
             }
 
@@ -7009,10 +7005,10 @@ namespace System.Windows.Forms
             bytes = Encoding.Unicode.GetBytes(value);
             nullBytes = Encoding.Unicode.GetBytes(nullChar);
 
-            Marshal.Copy(bytes, 0, m.LParam, bytes.Length);
-            Marshal.Copy(nullBytes, 0, unchecked((IntPtr)((long)m.LParam + (long)bytes.Length)), nullBytes.Length);
+            Marshal.Copy(bytes, 0, m._LParam, bytes.Length);
+            Marshal.Copy(nullBytes, 0, m._LParam + bytes.Length, nullBytes.Length);
 
-            m.Result = (IntPtr)((bytes.Length + nullBytes.Length) / sizeof(char));
+            m._Result = (bytes.Length + nullBytes.Length) / sizeof(char);
         }
 
         // Used by form to notify the control that it has been "entered"
@@ -9078,18 +9074,16 @@ namespace System.Windows.Forms
         /// </remarks>
         public virtual bool PreProcessMessage(ref Message msg)
         {
-            //   Debug.WriteLineIf(ControlKeyboardRouting.TraceVerbose, "Control.PreProcessMessage " + msg.ToString());
-
             bool result;
 
-            if (msg.Msg == (int)User32.WM.KEYDOWN || msg.Msg == (int)User32.WM.SYSKEYDOWN)
+            if (msg._Msg == User32.WM.KEYDOWN || msg._Msg == User32.WM.SYSKEYDOWN)
             {
                 if (!GetExtendedState(ExtendedStates.UiCues))
                 {
                     ProcessUICues(ref msg);
                 }
 
-                Keys keyData = (Keys)(unchecked((int)(long)msg.WParam) | (int)ModifierKeys);
+                Keys keyData = (Keys)msg._WParam | ModifierKeys;
                 if (ProcessCmdKey(ref msg, keyData))
                 {
                     result = true;
@@ -9104,16 +9098,16 @@ namespace System.Windows.Forms
                     result = ProcessDialogKey(keyData);
                 }
             }
-            else if (msg.Msg == (int)User32.WM.CHAR || msg.Msg == (int)User32.WM.SYSCHAR)
+            else if (msg._Msg == User32.WM.CHAR || msg._Msg == User32.WM.SYSCHAR)
             {
-                if (msg.Msg == (int)User32.WM.CHAR && IsInputChar((char)msg.WParam))
+                if (msg._Msg == User32.WM.CHAR && IsInputChar((char)msg._WParam))
                 {
                     SetExtendedState(ExtendedStates.InputChar, true);
                     result = false;
                 }
                 else
                 {
-                    result = ProcessDialogChar((char)msg.WParam);
+                    result = ProcessDialogChar((char)msg._WParam);
                 }
             }
             else
@@ -9159,7 +9153,7 @@ namespace System.Windows.Forms
 
             try
             {
-                Keys keyData = (Keys)(unchecked((int)(long)message.WParam) | (int)ModifierKeys);
+                Keys keyData = (Keys)message._WParam | ModifierKeys;
 
                 // Allow control to preview key down message.
                 if (message.Msg == (int)User32.WM.KEYDOWN || message.Msg == (int)User32.WM.SYSKEYDOWN)
@@ -9182,7 +9176,7 @@ namespace System.Windows.Forms
 
                 if (!target.PreProcessMessage(ref message))
                 {
-                    if (message.Msg == (int)User32.WM.KEYDOWN || message.Msg == (int)User32.WM.SYSKEYDOWN)
+                    if (message._Msg == User32.WM.KEYDOWN || message._Msg == User32.WM.SYSKEYDOWN)
                     {
                         // Check if IsInputKey has already processed this message
                         // or if it is safe to call - we only want it to be called once.
@@ -9192,11 +9186,11 @@ namespace System.Windows.Forms
                             state = PreProcessControlState.MessageNeeded;
                         }
                     }
-                    else if (message.Msg == (int)User32.WM.CHAR || message.Msg == (int)User32.WM.SYSCHAR)
+                    else if (message._Msg == User32.WM.CHAR || message._Msg == User32.WM.SYSCHAR)
                     {
                         // Check if IsInputChar has already processed this message
                         // or if it is safe to call - we only want it to be called once.
-                        if (target.GetExtendedState(ExtendedStates.InputChar) || target.IsInputChar((char)message.WParam))
+                        if (target.GetExtendedState(ExtendedStates.InputChar) || target.IsInputChar((char)message._WParam))
                         {
                             Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Control didn't preprocess this message but it needs to be dispatched");
                             state = PreProcessControlState.MessageNeeded;
@@ -9396,56 +9390,58 @@ namespace System.Windows.Forms
         /// </summary>
         protected virtual bool ProcessKeyEventArgs(ref Message m)
         {
-            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Control.ProcessKeyEventArgs " + m.ToString());
+            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"Control.ProcessKeyEventArgs {m}");
             KeyEventArgs ke = null;
             KeyPressEventArgs kpe = null;
-            IntPtr newWParam = IntPtr.Zero;
+            nint newWParam = 0;
 
-            if (m.Msg == (int)User32.WM.CHAR || m.Msg == (int)User32.WM.SYSCHAR)
+            if (m._Msg == User32.WM.CHAR || m._Msg == User32.WM.SYSCHAR)
             {
                 int charsToIgnore = ImeWmCharsToIgnore;
 
                 if (charsToIgnore > 0)
                 {
                     charsToIgnore--;
-                    Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, "charsToIgnore decreased, new val = " + charsToIgnore + ", this=" + this);
+                    Debug.WriteLineIf(
+                        CompModSwitches.ImeMode.Level >= TraceLevel.Info,
+                        $"charsToIgnore decreased, new val = {charsToIgnore}, this={this}");
 
                     ImeWmCharsToIgnore = charsToIgnore;
                     return false;
                 }
                 else
                 {
-                    kpe = new KeyPressEventArgs(unchecked((char)(long)m.WParam));
+                    kpe = new KeyPressEventArgs((char)m._WParam);
                     OnKeyPress(kpe);
                     newWParam = (IntPtr)kpe.KeyChar;
                 }
             }
-            else if (m.Msg == (int)User32.WM.IME_CHAR)
+            else if (m._Msg == User32.WM.IME_CHAR)
             {
                 int charsToIgnore = ImeWmCharsToIgnore;
 
                 charsToIgnore += (3 - sizeof(char));
                 ImeWmCharsToIgnore = charsToIgnore;
 
-                kpe = new KeyPressEventArgs(unchecked((char)(long)m.WParam));
+                kpe = new KeyPressEventArgs((char)m._WParam);
 
                 char preEventCharacter = kpe.KeyChar;
                 OnKeyPress(kpe);
 
-                //If the character wasn't changed, just use the original value rather than round tripping.
+                // If the character wasn't changed, just use the original value rather than round tripping.
                 if (kpe.KeyChar == preEventCharacter)
                 {
-                    newWParam = m.WParam;
+                    newWParam = m._WParam;
                 }
                 else
                 {
-                    newWParam = (IntPtr)kpe.KeyChar;
+                    newWParam = kpe.KeyChar;
                 }
             }
             else
             {
-                ke = new KeyEventArgs((Keys)(unchecked((int)(long)m.WParam)) | ModifierKeys);
-                if (m.Msg == (int)User32.WM.KEYDOWN || m.Msg == (int)User32.WM.SYSKEYDOWN)
+                ke = new KeyEventArgs((Keys)m._WParam | ModifierKeys);
+                if (m._Msg == User32.WM.KEYDOWN || m._Msg == User32.WM.SYSKEYDOWN)
                 {
                     OnKeyDown(ke);
                 }
@@ -9457,13 +9453,13 @@ namespace System.Windows.Forms
 
             if (kpe is not null)
             {
-                Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "    processkeyeventarg returning: " + kpe.Handled);
-                m.WParam = newWParam;
+                Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"    processkeyeventarg returning: {kpe.Handled}");
+                m._WParam = newWParam;
                 return kpe.Handled;
             }
             else
             {
-                Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "    processkeyeventarg returning: " + ke.Handled);
+                Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"    processkeyeventarg returning: {ke.Handled}");
                 if (ke.SuppressKeyPress)
                 {
                     RemovePendingMessages(User32.WM.CHAR, User32.WM.CHAR);
@@ -9492,7 +9488,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected internal virtual bool ProcessKeyMessage(ref Message m)
         {
-            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Control.ProcessKeyMessage " + m.ToString());
+            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"Control.ProcessKeyMessage {m}");
             if (_parent is not null && _parent.ProcessKeyPreview(ref m))
             {
                 return true;
@@ -9521,8 +9517,8 @@ namespace System.Windows.Forms
         /// </summary>
         protected virtual bool ProcessKeyPreview(ref Message m)
         {
-            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Control.ProcessKeyPreview " + m.ToString());
-            return _parent is null ? false : _parent.ProcessKeyPreview(ref m);
+            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"Control.ProcessKeyPreview {m}");
+            return _parent is not null && _parent.ProcessKeyPreview(ref m);
         }
 
         /// <summary>
@@ -9546,7 +9542,7 @@ namespace System.Windows.Forms
         protected internal virtual bool ProcessMnemonic(char charCode)
         {
 #if DEBUG
-            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Control.ProcessMnemonic [0x" + ((int)charCode).ToString("X", CultureInfo.InvariantCulture) + "]");
+            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"Control.ProcessMnemonic [0x{((int)charCode):X}]");
 #endif
             return false;
         }
@@ -9556,7 +9552,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal void ProcessUICues(ref Message msg)
         {
-            Keys keyCode = (Keys)(PARAM.ToInt(msg.WParam)) & Keys.KeyCode;
+            Keys keyCode = (Keys)msg._WParam & Keys.KeyCode;
 
             if (keyCode != Keys.F10 && keyCode != Keys.Menu && keyCode != Keys.Tab)
             {
@@ -9564,7 +9560,7 @@ namespace System.Windows.Forms
             }
 
             Control topMostParent = null;
-            User32.UISF current = unchecked((User32.UISF)(long)User32.SendMessageW(this, User32.WM.QUERYUISTATE));
+            User32.UISF current = (User32.UISF)User32.SendMessageW(this, User32.WM.QUERYUISTATE);
 
             // don't trust when a control says the accelerators are showing.
             // make sure the topmost parent agrees with this as we could be in a mismatched state.
@@ -9924,22 +9920,21 @@ namespace System.Windows.Forms
                 return false;
             }
 
-            m.Result = User32.SendMessageW(control, User32.WM.REFLECT | (User32.WM)m.Msg, m.WParam, m.LParam);
+            m._Result = User32.SendMessageW(control, User32.WM.REFLECT | m._Msg, m._WParam, m._LParam);
             return true;
         }
 
         /// <summary>
-        ///  Forces the control to invalidate and immediately
-        ///  repaint itself and any children.
+        ///  Forces the control to invalidate and immediately repaint itself and any children.
         /// </summary>
         public virtual void Refresh()
         {
-            Invalidate(true);
+            Invalidate(invalidateChildren: true);
             Update();
         }
 
         /// <summary>
-        ///  /Releases UI Automation provider for specified window.
+        ///  Releases UI Automation provider for specified window.
         /// </summary>
         /// <param name="handle">The window handle.</param>
         internal virtual void ReleaseUiaProvider(IntPtr handle)
@@ -9950,7 +9945,7 @@ namespace System.Windows.Forms
                 // you should notify UI Automation by calling the UiaReturnRawElementProvider
                 // as follows: UiaReturnRawElementProvider(hwnd, 0, 0, NULL). This call tells
                 // UI Automation that it can safely remove all map entries that refer to the specified window.
-                UiaCore.UiaReturnRawElementProvider(new HandleRef(this, handle), IntPtr.Zero, IntPtr.Zero, null);
+                UiaCore.UiaReturnRawElementProvider(handle, 0, 0, null);
             }
 
             if (OsVersion.IsWindows8OrGreater && IsAccessibilityObjectCreated)
@@ -10003,7 +9998,7 @@ namespace System.Windows.Forms
 #if DEBUG
             if (CompModSwitches.LayoutSuspendResume.TraceInfo)
             {
-                Debug.WriteLine(GetType().Name + "::ResumeLayout( preformLayout = " + performLayout + ", newCount = " + Math.Max(0, _layoutSuspendCount - 1) + ")");
+                Debug.WriteLine($"{GetType().Name}::ResumeLayout( preformLayout = {performLayout}, newCount = {Math.Max(0, _layoutSuspendCount - 1)})");
             }
 #endif
 
@@ -11789,16 +11784,16 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmCommand(ref Message m)
         {
-            if (IntPtr.Zero == m.LParam)
+            if (m._LParam == 0)
             {
-                if (Command.DispatchID(PARAM.LOWORD(m.WParam)))
+                if (Command.DispatchID(PARAM.LOWORD(m._WParam)))
                 {
                     return;
                 }
             }
             else
             {
-                if (ReflectMessage(m.LParam, ref m))
+                if (ReflectMessage(m._LParam, ref m))
                 {
                     return;
                 }
@@ -11807,7 +11802,7 @@ namespace System.Windows.Forms
             DefWndProc(ref m);
         }
 
-        // overridable so nested controls can provide a different source control.
+        // Overridable so nested controls can provide a different source control.
         internal virtual void WmContextMenu(ref Message m)
         {
             WmContextMenu(ref m, this);
@@ -11821,14 +11816,13 @@ namespace System.Windows.Forms
             var contextMenuStrip = (ContextMenuStrip)Properties.GetObject(s_contextMenuStripProperty);
             if (contextMenuStrip is not null)
             {
-                int x = PARAM.SignedLOWORD(m.LParam);
-                int y = PARAM.SignedHIWORD(m.LParam);
+                int x = PARAM.SignedLOWORD(m._LParam);
+                int y = PARAM.SignedHIWORD(m._LParam);
                 Point client;
                 bool keyboardActivated = false;
-                // lparam will be exactly -1 when the user invokes the context menu
-                // with the keyboard.
-                //
-                if (unchecked((int)(long)m.LParam) == -1)
+
+                // lparam will be exactly -1 when the user invokes the context menu with the keyboard.
+                if (m._LParam == -1)
                 {
                     keyboardActivated = true;
                     client = new Point(Width / 2, Height / 2);
@@ -11859,11 +11853,11 @@ namespace System.Windows.Forms
         private void WmCtlColorControl(ref Message m)
         {
             // We could simply reflect the message, but it's faster to handle it here if possible.
-            Control control = FromHandle(m.LParam);
+            Control control = FromHandle(m._LParam);
             if (control is not null)
             {
-                m.Result = (IntPtr)control.InitializeDCForWmCtlColor((Gdi32.HDC)m.WParam, (User32.WM)m.Msg);
-                if (m.Result != IntPtr.Zero)
+                m._Result = control.InitializeDCForWmCtlColor((Gdi32.HDC)m._WParam, m._Msg);
+                if (m._Result != 0)
                 {
                     return;
                 }
@@ -11890,11 +11884,11 @@ namespace System.Windows.Forms
                 // OptimizedDoubleBuffer is the "same" as turning on AllPaintingInWMPaint
                 if (!(GetStyle(ControlStyles.AllPaintingInWmPaint)))
                 {
-                    Gdi32.HDC dc = (Gdi32.HDC)m.WParam;
+                    Gdi32.HDC dc = (Gdi32.HDC)m._WParam;
                     if (dc.IsNull)
                     {
                         // This happens under extreme stress conditions
-                        m.Result = (IntPtr)0;
+                        m._Result = 0;
                         return;
                     }
 
@@ -11904,7 +11898,7 @@ namespace System.Windows.Forms
                     PaintWithErrorHandling(pevent, PaintLayerBackground);
                 }
 
-                m.Result = (IntPtr)1;
+                m._Result = 1;
             }
             else
             {
@@ -11950,22 +11944,22 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmGetObject(ref Message m)
         {
-            Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "In WmGetObject, this = " + GetType().FullName + ", lParam = " + m.LParam.ToString());
+            Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, $"In WmGetObject, this = {GetType().FullName}, lParam = {m._LParam}");
 
-            if (m.Msg == (int)User32.WM.GETOBJECT && m.LParam == (IntPtr)NativeMethods.UiaRootObjectId && SupportsUiaProviders)
+            if (m._Msg == User32.WM.GETOBJECT && m._LParam == NativeMethods.UiaRootObjectId && SupportsUiaProviders)
             {
                 // If the requested object identifier is UiaRootObjectId,
                 // we should return an UI Automation provider using the UiaReturnRawElementProvider function.
-                m.Result = UiaCore.UiaReturnRawElementProvider(
-                    new HandleRef(this, Handle),
-                    m.WParam,
-                    m.LParam,
+                m._Result = UiaCore.UiaReturnRawElementProvider(
+                    this,
+                    m._WParam,
+                    m._LParam,
                     AccessibilityObject);
 
                 return;
             }
 
-            AccessibleObject accessibleObject = GetAccessibilityObject(PARAM.ToInt(m.LParam));
+            AccessibleObject accessibleObject = GetAccessibilityObject((int)m._LParam);
 
             // See "How to Handle WM_GETOBJECT" in MSDN.
             if (accessibleObject is null)
@@ -11987,8 +11981,8 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    m.Result = Oleacc.LresultFromObject(ref IID_IAccessible, m.WParam, new HandleRef(accessibleObject, pUnknown));
-                    Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "LresultFromObject returned " + m.Result.ToString());
+                    m._Result = Oleacc.LresultFromObject(ref IID_IAccessible, m._WParam, new HandleRef(accessibleObject, pUnknown));
+                    Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, $"LresultFromObject returned {m._Result}");
                 }
                 finally
                 {
@@ -12028,7 +12022,7 @@ namespace System.Windows.Forms
             }
 
             // Note: info.hItemHandle is the handle of the window that sent the help message.
-            User32.HELPINFO* info = (User32.HELPINFO*)m.LParam;
+            User32.HELPINFO* info = (User32.HELPINFO*)m._LParam;
             var hevent = new HelpEventArgs(info->MousePos);
             OnHelpRequested(hevent);
             if (!hevent.Handled)
@@ -12182,7 +12176,7 @@ namespace System.Windows.Forms
             // disabled during its lifetime (e.g. through a Click or Focus listener).
             if (Enabled)
             {
-                OnMouseDown(new MouseEventArgs(button, clicks, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
+                OnMouseDown(new MouseEventArgs(button, clicks, PARAM.ToPoint(m._LParam)));
             }
         }
 
@@ -12215,7 +12209,7 @@ namespace System.Windows.Forms
             _oldDeviceDpi = _deviceDpi;
 
             // In order to support tests, will be querying Dpi from the message first.
-            int newDeviceDpi = PARAM.SignedLOWORD(m.WParam);
+            int newDeviceDpi = PARAM.SignedLOWORD(m._WParam);
 
             // On certain OS versions, for non-test scenarios, WParam may be empty.
             if (newDeviceDpi == 0)
@@ -12281,55 +12275,49 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles the WM_MOUSEMOVE message
+        ///  Handles the WM_MOUSEMOVE message.
         /// </summary>
         private void WmMouseMove(ref Message m)
         {
-            // If the UserMouse style is set, the control does its own processing
-            // of mouse messages
+            // If the UserMouse style is set, the control does its own processing of mouse messages.
             if (!GetStyle(ControlStyles.UserMouse))
             {
                 DefWndProc(ref m);
             }
 
-            OnMouseMove(new MouseEventArgs(MouseButtons, 0, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
+            OnMouseMove(new MouseEventArgs(MouseButtons, 0, PARAM.ToPoint(m._LParam)));
         }
 
         /// <summary>
-        ///  Handles the WM_MOUSEUP message
+        ///  Handles the WM_MOUSEUP message.
         /// </summary>
         private void WmMouseUp(ref Message m, MouseButtons button, int clicks)
         {
-            // Get the mouse location
             try
             {
-                int x = PARAM.SignedLOWORD(m.LParam);
-                int y = PARAM.SignedHIWORD(m.LParam);
-                Point pt = new Point(x, y);
-                pt = PointToScreen(pt);
+                Point location = PARAM.ToPoint(m._LParam);
+                Point screenLocation = PointToScreen(location);
 
-                // If the UserMouse style is set, the control does its own processing
-                // of mouse messages
+                // If the UserMouse style is set, the control does its own processing of mouse messages.
                 if (!GetStyle(ControlStyles.UserMouse))
                 {
                     DefWndProc(ref m);
                 }
                 else
                 {
-                    // DefWndProc would normally trigger a context menu here
-                    // (for a right button click), but since we're skipping DefWndProc
-                    // we have to do it ourselves.
+                    // DefWndProc would normally trigger a context menu here (for a right button click), but since
+                    // we're skipping DefWndProc we have to do it ourselves.
                     if (button == MouseButtons.Right)
                     {
-                        User32.SendMessageW(this, User32.WM.CONTEXTMENU, Handle, PARAM.FromLowHigh(pt.X, pt.Y));
+                        User32.SendMessageW(this, User32.WM.CONTEXTMENU, Handle, PARAM.FromPoint(screenLocation));
                     }
                 }
 
                 bool fireClick = false;
 
-                if ((_controlStyle & ControlStyles.StandardClick) == ControlStyles.StandardClick)
+                if (_controlStyle.HasFlag(ControlStyles.StandardClick))
                 {
-                    if (GetState(States.MousePressed) && !IsDisposed && User32.WindowFromPoint(pt) == Handle)
+                    if (GetState(States.MousePressed) && !IsDisposed && User32.WindowFromPoint(screenLocation) == Handle)
                     {
                         fireClick = true;
                     }
@@ -12339,58 +12327,53 @@ namespace System.Windows.Forms
                 {
                     if (!GetState(States.DoubleClickFired))
                     {
-                        //In Whidbey .. if the click in by MOUSE then pass the MouseEventArgs...
-                        OnClick(new MouseEventArgs(button, clicks, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
-                        OnMouseClick(new MouseEventArgs(button, clicks, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
+                        OnClick(new MouseEventArgs(button, clicks, location));
+                        OnMouseClick(new MouseEventArgs(button, clicks, location));
                     }
-
                     else
                     {
-                        OnDoubleClick(new MouseEventArgs(button, 2, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
-                        OnMouseDoubleClick(new MouseEventArgs(button, 2, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
+                        OnDoubleClick(new MouseEventArgs(button, 2, location));
+                        OnMouseDoubleClick(new MouseEventArgs(button, 2, location));
                     }
                 }
 
-                //call the MouseUp Finally...
-                OnMouseUp(new MouseEventArgs(button, clicks, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
+                OnMouseUp(new MouseEventArgs(button, clicks, location));
             }
             finally
             {
-                // Always reset the States.DoubleClickFired in UP.. Since we get UP - DOWN - DBLCLK - UP sequence
-                // The flag is set in L_BUTTONDBLCLK in the controls WndProc() ...
+                // Always reset the States.DoubleClickFired in UP. Since we get UP - DOWN - DBLCLK - UP sequence
+                // The flag is set in L_BUTTONDBLCLK in the controls WndProc().
                 SetState(States.DoubleClickFired, false);
                 SetState(States.MousePressed, false);
                 SetState(States.ValidationCancelled, false);
 
-                // Capture is reset while exiting MouseUp
+                // Capture is reset while exiting MouseUp.
                 Capture = false;
             }
         }
 
         /// <summary>
-        ///  Handles the WM_MOUSEWHEEL message
+        ///  Handles the WM_MOUSEWHEEL message.
         /// </summary>
         private void WmMouseWheel(ref Message m)
         {
-            Point p = new Point(PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam));
-            p = PointToClient(p);
-            HandledMouseEventArgs e = new HandledMouseEventArgs(MouseButtons.None,
-                                                                0,
-                                                                p.X,
-                                                                p.Y,
-                                                                PARAM.SignedHIWORD(m.WParam));
+            HandledMouseEventArgs e = new(
+                MouseButtons.None,
+                0,
+                PointToClient(PARAM.ToPoint(m._LParam)),
+                PARAM.SignedHIWORD(m._WParam));
+
             OnMouseWheel(e);
-            m.Result = (IntPtr)(e.Handled ? 0 : 1);
+            m._Result = e.Handled ? 0 : 1;
             if (!e.Handled)
             {
-                // Forwarding the message to the parent window
+                // Forwarding the message to the parent window.
                 DefWndProc(ref m);
             }
         }
 
         /// <summary>
-        ///  Handles the WM_MOVE message.  We must do this in
-        ///  addition to WM_WINDOWPOSCHANGED because windows may
+        ///  Handles the WM_MOVE message.  We must do this in addition to WM_WINDOWPOSCHANGED because windows may
         ///  send WM_MOVE directly.
         /// </summary>
         private void WmMove(ref Message m)
@@ -12400,20 +12383,20 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles the WM_NOTIFY message
+        ///  Handles the WM_NOTIFY message.
         /// </summary>
         private unsafe void WmNotify(ref Message m)
         {
-            User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+            User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
             if (!ReflectMessage(nmhdr->hwndFrom, ref m))
             {
                 switch ((ComCtl32.TTN)nmhdr->code)
                 {
                     case ComCtl32.TTN.SHOW:
-                        m.Result = User32.SendMessageW(nmhdr->hwndFrom, User32.WM.REFLECT | (User32.WM)m.Msg, m.WParam, m.LParam);
+                        m._Result = User32.SendMessageW(nmhdr->hwndFrom, User32.WM.REFLECT | m._Msg, m._WParam, m._LParam);
                         return;
                     case ComCtl32.TTN.POP:
-                        User32.SendMessageW(nmhdr->hwndFrom, User32.WM.REFLECT | (User32.WM)m.Msg, m.WParam, m.LParam);
+                        User32.SendMessageW(nmhdr->hwndFrom, User32.WM.REFLECT | m._Msg, m._WParam, m._LParam);
                         break;
                 }
 
@@ -12422,11 +12405,11 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles the WM_NOTIFYFORMAT message
+        ///  Handles the WM_NOTIFYFORMAT message.
         /// </summary>
         private void WmNotifyFormat(ref Message m)
         {
-            if (!ReflectMessage(m.WParam, ref m))
+            if (!ReflectMessage(m._WParam, ref m))
             {
                 DefWndProc(ref m);
             }
@@ -12439,27 +12422,27 @@ namespace System.Windows.Forms
         {
             bool reflectCalled = false;
 
-            int ctrlId = unchecked((int)(long)m.WParam);
+            int ctrlId = (int)m._WParam;
             IntPtr p = User32.GetDlgItem(m.HWnd, (User32.DialogItemID)ctrlId);
             if (p == IntPtr.Zero)
             {
                 // On 64-bit platforms wParam is already 64 bit but the control ID stored in it is only 32-bit
                 // Empirically, we have observed that the 64 bit HWND is just a sign extension of the 32-bit ctrl ID
-                // Since WParam is already 64-bit, we need to discard the high dword first and then re-extend the 32-bit value
-                // treating it as signed
-                p = (IntPtr)(long)ctrlId;
+                // Since WParam is already 64-bit, we need to discard the high dword first and then re-extend the
+                // 32-bit value treating it as signed.
+                p = (IntPtr)ctrlId;
             }
 
             if (!ReflectMessage(p, ref m))
             {
                 // Additional Check For Control .... TabControl truncates the Hwnd value...
-                IntPtr handle = _window.GetHandleFromWindowId((short)PARAM.LOWORD(m.WParam));
+                IntPtr handle = _window.GetHandleFromWindowId((short)PARAM.LOWORD(m._WParam));
                 if (handle != IntPtr.Zero)
                 {
                     Control control = FromHandle(handle);
                     if (control is not null)
                     {
-                        m.Result = User32.SendMessageW(control, User32.WM.REFLECT | (User32.WM)m.Msg, handle, m.LParam);
+                        m._Result = User32.SendMessageW(control, User32.WM.REFLECT | m._Msg, handle, m._LParam);
                         reflectCalled = true;
                     }
                 }
@@ -12488,7 +12471,7 @@ namespace System.Windows.Forms
             }
 #endif
             Rectangle clip;
-            Gdi32.HDC dc = (Gdi32.HDC)m.WParam;
+            Gdi32.HDC dc = (Gdi32.HDC)m._WParam;
 
             bool usingBeginPaint = dc.IsNull;
             using var paintScope = usingBeginPaint ? new User32.BeginPaintScope(Handle) : default;
@@ -12523,13 +12506,13 @@ namespace System.Windows.Forms
             {
                 try
                 {
-                    bufferedGraphics = BufferContext.Allocate((IntPtr)dc, ClientRectangle);
+                    bufferedGraphics = BufferContext.Allocate(dc, ClientRectangle);
 
 #if DEBUG
                     if (s_bufferPinkRect.Enabled)
                     {
                         Rectangle band = ClientRectangle;
-                        using (BufferedGraphics bufferedGraphics2 = BufferContext.Allocate((IntPtr)dc, band))
+                        using (BufferedGraphics bufferedGraphics2 = BufferContext.Allocate(dc, band))
                         {
                             bufferedGraphics2.Graphics.FillRectangle(Brushes.Red, band);
                             bufferedGraphics2.Render();
@@ -12552,7 +12535,7 @@ namespace System.Windows.Forms
                     // between that case and real out of memory exceptions but we see no reasons justifying the
                     // additional complexity.
 
-                    if (ClientUtils.IsCriticalException(ex) && !(ex is OutOfMemoryException))
+                    if (ClientUtils.IsCriticalException(ex) && ex is not OutOfMemoryException)
                     {
                         throw;
                     }
@@ -12604,16 +12587,14 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmPrintClient(ref Message m)
         {
-            Gdi32.HDC hdc = (Gdi32.HDC)m.WParam;
+            Gdi32.HDC hdc = (Gdi32.HDC)m._WParam;
             if (hdc.IsNull)
             {
                 return;
             }
 
-            using (PaintEventArgs e = new PrintPaintEventArgs(m, hdc, ClientRectangle))
-            {
-                OnPrint(e);
-            }
+            using PaintEventArgs e = new PrintPaintEventArgs(m, hdc, ClientRectangle);
+            OnPrint(e);
         }
 
         private void WmQueryNewPalette(ref Message m)
@@ -12629,7 +12610,7 @@ namespace System.Windows.Forms
                 realizePalette: true);
 
             Invalidate(true);
-            m.Result = (IntPtr)1;
+            m._Result = 1;
             DefWndProc(ref m);
         }
 
@@ -12638,10 +12619,8 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmSetCursor(ref Message m)
         {
-            // Accessing through the Handle property has side effects that break this
-            // logic. You must use InternalHandle.
-            //
-            if (m.WParam == InternalHandle && PARAM.LOWORD(m.LParam) == (int)User32.HT.CLIENT)
+            // Accessing through the Handle property has side effects that break this logic. You must use InternalHandle.
+            if (m._WParam == InternalHandle && (User32.HT)PARAM.LOWORD(m._LParam) == User32.HT.CLIENT)
             {
                 Cursor.Current = Cursor;
             }
@@ -12652,19 +12631,18 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles the WM_WINDOWPOSCHANGING message
+        ///  Handles the WM_WINDOWPOSCHANGING message.
         /// </summary>
         private unsafe void WmWindowPosChanging(ref Message m)
         {
             // We let this fall through to defwndproc unless we are being surfaced as
             // an ActiveX control.  In that case, we must let the ActiveX side of things
             // manipulate our bounds here.
-            //
             if (IsActiveX)
             {
-                User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
+                User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m._LParam;
+
                 // Only call UpdateBounds if the new bounds are different.
-                //
                 bool different = false;
 
                 if ((wp->flags & User32.SWP.NOMOVE) == 0 && (wp->x != Left || wp->y != Top))
@@ -12687,21 +12665,21 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles the WM_PARENTNOTIFY message
+        ///  Handles the WM_PARENTNOTIFY message.
         /// </summary>
         private void WmParentNotify(ref Message m)
         {
-            int msg = PARAM.LOWORD(m.WParam);
+            User32.WM msg = (User32.WM)PARAM.LOWORD(m._WParam);
             IntPtr hWnd = IntPtr.Zero;
-            switch ((User32.WM)msg)
+            switch (msg)
             {
                 case User32.WM.CREATE:
-                    hWnd = m.LParam;
+                    hWnd = m._LParam;
                     break;
                 case User32.WM.DESTROY:
                     break;
                 default:
-                    hWnd = User32.GetDlgItem(this, (User32.DialogItemID)PARAM.HIWORD(m.WParam));
+                    hWnd = User32.GetDlgItem(this, (User32.DialogItemID)PARAM.HIWORD(m._WParam));
                     break;
             }
 
@@ -12712,11 +12690,11 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles the WM_SETFOCUS message
+        ///  Handles the WM_SETFOCUS message.
         /// </summary>
         private void WmSetFocus(ref Message m)
         {
-            Debug.WriteLineIf(s_focusTracing.TraceVerbose, "Control::WmSetFocus - " + Name);
+            Debug.WriteLineIf(s_focusTracing.TraceVerbose, $"Control::WmSetFocus - {Name}");
             WmImeSetFocus();
 
             if (!HostedInWin32DialogManager)
@@ -12732,9 +12710,7 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        // Reviewed : Taking focus and activating a control in response
-                        //          : to a user gesture (WM_SETFOCUS) is OK.
-                        //
+                        // Taking focus and activating a control in response to a user gesture (WM_SETFOCUS) is OK.
                         activateSucceed = c.ActivateControl(this);
                     }
 
@@ -12750,7 +12726,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles the WM_SHOWWINDOW message
+        ///  Handles the WM_SHOWWINDOW message.
         /// </summary>
         private void WmShowWindow(ref Message m)
         {
@@ -12760,7 +12736,7 @@ namespace System.Windows.Forms
 
             if ((_state & States.Recreate) == 0)
             {
-                bool visible = m.WParam != IntPtr.Zero;
+                bool visible = m._WParam != 0;
                 bool oldVisibleProperty = Visible;
 
                 if (visible)
@@ -12838,7 +12814,7 @@ namespace System.Windows.Forms
 
             DefWndProc(ref m);
 
-            User32.UIS cmd = (User32.UIS)PARAM.LOWORD(m.WParam);
+            User32.UIS cmd = (User32.UIS)PARAM.LOWORD(m._WParam);
 
             // if we're initializing, don't bother updating the uiCuesState/Firing the event.
 
@@ -12856,7 +12832,7 @@ namespace System.Windows.Forms
             // When we're called here with a UIS_CLEAR and the hidden state is set
             // that means we want to show the accelerator.
             UICues UIcues = UICues.None;
-            if (((User32.UISF)PARAM.HIWORD(m.WParam) & User32.UISF.HIDEACCEL) != 0)
+            if (((User32.UISF)PARAM.HIWORD(m._WParam) & User32.UISF.HIDEACCEL) != 0)
             {
                 // yes, clear means show.  nice api, guys.
                 //
@@ -12866,8 +12842,7 @@ namespace System.Windows.Forms
                 {
                     UIcues |= UICues.ChangeKeyboard;
 
-                    // clear the old state.
-                    //
+                    // Clear the old state.
                     _uiCuesState &= ~UICuesStates.KeyboardMask;
                     _uiCuesState |= (showKeyboard ? UICuesStates.KeyboardShow : UICuesStates.KeyboardHidden);
                 }
@@ -12879,16 +12854,16 @@ namespace System.Windows.Forms
             }
 
             // Same deal for the Focus cues as the keyboard cues.
-            if (((User32.UISF)PARAM.HIWORD(m.WParam) & User32.UISF.HIDEFOCUS) != 0)
+            if (((User32.UISF)PARAM.HIWORD(m._WParam) & User32.UISF.HIDEFOCUS) != 0)
             {
-                // yes, clear means show.  nice api, guys.
-                bool showFocus = (cmd == User32.UIS.CLEAR);
+                // Yes, clear means show.
+                bool showFocus = cmd == User32.UIS.CLEAR;
 
                 if (showFocus != focus || !focusInitialized)
                 {
                     UIcues |= UICues.ChangeFocus;
 
-                    // clear the old state.
+                    // Clear the old state.
                     _uiCuesState &= ~UICuesStates.FocusMask;
                     _uiCuesState |= (showFocus ? UICuesStates.FocusShow : UICuesStates.FocusHidden);
                 }
@@ -12899,7 +12874,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            // fire the UI cues state changed event.
+            // Fire the UI cues state changed event.
             if ((UIcues & UICues.Changed) != 0)
             {
                 OnChangeUICues(new UICuesEventArgs(UIcues));
@@ -12908,17 +12883,19 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles the WM_WINDOWPOSCHANGED message
+        ///  Handles the WM_WINDOWPOSCHANGED message.
         /// </summary>
         private unsafe void WmWindowPosChanged(ref Message m)
         {
             DefWndProc(ref m);
+
             // Update new size / position
             UpdateBounds();
-            if (_parent is not null && User32.GetParent(new HandleRef(_window, InternalHandle)) == _parent.InternalHandle &&
-                (_state & States.NoZOrder) == 0)
+            if (_parent is not null
+                && User32.GetParent(new HandleRef(_window, InternalHandle)) == _parent.InternalHandle
+                && (_state & States.NoZOrder) == 0)
             {
-                User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
+                User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m._LParam;
                 if ((wp->flags & User32.SWP.NOZORDER) == 0)
                 {
                     _parent.UpdateChildControlIndex(this);
@@ -12933,21 +12910,18 @@ namespace System.Windows.Forms
         /// </summary>
         protected virtual void WndProc(ref Message m)
         {
-            // inlined code from GetStyle(...) to ensure no perf hit
-            // for a method call...
+            // Inlined code from GetStyle(...) to ensure no perf hit for a method call.
 
             if ((_controlStyle & ControlStyles.EnableNotifyMessage) == ControlStyles.EnableNotifyMessage)
             {
-                // pass message *by value* to avoid the possibility
-                // of the OnNotifyMessage modifying the message.
-                //
+                // Pass message *by value* to avoid the possibility of the OnNotifyMessage modifying the message.
                 OnNotifyMessage(m);
             }
 
             // If you add any new messages below (or change the message handling code for any messages)
             // please make sure that you also modify AxHost.WndProc to do the right thing and intercept
             // messages which the Ocx would own before passing them onto Control.WndProc.
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.CAPTURECHANGED:
                     WmCaptureChanged(ref m);
@@ -12974,7 +12948,7 @@ namespace System.Windows.Forms
                     break;
 
                 case User32.WM.DRAWITEM:
-                    if (m.WParam != IntPtr.Zero)
+                    if (m._WParam != 0)
                     {
                         WmOwnerDraw(ref m);
                     }
@@ -13014,16 +12988,16 @@ namespace System.Windows.Forms
                     break;
 
                 case User32.WM.SYSCOMMAND:
-                    if ((User32.SC)(unchecked((int)(long)m.WParam) & 0xFFF0) == User32.SC.KEYMENU)
+                    if ((User32.SC)(m._WParam & 0xFFF0) == User32.SC.KEYMENU)
                     {
-                        Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Control.WndProc processing " + m.ToString());
+                        Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"Control.WndProc processing {m}");
 
                         if (ToolStripManager.ProcessMenuKey(ref m))
                         {
                             Debug.WriteLineIf(
                                 s_controlKeyboardRouting.TraceVerbose,
-                                "Control.WndProc ToolStripManager.ProcessMenuKey returned true" + m.ToString());
-                            m.Result = IntPtr.Zero;
+                                $"Control.WndProc ToolStripManager.ProcessMenuKey returned true{m}");
+                            m._Result = 0;
                             return;
                         }
                     }
@@ -13040,7 +13014,7 @@ namespace System.Windows.Forms
                     break;
 
                 case User32.WM.MEASUREITEM:
-                    if (m.WParam != IntPtr.Zero)
+                    if (m._WParam != 0)
                     {
                         WmOwnerDraw(ref m);
                     }
@@ -13101,7 +13075,7 @@ namespace System.Windows.Forms
                 case User32.WM.VKEYTOITEM:
                 case User32.WM.CHARTOITEM:
                 case User32.WM.COMPAREITEM:
-                    if (!ReflectMessage(m.LParam, ref m))
+                    if (!ReflectMessage(m._LParam, ref m))
                     {
                         DefWndProc(ref m);
                     }
@@ -13163,15 +13137,15 @@ namespace System.Windows.Forms
                     break;
 
                 case User32.WM.XBUTTONDOWN:
-                    WmMouseDown(ref m, GetXButton(PARAM.HIWORD(m.WParam)), 1);
+                    WmMouseDown(ref m, GetXButton(PARAM.HIWORD(m._WParam)), 1);
                     break;
 
                 case User32.WM.XBUTTONUP:
-                    WmMouseUp(ref m, GetXButton(PARAM.HIWORD(m.WParam)), 1);
+                    WmMouseUp(ref m, GetXButton(PARAM.HIWORD(m._WParam)), 1);
                     break;
 
                 case User32.WM.XBUTTONDBLCLK:
-                    WmMouseDown(ref m, GetXButton(PARAM.HIWORD(m.WParam)), 2);
+                    WmMouseDown(ref m, GetXButton(PARAM.HIWORD(m._WParam)), 2);
                     if (GetStyle(ControlStyles.StandardDoubleClick))
                     {
                         SetState(States.DoubleClickFired, true);
@@ -13185,12 +13159,12 @@ namespace System.Windows.Forms
 
                 case User32.WM.DPICHANGED_BEFOREPARENT:
                     WmDpiChangedBeforeParent(ref m);
-                    m.Result = IntPtr.Zero;
+                    m._Result = 0;
                     break;
 
                 case User32.WM.DPICHANGED_AFTERPARENT:
                     WmDpiChangedAfterParent(ref m);
-                    m.Result = IntPtr.Zero;
+                    m._Result = 0;
                     break;
 
                 case User32.WM.MOUSEMOVE:
@@ -13214,7 +13188,7 @@ namespace System.Windows.Forms
                     break;
 
                 case User32.WM.REFLECT_NOTIFYFORMAT:
-                    m.Result = (IntPtr)User32.NFR.UNICODE;
+                    m._Result = (nint)User32.NFR.UNICODE;
                     break;
 
                 case User32.WM.SHOWWINDOW:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -22492,8 +22492,8 @@ namespace System.Windows.Forms
                         !IsSharedCellReadOnly(dataGridViewCell, _ptCurrentCell.Y) &&
                         (EditMode == DataGridViewEditMode.EditOnKeystroke || EditMode == DataGridViewEditMode.EditOnKeystrokeOrF2))
                     {
-                        KeyEventArgs ke = new KeyEventArgs((Keys)(unchecked((int)(long)m.WParam)) | ModifierKeys);
-                        if (ke.KeyCode != Keys.ProcessKey || (int)m.LParam != 0x01) // Changing IME context does not trigger editing mode
+                        KeyEventArgs ke = new KeyEventArgs((Keys)m._WParam | ModifierKeys);
+                        if (ke.KeyCode != Keys.ProcessKey || m._LParam != 0x01) // Changing IME context does not trigger editing mode
                         {
                             Type editControlType = dataGridViewCell.EditType;
                             Type editingCellInterface = null;
@@ -22514,7 +22514,7 @@ namespace System.Windows.Forms
                                     // Forward the key message to the editing control if any
                                     if (EditingControl is not null)
                                     {
-                                        User32.SendMessageW(EditingControl, (User32.WM)m.Msg, m.WParam, m.LParam);
+                                        User32.SendMessageW(EditingControl, m._Msg, m._WParam, m._LParam);
                                         _dataGridViewState1[State1_ForwardCharMessage] = true;
                                         return true;
                                     }
@@ -22524,13 +22524,13 @@ namespace System.Windows.Forms
                     }
                 }
             }
-            else if (_dataGridViewState1[State1_ForwardCharMessage] &&
-                     (m.Msg == (int)User32.WM.SYSCHAR || m.Msg == (int)User32.WM.CHAR || m.Msg == (int)User32.WM.IME_CHAR))
+            else if (_dataGridViewState1[State1_ForwardCharMessage]
+                && (m._Msg == User32.WM.SYSCHAR || m._Msg == User32.WM.CHAR || m._Msg == User32.WM.IME_CHAR))
             {
                 _dataGridViewState1[State1_ForwardCharMessage] = false;
                 if (EditingControl is not null)
                 {
-                    User32.SendMessageW(EditingControl, (User32.WM)m.Msg, m.WParam, m.LParam);
+                    User32.SendMessageW(EditingControl, m._Msg, m._WParam, m._LParam);
                     return true;
                 }
             }
@@ -22541,14 +22541,14 @@ namespace System.Windows.Forms
         protected override bool ProcessKeyPreview(ref Message m)
         {
             bool dataGridViewWantsInputKey;
-            KeyEventArgs ke = new KeyEventArgs((Keys)((int)m.WParam) | ModifierKeys);
+            KeyEventArgs ke = new KeyEventArgs((Keys)m._WParam | ModifierKeys);
 
             // Refactor the special keys into two parts.
             // 1. Escape and Space exist in both WM_CHAR and WM_KEYDOWN, WM_KEYUP.
             // 2. Other special keys do not exist in WM_CHAR message, and character code of WM_CHAR may have overlapped
             // w/ some of the key code. (Like character code of lowercase "q" is 0x71, it's overlapped w/ Keys.F2). This
             // may introduce problem when handling them.
-            if (m.Msg == (int)User32.WM.CHAR)
+            if (m._Msg == User32.WM.CHAR)
             {
                 switch (ke.KeyCode)
                 {
@@ -22590,9 +22590,10 @@ namespace System.Windows.Forms
                 }
             }
 
-            if (EditingControl is not null && (m.Msg == (int)User32.WM.KEYDOWN || m.Msg == (int)User32.WM.SYSKEYDOWN))
+            if (EditingControl is not null && (m._Msg == User32.WM.KEYDOWN || m._Msg == User32.WM.SYSKEYDOWN))
             {
-                _dataGridViewState2[State2_CurrentCellWantsInputKey] = ((IDataGridViewEditingControl)EditingControl).EditingControlWantsInputKey(ke.KeyData, dataGridViewWantsInputKey);
+                _dataGridViewState2[State2_CurrentCellWantsInputKey] =
+                    ((IDataGridViewEditingControl)EditingControl).EditingControlWantsInputKey(ke.KeyData, dataGridViewWantsInputKey);
             }
 
             if (_dataGridViewState2[State2_CurrentCellWantsInputKey])
@@ -22602,7 +22603,7 @@ namespace System.Windows.Forms
 
             if (dataGridViewWantsInputKey)
             {
-                if (m.Msg == (int)User32.WM.KEYDOWN || m.Msg == (int)User32.WM.SYSKEYDOWN)
+                if (m._Msg == User32.WM.KEYDOWN || m._Msg == User32.WM.SYSKEYDOWN)
                 {
                     if (ProcessDataGridViewKey(ke))
                     {
@@ -30299,22 +30300,19 @@ namespace System.Windows.Forms
         internal override void WmContextMenu(ref Message m)
         {
             ContextMenuStrip contextMenuStrip;
-            int x = unchecked((int)(short)(long)m.LParam);
-            int y = unchecked((int)(long)m.LParam) >> 16;
             Point client;
             bool keyboardActivated = false;
-            // lparam will be exactly -1 when the user invokes the context menu
-            // with the keyboard.
-            //
-            if (unchecked((int)(long)m.LParam) == -1)
+
+            // lparam will be -1 when the user invokes the context menu with the keyboard.
+            if (m._LParam == -1)
             {
                 keyboardActivated = true;
                 client = new Point(Width / 2, Height / 2);
-                contextMenuStrip = (ContextMenuStrip)ContextMenuStrip;
+                contextMenuStrip = ContextMenuStrip;
             }
             else
             {
-                client = PointToClient(new Point(x, y));
+                client = PointToClient(PARAM.ToPoint(m._LParam));
                 HitTestInfo hti = HitTest(client.X, client.Y);
                 DataGridViewCell dataGridViewCell = null;
                 switch (hti.Type)
@@ -30343,7 +30341,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    contextMenuStrip = (ContextMenuStrip)ContextMenuStrip;
+                    contextMenuStrip = ContextMenuStrip;
                 }
             }
 
@@ -30363,23 +30361,23 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmGetDlgCode(ref Message m)
         {
-            m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTARROWS | (int)User32.DLGC.WANTCHARS);
+            m._Result = m._Result | (int)User32.DLGC.WANTARROWS | (int)User32.DLGC.WANTCHARS;
 
             Keys modifierKeys = ModifierKeys;
             if (GetTabKeyEffective((modifierKeys & Keys.Shift) == Keys.Shift, (modifierKeys & Keys.Control) == Keys.Control))
             {
-                m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTTAB);
+                m._Result = m._Result | (int)User32.DLGC.WANTTAB;
             }
         }
 
         private unsafe bool WmNotify(ref Message m)
         {
-            if (m.LParam == IntPtr.Zero)
+            if (m._LParam == 0)
             {
                 return false;
             }
 
-            User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+            User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
             if (nmhdr->code == (int)ComCtl32.TTN.GETDISPINFOW && !DesignMode)
             {
                 string toolTip = ToolTipPrivate;
@@ -30389,7 +30387,7 @@ namespace System.Windows.Forms
                     // Setting the max width has the added benefit of enabling multiline tool tips
                     User32.SendMessageW(nmhdr->hwndFrom, (User32.WM)ComCtl32.TTM.SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
 
-                    ComCtl32.NMTTDISPINFOW* ttt = (ComCtl32.NMTTDISPINFOW*)m.LParam;
+                    ComCtl32.NMTTDISPINFOW* ttt = (ComCtl32.NMTTDISPINFOW*)m._LParam;
                     _toolTipBuffer.SetText(toolTip);
                     ttt->lpszText = _toolTipBuffer.Buffer;
                     ttt->hinst = IntPtr.Zero;
@@ -30408,7 +30406,7 @@ namespace System.Windows.Forms
 
         protected override void WndProc(ref Message m)
         {
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.GETDLGCODE:
                     WmGetDlgCode(ref m);
@@ -30441,7 +30439,7 @@ namespace System.Windows.Forms
                     if (EditingControl is not null)
                     {
                         // Make sure that the first character is forwarded to the editing control.
-                        User32.SendMessageW(EditingControl, (User32.WM)m.Msg, m.WParam, m.LParam);
+                        User32.SendMessageW(EditingControl, m._Msg, m._WParam, m._LParam);
                     }
 
                     break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.cs
@@ -257,29 +257,29 @@ namespace System.Windows.Forms
         protected override void OnTextChanged(EventArgs e)
         {
             base.OnTextChanged(e);
+
             // Let the DataGridView know about the value change
             NotifyDataGridViewOfValueChange();
         }
 
         protected override bool ProcessKeyEventArgs(ref Message m)
         {
-            switch ((Keys)PARAM.ToInt(m.WParam))
+            switch ((Keys)m._WParam)
             {
                 case Keys.Enter:
-                    if (m.Msg == (int)User32.WM.CHAR &&
-                        !(ModifierKeys == Keys.Shift && Multiline && AcceptsReturn))
+                    if (m._Msg == User32.WM.CHAR
+                        && !(ModifierKeys == Keys.Shift && Multiline && AcceptsReturn))
                     {
-                        // Ignore the Enter key and don't add it to the textbox content. This happens when failing validation brings
-                        // up a dialog box for example.
-                        // Shift-Enter for multiline textboxes need to be accepted however.
+                        // Ignore the Enter key and don't add it to the textbox content. This happens when failing
+                        // validation brings up a dialog box for example. Shift-Enter for multiline textboxes need to
+                        // be accepted however.
                         return true;
                     }
 
                     break;
 
                 case Keys.LineFeed:
-                    if (m.Msg == (int)User32.WM.CHAR &&
-                        ModifierKeys == Keys.Control && Multiline && AcceptsReturn)
+                    if (m._Msg == User32.WM.CHAR && ModifierKeys == Keys.Control && Multiline && AcceptsReturn)
                     {
                         // Ignore linefeed character when user hits Ctrl-Enter to commit the cell.
                         return true;
@@ -288,7 +288,7 @@ namespace System.Windows.Forms
                     break;
 
                 case Keys.A:
-                    if (m.Msg == (int)User32.WM.KEYDOWN && ModifierKeys == Keys.Control)
+                    if (m._Msg == User32.WM.KEYDOWN && ModifierKeys == Keys.Control)
                     {
                         SelectAll();
                         return true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -1455,7 +1455,7 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void WmDateTimeChange(ref Message m)
         {
-            NMDATETIMECHANGE* nmdtc = (NMDATETIMECHANGE*)m.LParam;
+            NMDATETIMECHANGE* nmdtc = (NMDATETIMECHANGE*)m._LParam;
             DateTime temp = _value;
             bool oldvalid = _validTime;
             if (nmdtc->dwFlags != GDT.NONE)
@@ -1513,7 +1513,7 @@ namespace System.Windows.Forms
         {
             if (m.HWnd == Handle)
             {
-                User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+                User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
                 switch ((DTN)nmhdr->code)
                 {
                     case DTN.CLOSEUP:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.PageSelector.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.PageSelector.cs
@@ -195,11 +195,11 @@ namespace System.Windows.Forms.Design
 
             private unsafe void OnCustomDraw(ref Message m)
             {
-                ComCtl32.NMTVCUSTOMDRAW* nmtvcd = (ComCtl32.NMTVCUSTOMDRAW*)m.LParam;
+                ComCtl32.NMTVCUSTOMDRAW* nmtvcd = (ComCtl32.NMTVCUSTOMDRAW*)m._LParam;
                 switch (nmtvcd->nmcd.dwDrawStage)
                 {
                     case ComCtl32.CDDS.PREPAINT:
-                        m.Result = (IntPtr)(ComCtl32.CDRF.NOTIFYITEMDRAW | ComCtl32.CDRF.NOTIFYPOSTPAINT);
+                        m._Result = (nint)(ComCtl32.CDRF.NOTIFYITEMDRAW | ComCtl32.CDRF.NOTIFYPOSTPAINT);
                         break;
                     case ComCtl32.CDDS.ITEMPREPAINT:
                         {
@@ -228,15 +228,15 @@ namespace System.Windows.Forms.Design
                                     ColorTranslator.ToWin32(SystemColors.ControlText));
                             }
 
-                            m.Result = (IntPtr)ComCtl32.CDRF.SKIPDEFAULT;
+                            m._Result = (nint)ComCtl32.CDRF.SKIPDEFAULT;
                         }
 
                         break;
                     case ComCtl32.CDDS.POSTPAINT:
-                        m.Result = (IntPtr)ComCtl32.CDRF.SKIPDEFAULT;
+                        m._Result = (nint)ComCtl32.CDRF.SKIPDEFAULT;
                         break;
                     default:
-                        m.Result = (IntPtr)ComCtl32.CDRF.DODEFAULT;
+                        m._Result = (nint)ComCtl32.CDRF.DODEFAULT;
                         break;
                 }
             }
@@ -269,9 +269,9 @@ namespace System.Windows.Forms.Design
 
             protected unsafe override void WndProc(ref Message m)
             {
-                if (m.Msg == (int)(User32.WM.REFLECT_NOTIFY))
+                if (m._Msg == User32.WM.REFLECT_NOTIFY)
                 {
-                    User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+                    User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
                     if (nmhdr->code == (int)ComCtl32.NM.CUSTOMDRAW)
                     {
                         OnCustomDraw(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DpiChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DpiChangedEventArgs.cs
@@ -5,7 +5,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
-using System.Runtime.InteropServices;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -18,12 +17,12 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Parameter units are pixels(dots) per inch.
         /// </summary>
-        internal DpiChangedEventArgs(int old, Message m)
+        internal unsafe DpiChangedEventArgs(int old, Message m)
         {
             DeviceDpiOld = old;
-            DeviceDpiNew = PARAM.SignedLOWORD(m.WParam);
-            Debug.Assert(PARAM.SignedHIWORD(m.WParam) == DeviceDpiNew, "Non-square pixels!");
-            RECT suggestedRect = Marshal.PtrToStructure<RECT>(m.LParam);
+            DeviceDpiNew = PARAM.SignedLOWORD(m._WParam);
+            Debug.Assert(PARAM.SignedHIWORD(m._WParam) == DeviceDpiNew, "Non-square pixels!");
+            RECT suggestedRect = *(RECT*)m._LParam;
             SuggestedRectangle = Rectangle.FromLTRB(suggestedRect.left, suggestedRect.top, suggestedRect.right, suggestedRect.bottom);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.cs
@@ -424,22 +424,22 @@ namespace System.Windows.Forms
             /// </summary>
             private void WmGetObject(ref Message m)
             {
-                Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, "In WmGetObject, this = " + GetType().FullName + ", lParam = " + m.LParam.ToString());
+                Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, $"In WmGetObject, this = {GetType().FullName}, lParam = {m._LParam}");
 
-                if (m.Msg == (int)User32.WM.GETOBJECT && m.LParam == (IntPtr)NativeMethods.UiaRootObjectId)
+                if (m.Msg == (int)User32.WM.GETOBJECT && m._LParam == NativeMethods.UiaRootObjectId)
                 {
                     // If the requested object identifier is UiaRootObjectId,
                     // we should return an UI Automation provider using the UiaReturnRawElementProvider function.
-                    m.Result = UiaCore.UiaReturnRawElementProvider(
-                        new HandleRef(this, Handle),
-                        m.WParam,
-                        m.LParam,
+                    m._Result = UiaCore.UiaReturnRawElementProvider(
+                        this,
+                        m._WParam,
+                        m._LParam,
                         AccessibilityObject);
 
                     return;
                 }
 
-                // some accessible object requested that we don't care about, so do default message processing
+                // Some accessible object requested that we don't care about, so do default message processing.
                 DefWndProc(ref m);
             }
 
@@ -448,13 +448,13 @@ namespace System.Windows.Forms
             /// </summary>
             protected unsafe override void WndProc(ref Message m)
             {
-                switch ((User32.WM)m.Msg)
+                switch (m._Msg)
                 {
                     case User32.WM.GETOBJECT:
                         WmGetObject(ref m);
                         break;
                     case User32.WM.NOTIFY:
-                        User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+                        User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
                         if (nmhdr->code == (int)ComCtl32.TTN.SHOW || nmhdr->code == (int)ComCtl32.TTN.POP)
                         {
                             OnToolTipVisibilityChanging(nmhdr->idFrom, nmhdr->code == (int)ComCtl32.TTN.SHOW);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.cs
@@ -658,7 +658,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmEraseBkgnd(ref Message m)
         {
-            if (m.WParam == IntPtr.Zero)
+            if (m._WParam == 0)
             {
                 return;
             }
@@ -670,18 +670,18 @@ namespace System.Windows.Forms
 
             if (backColor.HasTransparency())
             {
-                using Graphics graphics = Graphics.FromHdcInternal(m.WParam);
+                using Graphics graphics = Graphics.FromHdcInternal(m._WParam);
                 using var brush = backColor.GetCachedSolidBrushScope();
                 graphics.FillRectangle(brush, rect);
             }
             else
             {
-                var hdc = (Gdi32.HDC)m.WParam;
+                var hdc = (Gdi32.HDC)m._WParam;
                 using var hbrush = new Gdi32.CreateBrushScope(backColor);
                 User32.FillRect(hdc, ref rect, hbrush);
             }
 
-            m.Result = (IntPtr)1;
+            m._Result = 1;
         }
 
         protected override void WndProc(ref Message m)
@@ -692,7 +692,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.ERASEBKGND:
                 case User32.WM.PRINTCLIENT:
@@ -705,9 +705,9 @@ namespace System.Windows.Forms
                     // will always be exposed through MSAA. Reason: When FlatStyle=System, we map down to the Win32
                     // "Button" window class to get OS group box rendering; but the OS does not expose the children
                     // of buttons to MSAA (because it assumes buttons won't have children).
-                    if (unchecked((int)(long)m.LParam) == User32.OBJID.QUERYCLASSNAMEIDX)
+                    if (m._LParam == User32.OBJID.QUERYCLASSNAMEIDX)
                     {
-                        m.Result = IntPtr.Zero;
+                        m._Result = 0;
                     }
 
                     break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HandledMouseEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HandledMouseEventArgs.cs
@@ -2,15 +2,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+
 namespace System.Windows.Forms
 {
     public class HandledMouseEventArgs : MouseEventArgs
     {
-        public HandledMouseEventArgs(MouseButtons button, int clicks, int x, int y, int delta) : this(button, clicks, x, y, delta, false)
+        public HandledMouseEventArgs(MouseButtons button, int clicks, int x, int y, int delta)
+            : this(button, clicks, x, y, delta, false)
         {
         }
 
-        public HandledMouseEventArgs(MouseButtons button, int clicks, int x, int y, int delta, bool defaultHandledValue) : base(button, clicks, x, y, delta)
+        internal HandledMouseEventArgs(MouseButtons button, int clicks, Point location, int delta)
+            : this(button, clicks, location.X, location.Y, delta, false)
+        {
+        }
+
+        public HandledMouseEventArgs(MouseButtons button, int clicks, int x, int y, int delta, bool defaultHandledValue)
+            : base(button, clicks, x, y, delta)
         {
             Handled = defaultHandledValue;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/InputLanguage.cs
@@ -301,7 +301,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal static InputLanguageChangedEventArgs CreateInputLanguageChangedEventArgs(Message m)
         {
-            return new InputLanguageChangedEventArgs(new InputLanguage(m.LParam), unchecked((byte)(long)m.WParam));
+            return new InputLanguageChangedEventArgs(new InputLanguage(m._LParam), (byte)m._WParam);
         }
 
         /// <summary>
@@ -309,10 +309,10 @@ namespace System.Windows.Forms
         /// </summary>
         internal static InputLanguageChangingEventArgs CreateInputLanguageChangingEventArgs(Message m)
         {
-            var inputLanguage = new InputLanguage(m.LParam);
+            var inputLanguage = new InputLanguage(m._LParam);
 
             // NOTE: by default we should allow any locale switch
-            bool localeSupportedBySystem = m.WParam != IntPtr.Zero;
+            bool localeSupportedBySystem = m._WParam != 0;
             return new InputLanguageChangingEventArgs(inputLanguage, localeSupportedBySystem);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1498,8 +1498,8 @@ namespace System.Windows.Forms
                     // this so we can tell what's going on.
 
                     Rectangle rectInScreen = RectangleToScreen(new Rectangle(0, 0, Width, Height));
-                    Point pt = new Point(unchecked((int)(long)m.LParam));
-                    m.Result = (IntPtr)(rectInScreen.Contains(pt) ? User32.HT.CLIENT : User32.HT.NOWHERE);
+                    Point pt = new Point((int)m._LParam);
+                    m._Result = (nint)(rectInScreen.Contains(pt) ? User32.HT.CLIENT : User32.HT.NOWHERE);
                     break;
 
                 default:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -2008,23 +2008,14 @@ namespace System.Windows.Forms
         internal override bool SupportsUiaProviders => true;
 
         /// <summary>
-        ///  Handles the WM_SETCURSOR message
+        ///  Handles the WM_SETCURSOR message.
         /// </summary>
         private void WmSetCursor(ref Message m)
         {
-            // Accessing through the Handle property has side effects that break this
-            // logic. You must use InternalHandle.
-            //
-            if (m.WParam == InternalHandle && PARAM.LOWORD(m.LParam) == (int)User32.HT.CLIENT)
+            // Accessing through the Handle property has side effects that break this logic. You must use InternalHandle.
+            if (m._WParam == InternalHandle && (User32.HT)PARAM.LOWORD(m._LParam) == User32.HT.CLIENT)
             {
-                if (OverrideCursor is not null)
-                {
-                    Cursor.Current = OverrideCursor;
-                }
-                else
-                {
-                    Cursor.Current = Cursor;
-                }
+                Cursor.Current = OverrideCursor ?? Cursor;
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -2500,12 +2500,12 @@ namespace System.Windows.Forms
 
         private unsafe int CompensateColumnHeaderResize(Message m, bool columnResizeCancelled)
         {
-            if (Application.ComCtlSupportsVisualStyles &&
-                View == View.Details &&
-                !columnResizeCancelled &&
-                Items.Count > 0)
+            if (Application.ComCtlSupportsVisualStyles
+                && View == View.Details
+                && !columnResizeCancelled
+                && Items.Count > 0)
             {
-                NMHEADERW* header = (NMHEADERW*)m.LParam;
+                NMHEADERW* header = (NMHEADERW*)m._LParam;
                 return CompensateColumnHeaderResize(header->iItem, columnResizeCancelled);
             }
             else
@@ -2612,19 +2612,19 @@ namespace System.Windows.Forms
 
             try
             {
-                NMLVCUSTOMDRAW* nmcd = (NMLVCUSTOMDRAW*)m.LParam;
+                NMLVCUSTOMDRAW* nmcd = (NMLVCUSTOMDRAW*)m._LParam;
                 // Find out which stage we're drawing
                 switch (nmcd->nmcd.dwDrawStage)
                 {
                     case CDDS.PREPAINT:
                         if (OwnerDraw)
                         {
-                            m.Result = (IntPtr)CDRF.NOTIFYITEMDRAW;
+                            m._Result = (nint)CDRF.NOTIFYITEMDRAW;
                             return;
                         }
 
                         // We want custom draw for this paint cycle
-                        m.Result = (IntPtr)(CDRF.NOTIFYSUBITEMDRAW | CDRF.NEWFONT);
+                        m._Result = (nint)(CDRF.NOTIFYSUBITEMDRAW | CDRF.NEWFONT);
 
                         // refresh the cache of the current color & font settings for this paint cycle
                         odCacheBackColor = BackColor;
@@ -2641,15 +2641,15 @@ namespace System.Windows.Forms
                             odCacheFontHandleWrapper = new FontHandleWrapper(odCacheFont);
                             odCacheFontHandle = odCacheFontHandleWrapper.Handle;
                             Gdi32.SelectObject(nmcd->nmcd.hdc, odCacheFontHandleWrapper.Handle);
-                            m.Result = (IntPtr)CDRF.NEWFONT;
+                            m._Result = (nint)CDRF.NEWFONT;
                         }
 
                         return;
 
-                    //We have to return a NOTIFYSUBITEMDRAW (called NOTIFYSUBITEMREDRAW in the docs) here to
-                    //get it to enter "change all subitems instead of whole rows" mode.
+                    // We have to return a NOTIFYSUBITEMDRAW (called NOTIFYSUBITEMREDRAW in the docs) here to
+                    // get it to enter "change all subitems instead of whole rows" mode.
 
-                    //HOWEVER... we only want to do this for report styles...
+                    // HOWEVER... we only want to do this for report styles...
 
                     case CDDS.ITEMPREPAINT:
 
@@ -2684,13 +2684,13 @@ namespace System.Windows.Forms
                             // For other view styles, we do it here.
                             if (viewStyle == View.Details)
                             {
-                                m.Result = (IntPtr)CDRF.NOTIFYSUBITEMDRAW;
+                                m._Result = (nint)CDRF.NOTIFYSUBITEMDRAW;
                             }
                             else
                             {
                                 if (!e.DrawDefault)
                                 {
-                                    m.Result = (IntPtr)CDRF.SKIPDEFAULT;
+                                    m._Result = (nint)CDRF.SKIPDEFAULT;
                                 }
                             }
 
@@ -2702,16 +2702,16 @@ namespace System.Windows.Forms
 
                         if (viewStyle == View.Details || viewStyle == View.Tile)
                         {
-                            m.Result = (IntPtr)(CDRF.NOTIFYSUBITEMDRAW | CDRF.NEWFONT);
+                            m._Result = (nint)(CDRF.NOTIFYSUBITEMDRAW | CDRF.NEWFONT);
                             dontmess = true; // don't mess with our return value!
 
-                            //ITEMPREPAINT is used to work out the rect for the first column!!! GAH!!!
-                            //(which means we can't just do our color/font work on SUBITEM|ITEM_PREPAINT)
-                            //so fall through... and tell the end of SUBITEM|ITEM_PREPAINT not to mess
-                            //with our return value...
+                            // ITEMPREPAINT is used to work out the rect for the first column!!! GAH!!!
+                            // (which means we can't just do our color/font work on SUBITEM|ITEM_PREPAINT)
+                            // so fall through... and tell the end of SUBITEM|ITEM_PREPAINT not to mess
+                            // with our return value...
                         }
 
-                        //If it's not a report, we fall through and change the main item's styles
+                        // If it's not a report, we fall through and change the main item's styles
 
                         goto case (CDDS.SUBITEM | CDDS.ITEMPREPAINT);
 
@@ -2774,7 +2774,7 @@ namespace System.Windows.Forms
 
                             if (skipCustomDrawCode)
                             {
-                                m.Result = (IntPtr)CDRF.SKIPDEFAULT;
+                                m._Result = (nint)CDRF.SKIPDEFAULT;
                                 return; // skip our custom draw code
                             }
                         }
@@ -2784,7 +2784,7 @@ namespace System.Windows.Forms
                         // if we're doing the whole row in one style, change our result!
                         if (dontmess && item.UseItemStyleForSubItems)
                         {
-                            m.Result = (IntPtr)CDRF.NEWFONT;
+                            m._Result = (nint)CDRF.NEWFONT;
                         }
 
                         Debug.Assert(item is not null, "Item was null in ITEMPREPAINT");
@@ -2840,8 +2840,6 @@ namespace System.Windows.Forms
                         }
 
                         // We always have to set font and color data, because of comctl design
-
-                        //
 
                         Color riFore = Color.Empty;
                         Color riBack = Color.Empty;
@@ -2957,7 +2955,7 @@ namespace System.Windows.Forms
 
                         if (!dontmess)
                         {
-                            m.Result = (IntPtr)CDRF.NEWFONT;
+                            m._Result = (nint)CDRF.NEWFONT;
                         }
 
                         if (disposeSubItemFont)
@@ -2968,14 +2966,14 @@ namespace System.Windows.Forms
                         return;
 
                     default:
-                        m.Result = (IntPtr)CDRF.DODEFAULT;
+                        m._Result = (nint)CDRF.DODEFAULT;
                         return;
                 }
             }
             catch (Exception e)
             {
                 Debug.Fail("Exception occurred attempting to setup custom draw. Disabling custom draw for this control", e.ToString());
-                m.Result = (IntPtr)CDRF.DODEFAULT;
+                m._Result = (nint)CDRF.DODEFAULT;
             }
         }
 
@@ -2986,7 +2984,6 @@ namespace System.Windows.Forms
                 IO.FileInfo fi = new IO.FileInfo(fileName);
                 if (fi.Exists)
                 {
-                    //
                     // ComCtl ListView uses COM objects to manipulate the bitmap we send it to them.
                     // I could not find any resources which explain in detail when the IImgCtx objects
                     // release the temporary file. So if we get a FileIO when we delete the temporary file
@@ -3753,10 +3750,7 @@ namespace System.Windows.Forms
             User32.SendMessageW(this, (User32.WM)LVM.SETIMAGELIST, (nint)LVSIL.GROUPHEADER, handle);
         }
 
-        public ListViewHitTestInfo HitTest(Point point)
-        {
-            return HitTest(point.X, point.Y);
-        }
+        public ListViewHitTestInfo HitTest(Point point) => HitTest(point.X, point.Y);
 
         public ListViewHitTestInfo HitTest(int x, int y)
         {
@@ -4927,7 +4921,7 @@ namespace System.Windows.Forms
             {
                 var rc = new RECT();
                 var wpos = new User32.WINDOWPOS();
-                User32.GetClientRect(new HandleRef(this, Handle), ref rc);
+                User32.GetClientRect(this, ref rc);
 
                 var hd = new User32.HDLAYOUT
                 {
@@ -4940,13 +4934,15 @@ namespace System.Windows.Forms
 
                 // Position the header control.
                 User32.SetWindowPos(
-                    new HandleRef(this, hdrHWND),
-                    new HandleRef(this, wpos.hwndInsertAfter),
+                    hdrHWND,
+                    wpos.hwndInsertAfter,
                     wpos.x,
                     wpos.y,
                     wpos.cx,
                     wpos.cy,
                     wpos.flags | User32.SWP.SHOWWINDOW);
+
+                GC.KeepAlive(this);
             }
         }
 
@@ -5909,16 +5905,15 @@ namespace System.Windows.Forms
             // Windows ListView pushes its own Windows ListView in WM_xBUTTONDOWN, so fire the
             // event before calling defWndProc or else it won't get fired until the button
             // comes back up.
-            int x = PARAM.SignedLOWORD(m.LParam);
-            int y = PARAM.SignedHIWORD(m.LParam);
-            OnMouseDown(new MouseEventArgs(button, clicks, x, y, 0));
+            Point point = PARAM.ToPoint(m._LParam);
+            OnMouseDown(new MouseEventArgs(button, clicks, point));
 
-            //If Validation is cancelled don't fire any events through the Windows ListView's message loop...
+            // If Validation is cancelled don't fire any events through the Windows ListView's message loop.
             if (!ValidationCancelled)
             {
                 if (CheckBoxes)
                 {
-                    ListViewHitTestInfo lvhti = HitTest(x, y);
+                    ListViewHitTestInfo lvhti = HitTest(point);
                     if (_imageListState is not null && _imageListState.Images.Count < 2)
                     {
                         // When the user clicks on the check box and the listView's state image list
@@ -5946,37 +5941,37 @@ namespace System.Windows.Forms
                 }
             }
 
-            Point screenPoint = PointToScreen(new Point(x, y));
+            Point screenPoint = PointToScreen(point);
             AccessibleObject accessibilityObject = AccessibilityObject.HitTest(screenPoint.X, screenPoint.Y);
             accessibilityObject?.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
         }
 
         private unsafe bool WmNotify(ref Message m)
         {
-            User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+            User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
 
             if (nmhdr->code == (int)NM.CUSTOMDRAW && UiaCore.UiaClientsAreListening().IsTrue())
             {
                 // Checking that mouse buttons are not pressed is necessary to avoid
                 // multiple annotation of the column header when resizing the column with the mouse
-                if (m.LParam != IntPtr.Zero && Control.MouseButtons == MouseButtons.None)
+                if (m._LParam != 0 && MouseButtons == MouseButtons.None)
                 {
                     AnnounceColumnHeader(Cursor.Position);
                 }
             }
 
-            // column header custom draw message handling
+            // Column header custom draw message handling.
             if (nmhdr->code == (int)NM.CUSTOMDRAW && OwnerDraw)
             {
                 try
                 {
-                    NMCUSTOMDRAW* nmcd = (NMCUSTOMDRAW*)m.LParam;
+                    NMCUSTOMDRAW* nmcd = (NMCUSTOMDRAW*)m._LParam;
                     // Find out which stage we're drawing
                     switch (nmcd->dwDrawStage)
                     {
                         case CDDS.PREPAINT:
                             {
-                                m.Result = (IntPtr)CDRF.NOTIFYITEMDRAW;
+                                m._Result = (nint)CDRF.NOTIFYITEMDRAW;
                                 return true; // we are done - don't do default handling
                             }
 
@@ -5998,12 +5993,12 @@ namespace System.Windows.Forms
                                 OnDrawColumnHeader(e);
                                 if (e.DrawDefault)
                                 {
-                                    m.Result = (IntPtr)CDRF.DODEFAULT;
+                                    m._Result = (nint)CDRF.DODEFAULT;
                                     return false;
                                 }
                                 else
                                 {
-                                    m.Result = (IntPtr)CDRF.SKIPDEFAULT;
+                                    m._Result = (nint)CDRF.SKIPDEFAULT;
                                     return true; // we are done - don't do default handling
                                 }
                             }
@@ -6015,7 +6010,7 @@ namespace System.Windows.Forms
                 catch (Exception e)
                 {
                     Debug.Fail("Exception occurred attempting to setup header custom draw. Disabling custom draw for the column header", e.ToString());
-                    m.Result = (IntPtr)CDRF.DODEFAULT;
+                    m._Result = (nint)CDRF.DODEFAULT;
                 }
             }
 
@@ -6034,7 +6029,7 @@ namespace System.Windows.Forms
                 newWidthForColumnWidthChangingCancelled = -1;
                 listViewState1[LISTVIEWSTATE1_cancelledColumnWidthChanging] = false;
 
-                NMHEADERW* nmheader = (NMHEADERW*)m.LParam;
+                NMHEADERW* nmheader = (NMHEADERW*)m._LParam;
                 if (columnHeaders is not null && columnHeaders.Length > nmheader->iItem)
                 {
                     columnHeaderClicked = columnHeaders[nmheader->iItem];
@@ -6049,7 +6044,7 @@ namespace System.Windows.Forms
 
             if (nmhdr->code == (int)HDN.ITEMCHANGINGW)
             {
-                NMHEADERW* nmheader = (NMHEADERW*)m.LParam;
+                NMHEADERW* nmheader = (NMHEADERW*)m._LParam;
 
                 if (columnHeaders is not null && nmheader->iItem < columnHeaders.Length &&
                     (listViewState[LISTVIEWSTATE_headerControlTracking] || listViewState[LISTVIEWSTATE_headerDividerDblClick]))
@@ -6057,7 +6052,7 @@ namespace System.Windows.Forms
                     int newColumnWidth = ((nmheader->pitem->mask & HDI.WIDTH) != 0) ? nmheader->pitem->cxy : -1;
                     ColumnWidthChangingEventArgs colWidthChanging = new ColumnWidthChangingEventArgs(nmheader->iItem, newColumnWidth);
                     OnColumnWidthChanging(colWidthChanging);
-                    m.Result = (IntPtr)(colWidthChanging.Cancel ? 1 : 0);
+                    m._Result = colWidthChanging.Cancel ? 1 : 0;
                     if (colWidthChanging.Cancel)
                     {
                         nmheader->pitem->cxy = colWidthChanging.NewWidth;
@@ -6085,7 +6080,7 @@ namespace System.Windows.Forms
             if ((nmhdr->code == (int)HDN.ITEMCHANGEDW) &&
                 !listViewState[LISTVIEWSTATE_headerControlTracking])
             {
-                NMHEADERW* nmheader = (NMHEADERW*)m.LParam;
+                NMHEADERW* nmheader = (NMHEADERW*)m._LParam;
                 if (columnHeaders is not null && nmheader->iItem < columnHeaders.Length)
                 {
                     int w = columnHeaders[nmheader->iItem].Width;
@@ -6142,14 +6137,14 @@ namespace System.Windows.Forms
 
             if (nmhdr->code == (int)HDN.ENDTRACKW)
             {
-                Debug.Assert(listViewState[LISTVIEWSTATE_headerControlTracking], "HDN_ENDTRACK and HDN_BEGINTRACK are out of sync...");
+                Debug.Assert(listViewState[LISTVIEWSTATE_headerControlTracking], "HDN_ENDTRACK and HDN_BEGINTRACK are out of sync.");
                 listViewState[LISTVIEWSTATE_headerControlTracking] = false;
                 if (listViewState1[LISTVIEWSTATE1_cancelledColumnWidthChanging])
                 {
-                    m.Result = (IntPtr)1;
+                    m._Result = 1;
                     if (newWidthForColumnWidthChangingCancelled != -1)
                     {
-                        NMHEADERW* nmheader = (NMHEADERW*)m.LParam;
+                        NMHEADERW* nmheader = (NMHEADERW*)m._LParam;
                         if (columnHeaders is not null && columnHeaders.Length > nmheader->iItem)
                         {
                             columnHeaders[nmheader->iItem].Width = newWidthForColumnWidthChangingCancelled;
@@ -6170,7 +6165,7 @@ namespace System.Windows.Forms
 
             if (nmhdr->code == (int)HDN.ENDDRAG)
             {
-                NMHEADERW* header = (NMHEADERW*)m.LParam;
+                NMHEADERW* header = (NMHEADERW*)m._LParam;
                 if (header->pitem is not null)
                 {
                     if ((header->pitem->mask & HDI.ORDER) == HDI.ORDER)
@@ -6197,7 +6192,7 @@ namespace System.Windows.Forms
                         OnColumnReordered(chrevent);
                         if (chrevent.Cancel)
                         {
-                            m.Result = new IntPtr(1);
+                            m._Result = 1;
                             return true;
                         }
                         else
@@ -6271,7 +6266,7 @@ namespace System.Windows.Forms
                     // If the column resize was cancelled then apply the NewWidth supplied by the user.
                     if (newWidthForColumnWidthChangingCancelled != -1)
                     {
-                        NMHEADERW* nmheader = (NMHEADERW*)m.LParam;
+                        NMHEADERW* nmheader = (NMHEADERW*)m._LParam;
                         if (columnHeaders is not null && columnHeaders.Length > nmheader->iItem)
                         {
                             columnHeaders[nmheader->iItem].Width = newWidthForColumnWidthChangingCancelled;
@@ -6279,7 +6274,7 @@ namespace System.Windows.Forms
                     }
 
                     // Tell ComCtl that the HDN_DIVIDERDBLCLICK was cancelled.
-                    m.Result = (IntPtr)1;
+                    m._Result = 1;
                 }
                 else
                 {
@@ -6288,7 +6283,7 @@ namespace System.Windows.Forms
                     if (compensateForColumnResize != 0)
                     {
 #if DEBUG
-                        NMHEADERW* header = (NMHEADERW*)m.LParam;
+                        NMHEADERW* header = (NMHEADERW*)m._LParam;
                         Debug.Assert(header->iItem == 0, "we only need to compensate for the first column resize");
                         Debug.Assert(columnHeaders.Length > 0, "there should be a column that we need to compensate for");
 #endif
@@ -6391,7 +6386,7 @@ namespace System.Windows.Forms
 
         private unsafe void WmReflectNotify(ref Message m)
         {
-            User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+            User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
 
             switch (nmhdr->code)
             {
@@ -6401,17 +6396,17 @@ namespace System.Windows.Forms
 
                 case (int)LVN.BEGINLABELEDITW:
                     {
-                        NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m.LParam;
+                        NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m._LParam;
                         LabelEditEventArgs e = new LabelEditEventArgs(dispInfo->item.iItem);
                         OnBeforeLabelEdit(e);
-                        m.Result = (IntPtr)(e.CancelEdit ? 1 : 0);
+                        m._Result = e.CancelEdit ? 1 : 0;
                         listViewState[LISTVIEWSTATE_inLabelEdit] = !e.CancelEdit;
                         break;
                     }
 
                 case (int)LVN.COLUMNCLICK:
                     {
-                        NMLISTVIEW* nmlv = (NMLISTVIEW*)m.LParam;
+                        NMLISTVIEW* nmlv = (NMLISTVIEW*)m._LParam;
                         listViewState[LISTVIEWSTATE_columnClicked] = true;
                         columnIndex = nmlv->iSubItem;
                         break;
@@ -6419,7 +6414,7 @@ namespace System.Windows.Forms
 
                 case (int)LVN.LINKCLICK:
                     {
-                        NMLVLINK* pLink = (NMLVLINK*)m.LParam;
+                        NMLVLINK* pLink = (NMLVLINK*)m._LParam;
                         int groupID = pLink->iSubItem;
                         for (int i = 0; i < groups.Count; i++)
                         {
@@ -6436,11 +6431,11 @@ namespace System.Windows.Forms
                 case (int)LVN.ENDLABELEDITW:
                     {
                         listViewState[LISTVIEWSTATE_inLabelEdit] = false;
-                        NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m.LParam;
+                        NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m._LParam;
                         string text = dispInfo->item.pszText is null ? null : new string(dispInfo->item.pszText);
                         LabelEditEventArgs e = new LabelEditEventArgs(dispInfo->item.iItem, text);
                         OnAfterLabelEdit(e);
-                        m.Result = (IntPtr)(e.CancelEdit ? 0 : 1);
+                        m._Result = e.CancelEdit ? 0 : 1;
 
                         // from msdn:
                         //   "If the user cancels editing, the pszText member of the LVITEM structure is NULL"
@@ -6463,7 +6458,7 @@ namespace System.Windows.Forms
                         // started so don't tell the user about this operation.
                         if (!ItemCollectionChangedInMouseDown)
                         {
-                            NMLISTVIEW* nmlv = (NMLISTVIEW*)m.LParam;
+                            NMLISTVIEW* nmlv = (NMLISTVIEW*)m._LParam;
                             ListViewItem item = Items[nmlv->iItem];
                             OnItemDrag(new ItemDragEventArgs(MouseButtons.Left, item));
                         }
@@ -6478,7 +6473,7 @@ namespace System.Windows.Forms
                         // started so don't tell the user about this operation.
                         if (!ItemCollectionChangedInMouseDown)
                         {
-                            NMLISTVIEW* nmlv = (NMLISTVIEW*)m.LParam;
+                            NMLISTVIEW* nmlv = (NMLISTVIEW*)m._LParam;
                             ListViewItem item = Items[nmlv->iItem];
                             OnItemDrag(new ItemDragEventArgs(MouseButtons.Right, item));
                         }
@@ -6488,7 +6483,7 @@ namespace System.Windows.Forms
 
                 case (int)LVN.ITEMCHANGING:
                     {
-                        NMLISTVIEW* nmlv = (NMLISTVIEW*)m.LParam;
+                        NMLISTVIEW* nmlv = (NMLISTVIEW*)m._LParam;
                         if ((nmlv->uChanged & LVIF.STATE) != 0)
                         {
                             // Because the state image mask is 1-based, a value of 1 means unchecked,
@@ -6500,7 +6495,7 @@ namespace System.Windows.Forms
                             {
                                 ItemCheckEventArgs e = new ItemCheckEventArgs(nmlv->iItem, newState, oldState);
                                 OnItemCheck(e);
-                                m.Result = (IntPtr)(((int)e.NewValue == 0 ? 0 : 1) == (int)oldState ? 1 : 0);
+                                m._Result = (e.NewValue == 0 ? 0 : 1) == (int)oldState ? 1 : 0;
                             }
                         }
 
@@ -6509,7 +6504,7 @@ namespace System.Windows.Forms
 
                 case (int)LVN.ITEMCHANGED:
                     {
-                        NMLISTVIEW* nmlv = (NMLISTVIEW*)m.LParam;
+                        NMLISTVIEW* nmlv = (NMLISTVIEW*)m._LParam;
                         // Check for state changes to the selected state...
                         if ((nmlv->uChanged & LVIF.STATE) != 0)
                         {
@@ -6648,7 +6643,7 @@ namespace System.Windows.Forms
                 case (int)LVN.KEYDOWN:
                     if (GroupsEnabled)
                     {
-                        NMLVKEYDOWN* lvkd = (NMLVKEYDOWN*)m.LParam;
+                        NMLVKEYDOWN* lvkd = (NMLVKEYDOWN*)m._LParam;
                         if ((lvkd->wVKey == (short)Keys.Down || lvkd->wVKey == (short)Keys.Up) && SelectedItems.Count > 0)
                         {
                             AccessibleObject accessibleObject = SelectedItems[0].AccessibilityObject;
@@ -6671,7 +6666,7 @@ namespace System.Windows.Forms
 
                     if (CheckBoxes)
                     {
-                        NMLVKEYDOWN* lvkd = (NMLVKEYDOWN*)m.LParam;
+                        NMLVKEYDOWN* lvkd = (NMLVKEYDOWN*)m._LParam;
                         if (lvkd->wVKey == (short)Keys.Space)
                         {
                             ListViewItem focusedItem = FocusedItem;
@@ -6696,7 +6691,7 @@ namespace System.Windows.Forms
 
                 case (int)LVN.ODCACHEHINT:
                     // tell the user to prepare the cache:
-                    NMLVCACHEHINT* cacheHint = (NMLVCACHEHINT*)m.LParam;
+                    NMLVCACHEHINT* cacheHint = (NMLVCACHEHINT*)m._LParam;
                     OnCacheVirtualItems(new CacheVirtualItemsEventArgs(cacheHint->iFrom, cacheHint->iTo));
                     break;
 
@@ -6704,9 +6699,9 @@ namespace System.Windows.Forms
                     if (nmhdr->code == (int)LVN.GETDISPINFOW)
                     {
                         // we use the LVN_GETDISPINFO message only in virtual mode
-                        if (VirtualMode && m.LParam != IntPtr.Zero)
+                        if (VirtualMode && m._LParam != 0)
                         {
-                            NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m.LParam;
+                            NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m._LParam;
 
                             RetrieveVirtualItemEventArgs rVI = new RetrieveVirtualItemEventArgs(dispInfo->item.iItem);
                             OnRetrieveVirtualItem(rVI);
@@ -6757,9 +6752,9 @@ namespace System.Windows.Forms
                     }
                     else if (nmhdr->code == (int)LVN.ODSTATECHANGED)
                     {
-                        if (VirtualMode && m.LParam != IntPtr.Zero)
+                        if (VirtualMode && m._LParam != 0)
                         {
-                            NMLVODSTATECHANGE* odStateChange = (NMLVODSTATECHANGE*)m.LParam;
+                            NMLVODSTATECHANGE* odStateChange = (NMLVODSTATECHANGE*)m._LParam;
                             bool selectedChanged = (odStateChange->uNewState & LVIS.SELECTED) != (odStateChange->uOldState & LVIS.SELECTED);
                             if (selectedChanged)
                             {
@@ -6772,9 +6767,9 @@ namespace System.Windows.Forms
                     }
                     else if (nmhdr->code == (int)LVN.GETINFOTIPW)
                     {
-                        if (ShowItemToolTips && m.LParam != IntPtr.Zero)
+                        if (ShowItemToolTips && m._LParam != 0)
                         {
-                            NMLVGETINFOTIPW* infoTip = (NMLVGETINFOTIPW*)m.LParam;
+                            NMLVGETINFOTIPW* infoTip = (NMLVGETINFOTIPW*)m._LParam;
                             ListViewItem lvi = Items[infoTip->item];
 
                             // This code is needed to hide the keyboard tooltip before showing the mouse tooltip
@@ -6796,11 +6791,11 @@ namespace System.Windows.Forms
                     {
                         if (VirtualMode)
                         {
-                            NMLVFINDITEMW* nmlvif = (NMLVFINDITEMW*)m.LParam;
+                            NMLVFINDITEMW* nmlvif = (NMLVFINDITEMW*)m._LParam;
 
                             if ((nmlvif->lvfi.flags & LVFI.PARAM) != 0)
                             {
-                                m.Result = (IntPtr)(-1);
+                                m._Result = -1;
                                 return;
                             }
 
@@ -6847,11 +6842,11 @@ namespace System.Windows.Forms
                             OnSearchForVirtualItem(sviEvent);
                             if (sviEvent.Index != -1)
                             {
-                                m.Result = (IntPtr)sviEvent.Index;
+                                m._Result = sviEvent.Index;
                             }
                             else
                             {
-                                m.Result = (IntPtr)(-1);
+                                m._Result = -1;
                             }
                         }
                     }
@@ -6863,9 +6858,9 @@ namespace System.Windows.Forms
         private void WmPrint(ref Message m)
         {
             base.WndProc(ref m);
-            if (((User32.PRF)m.LParam & User32.PRF.NONCLIENT) != 0 && Application.RenderWithVisualStyles && BorderStyle == BorderStyle.Fixed3D)
+            if (((User32.PRF)m._LParam & User32.PRF.NONCLIENT) != 0 && Application.RenderWithVisualStyles && BorderStyle == BorderStyle.Fixed3D)
             {
-                using Graphics g = Graphics.FromHdc(m.WParam);
+                using Graphics g = Graphics.FromHdc(m._WParam);
                 Rectangle rect = new Rectangle(0, 0, Size.Width - 1, Size.Height - 1);
                 using var pen = VisualStyleInformation.TextControlBorder.GetCachedPenScope();
                 g.DrawRectangle(pen, rect);
@@ -6876,7 +6871,7 @@ namespace System.Windows.Forms
 
         protected override void WndProc(ref Message m)
         {
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.REFLECT_NOTIFY:
                     WmReflectNotify(ref m);
@@ -6904,19 +6899,19 @@ namespace System.Windows.Forms
                 case User32.WM.RBUTTONUP:
                 case User32.WM.MBUTTONUP:
 
-                    // see the mouse is on item
+                    // See if the mouse is on the item.
                     int index = UpdateGroupCollapse(User32.WM.LBUTTONUP);
 
                     if (!ValidationCancelled && listViewState[LISTVIEWSTATE_doubleclickFired] && index != -1)
                     {
                         listViewState[LISTVIEWSTATE_doubleclickFired] = false;
                         OnDoubleClick(EventArgs.Empty);
-                        OnMouseDoubleClick(new MouseEventArgs(downButton, 2, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
+                        OnMouseDoubleClick(new MouseEventArgs(downButton, 2, PARAM.ToPoint(m._LParam)));
                     }
 
                     if (!listViewState[LISTVIEWSTATE_mouseUpFired])
                     {
-                        OnMouseUp(new MouseEventArgs(downButton, 1, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
+                        OnMouseUp(new MouseEventArgs(downButton, 1, PARAM.ToPoint(m._LParam)));
                         listViewState[LISTVIEWSTATE_expectingMouseUp] = false;
                     }
 
@@ -6942,7 +6937,7 @@ namespace System.Windows.Forms
                 case User32.WM.MOUSEMOVE:
                     if (listViewState[LISTVIEWSTATE_expectingMouseUp] && !listViewState[LISTVIEWSTATE_mouseUpFired] && MouseButtons == MouseButtons.None)
                     {
-                        OnMouseUp(new MouseEventArgs(downButton, 1, PARAM.SignedLOWORD(m.LParam), PARAM.SignedHIWORD(m.LParam), 0));
+                        OnMouseUp(new MouseEventArgs(downButton, 1, PARAM.ToPoint(m._LParam)));
                         listViewState[LISTVIEWSTATE_mouseUpFired] = true;
                     }
 
@@ -7005,7 +7000,7 @@ namespace System.Windows.Forms
                     WmPrint(ref m);
                     break;
                 case User32.WM.TIMER:
-                    if (unchecked((int)(long)m.WParam) != LVTOOLTIPTRACKING || !Application.ComCtlSupportsVisualStyles)
+                    if (m._WParam != LVTOOLTIPTRACKING || !Application.ComCtlSupportsVisualStyles)
                     {
                         base.WndProc(ref m);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
@@ -10,7 +10,6 @@ using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Design;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Windows.Forms.VisualStyles;
 using static Interop;
 using static Interop.User32;
@@ -1795,20 +1794,17 @@ namespace System.Windows.Forms
             bool includePrompt = (CutCopyMaskFormat & MaskFormat.IncludePrompt) != 0;
             bool includeLiterals = (CutCopyMaskFormat & MaskFormat.IncludeLiterals) != 0;
 
-            return maskedTextProvider.ToString( /*ignorePasswordChar*/ true, includePrompt, includeLiterals, selStart, selLength);
+            return maskedTextProvider.ToString(ignorePasswordChar: true, includePrompt, includeLiterals, selStart, selLength);
         }
 
         protected unsafe override void OnBackColorChanged(EventArgs e)
         {
             base.OnBackColorChanged(e);
-            // Force repainting of the entire window frame
+
+            // Force repainting of the entire window frame.
             if (Application.RenderWithVisualStyles && IsHandleCreated && BorderStyle == BorderStyle.Fixed3D)
             {
-                RedrawWindow(
-                    new HandleRef(this, Handle),
-                    null,
-                    IntPtr.Zero,
-                    RDW.INVALIDATE | RDW.FRAME);
+                RedrawWindow(this, flags: RDW.INVALIDATE | RDW.FRAME);
             }
         }
 
@@ -2778,12 +2774,12 @@ namespace System.Windows.Forms
                 byte imeConversionType = imeConversionNone;
 
                 // Check if there's an update to the composition string:
-                if ((PARAM.ToInt(m.LParam) & (int)Imm32.GCS.COMPSTR) != 0)
+                if ((m._LParam & (int)Imm32.GCS.COMPSTR) != 0)
                 {
                     // The character in the composition has been updated but not yet converted.
                     imeConversionType = imeConversionUpdate;
                 }
-                else if ((PARAM.ToInt(m.LParam) & (int)Imm32.GCS.RESULTSTR) != 0)
+                else if ((m._LParam & (int)Imm32.GCS.RESULTSTR) != 0)
                 {
                     // The character(s) in the composition has been fully converted.
                     imeConversionType = imeConversionCompleted;
@@ -2898,10 +2894,10 @@ namespace System.Windows.Forms
         private void WmPrint(ref Message m)
         {
             base.WndProc(ref m);
-            if ((unchecked((User32.PRF)(long)m.LParam) & User32.PRF.NONCLIENT) != 0
+            if (((User32.PRF)m._LParam & User32.PRF.NONCLIENT) != 0
                 && Application.RenderWithVisualStyles && BorderStyle == BorderStyle.Fixed3D)
             {
-                using Graphics g = Graphics.FromHdc(m.WParam);
+                using Graphics g = Graphics.FromHdc(m._WParam);
                 Rectangle rect = new Rectangle(0, 0, Size.Width - 1, Size.Height - 1);
                 using var pen = VisualStyleInformation.TextControlBorder.GetCachedPenScope();
                 g.DrawRectangle(pen, rect);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -2138,7 +2138,7 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void WmDateChanged(ref Message m)
         {
-            NMSELCHANGE* nmmcsc = (NMSELCHANGE*)m.LParam;
+            NMSELCHANGE* nmmcsc = (NMSELCHANGE*)m._LParam;
             DateTime start = nmmcsc->stSelStart;
             DateTime end = nmmcsc->stSelEnd;
 
@@ -2189,7 +2189,7 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void WmDateBold(ref Message m)
         {
-            NMDAYSTATE* nmmcds = (NMDAYSTATE*)m.LParam;
+            NMDAYSTATE* nmmcds = (NMDAYSTATE*)m._LParam;
             Span<int> boldDates = new Span<int>((int*)nmmcds->prgDayState, nmmcds->cDayState);
             WriteBoldDates(boldDates);
         }
@@ -2199,7 +2199,7 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void WmCalViewChanged(ref Message m)
         {
-            NMVIEWCHANGE* nmmcvm = (NMVIEWCHANGE*)m.LParam;
+            NMVIEWCHANGE* nmmcvm = (NMVIEWCHANGE*)m._LParam;
             Debug.Assert(_mcCurView == nmmcvm->uOldView, "Calendar view mode is out of sync with native control");
             if (_mcCurView != nmmcvm->uNewView)
             {
@@ -2217,7 +2217,7 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void WmDateSelected(ref Message m)
         {
-            NMSELCHANGE* nmmcsc = (NMSELCHANGE*)m.LParam;
+            NMSELCHANGE* nmmcsc = (NMSELCHANGE*)m._LParam;
             DateTime start = _selectionStart = nmmcsc->stSelStart;
             DateTime end = _selectionEnd = nmmcsc->stSelEnd;
 
@@ -2237,12 +2237,12 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Handles the WM_GETDLGCODE message
+        ///  Handles the WM_GETDLGCODE message.
         /// </summary>
         private void WmGetDlgCode(ref Message m)
         {
-            // The MonthCalendar does its own handling of arrow keys
-            m.Result = (IntPtr)User32.DLGC.WANTARROWS;
+            // The MonthCalendar does its own handling of arrow keys.
+            m._Result = (nint)User32.DLGC.WANTARROWS;
         }
 
         /// <summary>
@@ -2252,7 +2252,7 @@ namespace System.Windows.Forms
         {
             if (m.HWnd == Handle)
             {
-                User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+                User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
 
                 switch ((MCN)nmhdr->code)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MouseEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MouseEventArgs.cs
@@ -25,6 +25,18 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///  Initializes a new instance of the <see cref='MouseEventArgs'/> class.
+        /// </summary>
+        internal MouseEventArgs(MouseButtons button, int clicks, Point location, int delta = 0)
+        {
+            Button = button;
+            Clicks = clicks;
+            X = location.X;
+            Y = location.Y;
+            Delta = delta;
+        }
+
+        /// <summary>
         ///  Gets which mouse button was pressed.
         /// </summary>
         public MouseButtons Button { get; }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -396,7 +396,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            return m.Result;
+            return m._Result;
         }
 
         /// <summary>
@@ -509,15 +509,15 @@ namespace System.Windows.Forms
 
                     // At this point, there isn't much we can do.  There's a small chance the following
                     // line will allow the rest of the program to run, but don't get your hopes up.
-                    m.Result = User32.DefWindowProcW(m.HWnd, (User32.WM)m.Msg, m.WParam, m.LParam);
+                    m._Result = User32.DefWindowProcW(m.HWnd, m._Msg, m._WParam, m._LParam);
                     return;
                 }
 
-                m.Result = User32.CallWindowProcW(_priorWindowProcHandle, m.HWnd, (User32.WM)m.Msg, m.WParam, m.LParam);
+                m._Result = User32.CallWindowProcW(_priorWindowProcHandle, m.HWnd, m._Msg, m._WParam, m._LParam);
             }
             else
             {
-                m.Result = PreviousWindow.Callback(m.HWnd, (User32.WM)m.Msg, m.WParam, m.LParam);
+                m._Result = PreviousWindow.Callback(m.HWnd, m._Msg, m._WParam, m._LParam);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -740,39 +740,39 @@ namespace System.Windows.Forms
 
         private void WndProc(ref Message msg)
         {
-            switch ((User32.WM)msg.Msg)
+            switch (msg._Msg)
             {
                 case (User32.WM)WM_TRAYMOUSEMESSAGE:
-                    switch (PARAM.ToInt(msg.LParam))
+                    switch ((User32.WM)msg._LParam)
                     {
-                        case (int)User32.WM.LBUTTONDBLCLK:
+                        case User32.WM.LBUTTONDBLCLK:
                             WmMouseDown(ref msg, MouseButtons.Left, 2);
                             break;
-                        case (int)User32.WM.LBUTTONDOWN:
+                        case User32.WM.LBUTTONDOWN:
                             WmMouseDown(ref msg, MouseButtons.Left, 1);
                             break;
-                        case (int)User32.WM.LBUTTONUP:
+                        case User32.WM.LBUTTONUP:
                             WmMouseUp(ref msg, MouseButtons.Left);
                             break;
-                        case (int)User32.WM.MBUTTONDBLCLK:
+                        case User32.WM.MBUTTONDBLCLK:
                             WmMouseDown(ref msg, MouseButtons.Middle, 2);
                             break;
-                        case (int)User32.WM.MBUTTONDOWN:
+                        case User32.WM.MBUTTONDOWN:
                             WmMouseDown(ref msg, MouseButtons.Middle, 1);
                             break;
-                        case (int)User32.WM.MBUTTONUP:
+                        case User32.WM.MBUTTONUP:
                             WmMouseUp(ref msg, MouseButtons.Middle);
                             break;
-                        case (int)User32.WM.MOUSEMOVE:
+                        case User32.WM.MOUSEMOVE:
                             WmMouseMove(ref msg);
                             break;
-                        case (int)User32.WM.RBUTTONDBLCLK:
+                        case User32.WM.RBUTTONDBLCLK:
                             WmMouseDown(ref msg, MouseButtons.Right, 2);
                             break;
-                        case (int)User32.WM.RBUTTONDOWN:
+                        case User32.WM.RBUTTONDOWN:
                             WmMouseDown(ref msg, MouseButtons.Right, 1);
                             break;
-                        case (int)User32.WM.RBUTTONUP:
+                        case User32.WM.RBUTTONUP:
                             if (contextMenuStrip is not null)
                             {
                                 ShowContextMenu();
@@ -780,25 +780,25 @@ namespace System.Windows.Forms
 
                             WmMouseUp(ref msg, MouseButtons.Right);
                             break;
-                        case (int)NIN.BALLOONSHOW:
+                        case (User32.WM)NIN.BALLOONSHOW:
                             OnBalloonTipShown();
                             break;
-                        case (int)NIN.BALLOONHIDE:
+                        case (User32.WM)NIN.BALLOONHIDE:
                             OnBalloonTipClosed();
                             break;
-                        case (int)NIN.BALLOONTIMEOUT:
+                        case (User32.WM)NIN.BALLOONTIMEOUT:
                             OnBalloonTipClosed();
                             break;
-                        case (int)NIN.BALLOONUSERCLICK:
+                        case (User32.WM)NIN.BALLOONUSERCLICK:
                             OnBalloonTipClicked();
                             break;
                     }
 
                     break;
                 case User32.WM.COMMAND:
-                    if (IntPtr.Zero == msg.LParam)
+                    if (msg._LParam == 0)
                     {
-                        if (Command.DispatchID(PARAM.ToInt(msg.WParam) & 0xFFFF))
+                        if (Command.DispatchID((int)msg._WParam & 0xFFFF))
                         {
                             return;
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -311,7 +311,7 @@ namespace System.Windows.Forms
 
         private unsafe int AdjustScroll(Message m, int pos, int maxPos, bool horizontal)
         {
-            switch ((User32.SBH)PARAM.LOWORD(m.WParam))
+            switch ((User32.SBH)PARAM.LOWORD(m._WParam))
             {
                 case User32.SBH.THUMBPOSITION:
                 case User32.SBH.THUMBTRACK:
@@ -328,7 +328,7 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        pos = PARAM.HIWORD(m.WParam);
+                        pos = PARAM.HIWORD(m._WParam);
                     }
 
                     break;
@@ -695,14 +695,13 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  WM_HSCROLL handler
+        ///  WM_HSCROLL handler.
         /// </summary>
         private void WmHScroll(ref Message m)
         {
-            // The lparam is handle of the sending scrollbar, or NULL when
-            // the scrollbar sending the message is the "form" scrollbar...
-            //
-            if (m.LParam != IntPtr.Zero)
+            // The lparam is the handle of the sending scrollbar, or NULL when the scrollbar sending
+            // the message is the built-in Window scrollbar.
+            if (m._LParam != 0)
             {
                 base.WndProc(ref m);
                 return;
@@ -769,14 +768,13 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  WM_VSCROLL handler
+        ///  WM_VSCROLL handler.
         /// </summary>
         private void WmVScroll(ref Message m)
         {
-            // The lparam is handle of the sending scrollbar, or NULL when
-            // the scrollbar sending the message is the "form" scrollbar...
-            //
-            if (m.LParam != IntPtr.Zero)
+            // The lparam is the handle of the sending scrollbar, or NULL when the scrollbar sending
+            // the message is the built-in Window scrollbar.
+            if (m._LParam != 0)
             {
                 base.WndProc(ref m);
                 return;
@@ -795,10 +793,10 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmKeyDown(ref Message msg)
         {
-            Keys keyData = (Keys)(PARAM.ToInt(msg.WParam) | (int)ModifierKeys);
+            Keys keyData = (Keys)msg._WParam | ModifierKeys;
             Point locPos = Position;
-            int pos = 0;
-            int maxPos = 0;
+            int pos;
+            int maxPos;
 
             switch (keyData & Keys.KeyCode)
             {
@@ -828,7 +826,7 @@ namespace System.Windows.Forms
                     if ((keyData & Keys.Modifiers) == Keys.Control)
                     {
                         pos = locPos.X;
-                        maxPos = Math.Max(Width, virtualSize.Width /*- Width*/);
+                        maxPos = Math.Max(Width, virtualSize.Width);
                         if (pos < maxPos - SCROLL_PAGE)
                         {
                             pos += SCROLL_PAGE;
@@ -879,7 +877,7 @@ namespace System.Windows.Forms
                 case Keys.Down:
 
                     pos = locPos.Y;
-                    maxPos = Math.Max(Height, virtualSize.Height/* - Height*/);
+                    maxPos = Math.Max(Height, virtualSize.Height);
 
                     if (pos < maxPos - SCROLL_LINE)
                     {
@@ -910,7 +908,7 @@ namespace System.Windows.Forms
                     break;
                 case Keys.Right:
                     pos = locPos.X;
-                    maxPos = Math.Max(Width, virtualSize.Width /*- Width*/);
+                    maxPos = Math.Max(Width, virtualSize.Width);
                     if (pos < maxPos - SCROLL_LINE)
                     {
                         pos += SCROLL_LINE;
@@ -928,7 +926,7 @@ namespace System.Windows.Forms
 
         protected override void WndProc(ref Message m)
         {
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.VSCROLL:
                     WmVScroll(ref m);
@@ -946,8 +944,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Indicates whether the <see cref='Control.BackColor'/> property should be
-        ///  persisted.
+        ///  Indicates whether the <see cref='Control.BackColor'/> property should be persisted.
         /// </summary>
         internal override bool ShouldSerializeBackColor()
         {
@@ -955,8 +952,7 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Indicates whether the <see cref='Control.ForeColor'/> property should be
-        ///  persisted.
+        ///  Indicates whether the <see cref='Control.ForeColor'/> property should be persisted.
         /// </summary>
         internal override bool ShouldSerializeForeColor()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -4284,10 +4284,8 @@ namespace System.Windows.Forms
             }
         }
 
-        /// <inheritdoc/>
         internal override bool SupportsUiaProviders => true;
 
-        /// <inheritdoc/>
         internal override bool SupportsUseCompatibleTextRendering => true;
 
         internal override bool AllowsKeyboardToolTip() => false;
@@ -4334,57 +4332,57 @@ namespace System.Windows.Forms
 
         protected unsafe override void WndProc(ref Message m)
         {
-            switch (m.Msg)
+            switch (m._Msg)
             {
-                case (int)User32.WM.UNDO:
-                    if ((long)m.LParam == 0)
+                case User32.WM.UNDO:
+                    if (m._LParam == 0)
                     {
                         _gridView.DoUndoCommand();
                     }
                     else
                     {
-                        m.Result = CanUndo ? (IntPtr)1 : (IntPtr)0;
+                        m._Result = CanUndo ? 1 : 0;
                     }
 
                     return;
-                case (int)User32.WM.CUT:
-                    if ((long)m.LParam == 0)
+                case User32.WM.CUT:
+                    if (m._LParam == 0)
                     {
                         _gridView.DoCutCommand();
                     }
                     else
                     {
-                        m.Result = CanCut ? (IntPtr)1 : (IntPtr)0;
+                        m._Result = CanCut ? 1 : 0;
                     }
 
                     return;
 
-                case (int)User32.WM.COPY:
-                    if ((long)m.LParam == 0)
+                case User32.WM.COPY:
+                    if (m._LParam == 0)
                     {
                         _gridView.DoCopyCommand();
                     }
                     else
                     {
-                        m.Result = CanCopy ? (IntPtr)1 : (IntPtr)0;
+                        m._Result = CanCopy ? 1 : 0;
                     }
 
                     return;
 
-                case (int)User32.WM.PASTE:
-                    if ((long)m.LParam == 0)
+                case User32.WM.PASTE:
+                    if (m._LParam == 0)
                     {
                         _gridView.DoPasteCommand();
                     }
                     else
                     {
-                        m.Result = CanPaste ? (IntPtr)1 : (IntPtr)0;
+                        m._Result = CanPaste ? 1 : 0;
                     }
 
                     return;
 
-                case (int)User32.WM.COPYDATA:
-                    var cds = (User32.COPYDATASTRUCT*)m.LParam;
+                case User32.WM.COPYDATA:
+                    var cds = (User32.COPYDATASTRUCT*)m._LParam;
 
                     if (cds is not null && cds->lpData != IntPtr.Zero)
                     {
@@ -4392,29 +4390,29 @@ namespace System.Windows.Forms
                         _copyDataMessage = (int)cds->dwData;
                     }
 
-                    m.Result = (IntPtr)1;
+                    m._Result = 1;
                     return;
-                case AutomationMessages.PGM_GETBUTTONCOUNT:
+                case (User32.WM)AutomationMessages.PGM_GETBUTTONCOUNT:
                     if (_toolStrip is not null)
                     {
-                        m.Result = (IntPtr)_toolStrip.Items.Count;
+                        m._Result = _toolStrip.Items.Count;
                         return;
                     }
 
                     break;
-                case AutomationMessages.PGM_GETBUTTONSTATE:
+                case (User32.WM)AutomationMessages.PGM_GETBUTTONSTATE:
                     if (_toolStrip is not null)
                     {
-                        int index = unchecked((int)(long)m.WParam);
+                        int index = (int)m._WParam;
                         if (index >= 0 && index < _toolStrip.Items.Count)
                         {
                             if (_toolStrip.Items[index] is ToolStripButton button)
                             {
-                                m.Result = (IntPtr)(button.Checked ? 1 : 0);
+                                m._Result = button.Checked ? 1 : 0;
                             }
                             else
                             {
-                                m.Result = IntPtr.Zero;
+                                m._Result = 0;
                             }
                         }
 
@@ -4422,32 +4420,30 @@ namespace System.Windows.Forms
                     }
 
                     break;
-                case AutomationMessages.PGM_SETBUTTONSTATE:
+                case (User32.WM)AutomationMessages.PGM_SETBUTTONSTATE:
                     if (_toolStrip is not null)
                     {
-                        int index = unchecked((int)(long)m.WParam);
-                        if (index >= 0 && index < _toolStrip.Items.Count)
+                        int index = (int)m._WParam;
+                        if (index >= 0 && index < _toolStrip.Items.Count && _toolStrip.Items[index] is ToolStripButton button)
                         {
-                            if (_toolStrip.Items[index] is ToolStripButton button)
+                            button.Checked = !button.Checked;
+
+                            // Special treatment for the properties page button.
+                            if (button == _viewPropertyPagesButton)
                             {
-                                button.Checked = !button.Checked;
-                                // special treatment for the properties page button
-                                if (button == _viewPropertyPagesButton)
+                                OnViewButtonClickPP(button, EventArgs.Empty);
+                            }
+                            else
+                            {
+                                switch ((int)m._WParam)
                                 {
-                                    OnViewButtonClickPP(button, EventArgs.Empty);
-                                }
-                                else
-                                {
-                                    switch (unchecked((int)(long)m.WParam))
-                                    {
-                                        case AlphaSortButtonIndex:
-                                        case CategorySortButtonIndex:
-                                            OnViewSortButtonClick(button, EventArgs.Empty);
-                                            break;
-                                        default:
-                                            SelectViewTabButton(button, true);
-                                            break;
-                                    }
+                                    case AlphaSortButtonIndex:
+                                    case CategorySortButtonIndex:
+                                        OnViewSortButtonClick(button, EventArgs.Empty);
+                                        break;
+                                    default:
+                                        SelectViewTabButton(button, true);
+                                        break;
                                 }
                             }
                         }
@@ -4457,11 +4453,11 @@ namespace System.Windows.Forms
 
                     break;
 
-                case AutomationMessages.PGM_GETBUTTONTEXT:
-                case AutomationMessages.PGM_GETBUTTONTOOLTIPTEXT:
+                case (User32.WM)AutomationMessages.PGM_GETBUTTONTEXT:
+                case (User32.WM)AutomationMessages.PGM_GETBUTTONTOOLTIPTEXT:
                     if (_toolStrip is not null)
                     {
-                        int index = unchecked((int)(long)m.WParam);
+                        int index = (int)m._WParam;
                         if (index >= 0 && index < _toolStrip.Items.Count)
                         {
                             string text;
@@ -4475,7 +4471,7 @@ namespace System.Windows.Forms
                             }
 
                             // Write text into test file.
-                            m.Result = AutomationMessages.WriteAutomationText(text);
+                            m._Result = AutomationMessages.WriteAutomationText(text);
                         }
 
                         return;
@@ -4483,46 +4479,46 @@ namespace System.Windows.Forms
 
                     break;
 
-                case AutomationMessages.PGM_GETTESTINGINFO:
+                case (User32.WM)AutomationMessages.PGM_GETTESTINGINFO:
                     {
                         // Get "testing info" string for Nth grid entry (or active entry if N < 0)
-                        string testingInfo = _gridView.GetTestingInfo(unchecked((int)(long)m.WParam));
-                        m.Result = AutomationMessages.WriteAutomationText(testingInfo);
+                        string testingInfo = _gridView.GetTestingInfo((int)m._WParam);
+                        m._Result = AutomationMessages.WriteAutomationText(testingInfo);
                         return;
                     }
 
-                case AutomationMessages.PGM_GETROWCOORDS:
+                case (User32.WM)AutomationMessages.PGM_GETROWCOORDS:
                     if (m.Msg == _copyDataMessage)
                     {
-                        m.Result = (IntPtr)_gridView.GetPropertyLocation(
+                        m._Result = _gridView.GetPropertyLocation(
                             _propertyName,
-                            getXY: m.LParam == IntPtr.Zero,
-                            rowValue: m.WParam == IntPtr.Zero);
+                            getXY: m._LParam == 0,
+                            rowValue: m._WParam == 0);
                         return;
                     }
 
                     break;
-                case AutomationMessages.PGM_GETSELECTEDROW:
-                case AutomationMessages.PGM_GETVISIBLEROWCOUNT:
-                    m.Result = User32.SendMessageW(_gridView, (User32.WM)m.Msg, m.WParam, m.LParam);
+                case (User32.WM)AutomationMessages.PGM_GETSELECTEDROW:
+                case (User32.WM)AutomationMessages.PGM_GETVISIBLEROWCOUNT:
+                    m._Result = User32.SendMessageW(_gridView, m._Msg, m._WParam, m._LParam);
                     return;
-                case AutomationMessages.PGM_SETSELECTEDTAB:
-                    if (m.LParam != IntPtr.Zero)
+                case (User32.WM)AutomationMessages.PGM_SETSELECTEDTAB:
+                    if (m._LParam != 0)
                     {
-                        string tabTypeName = AutomationMessages.ReadAutomationText(m.LParam);
+                        string tabTypeName = AutomationMessages.ReadAutomationText(m._LParam);
 
                         for (int i = 0; i < _viewTabs.Length; i++)
                         {
                             if (_viewTabs[i].GetType().FullName == tabTypeName && _viewTabButtons[i].Visible)
                             {
                                 SelectViewTabButtonDefault(_viewTabButtons[i]);
-                                m.Result = (IntPtr)1;
+                                m._Result = 1;
                                 break;
                             }
                         }
                     }
 
-                    m.Result = (IntPtr)0;
+                    m._Result = 0;
                     return;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridToolTip.cs
@@ -5,7 +5,6 @@
 #nullable disable
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using static Interop;
 
 namespace System.Windows.Forms.PropertyGridInternal
@@ -136,12 +135,12 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (IsHandleCreated)
             {
                 User32.SetWindowPos(
-                    new HandleRef(this, Handle),
+                    this,
                     User32.HWND_TOPMOST,
                     flags: User32.SWP.NOMOVE | User32.SWP.NOSIZE | User32.SWP.NOACTIVATE);
 
                 ComCtl32.ToolInfoWrapper<Control> info = GetTOOLINFO(control);
-                if (info.SendMessage(this, (User32.WM)ComCtl32.TTM.ADDTOOLW) == IntPtr.Zero)
+                if (info.SendMessage(this, (User32.WM)ComCtl32.TTM.ADDTOOLW) == 0)
                 {
                     Debug.Fail($"TTM_ADDTOOL failed for {control.GetType().Name}");
                 }
@@ -176,12 +175,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         protected override void WndProc(ref Message msg)
         {
-            switch ((User32.WM)msg.Msg)
+            switch (msg._Msg)
             {
                 case User32.WM.SHOWWINDOW:
-                    if (unchecked((int)(long)msg.WParam) != 0 && _dontShow)
+                    if ((int)msg._WParam != 0 && _dontShow)
                     {
-                        msg.WParam = IntPtr.Zero;
+                        msg._WParam = 0;
                     }
 
                     break;
@@ -191,7 +190,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     // thru to controls underneath. This is due to a combination of old app-specific code in comctl32,
                     // functional changes between v5 and v6, and the specific way the property grid drives its tooltip.
                     // Workaround is to just force HTTRANSPARENT all the time.
-                    msg.Result = (IntPtr)User32.HT.TRANSPARENT;
+                    msg._Result = (nint)User32.HT.TRANSPARENT;
                     return;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.cs
@@ -671,18 +671,18 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             protected override void WndProc(ref Message m)
             {
-                if (m.Msg == (int)User32.WM.ACTIVATE)
+                if (m._Msg == User32.WM.ACTIVATE)
                 {
                     SetState(States.Modal, true);
                     Debug.WriteLineIf(CompModSwitches.DebugGridView.TraceVerbose, "DropDownHolder:WM_ACTIVATE()");
-                    IntPtr activatedWindow = m.LParam;
-                    if (Visible && PARAM.LOWORD(m.WParam) == (int)User32.WA.INACTIVE && !OwnsWindow(activatedWindow))
+                    IntPtr activatedWindow = m._LParam;
+                    if (Visible && (User32.WA)PARAM.LOWORD(m._WParam) == User32.WA.INACTIVE && !OwnsWindow(activatedWindow))
                     {
                         _gridView.CloseDropDownInternal(false);
                         return;
                     }
                 }
-                else if (m.Msg == (int)User32.WM.CLOSE)
+                else if (m._Msg == User32.WM.CLOSE)
                 {
                     // Don't let an ALT-F4 get you down.
                     if (Visible)
@@ -692,12 +692,12 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     return;
                 }
-                else if (m.Msg == (int)User32.WM.DPICHANGED)
+                else if (m._Msg == User32.WM.DPICHANGED)
                 {
                     // Dropdownholder in PropertyGridView is already scaled based on the parent font and other
                     // properties that were already set for the new DPI. This case is to avoid rescaling
                     // (double scaling) of this form.
-                    m.Result = IntPtr.Zero;
+                    m._Result = 0;
                     return;
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.cs
@@ -289,9 +289,9 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             private unsafe bool WmNotify(ref Message m)
             {
-                if (m.LParam != IntPtr.Zero)
+                if (m._LParam != 0)
                 {
-                    User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+                    User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
 
                     if (nmhdr->hwndFrom == PropertyGridView.ToolTip.Handle)
                     {
@@ -299,7 +299,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                         {
                             case ComCtl32.TTN.SHOW:
                                 PositionTooltip(this, PropertyGridView.ToolTip, ClientRectangle);
-                                m.Result = (IntPtr)1;
+                                m._Result = 1;
                                 return true;
                             default:
                                 PropertyGridView.WndProc(ref m);
@@ -318,28 +318,28 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return;
                 }
 
-                switch ((User32.WM)m.Msg)
+                switch (m._Msg)
                 {
                     case User32.WM.STYLECHANGED:
-                        if ((unchecked((int)(long)m.WParam) & (int)User32.GWL.EXSTYLE) != 0)
+                        if ((User32.GWL)m._WParam == User32.GWL.EXSTYLE)
                         {
                             PropertyGridView.Invalidate();
                         }
 
                         break;
                     case User32.WM.MOUSEMOVE:
-                        if (unchecked((int)(long)m.LParam) == _lastMove)
+                        if (m._LParam == _lastMove)
                         {
                             return;
                         }
 
-                        _lastMove = unchecked((int)(long)m.LParam);
+                        _lastMove = (int)m._LParam;
                         break;
                     case User32.WM.DESTROY:
                         _mouseHook.HookMouseDown = false;
                         break;
                     case User32.WM.SHOWWINDOW:
-                        if (IntPtr.Zero == m.WParam)
+                        if (m._WParam == 0)
                         {
                             _mouseHook.HookMouseDown = false;
                         }
@@ -355,10 +355,10 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                     case User32.WM.GETDLGCODE:
 
-                        m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTARROWS | (int)User32.DLGC.WANTCHARS);
+                        m._Result = m._Result | (nint)(User32.DLGC.WANTARROWS | User32.DLGC.WANTCHARS);
                         if (PropertyGridView.EditTextBoxNeedsCommit || PropertyGridView.WantsTab(forward: (ModifierKeys & Keys.Shift) == 0))
                         {
-                            m.Result = (IntPtr)((long)m.Result | (int)User32.DLGC.WANTALLKEYS | (int)User32.DLGC.WANTTAB);
+                            m._Result = m._Result | (nint)(User32.DLGC.WANTALLKEYS | User32.DLGC.WANTTAB);
                         }
 
                         return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.MouseHook.MouseHookObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.MouseHook.MouseHookObject.cs
@@ -25,9 +25,9 @@ namespace System.Windows.Forms.PropertyGridInternal
                     _reference = new WeakReference(parent, trackResurrection: false);
                 }
 
-                public virtual IntPtr Callback(User32.HC nCode, IntPtr wparam, IntPtr lparam)
+                public virtual nint Callback(User32.HC nCode, nint wparam, nint lparam)
                 {
-                    IntPtr result = IntPtr.Zero;
+                    nint result = 0;
                     try
                     {
                         if (_reference.Target is MouseHook hook)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.MouseHook.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.MouseHook.cs
@@ -116,15 +116,14 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// <summary>
             ///  HookProc used for catch mouse messages.
             /// </summary>
-            private unsafe IntPtr MouseHookProc(User32.HC nCode, IntPtr wparam, IntPtr lparam)
+            private unsafe nint MouseHookProc(User32.HC nCode, nint wparam, nint lparam)
             {
-                GC.KeepAlive(this);
                 if (nCode == User32.HC.ACTION)
                 {
                     var mhs = (User32.MOUSEHOOKSTRUCT*)lparam;
                     if (mhs is not null)
                     {
-                        switch (unchecked((User32.WM)(long)wparam))
+                        switch ((User32.WM)wparam)
                         {
                             case User32.WM.LBUTTONDOWN:
                             case User32.WM.MBUTTONDOWN:
@@ -135,7 +134,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                             case User32.WM.MOUSEACTIVATE:
                                 if (ProcessMouseDown(mhs->hWnd))
                                 {
-                                    return (IntPtr)1;
+                                    return 1;
                                 }
 
                                 break;
@@ -143,7 +142,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
 
-                return User32.CallNextHookEx(new HandleRef(this, _mouseHookHandle), nCode, wparam, lparam);
+                return User32.CallNextHookEx(_mouseHookHandle, nCode, wparam, lparam);
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -621,7 +621,7 @@ namespace System.Windows.Forms
 
         private void WmReflectScroll(ref Message m)
         {
-            ScrollEventType type = (ScrollEventType)PARAM.LOWORD(m.WParam);
+            ScrollEventType type = (ScrollEventType)PARAM.LOWORD(m._WParam);
             DoScroll(type);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.cs
@@ -1281,14 +1281,14 @@ namespace System.Windows.Forms
         {
             // The lparam is handle of the sending scrollbar, or NULL when
             // the scrollbar sending the message is the "form" scrollbar.
-            if (m.LParam != IntPtr.Zero)
+            if (m._LParam != 0)
             {
                 base.WndProc(ref m);
                 return;
             }
 
             Rectangle client = ClientRectangle;
-            User32.SBV loWord = (User32.SBV)PARAM.LOWORD(m.WParam);
+            User32.SBV loWord = (User32.SBV)PARAM.LOWORD(m._WParam);
             bool thumbTrack = loWord != User32.SBV.THUMBTRACK;
             int pos = -_displayRect.Y;
             int oldValue = pos;
@@ -1376,7 +1376,7 @@ namespace System.Windows.Forms
         {
             // The lparam is handle of the sending scrollbar, or NULL when
             // the scrollbar sending the message is the "form" scrollbar.
-            if (m.LParam != IntPtr.Zero)
+            if (m._LParam != 0)
             {
                 base.WndProc(ref m);
                 return;
@@ -1392,7 +1392,7 @@ namespace System.Windows.Forms
                 maxPos = HorizontalScroll.Maximum;
             }
 
-            User32.SBH loWord = (User32.SBH)PARAM.LOWORD(m.WParam);
+            User32.SBH loWord = (User32.SBH)PARAM.LOWORD(m._WParam);
             switch (loWord)
             {
                 case User32.SBH.THUMBPOSITION:
@@ -1467,7 +1467,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmOnScroll(ref Message m, int oldValue, int value, ScrollOrientation scrollOrientation)
         {
-            ScrollEventType type = (ScrollEventType)PARAM.LOWORD(m.WParam);
+            ScrollEventType type = (ScrollEventType)PARAM.LOWORD(m._WParam);
             if (type != ScrollEventType.EndScroll)
             {
                 ScrollEventArgs se = new ScrollEventArgs(type, oldValue, value, scrollOrientation);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.SendKeysHookProc.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.SendKeysHookProc.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms
 
             private bool _gotNextEvent;
 
-            public unsafe virtual IntPtr Callback(User32.HC nCode, IntPtr wparam, IntPtr lparam)
+            public unsafe virtual nint Callback(User32.HC nCode, nint wparam, nint lparam)
             {
                 User32.EVENTMSG* eventmsg = (User32.EVENTMSG*)lparam;
 
@@ -52,11 +52,11 @@ namespace System.Windows.Forms
                             s_events is not null && s_events.Count > 0 && !s_stopHook,
                             "HC_GETNEXT when queue is empty!");
 
-                        SKEvent evt = (SKEvent)s_events.Peek();
-                        eventmsg->message = evt.WM;
-                        eventmsg->paramL = evt.ParamL;
-                        eventmsg->paramH = evt.ParamH;
-                        eventmsg->hwnd = evt.HWND;
+                        SKEvent @event = s_events.Peek();
+                        eventmsg->message = @event.WM;
+                        eventmsg->paramL = @event.ParamL;
+                        eventmsg->paramH = @event.ParamH;
+                        eventmsg->hwnd = @event.HWND;
                         eventmsg->time = Kernel32.GetTickCount();
                         break;
                     default:
@@ -74,7 +74,7 @@ namespace System.Windows.Forms
                     _gotNextEvent = false;
                 }
 
-                return IntPtr.Zero;
+                return 0;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -265,7 +265,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private static IntPtr EmptyHookCallback(User32.HC nCode, IntPtr wparam, IntPtr lparam) => IntPtr.Zero;
+        private static nint EmptyHookCallback(User32.HC nCode, nint wparam, nint lparam) => 0;
 
         private static void LoadSendMethodFromConfig()
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -2327,9 +2327,8 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmSetCursor(ref Message m)
         {
-            // Accessing through the Handle property has side effects that break this
-            // logic. You must use InternalHandle.
-            if (m.WParam == InternalHandle && ((int)m.LParam & 0x0000FFFF) == (int)User32.HT.CLIENT)
+            // Accessing through the Handle property has side effects that break this logic. You must use InternalHandle.
+            if (m._WParam == InternalHandle && (User32.HT)(m._LParam & 0x0000FFFF) == User32.HT.CLIENT)
             {
                 Cursor.Current = OverrideCursor ?? Cursor;
             }
@@ -2339,16 +2338,6 @@ namespace System.Windows.Forms
             }
         }
 
-        ///////////////////////////////////////////////////////////////////////////////////////////////////
-        //                                                                                               //
-        // END PRIVATE FUNCTIONS ...                                                                     //
-        //                                                                                               //
-        ///////////////////////////////////////////////////////////////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////////////////////////////////
-        //                                                                                               //
-        // Start PROTECTED OVERRIDE FUNCTIONS                                                            //
-        //                                                                                               //
-        ///////////////////////////////////////////////////////////////////////////////////////////////////
         internal override Rectangle GetToolNativeScreenRectangle()
         {
             // Return splitter rectangle instead of the whole container rectangle to be consistent with the mouse ToolTip
@@ -2517,17 +2506,14 @@ namespace System.Windows.Forms
                 _owner = splitContainer;
             }
 
-            /// <summary>
-            /// </summary>
             bool IMessageFilter.PreFilterMessage(ref Message m)
             {
-                if (m.Msg >= (int)User32.WM.KEYFIRST && m.Msg <= (int)User32.WM.KEYLAST)
+                if (m._Msg >= User32.WM.KEYFIRST && m._Msg <= User32.WM.KEYLAST)
                 {
-                    if ((m.Msg == (int)User32.WM.KEYDOWN && PARAM.ToInt(m.WParam) == (int)Keys.Escape)
-                        || (m.Msg == (int)User32.WM.SYSKEYDOWN))
+                    if ((m._Msg == User32.WM.KEYDOWN && (Keys)m._WParam == Keys.Escape)
+                        || (m._Msg == User32.WM.SYSKEYDOWN))
                     {
-                        //Notify that splitMOVE was reverted ..
-                        //this is used in ONKEYUP!!
+                        // Notify that splitMOVE was reverted. This is used in ONKEYUP.
                         _owner._splitBegin = false;
                         _owner.SplitEnd(false);
                         _owner._splitterClick = false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
@@ -1014,9 +1014,9 @@ namespace System.Windows.Forms
             /// </summary>
             public bool PreFilterMessage(ref Message m)
             {
-                if (m.Msg >= (int)User32.WM.KEYFIRST && m.Msg <= (int)User32.WM.KEYLAST)
+                if (m._Msg >= User32.WM.KEYFIRST && m._Msg <= User32.WM.KEYLAST)
                 {
-                    if (m.Msg == (int)User32.WM.KEYDOWN && unchecked((int)(long)m.WParam) == (int)Keys.Escape)
+                    if (m._Msg == User32.WM.KEYDOWN && (Keys)m._WParam == Keys.Escape)
                     {
                         owner.SplitEnd(false);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StatusStrip.cs
@@ -579,10 +579,8 @@ namespace System.Windows.Forms
                 // if we're within the grip bounds tell windows
                 // that we're the bottom right of the window.
                 Rectangle sizeGripBounds = SizeGripBounds;
-                int x = PARAM.LOWORD(m.LParam);
-                int y = PARAM.HIWORD(m.LParam);
 
-                if (sizeGripBounds.Contains(PointToClient(new Point(x, y))))
+                if (sizeGripBounds.Contains(PointToClient(PARAM.ToPoint(m._LParam))))
                 {
                     IntPtr rootHwnd = User32.GetAncestor(this, User32.GA.ROOT);
 
@@ -615,7 +613,7 @@ namespace System.Windows.Forms
                         {
                             if ((deltaRightEdge + deltaBottomEdge) < 2)
                             {
-                                m.Result = (IntPtr)User32.HT.BOTTOMRIGHT;
+                                m._Result = (nint)User32.HT.BOTTOMRIGHT;
                                 return;
                             }
                         }
@@ -647,14 +645,11 @@ namespace System.Windows.Forms
 
             protected override void WndProc(ref Message m)
             {
-                if (m.Msg == (int)User32.WM.NCHITTEST)
+                if (m._Msg == User32.WM.NCHITTEST)
                 {
-                    int x = PARAM.LOWORD(m.LParam);
-                    int y = PARAM.HIWORD(m.LParam);
-
-                    if (ClientRectangle.Contains(PointToClient(new Point(x, y))))
+                    if (ClientRectangle.Contains(PointToClient(PARAM.ToPoint(m._LParam))))
                     {
-                        m.Result = (IntPtr)User32.HT.BOTTOMLEFT;
+                        m._Result = (nint)User32.HT.BOTTOMLEFT;
                         return;
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1294,7 +1294,7 @@ namespace System.Windows.Forms
             // horizontal and vertical dimensions of the padding rectangle.
             if (!_padding.IsEmpty)
             {
-                User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.SETPADDING, 0, PARAM.FromLowHigh(_padding.X, _padding.Y));
+                User32.SendMessageW(this, (User32.WM)ComCtl32.TCM.SETPADDING, 0, PARAM.FromPoint(_padding));
             }
 
             base.OnHandleCreated(e);
@@ -1997,7 +1997,7 @@ namespace System.Windows.Forms
 
         private unsafe void WmNeedText(ref Message m)
         {
-            NMTTDISPINFOW* ttt = (NMTTDISPINFOW*)m.LParam;
+            NMTTDISPINFOW* ttt = (NMTTDISPINFOW*)m._LParam;
 
             int commandID = (int)ttt->hdr.idFrom;
 
@@ -2020,7 +2020,7 @@ namespace System.Windows.Forms
 
         private unsafe void WmReflectDrawItem(ref Message m)
         {
-            User32.DRAWITEMSTRUCT* dis = (User32.DRAWITEMSTRUCT*)m.LParam;
+            User32.DRAWITEMSTRUCT* dis = (User32.DRAWITEMSTRUCT*)m._LParam;
 
             using var e = new DrawItemEventArgs(
                 dis->hDC,
@@ -2031,7 +2031,7 @@ namespace System.Windows.Forms
 
             OnDrawItem(e);
 
-            m.Result = (IntPtr)1;
+            m._Result = 1;
         }
 
         private bool WmSelChange()
@@ -2112,7 +2112,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected unsafe override void WndProc(ref Message m)
         {
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.REFLECT_DRAWITEM:
                     WmReflectDrawItem(ref m);
@@ -2124,7 +2124,7 @@ namespace System.Windows.Forms
 
                 case User32.WM.NOTIFY:
                 case User32.WM.REFLECT_NOTIFY:
-                    User32.NMHDR* nmhdr = (User32.NMHDR*)m.LParam;
+                    User32.NMHDR* nmhdr = (User32.NMHDR*)m._LParam;
                     switch (nmhdr->code)
                     {
                         // new switch added to prevent the TabControl from changing to next TabPage ...
@@ -2136,14 +2136,14 @@ namespace System.Windows.Forms
                         case (int)TCN.SELCHANGING:
                             if (WmSelChanging())
                             {
-                                m.Result = (IntPtr)1;
+                                m._Result = 1;
                                 SetState(State.UISelection, false);
                                 return;
                             }
 
                             if (ValidationCancelled)
                             {
-                                m.Result = (IntPtr)1;
+                                m._Result = 1;
                                 SetState(State.UISelection, false);
                                 return;
                             }
@@ -2156,7 +2156,7 @@ namespace System.Windows.Forms
                         case (int)TCN.SELCHANGE:
                             if (WmSelChange())
                             {
-                                m.Result = (IntPtr)1;
+                                m._Result = 1;
                                 SetState(State.UISelection, false);
                                 return;
                             }
@@ -2170,14 +2170,14 @@ namespace System.Windows.Forms
                             // Setting the max width has the added benefit of enabling Multiline tool tips
                             User32.SendMessageW(nmhdr->hwndFrom, (User32.WM)TTM.SETMAXTIPWIDTH, 0, SystemInformation.MaxWindowTrackSize.Width);
                             WmNeedText(ref m);
-                            m.Result = (IntPtr)1;
+                            m._Result = 1;
                             return;
                     }
 
                     break;
             }
 
-            if (m.Msg == (int)_tabBaseReLayoutMessage)
+            if (m._Msg == _tabBaseReLayoutMessage)
             {
                 WmTabBaseReLayout(ref m);
                 return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -554,14 +554,10 @@ namespace System.Windows.Forms
         {
             base.OnBackColorChanged(e);
 
-            // Force repainting of the entire window frame
+            // Force repainting of the entire window frame.
             if (Application.RenderWithVisualStyles && IsHandleCreated && BorderStyle == BorderStyle.Fixed3D)
             {
-                RedrawWindow(
-                    new HandleRef(this, Handle),
-                    null,
-                    IntPtr.Zero,
-                    RDW.INVALIDATE | RDW.FRAME);
+                RedrawWindow(this, flags: RDW.INVALIDATE | RDW.FRAME);
             }
         }
 
@@ -845,10 +841,10 @@ namespace System.Windows.Forms
         private void WmPrint(ref Message m)
         {
             base.WndProc(ref m);
-            if (((PRF)m.LParam & PRF.NONCLIENT) != 0 && Application.RenderWithVisualStyles
+            if (((PRF)m._LParam & PRF.NONCLIENT) != 0 && Application.RenderWithVisualStyles
                 && BorderStyle == BorderStyle.Fixed3D)
             {
-                using Graphics g = Graphics.FromHdc(m.WParam);
+                using Graphics g = Graphics.FromHdc(m._WParam);
                 Rectangle rect = new Rectangle(0, 0, Size.Width - 1, Size.Height - 1);
                 using var pen = VisualStyleInformation.TextControlBorder.GetCachedPenScope();
                 g.DrawRectangle(pen, rect);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Timer.cs
@@ -347,15 +347,15 @@ namespace System.Windows.Forms
                 Debug.Assert(m.HWnd == Handle && Handle != IntPtr.Zero, "Timer getting messages for other windows?");
 
                 // For timer messages call the timer event.
-                if (m.Msg == (int)User32.WM.TIMER)
+                if (m._Msg == User32.WM.TIMER)
                 {
-                    if (m.WParam == _timerID)
+                    if (m._WParam == _timerID)
                     {
                         _owner.OnTick(EventArgs.Empty);
                         return;
                     }
                 }
-                else if (m.Msg == (int)User32.WM.CLOSE)
+                else if (m._Msg == User32.WM.CLOSE)
                 {
                     // This is a posted method from another thread that tells us we need
                     // to kill the timer. The handle may already be gone, so we specify it here.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4928,12 +4928,12 @@ namespace System.Windows.Forms
 
         protected override void WndProc(ref Message m)
         {
-            if (m.Msg == (int)User32.WM.SETFOCUS)
+            if (m._Msg == User32.WM.SETFOCUS)
             {
-                SnapFocus(m.WParam);
+                SnapFocus(m._WParam);
             }
 
-            if (m.Msg == (int)User32.WM.MOUSEACTIVATE)
+            if (m._Msg == User32.WM.MOUSEACTIVATE)
             {
                 // we want to prevent taking focus if someone clicks on the toolstrip dropdown
                 // itself.  the mouse message will still go through, but focus won't be taken.
@@ -4947,7 +4947,7 @@ namespace System.Windows.Forms
                 if (hwndClicked == Handle)
                 {
                     _lastMouseDownedItem = null;
-                    m.Result = (IntPtr)User32.MA.NOACTIVATE;
+                    m._Result = (nint)User32.MA.NOACTIVATE;
 
                     if (!IsDropDown && !IsInDesignMode)
                     {
@@ -4962,7 +4962,7 @@ namespace System.Windows.Forms
                             {
                                 // Activate the window, and discard the mouse message.
                                 // this appears to be the same behavior as office.
-                                m.Result = (IntPtr)User32.MA.ACTIVATEANDEAT;
+                                m._Result = (nint)User32.MA.ACTIVATEANDEAT;
                             }
                         }
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -2095,7 +2095,7 @@ namespace System.Windows.Forms
 
         protected override void WndProc(ref Message m)
         {
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.NCACTIVATE:
                     // if someone clicks on a child control of the toolstrip dropdown, we want
@@ -2108,9 +2108,11 @@ namespace System.Windows.Forms
                     // This is the Chrome Panel collection editor scenario
                     // we had focus, then the Chrome panel was activated and we never went away
                     // when we get focus again, we should reactivate our message filter.
-                    Debug.WriteLineIf(ToolStrip.s_snapFocusDebug.TraceVerbose, "[ToolStripDropDown.WndProc] got a WM_ACTIVATE " + ((PARAM.ToInt(m.WParam) == (int)User32.WA.ACTIVE) ? "WA_ACTIVE" : "WA_INACTIVE") + " - checkin if we need to set the active toolstrip");
+                    Debug.WriteLineIf(
+                        s_snapFocusDebug.TraceVerbose,
+                        $"[ToolStripDropDown.WndProc] got a WM_ACTIVATE {((User32.WA)m._WParam == User32.WA.ACTIVE ? "WA_ACTIVE" : "WA_INACTIVE")} - checking if we need to set the active toolstrip");
 
-                    if (PARAM.ToInt(m.WParam) == (int)User32.WA.ACTIVE)
+                    if ((User32.WA)m._WParam == User32.WA.ACTIVE)
                     {
                         if (Visible)
                         {
@@ -2122,12 +2124,12 @@ namespace System.Windows.Forms
                         }
                         else
                         {
-                            Debug.Fail("Why are we being activated when we're not visible? Deactivating thingie is " + WindowsFormsUtils.GetControlInformation(m.LParam));
+                            Debug.Fail($"Why are we being activated when we're not visible? Deactivating thing is {WindowsFormsUtils.GetControlInformation(m._LParam)}");
                         }
                     }
                     else
                     {
-                        Debug.WriteLineIf(ToolStrip.s_snapFocusDebug.TraceVerbose, "[ToolStripDropDown.WndProc] activating thingie is " + WindowsFormsUtils.GetControlInformation(m.LParam));
+                        Debug.WriteLineIf(s_snapFocusDebug.TraceVerbose, $"[ToolStripDropDown.WndProc] activating thing is {WindowsFormsUtils.GetControlInformation(m._LParam)}");
                     }
 
                     base.WndProc(ref m);
@@ -2186,7 +2188,11 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void WmNCActivate(ref Message m)
         {
-            if (m.WParam != IntPtr.Zero /*activating*/)
+            if (m._WParam == 0)
+            {
+                base.WndProc(ref m);
+            }
+            else
             {
                 if (!_sendingActivateMessage)
                 {
@@ -2200,11 +2206,10 @@ namespace System.Windows.Forms
 
                         User32.SendMessageW(activeHwndHandleRef.Handle, User32.WM.NCACTIVATE, (nint)BOOL.TRUE, -1);
                         User32.RedrawWindow(
-                            activeHwndHandleRef,
-                            null,
-                            IntPtr.Zero,
-                            User32.RDW.FRAME | User32.RDW.INVALIDATE);
-                        m.WParam = (IntPtr)1;
+                            activeHwndHandleRef.Handle,
+                            flags: User32.RDW.FRAME | User32.RDW.INVALIDATE);
+
+                        m._WParam = 1;
 
                         GC.KeepAlive(activeHwndHandleRef.Wrapper);
                     }
@@ -2216,10 +2221,6 @@ namespace System.Windows.Forms
 
                 DefWndProc(ref m);
                 return;
-            }
-            else
-            {
-                base.WndProc(ref m);
             }
         }
         #endregion

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.ModalMenuFilter.HostedWindowsFormsMessageHook.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.ModalMenuFilter.HostedWindowsFormsMessageHook.cs
@@ -83,27 +83,23 @@ namespace System.Windows.Forms
                     }
                 }
 
-                private unsafe IntPtr MessageHookProc(User32.HC nCode, IntPtr wparam, IntPtr lparam)
+                private unsafe nint MessageHookProc(User32.HC nCode, nint wparam, nint lparam)
                 {
-                    if (nCode == User32.HC.ACTION)
+                    if (nCode == User32.HC.ACTION && _isHooked && (User32.PM)wparam == User32.PM.REMOVE)
                     {
-                        if (_isHooked && (User32.PM)wparam == User32.PM.REMOVE)
+                        // Only process messages we've pulled off the queue.
+                        User32.MSG* msg = (User32.MSG*)lparam;
+                        if (msg is not null)
                         {
-                            // only process messages we've pulled off the queue
-                            User32.MSG* msg = (User32.MSG*)lparam;
-                            if (msg is not null)
+                            // Call pretranslate on the message to execute the message filters and preprocess message.
+                            if (Application.ThreadContext.FromCurrent().PreTranslateMessage(ref *msg))
                             {
-                                // call pretranslate on the message - this should execute
-                                // the message filters and preprocess message.
-                                if (Application.ThreadContext.FromCurrent().PreTranslateMessage(ref *msg))
-                                {
-                                    msg->message = User32.WM.NULL;
-                                }
+                                msg->message = User32.WM.NULL;
                             }
                         }
                     }
 
-                    return User32.CallNextHookEx(new HandleRef(this, _messageHookHandle), nCode, wparam, lparam);
+                    return User32.CallNextHookEx(_messageHookHandle, nCode, wparam, lparam);
                 }
 
                 private void UninstallMessageHook()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
@@ -1000,7 +1000,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal static bool ProcessMenuKey(ref Message m)
         {
-            Debug.WriteLineIf(Control.s_controlKeyboardRouting.TraceVerbose, "ToolStripManager.ProcessMenuKey: [" + m.ToString() + "]");
+            Debug.WriteLineIf(Control.s_controlKeyboardRouting.TraceVerbose, $"ToolStripManager.ProcessMenuKey: [{m.ToString()}]");
             if (!IsThreadUsingToolStrips())
             {
                 return false;
@@ -1008,7 +1008,7 @@ namespace System.Windows.Forms
 
             Debug.WriteLineIf(ToolStrip.s_snapFocusDebug.TraceVerbose, "[ProcessMenuKey] Determining whether we should send focus to MenuStrip");
 
-            Keys keyData = (Keys)(int)m.LParam;
+            Keys keyData = (Keys)m._LParam;
 
             // Search for our menu to work with
             Control intendedControl = Control.FromHandle(m.HWnd);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.FeedbackRectangle.FeedbackDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.FeedbackRectangle.FeedbackDropDown.cs
@@ -106,9 +106,9 @@ namespace System.Windows.Forms
 
                 protected override void WndProc(ref Message m)
                 {
-                    if (m.Msg == (int)User32.WM.NCHITTEST)
+                    if (m._Msg == User32.WM.NCHITTEST)
                     {
-                        m.Result = (IntPtr)User32.HT.TRANSPARENT;
+                        m._Result = (nint)User32.HT.TRANSPARENT;
                     }
 
                     base.WndProc(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
@@ -137,7 +137,7 @@ namespace System.Windows.Forms
 
                 // Call RedrawWindow with the region.
                 User32.RedrawWindow(
-                    new HandleRef(this, Handle),
+                    this,
                     null,
                     hNonClientRegion,
                     User32.RDW.INVALIDATE | User32.RDW.ERASE | User32.RDW.UPDATENOW
@@ -276,12 +276,12 @@ namespace System.Windows.Forms
                 g.DrawRectangle(pen, 0, 0, Width - 1, Height - 1);
 
                 // We've handled WM_NCPAINT.
-                m.Result = IntPtr.Zero;
+                m._Result = 0;
             }
 
             protected override void WndProc(ref Message m)
             {
-                if (m.Msg == (int)User32.WM.NCPAINT)
+                if (m._Msg == User32.WM.NCPAINT)
                 {
                     WmNCPaint(ref m);
                     return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -2054,7 +2054,7 @@ namespace System.Windows.Forms
             if (cursorLocation.X >= r.left && cursorLocation.X <= r.right &&
                 cursorLocation.Y >= r.top && cursorLocation.Y <= r.bottom)
             {
-                message.Result = (IntPtr)User32.MA.NOACTIVATE;
+                message._Result = (nint)User32.MA.NOACTIVATE;
             }
         }
 
@@ -2065,7 +2065,7 @@ namespace System.Windows.Forms
         {
             var point = (Point)message.GetLParam(typeof(Point));
             bool result = false;
-            message.Result = GetWindowFromPoint(point, ref result);
+            message._Result = GetWindowFromPoint(point, ref result);
         }
 
         /// <summary>
@@ -2178,7 +2178,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            User32.WINDOWPOS* wp = (User32.WINDOWPOS*)message.LParam;
+            User32.WINDOWPOS* wp = (User32.WINDOWPOS*)message._LParam;
 
             Cursor currentCursor = Cursor.Current;
             Point cursorPos = Cursor.Position;
@@ -2256,7 +2256,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            message.Result = IntPtr.Zero;
+            message._Result = 0;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -1045,11 +1045,11 @@ namespace System.Windows.Forms
 
         protected override void WndProc(ref Message m)
         {
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.REFLECT_HSCROLL:
                 case User32.WM.REFLECT_VSCROLL:
-                    switch (PARAM.LOWORD(m.WParam))
+                    switch (PARAM.LOWORD(m._WParam))
                     {
                         case NativeMethods.TB_LINEUP:
                         case NativeMethods.TB_LINEDOWN:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.WebBrowserSite.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.WebBrowserSite.cs
@@ -50,7 +50,8 @@ namespace System.Windows.Forms
                     pt->Y = -1;
                 }
 
-                wb.ShowContextMenu(pt->X, pt->Y);
+                wb.ShowContextMenu(*pt);
+
                 // MSHTML should not display its context menu because we displayed ours
                 return HRESULT.S_OK;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
@@ -1362,26 +1362,26 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Returns TRUE if there is a context menu to show
-        ///  Returns FALSE otherwise
+        ///  Returns true if there is a context menu to show.
         /// </summary>
-        private bool ShowContextMenu(int x, int y)
+        private bool ShowContextMenu(Point location)
         {
             ContextMenuStrip contextMenuStrip = ContextMenuStrip;
             if (contextMenuStrip is not null)
             {
                 Point client;
+
                 bool keyboardActivated = false;
-                // X will be exactly -1 when the user invokes the context menu from the keyboard
-                //
-                if (x == -1)
+
+                // X will be -1 when the user invokes the context menu from the keyboard
+                if (location.X == -1)
                 {
                     keyboardActivated = true;
                     client = new Point(Width / 2, Height / 2);
                 }
                 else
                 {
-                    client = PointToClient(new Point(x, y));
+                    client = PointToClient(location);
                 }
 
                 if (ClientRectangle.Contains(client))
@@ -1406,13 +1406,10 @@ namespace System.Windows.Forms
 
         protected override void WndProc(ref Message m)
         {
-            switch ((User32.WM)m.Msg)
+            switch (m._Msg)
             {
                 case User32.WM.CONTEXTMENU:
-                    int x = PARAM.SignedLOWORD(m.LParam);
-                    int y = PARAM.SignedHIWORD(m.LParam);
-
-                    if (!ShowContextMenu(x, y))
+                    if (!ShowContextMenu(PARAM.ToPoint(m._LParam)))
                     {
                         DefWndProc(ref m);
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.WebBrowserBaseNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.WebBrowserBaseNativeWindow.cs
@@ -41,7 +41,7 @@ namespace System.Windows.Forms
 
             private unsafe void WmWindowPosChanging(ref Message m)
             {
-                User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParam;
+                User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m._LParam;
                 wp->x = 0;
                 wp->y = 0;
                 Size s = WebBrowserBase.webBrowserBaseChangingSize;
@@ -56,7 +56,7 @@ namespace System.Windows.Forms
                     wp->cy = s.Height;
                 }
 
-                m.Result = (IntPtr)0;
+                m._Result = 0;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -239,76 +239,82 @@ namespace System.Windows.Forms
             // WebBrowserSiteBase's IOleControlSite.TranslateAccelerator implementation. There, we
             // set a flag and call back into this method. In this method, we first check
             // if this flag is set. If so, we call base.PreProcessMessage.
-            if (IsUserMode)
+            if (!IsUserMode)
             {
-                if (GetAXHostState(WebBrowserHelper.siteProcessedInputKey))
-                {
-                    // In this case, the control called us back through IOleControlSite
-                    // and is now giving us a chance to see if we want to process it.
-                    return base.PreProcessMessage(ref msg);
-                }
-
-                // Convert Message to MSG
-                User32.MSG win32Message = msg;
-                SetAXHostState(WebBrowserHelper.siteProcessedInputKey, false);
-                try
-                {
-                    if (axOleInPlaceObject is not null)
-                    {
-                        // Give the ActiveX control a chance to process this key by calling
-                        // IOleInPlaceActiveObject::TranslateAccelerator.
-                        HRESULT hr = axOleInPlaceActiveObject.TranslateAccelerator(&win32Message);
-                        if (hr == HRESULT.S_OK)
-                        {
-                            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "\t Message translated to " + win32Message);
-                            return true;
-                        }
-                        else
-                        {
-                            // win32Message may have been modified. Lets copy it back.
-                            msg.Msg = (int)win32Message.message;
-                            msg.WParam = win32Message.wParam;
-                            msg.LParam = win32Message.lParam;
-                            msg.HWnd = win32Message.hwnd;
-
-                            if (hr == HRESULT.S_FALSE)
-                            {
-                                // Same code as in AxHost (ignore dialog keys here).
-                                // We have the same problem here
-                                bool ret = false;
-
-                                ignoreDialogKeys = true;
-                                try
-                                {
-                                    ret = base.PreProcessMessage(ref msg);
-                                }
-                                finally
-                                {
-                                    ignoreDialogKeys = false;
-                                }
-
-                                return ret;
-                            }
-                            else if (GetAXHostState(WebBrowserHelper.siteProcessedInputKey))
-                            {
-                                Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "\t Message processed by site. Calling base.PreProcessMessage() " + msg);
-                                return base.PreProcessMessage(ref msg);
-                            }
-                            else
-                            {
-                                Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "\t Message not processed by site. Returning false. " + msg);
-                                return false;
-                            }
-                        }
-                    }
-                }
-                finally
-                {
-                    SetAXHostState(WebBrowserHelper.siteProcessedInputKey, false);
-                }
+                return false;
             }
 
-            return false;
+            if (GetAXHostState(WebBrowserHelper.siteProcessedInputKey))
+            {
+                // In this case, the control called us back through IOleControlSite
+                // and is now giving us a chance to see if we want to process it.
+                return base.PreProcessMessage(ref msg);
+            }
+
+            // Convert Message to MSG
+            User32.MSG win32Message = msg;
+            SetAXHostState(WebBrowserHelper.siteProcessedInputKey, false);
+            try
+            {
+                if (axOleInPlaceObject is null)
+                {
+                    return false;
+                }
+
+                // Give the ActiveX control a chance to process this key by calling
+                // IOleInPlaceActiveObject::TranslateAccelerator.
+                HRESULT hr = axOleInPlaceActiveObject.TranslateAccelerator(&win32Message);
+                if (hr == HRESULT.S_OK)
+                {
+                    Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"\t Message translated to {win32Message}");
+                    return true;
+                }
+                else
+                {
+                    // win32Message may have been modified. Lets copy it back.
+                    msg._Msg = win32Message.message;
+                    msg._WParam = win32Message.wParam;
+                    msg._LParam = win32Message.lParam;
+                    msg.HWnd = win32Message.hwnd;
+
+                    if (hr == HRESULT.S_FALSE)
+                    {
+                        // Same code as in AxHost (ignore dialog keys here).
+                        // We have the same problem here.
+                        bool ret = false;
+
+                        ignoreDialogKeys = true;
+                        try
+                        {
+                            ret = base.PreProcessMessage(ref msg);
+                        }
+                        finally
+                        {
+                            ignoreDialogKeys = false;
+                        }
+
+                        return ret;
+                    }
+                    else if (GetAXHostState(WebBrowserHelper.siteProcessedInputKey))
+                    {
+                        Debug.WriteLineIf(
+                            s_controlKeyboardRouting.TraceVerbose,
+                            $"\t Message processed by site. Calling base.PreProcessMessage() {msg}");
+                        return base.PreProcessMessage(ref msg);
+                    }
+                    else
+                    {
+                        Debug.WriteLineIf(
+                            s_controlKeyboardRouting.TraceVerbose,
+                            $"\t Message not processed by site. Returning false. {msg}");
+                        return false;
+                    }
+                }
+            }
+            finally
+            {
+                SetAXHostState(WebBrowserHelper.siteProcessedInputKey, false);
+            }
         }
 
         //
@@ -398,7 +404,7 @@ namespace System.Windows.Forms
                     break;
 
                 case User32.WM.COMMAND:
-                    if (!ReflectMessage(m.LParam, ref m))
+                    if (!ReflectMessage(m._LParam, ref m))
                     {
                         DefWndProc(ref m);
                     }
@@ -427,7 +433,7 @@ namespace System.Windows.Forms
                     break;
 
                 case User32.WM.KILLFOCUS:
-                    hwndFocus = (IntPtr)m.WParam;
+                    hwndFocus = m._WParam;
                     try
                     {
                         base.WndProc(ref m);
@@ -477,9 +483,9 @@ namespace System.Windows.Forms
                     break;
 
                 default:
-                    if (m.Msg == (int)WebBrowserHelper.REGMSG_MSG)
+                    if (m._Msg == WebBrowserHelper.REGMSG_MSG)
                     {
-                        m.Result = (IntPtr)WebBrowserHelper.REGMSG_RETVAL;
+                        m._Result = WebBrowserHelper.REGMSG_RETVAL;
                     }
                     else
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WindowSubclassHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WindowSubclassHandler.cs
@@ -230,12 +230,12 @@ namespace System.Windows.Forms
             // Call the original window procedure to process the message.
             if (_originalWindowProc != IntPtr.Zero)
             {
-                m.Result = User32.CallWindowProcW(
+                m._Result = User32.CallWindowProcW(
                     _originalWindowProc,
                     m.HWnd,
-                    (User32.WM)m.Msg,
-                    m.WParam,
-                    m.LParam);
+                    m._Msg,
+                    m._WParam,
+                    m._LParam);
             }
         }
 
@@ -281,7 +281,7 @@ namespace System.Windows.Forms
                 HandleWndProcException(ex);
             }
 
-            return m.Result;
+            return m._Result;
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
@@ -12,6 +12,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>$(NoWarn),WINFORMSDEV0001</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\System.Design\src\System.Design.Facade.csproj" />
     <ProjectReference Include="..\..\..\..\System.Windows.Forms.Design\src\System.Windows.Forms.Design.csproj" />

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -5,6 +5,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <NoWarn>$(NoWarn),1573,1591,1712,WINFORMSDEV0001</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="xunit.stafact" Version="$(XUnitStaFactPackageVersion)" />


### PR DESCRIPTION
Store PARAM and result as nint and expose internally. Add DEBUG obsoletion to flush out any usages of the IntPtr properties (and suppress in consuming projects).

Note that the Message field names are deliberately named to match the properties for easier diffing in this PR.

Other changes:

- Add Point helpers to PARAM
- Update some GDI handle wrappers to nint
- Update a few other native APIs to use nint

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5849)