### PR TITLE
Filling empty test files for missing ao (part 3)

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewColumnHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewColumnHeaderCellAccessibleObjectTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -13,6 +15,126 @@ namespace System.Windows.Forms.Tests
         {
             var accessibleObject = new DataGridViewColumnHeaderCellAccessibleObject(null);
             Assert.Null(accessibleObject.Owner);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Parent_ThrowException_IfOwnerIsNull()
+        {
+            Assert.Throws<InvalidOperationException>(() => new DataGridViewColumnHeaderCellAccessibleObject(null).Parent);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Parent_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewColumnHeaderCell cell = control.Columns[0].HeaderCell;
+
+            var accessibleObject = (DataGridViewColumnHeaderCellAccessibleObject)cell.AccessibilityObject;
+
+            Assert.Equal(control.AccessibilityObject.GetChild(0), accessibleObject.Parent);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Role_ReturnsExpected()
+        {
+            DataGridViewColumnHeaderCellAccessibleObject accessibleObject = new(null);
+            Assert.Equal(AccessibleRole.ColumnHeader, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Name_ReturnsExpected()
+        {
+            string testHeaderName = "Test header name";
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", testHeaderName);
+
+            var accessibleObject = (DataGridViewColumnHeaderCellAccessibleObject)control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(testHeaderName, accessibleObject.Name);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Value_ReturnsExpected()
+        {
+            string testHeaderName = "Test header name";
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", testHeaderName);
+
+            var accessibleObject = (DataGridViewColumnHeaderCellAccessibleObject)control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(testHeaderName, accessibleObject.Value);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Bounds_IsNotEmptyRectangle_IfHandleIsCreated()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.CreateControl();
+
+            var accessibleObject = (DataGridViewColumnHeaderCellAccessibleObject)control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.NotEqual(Rectangle.Empty, accessibleObject.Bounds);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Bounds_IsEmptyRectangle_IfHandleIsNotCreated()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+
+            var accessibleObject = (DataGridViewColumnHeaderCellAccessibleObject)control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(Rectangle.Empty, accessibleObject.Bounds);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_DefaultAction_ReturnsExpected_IfSortModeIsAutomatic()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewColumn column = control.Columns[0];
+            column.SortMode = DataGridViewColumnSortMode.Automatic;
+
+            var accessibleObject = (DataGridViewColumnHeaderCellAccessibleObject)column.HeaderCell.AccessibilityObject;
+
+            Assert.Equal(SR.DataGridView_AccColumnHeaderCellDefaultAction, accessibleObject.DefaultAction);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.InvokePatternId)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        public void DataGridViewColumnHeaderCellAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
+        {
+            var accessibleObject = new DataGridViewColumnHeaderCellAccessibleObject(null);
+            Assert.True((bool)accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_ControlType_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewColumnHeaderCellAccessibleObject(null);
+            Assert.Equal(UiaCore.UIA.HeaderControlTypeId, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewColumn column = control.Columns[0];
+
+            var accessibleObject = (DataGridViewColumnHeaderCellAccessibleObject)column.HeaderCell.AccessibilityObject;
+
+            Assert.Equal(control.AccessibilityObject.GetChild(0), accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeaderCellAccessibleObjectTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -11,8 +13,159 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewRowHeaderCellAccessibleObject_Ctor_Default()
         {
-            var accessibleObject = new DataGridViewRowHeaderCellAccessibleObject(null);
+            DataGridViewRowHeaderCellAccessibleObject accessibleObject = new(null);
             Assert.Null(accessibleObject.Owner);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_Parent_ThrowException_IfOwnerIsNull()
+        {
+            Assert.Throws<InvalidOperationException>(() => new DataGridViewRowHeaderCellAccessibleObject(null).Parent);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_Parent_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewRowHeaderCell cell = control.Rows[0].HeaderCell;
+
+            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)cell.AccessibilityObject;
+
+            Assert.Equal(cell.OwningRow.AccessibilityObject, accessibleObject.Parent);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_Value_ReturnsExpected()
+        {
+            DataGridViewRowHeaderCellAccessibleObject accessibleObject = new(null);
+            Assert.Equal(string.Empty, accessibleObject.Value);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_Role_ReturnsExpected()
+        {
+            DataGridViewRowHeaderCellAccessibleObject accessibleObject = new(null);
+            Assert.Equal(AccessibleRole.RowHeader, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_Name_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewRow row = control.Rows[0];
+
+            Assert.Equal(row.AccessibilityObject.Name, row.HeaderCell.AccessibilityObject.Name);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> DataGridViewRowHeaderCellAccessibleObject_DefaultAction_TestData()
+        {
+            yield return new object[] { DataGridViewSelectionMode.FullRowSelect, SR.DataGridView_RowHeaderCellAccDefaultAction };
+            yield return new object[] { DataGridViewSelectionMode.RowHeaderSelect, SR.DataGridView_RowHeaderCellAccDefaultAction };
+            yield return new object[] { DataGridViewSelectionMode.CellSelect, string.Empty };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DataGridViewRowHeaderCellAccessibleObject_DefaultAction_TestData))]
+        public void DataGridViewRowHeaderCellAccessibleObject_DefaultAction_ReturnsExpected(DataGridViewSelectionMode mode, string expected)
+        {
+            using DataGridView control = new();
+            control.SelectionMode = mode;
+            control.Columns.Add("Column 1", "Header text 1");
+
+            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)control.Rows[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.DefaultAction);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(DataGridViewSelectionMode.FullRowSelect, true)]
+        [InlineData(DataGridViewSelectionMode.RowHeaderSelect, true)]
+        [InlineData(DataGridViewSelectionMode.CellSelect, false)]
+        public void DataGridViewRowHeaderCellAccessibleObject_DoDefaultAction_WorksExpected(DataGridViewSelectionMode mode, bool expected)
+        {
+            using DataGridView control = new();
+            control.SelectionMode = mode;
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewRowHeaderCell cell = control.Rows[0].HeaderCell;
+            control.CreateControl();
+
+            Assert.False(cell.OwningRow.Selected);
+
+            cell.AccessibilityObject.DoDefaultAction();
+
+            Assert.Equal(expected, cell.OwningRow.Selected);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(DataGridViewSelectionMode.FullRowSelect)]
+        [InlineData(DataGridViewSelectionMode.RowHeaderSelect)]
+        [InlineData(DataGridViewSelectionMode.CellSelect)]
+        public void DataGridViewRowHeaderCellAccessibleObject_DoDefaultAction_DoesNothing_IfHandleIsNotCreated(DataGridViewSelectionMode mode)
+        {
+            using DataGridView control = new();
+            control.SelectionMode = mode;
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewRowHeaderCell cell = control.Rows[0].HeaderCell;
+
+            Assert.False(cell.OwningRow.Selected);
+
+            cell.AccessibilityObject.DoDefaultAction();
+
+            Assert.False(cell.OwningRow.Selected);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_Bounds_IsNotEmptyRectangle()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+
+            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)control.Rows[0].HeaderCell.AccessibilityObject;
+
+            Assert.NotEqual(Rectangle.Empty, accessibleObject.Bounds);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_IsNull_IfOwningRowIsNull()
+        {
+            DataGridViewRowHeaderCellAccessibleObject accessibleObject = new(new());
+
+            Assert.Null(accessibleObject.Owner.OwningRow);
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewRow row = control.Rows[0];
+
+            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+
+            Assert.Equal(row.AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewRow row = control.Rows[0];
+
+            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+
+            Assert.Equal(row.Cells[0].AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedCellsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedCellsAccessibleObjectTests.cs
@@ -15,8 +15,179 @@ namespace System.Windows.Forms.Tests
             Type type = typeof(DataGridView)
                 .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
             var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
             Assert.Null(accessibleObject.TestAccessor().Dynamic._ownerDataGridView);
             Assert.Equal(AccessibleRole.Grouping, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_Name_ReturnsExpected()
+        {
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
+            Assert.Equal(SR.DataGridView_AccSelectedCellsName, accessibleObject.Name);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_Value_ReturnsExpected()
+        {
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
+            Assert.Equal(SR.DataGridView_AccSelectedCellsName, accessibleObject.Value);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_State_ReturnsExpected()
+        {
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
+            Assert.Equal(AccessibleStates.Selected | AccessibleStates.Selectable, accessibleObject.State);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_Parent_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control });
+
+            Assert.Equal(control.AccessibilityObject, accessibleObject.Parent);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_GetSelected_ReturnsExpected()
+        {
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
+            Assert.Equal(accessibleObject, accessibleObject.GetSelected());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_GetFocused_ReturnsExpected_IfCurrentCellIsSelected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Rows.Add("Row1");
+            DataGridViewCell currentCell = control.Rows[0].Cells[0];
+            control.CurrentCell = currentCell;
+            currentCell.Selected = true;
+
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control });
+
+            Assert.NotNull(currentCell);
+            Assert.Equal(currentCell.AccessibilityObject, accessibleObject.GetFocused());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_GetFocused_ReturnsNull_IfCurrentCellIsNotSelected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewCell currentCell = control.Rows[0].Cells[0];
+            control.CurrentCell = currentCell;
+            currentCell.Selected = false;
+
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control });
+
+            Assert.NotNull(currentCell);
+            Assert.Null(accessibleObject.GetFocused());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_GetChildCount_ReturnsExpected()
+        {
+            int selecetedCellsCount = 2;
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Columns.Add("Column 3", "Header text 3");
+            control.Rows.Add("Row1");
+
+            for (int i = 0; i < selecetedCellsCount; i++)
+            {
+                control.Rows[0].Cells[i].Selected = true;
+            }
+
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control });
+
+            Assert.Equal(selecetedCellsCount, accessibleObject.GetChildCount());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_GetChild_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Rows.Add("Row1");
+
+            DataGridViewCell selecetedCell1 = control.Rows[0].Cells[0];
+            selecetedCell1.Selected = true;
+
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control });
+
+            Assert.Null(accessibleObject.GetChild(-1));
+            Assert.Equal(selecetedCell1.AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Null(accessibleObject.GetChild(1));
+
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_Navigate_ReturnsExpected_NoChilds()
+        {
+            using DataGridView control = new();
+
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control });
+
+            Assert.Equal(0, accessibleObject.GetChildCount());
+            Assert.Null(accessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Null(accessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_Navigate_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Rows.Add("Row1");
+
+            DataGridViewCell selecetedCell1 = control.Rows[0].Cells[0];
+            selecetedCell1.Selected = true;
+
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control });
+
+            Assert.Equal(1, accessibleObject.GetChildCount());
+            Assert.Equal(selecetedCell1.AccessibilityObject, accessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(selecetedCell1.AccessibilityObject, accessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(control.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCellsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCellsAccessibleObjectTests.cs
@@ -19,5 +19,183 @@ namespace System.Windows.Forms.Tests
             Assert.Null(accessibleObject.TestAccessor().Dynamic.owner);
             Assert.Equal(AccessibleRole.Grouping, accessibleObject.Role);
         }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_Name_ReturnsExpected()
+        {
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { null }, null);
+
+            Assert.Equal(SR.DataGridView_AccSelectedRowCellsName, accessibleObject.Name);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_Value_ReturnsExpected()
+        {
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { null }, null);
+
+            Assert.Equal(SR.DataGridView_AccSelectedRowCellsName, accessibleObject.Value);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_State_ReturnsExpected()
+        {
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { null }, null);
+
+            Assert.Equal(AccessibleStates.Selected | AccessibleStates.Selectable, accessibleObject.State);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_Parent_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Rows.Add("Row1");
+            DataGridViewRow row = control.Rows[0];
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { row }, null);
+
+            Assert.Equal(row.AccessibilityObject, accessibleObject.Parent);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_GetSelected_ReturnsExpected()
+        {
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { null }, null);
+
+            Assert.Equal(accessibleObject, accessibleObject.GetSelected());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_GetFocused_ReturnsExpected_IfCurrentCellIsSelected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Rows.Add("Row1");
+            DataGridViewCell currentCell = control.Rows[0].Cells[0];
+            control.CurrentCell = currentCell;
+            currentCell.Selected = true;
+
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { control.Rows[0] }, null);
+
+            Assert.NotNull(currentCell);
+            Assert.Equal(currentCell.AccessibilityObject, accessibleObject.GetFocused());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_GetFocused_ReturnsNull_IfCurrentCellIsNotSelected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewCell currentCell = control.Rows[0].Cells[0];
+            control.CurrentCell = currentCell;
+            currentCell.Selected = false;
+
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { control.Rows[0] }, null);
+
+            Assert.NotNull(currentCell);
+            Assert.Null(accessibleObject.GetFocused());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_GetChildCount_ReturnsExpected()
+        {
+            int selecetedCellsCount = 2;
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Columns.Add("Column 3", "Header text 3");
+            control.Rows.Add("Row1");
+            DataGridViewRow row = control.Rows[0];
+
+            for (int i = 0; i < selecetedCellsCount; i++)
+            {
+                row.Cells[i].Selected = true;
+            }
+
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { row }, null);
+
+            Assert.Equal(selecetedCellsCount, accessibleObject.GetChildCount());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_GetChild_ReturnsExpected()
+        {
+            using NoAssertContext context = new();
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Rows.Add("Row1");
+            DataGridViewRow row = control.Rows[0];
+
+            DataGridViewCell selecetedCell1 = row.Cells[0];
+            selecetedCell1.Selected = true;
+
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { row }, null);
+
+            Assert.Null(accessibleObject.GetChild(-1));
+            Assert.Equal(selecetedCell1.AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Null(accessibleObject.GetChild(1));
+
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_Navigate_ReturnsExpected_NoChilds()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { control.Rows[0] }, null);
+
+            Assert.Equal(0, accessibleObject.GetChildCount());
+            Assert.Null(accessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Null(accessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_Navigate_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Rows.Add("Row1");
+            DataGridViewRow row = control.Rows[0];
+
+            DataGridViewCell selecetedCell1 = row.Cells[0];
+            selecetedCell1.Selected = true;
+
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { row }, null);
+
+            Assert.Equal(1, accessibleObject.GetChildCount());
+            Assert.Equal(selecetedCell1.AccessibilityObject, accessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(selecetedCell1.AccessibilityObject, accessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

This opportunity appears after creating test files for missing ao classes in pr #5731.
Added unit tests for the following classes:
- `DataGridViewColumnHeaderCellAccessibleObject`
- `DataGridViewRowHeaderCellAccessibleObject`
- `DataGridViewSelectedCellsAccessibleObject`
- `DataGridViewSelectedRowCellsAccessibleObject`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5864)