### PR TITLE
Fixing missing control type for custom `DataGridViewCell`s

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -684,6 +684,7 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.DataItemControlTypeId,
                     UiaCore.UIA.NamePropertyId => Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,// Announce the cell when focusing.
                     UiaCore.UIA.IsEnabledPropertyId => _owner?.DataGridView?.Enabled ?? false,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using Moq;
 using Moq.Protected;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -528,6 +529,14 @@ namespace System.Windows.Forms.Tests
                     Assert.Equal(cell.ReadOnly, value);
                 }
             }
+        }
+
+        [Fact]
+        public void DataGridViewCellAccessibleObject_ControlType_IsDefined()
+        {
+            UiaCore.IRawElementProviderSimple provider = new DataGridViewCellAccessibleObject();
+
+            Assert.Equal(UiaCore.UIA.DataItemControlTypeId, provider.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
         }
 
         private class SubDataGridViewCell : DataGridViewCell


### PR DESCRIPTION
Fixes #5792. To fix custom `DataGridViewCell`s we're providing default control type for the base `DataGridViewCellAccessibleObject`.


## Proposed changes

- Added `ControlTypePropertyId` with `DataItemControlTypeId` value to the `GetPropertyValue` of `DataGridViewCellAccessibleObject`.

## Customer Impact

- Control type of custom `DataGridViewCell`s is correctly recognized by accessibility tools.

## Regression? 

- No

## Risk

- Minimal



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![ControlType is missing for custom DataGridViewCell](https://user-images.githubusercontent.com/5282741/134864199-adc4a89e-93ef-46e6-adbd-d1f67880cadf.png)

### After

![ControlType is present for custom DataGridViewCell](https://user-images.githubusercontent.com/5282741/134864714-64764fd6-7c7c-4b89-8057-d82da4e54c0f.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests
- CTI (planned)



## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19043.1237]
- .NET 7.0.0-beta.21474.2


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5868)