### PR TITLE
Enable nullability in ColumnReorderedEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1627,8 +1627,8 @@ static readonly System.Windows.Forms.PropertyGridInternal.PropertyGridCommands.R
 ~System.Windows.Forms.ColumnHeader.Tag.set -> void
 ~System.Windows.Forms.ColumnHeader.Text.get -> string
 ~System.Windows.Forms.ColumnHeader.Text.set -> void
-~System.Windows.Forms.ColumnReorderedEventArgs.ColumnReorderedEventArgs(int oldDisplayIndex, int newDisplayIndex, System.Windows.Forms.ColumnHeader header) -> void
-~System.Windows.Forms.ColumnReorderedEventArgs.Header.get -> System.Windows.Forms.ColumnHeader
+System.Windows.Forms.ColumnReorderedEventArgs.ColumnReorderedEventArgs(int oldDisplayIndex, int newDisplayIndex, System.Windows.Forms.ColumnHeader? header) -> void
+System.Windows.Forms.ColumnReorderedEventArgs.Header.get -> System.Windows.Forms.ColumnHeader?
 ~System.Windows.Forms.ComboBox.AutoCompleteCustomSource.get -> System.Windows.Forms.AutoCompleteStringCollection
 ~System.Windows.Forms.ComboBox.AutoCompleteCustomSource.set -> void
 ~System.Windows.Forms.ComboBox.ChildAccessibleObject.ChildAccessibleObject(System.Windows.Forms.ComboBox owner, System.IntPtr handle) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnReorderedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnReorderedEventArgs.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms
 {
     public class ColumnReorderedEventArgs : CancelEventArgs
     {
-        public ColumnReorderedEventArgs(int oldDisplayIndex, int newDisplayIndex, ColumnHeader header) : base()
+        public ColumnReorderedEventArgs(int oldDisplayIndex, int newDisplayIndex, ColumnHeader? header) : base()
         {
             OldDisplayIndex = oldDisplayIndex;
             NewDisplayIndex = newDisplayIndex;
@@ -21,6 +19,6 @@ namespace System.Windows.Forms
 
         public int NewDisplayIndex { get; }
 
-        public ColumnHeader Header { get; }
+        public ColumnHeader? Header { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ColumnReorderedEventArgs


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5898)