### PR TITLE
Enable nullability in DataGridViewCellCancelEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCancelEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCancelEventArgs.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms
 {
     public class DataGridViewCellCancelEventArgs : CancelEventArgs
     {
-        internal DataGridViewCellCancelEventArgs(DataGridViewCell dataGridViewCell) : this(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex)
+        internal DataGridViewCellCancelEventArgs(DataGridViewCell dataGridViewCell)
+            : this(dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex)
         {
         }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewCellCancelEventArgs

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5907)