### PR TITLE
Enable nullability in ListViewItemMouseHoverEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2480,8 +2480,8 @@ System.Windows.Forms.Design.IWindowsFormsEditorService.ShowDialog(System.Windows
 ~System.Windows.Forms.ListViewItem.Text.set -> void
 ~System.Windows.Forms.ListViewItem.ToolTipText.get -> string
 ~System.Windows.Forms.ListViewItem.ToolTipText.set -> void
-~System.Windows.Forms.ListViewItemMouseHoverEventArgs.Item.get -> System.Windows.Forms.ListViewItem
-~System.Windows.Forms.ListViewItemMouseHoverEventArgs.ListViewItemMouseHoverEventArgs(System.Windows.Forms.ListViewItem item) -> void
+System.Windows.Forms.ListViewItemMouseHoverEventArgs.Item.get -> System.Windows.Forms.ListViewItem?
+System.Windows.Forms.ListViewItemMouseHoverEventArgs.ListViewItemMouseHoverEventArgs(System.Windows.Forms.ListViewItem? item) -> void
 ~System.Windows.Forms.ListViewItemSelectionChangedEventArgs.Item.get -> System.Windows.Forms.ListViewItem
 ~System.Windows.Forms.ListViewItemSelectionChangedEventArgs.ListViewItemSelectionChangedEventArgs(System.Windows.Forms.ListViewItem item, int itemIndex, bool isSelected) -> void
 ~System.Windows.Forms.MaskedTextBox.Culture.get -> System.Globalization.CultureInfo

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemMouseHoverEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemMouseHoverEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -11,11 +9,11 @@ namespace System.Windows.Forms
     /// </summary>
     public class ListViewItemMouseHoverEventArgs : EventArgs
     {
-        public ListViewItemMouseHoverEventArgs(ListViewItem item)
+        public ListViewItemMouseHoverEventArgs(ListViewItem? item)
         {
             Item = item;
         }
 
-        public ListViewItem Item { get; }
+        public ListViewItem? Item { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ListViewItemMouseHoverEventArgs


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5900)