### PR TITLE
Fix incorrect ToggleState of DataGridViewCheckBoxCellAO class

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.cs
@@ -176,10 +176,10 @@ namespace System.Windows.Forms
                     switch (Owner.FormattedValue)
                     {
                         case CheckState checkState:
-                            toggledState = checkState == CheckState.Unchecked;
+                            toggledState = checkState == CheckState.Checked;
                             break;
                         case bool boolState:
-                            toggledState = !boolState;
+                            toggledState = boolState;
                             break;
                         default:
                             return UiaCore.ToggleState.Indeterminate;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCheckBoxCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCheckBoxCellAccessibleObjectTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -14,6 +15,35 @@ namespace System.Windows.Forms.Tests
             var accessibleObject = new DataGridViewCheckBoxCellAccessibleObject(null);
             Assert.Null(accessibleObject.Owner);
             Assert.Equal(AccessibleRole.Cell, accessibleObject.Role);
+        }
+
+        public static IEnumerable<object[]> DataGridViewCheckBoxCellAccessibleObject_ToggleState_TestData()
+        {
+            yield return new object[] { false, (int)UiaCore.ToggleState.Off };
+            yield return new object[] { true, (int)UiaCore.ToggleState.On };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DataGridViewCheckBoxCellAccessibleObject_ToggleState_TestData))]
+        public void DataGridViewCheckBoxCellAccessibleObject_ToggleState_ReturnsExpected(bool isChecked, int expected)
+        {
+            using DataGridView control = new();
+            control.Columns.Add(new DataGridViewCheckBoxColumn());
+            var cell = control.Rows[0].Cells[0];
+            // Create control to check cell if it is needed.
+            control.CreateControl();
+
+            var accessibleObject = (DataGridViewCheckBoxCellAccessibleObject)cell.AccessibilityObject;
+            if (isChecked)
+            {
+                // Make sure that toggle state is on as a default case.
+                Assert.Equal(UiaCore.ToggleState.Off, accessibleObject.ToggleState);
+                // Check it.
+                accessibleObject.DoDefaultAction();
+            }
+
+            Assert.Equal((UiaCore.ToggleState)expected, accessibleObject.ToggleState);
+            Assert.True(control.IsHandleCreated);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5886 


## Proposed changes

- Reworked incorrect condition in ToggleState method
- Added unit test

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Has no incorrect behavior of properties during work with this control.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![1](https://user-images.githubusercontent.com/58004471/135487186-92c3b642-6f08-4a2b-a1a0-4a4f1affe39f.png)

![2](https://user-images.githubusercontent.com/58004471/135487197-e6bfa8a6-f7d8-4944-998d-e3c2e41c334d.png)

### After

![new1](https://user-images.githubusercontent.com/58004471/135487245-72c0f407-ccc0-42fb-b31e-c0297639036f.png)

![new2](https://user-images.githubusercontent.com/58004471/135487262-df5ac57c-82c8-427e-960c-61d8300c3464.png)

## Test methodology

- Manually
- Unit test
- Accessibility tests

## Accessibility testing

- Inspect
- Accessibility Insights
- Narrator

## Test environment(s) 

- dotnet version: 6.0.100-rc.2.21456.2


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5887)