### PR TITLE
Filling empty test files for missing ao (part 4)

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObjectTests.cs
@@ -2,16 +2,18 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using System.Reflection;
 using Xunit;
 using static System.Windows.Forms.ErrorProvider;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
     public class ErrorProvider_ControlItem_ControlItemAccessibleObjectTests
     {
         [WinFormsFact]
-        public void ErrorWindowAccessibleObject_Ctor_Default()
+        public void ControlItemAccessibleObjectTests_Ctor_Default()
         {
             Type type = typeof(ControlItem)
                 .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -22,6 +24,253 @@ namespace System.Windows.Forms.Tests
             Assert.Null(accessibleObject.TestAccessor().Dynamic._control);
             Assert.Null(accessibleObject.TestAccessor().Dynamic._provider);
             Assert.Equal(AccessibleRole.Alert, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_Bounds_ReturnsEmptyRectangle_IfControlIsNotCreated()
+        {
+            using Control control = new();
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null, null, control, null });
+
+            Assert.Equal(Rectangle.Empty, accessibleObject.Bounds);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_Bounds_ReturnsNoEmptyRectangle_IfControlIsCreated()
+        {
+            using Control control = new();
+            using ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+            ControlItem item = new(provider, control, (IntPtr)100);
+            window.Add(item);
+            control.CreateControl();
+
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { item, window, control, provider });
+
+            Assert.NotEqual(Rectangle.Empty, accessibleObject.Bounds);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_Parent_ReturnsExpected()
+        {
+            using Control control = new();
+            using ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null, window, control, provider });
+
+            Assert.Equal(window.AccessibilityObject, accessibleObject.Parent);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_FragmentRoot_ReturnsExpected()
+        {
+            using Control control = new();
+            using ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null, window, control, provider });
+
+            Assert.Equal(window.AccessibilityObject, accessibleObject.FragmentRoot);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_IsReadOnly_ReturnsExpected()
+        {
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null, null, null, null });
+
+            Assert.True(accessibleObject.IsReadOnly);
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_State_ReturnsExpected()
+        {
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null, null, null, null });
+
+            Assert.Equal(AccessibleStates.HasPopup | AccessibleStates.ReadOnly, accessibleObject.State);
+        }
+
+        [WinFormsTheory]
+        [InlineData("")]
+        [InlineData(null)]
+
+        public void ControlItemAccessibleObjectTests_Name_ReturnsExpected_IfNameIsNullOrEmptyString(string testName)
+        {
+            string testError = "This is test string";
+            using Control control = new();
+            using ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+            ControlItem item = new(provider, control, (IntPtr)100) { Error = testError };
+            window.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+            accessibleObject.Name = testName;
+
+            Assert.Equal(testError, accessibleObject.Name);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        public void ControlItemAccessibleObjectTests_IsPatternSupported_ReturnsExpected(int patternId)
+        {
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null, null, null, null });
+
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_IsIAccessibleExSupported_ReturnsExpected_IfItemIsNotNull()
+        {
+            using Control control = new();
+            using ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+            ControlItem item = new(provider, control, (IntPtr)100);
+            window.Add(item);
+
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { item, window, control, provider });
+
+            Assert.NotNull(accessibleObject.TestAccessor().Dynamic._controlItem);
+            Assert.True(accessibleObject.IsIAccessibleExSupported());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_ControlType_ReturnsExpected()
+        {
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null, null, null, null });
+
+            Assert.Equal(UiaCore.UIA.ImageControlTypeId, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_GetChildId_ReturnsExpected()
+        {
+            using Control control = new();
+            using ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            ControlItem item1 = new(provider, control, (IntPtr)100);
+            ControlItem item2 = new(provider, control, (IntPtr)200);
+            ControlItem item3 = new(provider, control, (IntPtr)300);
+
+            window.ControlItems.AddRange(new[] { item1, item2, item3 });
+
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject1 = (AccessibleObject)Activator.CreateInstance(type, new object[] { item1, window, control, provider });
+            var accessibleObject2 = (AccessibleObject)Activator.CreateInstance(type, new object[] { item2, window, control, provider });
+            var accessibleObject3 = (AccessibleObject)Activator.CreateInstance(type, new object[] { item3, window, control, provider });
+
+            // Make sure that returns index in window.Items collection + 1
+
+            Assert.Equal(1, accessibleObject1.GetChildId());
+            Assert.Equal(2, accessibleObject2.GetChildId());
+            Assert.Equal(3, accessibleObject3.GetChildId());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using Control control = new();
+            using ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            Type type = typeof(ControlItem)
+                .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null, window, control, provider });
+
+            Assert.Equal(window.AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_FragmentNavigate_NextSibling_ReturnsExpected()
+        {
+            using Control control = new();
+            using ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            ControlItem item1 = new(provider, control, (IntPtr)100);
+            ControlItem item2 = new(provider, control, (IntPtr)200);
+            ControlItem item3 = new(provider, control, (IntPtr)300);
+
+            window.ControlItems.AddRange(new[] { item1, item2, item3 });
+
+            AccessibleObject accessibleObject1 = item1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = item2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = item3.AccessibilityObject;
+
+            // Window is null while controlItem isn't added to window.
+            Assert.Null(accessibleObject1.TestAccessor().Dynamic._window);
+            Assert.Null(accessibleObject2.TestAccessor().Dynamic._window);
+            Assert.Null(accessibleObject3.TestAccessor().Dynamic._window);
+
+            // So add the reference manually.
+            accessibleObject1.TestAccessor().Dynamic._window = window;
+            accessibleObject2.TestAccessor().Dynamic._window = window;
+            accessibleObject3.TestAccessor().Dynamic._window = window;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        {
+            using Control control = new();
+            using ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            ControlItem item1 = new(provider, control, (IntPtr)100);
+            ControlItem item2 = new(provider, control, (IntPtr)200);
+            ControlItem item3 = new(provider, control, (IntPtr)300);
+
+            window.ControlItems.AddRange(new[] { item1, item2, item3 });
+
+            AccessibleObject accessibleObject1 = item1.AccessibilityObject;
+            AccessibleObject accessibleObject2 = item2.AccessibilityObject;
+            AccessibleObject accessibleObject3 = item3.AccessibilityObject;
+
+            // Window is null while controlItem isn't added to window.
+            Assert.Null(accessibleObject1.TestAccessor().Dynamic._window);
+            Assert.Null(accessibleObject2.TestAccessor().Dynamic._window);
+            Assert.Null(accessibleObject3.TestAccessor().Dynamic._window);
+
+            // So add the reference manually.
+            accessibleObject1.TestAccessor().Dynamic._window = window;
+            accessibleObject2.TestAccessor().Dynamic._window = window;
+            accessibleObject3.TestAccessor().Dynamic._window = window;
+
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObjectTests.cs
@@ -5,6 +5,7 @@
 using System.Reflection;
 using Xunit;
 using static System.Windows.Forms.ErrorProvider;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -16,8 +17,164 @@ namespace System.Windows.Forms.Tests
             Type type = typeof(ErrorWindow)
                 .GetNestedType("ErrorWindowAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
             var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
             Assert.Null(accessibleObject.TestAccessor().Dynamic._owner);
             Assert.Equal(AccessibleRole.Grouping, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void ErrorWindowAccessibleObject_IsReadOnly_ReturnsExpected()
+        {
+            Type type = typeof(ErrorWindow)
+                .GetNestedType("ErrorWindowAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
+            Assert.True(accessibleObject.IsReadOnly);
+        }
+
+        [WinFormsFact]
+        public void ErrorWindowAccessibleObject_State_ReturnsExpected()
+        {
+            Type type = typeof(ErrorWindow)
+                .GetNestedType("ErrorWindowAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
+            Assert.Equal(AccessibleStates.ReadOnly, accessibleObject.State);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        public void ErrorWindowAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
+        {
+            Type type = typeof(ErrorWindow)
+                .GetNestedType("ErrorWindowAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+        }
+
+        [WinFormsFact]
+        public void ErrorWindowAccessibleObject_ControlType_ReturnsExpected()
+        {
+            Type type = typeof(ErrorWindow)
+                .GetNestedType("ErrorWindowAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
+            Assert.Equal(UiaCore.UIA.GroupControlTypeId, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsFact]
+        public void ErrorWindowAccessibleObject_FragmentRoot_ReturnsExpected()
+        {
+            Type type = typeof(ErrorWindow)
+                .GetNestedType("ErrorWindowAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
+            Assert.Equal(accessibleObject, accessibleObject.FragmentRoot);
+        }
+
+        [WinFormsFact]
+        public void ErrorWindowAccessibleObject_IsIAccessibleExSupported_ReturnsExpected()
+        {
+            using Control control = new();
+            ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            AccessibleObject accessibleObject = window.AccessibilityObject;
+
+            Assert.True(accessibleObject.IsIAccessibleExSupported());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ErrorWindowAccessibleObject_GetChildCount_ReturnsExpected()
+        {
+            int testCount = 2;
+            using Control control = new();
+            ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+            for (int i = 0; i < testCount; i++)
+            {
+                window.ControlItems.Add(new(provider, control, (IntPtr)i));
+            }
+
+            AccessibleObject accessibleObject = window.AccessibilityObject;
+
+            Assert.Equal(testCount, accessibleObject.GetChildCount());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ErrorWindowAccessibleObject_GetChild_ReturnsExpected()
+        {
+            using Control control = new();
+            ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            ControlItem item1 = new(provider, control, (IntPtr)100);
+            ControlItem item2 = new(provider, control, (IntPtr)200);
+
+            window.ControlItems.AddRange(new[] { item1, item2 });
+            AccessibleObject accessibleObject = window.AccessibilityObject;
+
+            Assert.Null(accessibleObject.GetChild(-1));
+            Assert.Equal(item1.AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(item2.AccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Null(accessibleObject.GetChild(2));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void ErrorWindowAccessibleObject_Name_ReturnsExpected_IfNullOrStringEmptyString(string testName)
+        {
+            using Control control = new();
+            ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            ControlItem item1 = new(provider, control, (IntPtr)100);
+            ControlItem item2 = new(provider, control, (IntPtr)200);
+            window.ControlItems.AddRange(new[] { item1, item2 });
+
+            AccessibleObject accessibleObject = window.AccessibilityObject;
+            accessibleObject.Name = testName;
+
+            Assert.Equal(SR.ErrorProviderDefaultAccessibleName, accessibleObject.Name);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ErrorWindowAccessibleObject_FragmentNavigate_ReturnsExpected()
+        {
+            using Control control = new();
+            ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            ControlItem item1 = new(provider, control, (IntPtr)100);
+            ControlItem item2 = new(provider, control, (IntPtr)200);
+            ControlItem item3 = new(provider, control, (IntPtr)300);
+
+            window.ControlItems.AddRange(new[] { item1, item2, item3 });
+            AccessibleObject accessibleObject = window.AccessibilityObject;
+
+            Assert.Equal(item1.AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(item3.AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ErrorWindowAccessibleObject_FragmentNavigate_ReturnsExpected_NoItems()
+        {
+            using Control control = new();
+            ErrorProvider provider = new();
+            ErrorWindow window = new(provider, control);
+
+            AccessibleObject accessibleObject = window.AccessibilityObject;
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHost.ToolStripControlHostAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHost.ToolStripControlHostAccessibleObjectTests.cs
@@ -14,5 +14,54 @@ namespace System.Windows.Forms.Tests
         {
             Assert.Throws<ArgumentNullException>(() => new ToolStripControlHostAccessibleObject(null));
         }
+
+        [WinFormsFact]
+        public void ToolStripControlHostAccessibleObject_Ctor_Default()
+        {
+            using Control control = new();
+            using ToolStripControlHost toolStrip = new(control);
+            var accessibleObject = (ToolStripControlHostAccessibleObject)toolStrip.AccessibilityObject;
+
+            Assert.NotNull(accessibleObject);
+            Assert.Equal(toolStrip, accessibleObject.Owner);
+            Assert.False(toolStrip.Control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ToolStripControlHostAccessibleObject_DefaultAction_ReturnsExpected()
+        {
+            using Control control = new();
+            using ToolStripControlHost toolStrip = new(control);
+            var accessibleObject = (ToolStripControlHostAccessibleObject)toolStrip.AccessibilityObject;
+
+            Assert.Equal(string.Empty, accessibleObject.DefaultAction);
+            Assert.False(toolStrip.Control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ToolStripControlHostAccessibleObject_Role_ReturnsExpected()
+        {
+            AccessibleRole testRole = AccessibleRole.Cell;
+            using Control control = new();
+            using ToolStripControlHost toolStrip = new(control);
+            var accessibleObject = (ToolStripControlHostAccessibleObject)toolStrip.AccessibilityObject;
+
+            control.AccessibleRole = testRole;
+
+            Assert.Equal(testRole, accessibleObject.Role);
+            Assert.False(toolStrip.Control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ToolStripControlHostAccessibleObject_FragmentNavigate_ReturnsExpected()
+        {
+            using Control control = new();
+            using ToolStripControlHost toolStrip = new(control);
+            var accessibleObject = (ToolStripControlHostAccessibleObject)toolStrip.AccessibilityObject;
+
+            Assert.Equal(control.AccessibilityObject, accessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(control.AccessibilityObject, accessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(toolStrip.Control.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownItemAccessibleObjectTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using static Interop.UiaCore;
 
 namespace System.Windows.Forms.Tests
 {
@@ -12,6 +13,200 @@ namespace System.Windows.Forms.Tests
         public void ToolStripDropDownItemAccessibleObject_Ctor_OwnerToolStripDropDownItemCannotBeNull()
         {
             Assert.Throws<ArgumentNullException>(() => new ToolStripDropDownItemAccessibleObject(null));
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_Ctor_Default()
+        {
+            using SubToolStripDropDownItem control = new();
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+
+            Assert.NotNull(accessibleObject);
+            Assert.Equal(control, accessibleObject.Owner);
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_Role_ReturnsExpected_ControlHasDefaultRole()
+        {
+            using SubToolStripDropDownItem control = new();
+            control.AccessibleRole = AccessibleRole.Default;
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+
+            Assert.Equal(AccessibleRole.MenuItem, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_Role_ReturnsExpected_ControlHasNotDefaultRole()
+        {
+            AccessibleRole testRole = AccessibleRole.Cell;
+            using SubToolStripDropDownItem control = new();
+            control.AccessibleRole = testRole;
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+
+            Assert.Equal(testRole, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_IsIAccessibleExSupported_ReturnsExpected()
+        {
+            using SubToolStripDropDownItem control = new();
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+
+            Assert.True(accessibleObject.IsIAccessibleExSupported());
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, ((int)ExpandCollapseState.Collapsed))]
+        [InlineData(true, ((int)ExpandCollapseState.Expanded))]
+        public void ToolStripDropDownItemAccessibleObject_ExpandCollapseState_ReturnsExpected(bool visible, int expected)
+        {
+            using SubToolStripDropDownItem control = new();
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+            control.DropDown.Items.Add(new SubToolStripDropDownItem());
+            control.DropDown.Visible = visible;
+
+            Assert.Equal((ExpandCollapseState)expected, accessibleObject.ExpandCollapseState);
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_GetChildCount_ReturnsExpected_IfNoDropDownItems()
+        {
+            using SubToolStripDropDownItem control = new();
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+
+            Assert.Equal(-1, accessibleObject.GetChildCount());
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_GetChildCount_ReturnsExpected_IfCollapsed()
+        {
+            using SubToolStripDropDownItem control = new();
+            control.DropDown.Items.Add(new SubToolStripDropDownItem());
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+
+            Assert.Equal(0, accessibleObject.GetChildCount());
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_GetChildCount_ReturnsExpected()
+        {
+            int testCount = 2;
+            using SubToolStripDropDownItem control = new();
+            for (int i = 0; i < testCount; i++)
+            {
+                control.DropDown.Items.Add(new SubToolStripDropDownItem() { Available = true });
+            }
+
+            control.DropDown.Visible = true;
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+
+            Assert.Equal(testCount, accessibleObject.GetChildCount());
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_GetChildCount_ReturnsNull_IfNoDropDownItems()
+        {
+            using SubToolStripDropDownItem control = new();
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+
+            Assert.Null(accessibleObject.GetChild(0));
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_GetChild_ReturnsExpected()
+        {
+            using NoAssertContext context = new();
+            using SubToolStripDropDownItem control = new();
+            using SubToolStripDropDownItem item1 = new() { Available = true };
+            using SubToolStripDropDownItem item2 = new() { Available = true };
+            control.DropDown.Items.AddRange(new [] { item1, item2 });
+
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+
+            Assert.Null(accessibleObject.GetChild(-1));
+            Assert.Equal(item1.AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(item2.AccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Null(accessibleObject.GetChild(2));
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected()
+        {
+            using NoAssertContext context = new();
+            using SubToolStripDropDownItem control = new();
+            using SubToolStripDropDownItem item1 = new();
+            using SubToolStripDropDownItem item2 = new();
+            using SubToolStripDropDownItem notItem = new();
+            control.DropDown.Items.AddRange(new[] { item1, item2 });
+
+            var accessibleObjectItem1 = (ToolStripDropDownItemAccessibleObject)item1.AccessibilityObject;
+            var accessibleObjectItem2 = (ToolStripDropDownItemAccessibleObject)item2.AccessibilityObject;
+            var accessibleObjectNotItem = (ToolStripDropDownItemAccessibleObject)notItem.AccessibilityObject;
+
+            Assert.Equal(accessibleObjectItem2, accessibleObjectItem1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObjectItem2.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObjectNotItem.FragmentNavigate(NavigateDirection.NextSibling));
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        {
+            using NoAssertContext context = new();
+            using SubToolStripDropDownItem control = new();
+            using SubToolStripDropDownItem item1 = new();
+            using SubToolStripDropDownItem item2 = new();
+            using SubToolStripDropDownItem notItem = new();
+            control.DropDown.Items.AddRange(new[] { item1, item2 });
+
+            var accessibleObjectItem1 = (ToolStripDropDownItemAccessibleObject)item1.AccessibilityObject;
+            var accessibleObjectItem2 = (ToolStripDropDownItemAccessibleObject)item2.AccessibilityObject;
+            var accessibleObjectNotItem = (ToolStripDropDownItemAccessibleObject)notItem.AccessibilityObject;
+
+            Assert.Null(accessibleObjectItem1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObjectItem1, accessibleObjectItem2.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObjectNotItem.FragmentNavigate(NavigateDirection.PreviousSibling));
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_GetChildFragmentCount_ReturnsExpected()
+        {
+            int testCount = 2;
+            using SubToolStripDropDownItem control = new();
+            for (int i = 0; i < testCount; i++)
+            {
+                control.DropDownItems.Add(new SubToolStripDropDownItem() { Available = true });
+            }
+
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+            accessibleObject.GetChildCount();
+
+            Assert.Equal(testCount, accessibleObject.GetChildFragmentCount());
+        }
+
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_GetChildFragmentIndex_ReturnsExpected()
+        {
+            using NoAssertContext context = new();
+            using SubToolStripDropDownItem control = new();
+
+            using SubToolStripDropDownItem item1 = new() { Available = true };
+            using SubToolStripDropDownItem item2 = new() { Available = true };
+            using SubToolStripDropDownItem notItem = new();
+            control.DropDownItems.AddRange(new[] { item1, item2 });
+
+            var accessibleObject = (ToolStripDropDownItemAccessibleObject)control.AccessibilityObject;
+            var accessibleObjectItem1 = (ToolStripDropDownItemAccessibleObject)item1.AccessibilityObject;
+            var accessibleObjectItem2 = (ToolStripDropDownItemAccessibleObject)item2.AccessibilityObject;
+            var accessibleObjectNotItem = (ToolStripDropDownItemAccessibleObject)notItem.AccessibilityObject;
+
+            Assert.Equal(0, accessibleObject.GetChildFragmentIndex(accessibleObjectItem1));
+            Assert.Equal(1, accessibleObject.GetChildFragmentIndex(accessibleObjectItem2));
+            Assert.Equal(-1, accessibleObject.GetChildFragmentIndex(accessibleObjectNotItem));
+        }
+
+        private class SubToolStripDropDownItem : ToolStripDropDownItem
+        {
+            public SubToolStripDropDownItem() : base() { }
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

This opportunity appears after creating test files for missing ao classes in pr #5731.
Added unit tests for the following classes:
- `ToolStripControlHostAccessibleObject`
- `ToolStripDropDownItemAccessibleObject`
- `ControlItemAccessibleObject`
- `ErrorWindowAccessibleObject`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5877)