### PR TITLE
Filling empty test files for missing ao (part 5)

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewButtonCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewButtonCellAccessibleObjectTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -14,6 +15,51 @@ namespace System.Windows.Forms.Tests
             var accessibleObject = new DataGridViewButtonCellAccessibleObject(null);
             Assert.Null(accessibleObject.Owner);
             Assert.Equal(AccessibleRole.Cell, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewButtonCellAccessibleObject_DefaultAction_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewButtonCellAccessibleObject(null);
+            Assert.Equal(SR.DataGridView_AccButtonCellDefaultAction, accessibleObject.DefaultAction);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewButtonCellAccessibleObject_GetChildCount_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewButtonCellAccessibleObject(null);
+            Assert.Equal(0, accessibleObject.GetChildCount());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewButtonCellAccessibleObject_IsIAccessibleExSupported_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewButtonCellAccessibleObject(null);
+            Assert.True(accessibleObject.IsIAccessibleExSupported());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewButtonCellAccessibleObject_ControlType_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewButtonCellAccessibleObject(null);
+            Assert.Equal(UiaCore.UIA.ButtonControlTypeId, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewButtonCellAccessibleObject_DoDefaultAction_ThrowsException_IfOwnerIsNull()
+        {
+            Assert.Throws <InvalidOperationException> (()
+                => new DataGridViewButtonCellAccessibleObject(null).DoDefaultAction());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewButtonCellAccessibleObject_DoDefaultAction_ThrowsException_IfOwnerRowIndexIncorrect()
+        {
+            using DataGridViewCell cell = new DataGridViewButtonCell();
+            AccessibleObject accessibleObject = cell.AccessibilityObject;
+
+            Assert.Equal(-1, cell.RowIndex);
+            Assert.Throws<InvalidOperationException>(() => accessibleObject.DoDefaultAction());
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCheckBoxCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCheckBoxCellAccessibleObjectTests.cs
@@ -29,6 +29,7 @@ namespace System.Windows.Forms.Tests
         {
             using DataGridView control = new();
             control.Columns.Add(new DataGridViewCheckBoxColumn());
+
             var cell = control.Rows[0].Cells[0];
             // Create control to check cell if it is needed.
             control.CreateControl();
@@ -36,7 +37,7 @@ namespace System.Windows.Forms.Tests
             var accessibleObject = (DataGridViewCheckBoxCellAccessibleObject)cell.AccessibilityObject;
             if (isChecked)
             {
-                // Make sure that toggle state is on as a default case.
+                // Make sure that toggle state is off as a default case.
                 Assert.Equal(UiaCore.ToggleState.Off, accessibleObject.ToggleState);
                 // Check it.
                 accessibleObject.DoDefaultAction();
@@ -44,6 +45,154 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal((UiaCore.ToggleState)expected, accessibleObject.ToggleState);
             Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCheckBoxCellAccessibleObject_GetChildCount_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewCheckBoxCellAccessibleObject(null);
+            Assert.Equal(0, accessibleObject.GetChildCount());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCheckBoxCellAccessibleObject_ControlType_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewCheckBoxCellAccessibleObject(null);
+            Assert.Equal(UiaCore.UIA.CheckBoxControlTypeId, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.TogglePatternId)]
+        public void DataGridViewCheckBoxCellAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
+        {
+            var accessibleObject = new DataGridViewCheckBoxCellAccessibleObject(null);
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCheckBoxCellAccessibleObject_IsIAccessibleExSupported_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewCheckBoxCellAccessibleObject(null);
+            Assert.True(accessibleObject.IsIAccessibleExSupported());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCheckBoxCellAccessibleObject_DefaultAction_ThrowsException_IfOwnerIsNull()
+        {
+            Assert.Throws<InvalidOperationException>(()
+              => new DataGridViewCheckBoxCellAccessibleObject(null).DefaultAction);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCheckBoxCellAccessibleObject_DefaultAction_ReturnsExpected_IfOwnerIsReadOnly()
+        {
+            using DataGridViewCheckBoxCell cell = new();
+            using DataGridViewRow row = new();
+            row.Cells.Add(cell);
+            cell.ReadOnly = true;
+
+            Assert.True(cell.ReadOnly);
+            Assert.Equal(string.Empty, cell.AccessibilityObject.DefaultAction);
+        }
+
+        public static IEnumerable<object[]> DataGridViewCheckBoxCellAccessibleObject_DefaultAction_TestData()
+        {
+            yield return new object[] { false, SR.DataGridView_AccCheckBoxCellDefaultActionCheck };
+            yield return new object[] { true, SR.DataGridView_AccCheckBoxCellDefaultActionUncheck };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DataGridViewCheckBoxCellAccessibleObject_DefaultAction_TestData))]
+        public void DataGridViewCheckBoxCellAccessibleObject_DefaultAction_ReturnsExpected(bool isChecked, string expected)
+        {
+            using DataGridView control = new();
+            control.Columns.Add(new DataGridViewCheckBoxColumn());
+            control.Rows.Add(new DataGridViewRow());
+            var cell = control.Rows[0].Cells[0];
+            // Create control to check cell if it is needed.
+            control.CreateControl();
+
+            var accessibleObject = (DataGridViewCheckBoxCellAccessibleObject)cell.AccessibilityObject;
+            if (isChecked)
+            {
+                // Make sure that default action is check as a default case.
+                Assert.Equal(SR.DataGridView_AccCheckBoxCellDefaultActionCheck, accessibleObject.DefaultAction);
+                // Check it.
+                accessibleObject.DoDefaultAction();
+            }
+
+            Assert.Equal(expected, accessibleObject.DefaultAction);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCheckBoxCellAccessibleObject_ToggleState_ThrowsException_IfOwnerIsNull()
+        {
+            Assert.Throws<InvalidOperationException>(()
+              => new DataGridViewCheckBoxCellAccessibleObject(null).ToggleState);
+        }
+
+        public static IEnumerable<object[]> DataGridViewCheckBoxCellAccessibleObject_DoDefaultAction_TestData()
+        {
+            yield return new object[] { false, true, (int)UiaCore.ToggleState.Off };
+            yield return new object[] { false, false, (int)UiaCore.ToggleState.Off };
+            yield return new object[] { true, true, (int)UiaCore.ToggleState.Off };
+            yield return new object[] { true, false, (int)UiaCore.ToggleState.On };
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCheckBoxCellAccessibleObject_DoDefaultAction_ThrowsException_IfOwnerIsNull()
+        {
+            Assert.Throws<InvalidOperationException>(()
+              => new DataGridViewCheckBoxCellAccessibleObject(null).DoDefaultAction());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCheckBoxCellAccessibleObject_DoDefaultAction_ThrowsException_IfRowIndexIsIncorrect()
+        {
+            using DataGridViewCheckBoxCell cell = new();
+
+            Assert.Equal(-1, cell.RowIndex);
+            Assert.Throws<InvalidOperationException>(() => cell.AccessibilityObject.DoDefaultAction());
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DataGridViewCheckBoxCellAccessibleObject_DoDefaultAction_TestData))]
+        public void DataGridViewCheckBoxCellAccessibleObject_DoDefaultAction_WorksExpected(bool createControl, bool isChecked, int expected)
+        {
+            using DataGridView control = new();
+            control.Columns.Add(new DataGridViewCheckBoxColumn());
+            control.Rows.Add(new DataGridViewRow());
+            var cell = control.Rows[0].Cells[0];
+            if (createControl)
+            {
+                control.CreateControl();
+            }
+
+            var accessibleObject = (DataGridViewCheckBoxCellAccessibleObject)cell.AccessibilityObject;
+            if (isChecked)
+            {
+                // Make sure that toogle state is off as a default case.
+                Assert.Equal(UiaCore.ToggleState.Off, accessibleObject.ToggleState);
+                // Check it.
+                accessibleObject.DoDefaultAction();
+
+                if (createControl)
+                {
+                    // Make sure that toogle state has been changed.
+                    Assert.Equal(UiaCore.ToggleState.On, accessibleObject.ToggleState);
+                }
+                else
+                {
+                    // Make sure that nothing changes.
+                    Assert.Equal(UiaCore.ToggleState.Off, accessibleObject.ToggleState);
+                }
+            }
+
+            accessibleObject.DoDefaultAction();
+
+            Assert.Equal((UiaCore.ToggleState)expected, accessibleObject.ToggleState);
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewImageCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewImageCellAccessibleObjectTests.cs
@@ -1,8 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -12,8 +13,85 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewImageCellAccessibleObject_Ctor_Default()
         {
             var accessibleObject = new DataGridViewImageCellAccessibleObject(null);
+
             Assert.Null(accessibleObject.Owner);
             Assert.Equal(AccessibleRole.Cell, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewImageCellAccessibleObject_DefaultAction_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewImageCellAccessibleObject(null);
+
+            Assert.Equal(string.Empty, accessibleObject.DefaultAction);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewImageCellAccessibleObject_GetChildCount_Default()
+        {
+            var accessibleObject = new DataGridViewImageCellAccessibleObject(null);
+
+            Assert.Equal(0, accessibleObject.GetChildCount());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewImageCellAccessibleObject_IsIAccessibleExSupported_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewImageCellAccessibleObject(null);
+
+            Assert.True(accessibleObject.IsIAccessibleExSupported());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewImageCellAccessibleObject_ControlType_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewImageCellAccessibleObject(null);
+
+            UiaCore.UIA expected = UiaCore.UIA.ImageControlTypeId;
+            Assert.Equal(expected, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewImageCellAccessibleObject_IsInvokePatternAvailable_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewImageCellAccessibleObject(null);
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsInvokePatternAvailablePropertyId));
+        }
+
+        [WinFormsTheory]
+        [InlineData(((int)UiaCore.UIA.InvokePatternId))]
+        public void DataGridViewImageCellAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
+        {
+            var accessibleObject = new DataGridViewImageCellAccessibleObject(null);
+
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewImageCellAccessibleObject_Description_IsNull_IfOwnerIsNotImageCell()
+        {
+            var accessibleObject = new DataGridViewImageCellAccessibleObject(null);
+
+            Assert.Null(accessibleObject.Description);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewImageCellAccessibleObject_Description_ReturnsExpected()
+        {
+            string testDescription = "This is a test description string";
+            using DataGridViewImageCell cell = new();
+
+            cell.Description = testDescription;
+
+            Assert.Equal(testDescription, cell.AccessibilityObject.Description);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewImageCellAccessibleObject_DoDefaultAction_ThrowsException_IfOwnerIsNull()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            new DataGridViewImageCellAccessibleObject(null).DoDefaultAction());
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewLinkCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewLinkCellAccessibleObjectTests.cs
@@ -1,8 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -12,8 +13,59 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewLinkCellAccessibleObject_Ctor_Default()
         {
             var accessibleObject = new DataGridViewLinkCellAccessibleObject(null);
+
             Assert.Null(accessibleObject.Owner);
             Assert.Equal(AccessibleRole.Cell, accessibleObject.Role);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewLinkCellAccessibleObject_DefaultAction_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewLinkCellAccessibleObject(null);
+
+            Assert.Equal(SR.DataGridView_AccLinkCellDefaultAction, accessibleObject.DefaultAction);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewLinkCellAccessibleObject_GetChildCount_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewLinkCellAccessibleObject(null);
+
+            Assert.Equal(0, accessibleObject.GetChildCount());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewLinkCellAccessibleObject_IsIAccessibleExSupported_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewLinkCellAccessibleObject(null);
+
+            Assert.True(accessibleObject.IsIAccessibleExSupported());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewLinkCellAccessibleObject_ControlType_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewLinkCellAccessibleObject(null);
+
+            UiaCore.UIA expected = UiaCore.UIA.HyperlinkControlTypeId;
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewLinkCellAccessibleObject_DoDefaultAction_ThrowsException_IfOwnerIsNull()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            new DataGridViewLinkCellAccessibleObject(null).DoDefaultAction());
+        }
+
+        [WinFormsFact]
+        public void DataGridViewLinkCellAccessibleObject_DoDefaultAction_ThrowsException_IfRowIndexIsIncorrect()
+        {
+            using DataGridViewLinkCell cell = new();
+
+            Assert.Equal(-1, cell.RowIndex);
+            Assert.Throws<InvalidOperationException>(() => cell.AccessibilityObject.DoDefaultAction());
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

This opportunity appears after creating test files for missing ao classes in pr #5731.
Added unit tests for the following classes:
- `DataGridViewButtonCellAccessibleObject`
- `DataGridViewCheckBoxCellAccessibleObject`
- `DataGridViewImageCellAccessibleObject`
- `DataGridViewLinkCellAccessibleObject`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5890)