### PR TITLE
Fixed getting an month index of a bolded date of a MonthCalendar

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Calendar.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Calendar.cs
@@ -15,6 +15,21 @@ namespace WinformsControlsTest
             daysOfWeekComboBox.SelectedIndex = (int)monthCalendar1.FirstDayOfWeek;
             showWeekNumbersCheckBox.Checked = monthCalendar1.ShowWeekNumbers;
             showTodayCheckBox.Checked = monthCalendar1.ShowToday;
+            monthCalendar1.DateSelected += monthCalendar1_DateSelected;
+        }
+
+        private unsafe void monthCalendar1_DateSelected(object sender, DateRangeEventArgs e)
+        {
+            if (monthCalendar1.BoldedDates.Contains(e.Start))
+            {
+                monthCalendar1.RemoveBoldedDate(e.Start);
+            }
+            else
+            {
+                monthCalendar1.AddBoldedDate(e.Start);
+            }
+
+            monthCalendar1.UpdateBoldedDates();
         }
 
         private void setMinDateButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #5853

The regression came from #4317, the previous implementation didn't not take into account gray dates of a display range. So the max index was 11, but in real, 13 is the max month index (including the first and last gray months).

## Proposed changes

- Rework getting current month index when setting a new bolded date

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user can bold a MonthCalendar date correctly


## Regression? 

- Yes (from #4317)

## Risk

- Minimal

## Screenshots

### Before
MonthCalendar doesn't show bolded dates:
![K29yyG2JFB](https://user-images.githubusercontent.com/49272759/135065436-c23a25bd-d980-4f09-93d3-4158075be222.gif)

### After
MonthCalendar shows bolded dates:
![bby0rqDoqn](https://user-images.githubusercontent.com/49272759/135065493-50dfa763-47a8-4e94-ad48-9cd9ca9e517b.gif)

## Test methodology <!-- How did you ensure quality? -->

- CTI
- Unit tests
- Manual testing

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0-alpha
- Windows 10



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5869)