### PR TITLE
Enable nullability in DataGridViewAutoSizeColumnModeEventArgs and DataGridViewAutoSizeColumnsModeEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1796,10 +1796,10 @@ static readonly System.Windows.Forms.PropertyGridInternal.PropertyGridCommands.R
 ~System.Windows.Forms.DataGridView.TopLeftHeaderCell.set -> void
 ~System.Windows.Forms.DataGridView.UserSetCursor.get -> System.Windows.Forms.Cursor
 ~System.Windows.Forms.DataGridView.VerticalScrollBar.get -> System.Windows.Forms.ScrollBar
-~System.Windows.Forms.DataGridViewAutoSizeColumnModeEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn
-~System.Windows.Forms.DataGridViewAutoSizeColumnModeEventArgs.DataGridViewAutoSizeColumnModeEventArgs(System.Windows.Forms.DataGridViewColumn dataGridViewColumn, System.Windows.Forms.DataGridViewAutoSizeColumnMode previousMode) -> void
-~System.Windows.Forms.DataGridViewAutoSizeColumnsModeEventArgs.DataGridViewAutoSizeColumnsModeEventArgs(System.Windows.Forms.DataGridViewAutoSizeColumnMode[] previousModes) -> void
-~System.Windows.Forms.DataGridViewAutoSizeColumnsModeEventArgs.PreviousModes.get -> System.Windows.Forms.DataGridViewAutoSizeColumnMode[]
+System.Windows.Forms.DataGridViewAutoSizeColumnModeEventArgs.Column.get -> System.Windows.Forms.DataGridViewColumn?
+System.Windows.Forms.DataGridViewAutoSizeColumnModeEventArgs.DataGridViewAutoSizeColumnModeEventArgs(System.Windows.Forms.DataGridViewColumn? dataGridViewColumn, System.Windows.Forms.DataGridViewAutoSizeColumnMode previousMode) -> void
+System.Windows.Forms.DataGridViewAutoSizeColumnsModeEventArgs.DataGridViewAutoSizeColumnsModeEventArgs(System.Windows.Forms.DataGridViewAutoSizeColumnMode[]? previousModes) -> void
+System.Windows.Forms.DataGridViewAutoSizeColumnsModeEventArgs.PreviousModes.get -> System.Windows.Forms.DataGridViewAutoSizeColumnMode[]?
 ~System.Windows.Forms.DataGridViewButtonColumn.Text.get -> string
 ~System.Windows.Forms.DataGridViewButtonColumn.Text.set -> void
 ~System.Windows.Forms.DataGridViewCell.AccessibilityObject.get -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeColumnModeEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeColumnModeEventArgs.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewAutoSizeColumnModeEventArgs : EventArgs
     {
-        public DataGridViewAutoSizeColumnModeEventArgs(DataGridViewColumn dataGridViewColumn, DataGridViewAutoSizeColumnMode previousMode)
+        public DataGridViewAutoSizeColumnModeEventArgs(DataGridViewColumn? dataGridViewColumn, DataGridViewAutoSizeColumnMode previousMode)
         {
             Column = dataGridViewColumn;
             PreviousMode = previousMode;
         }
 
-        public DataGridViewColumn Column { get; }
+        public DataGridViewColumn? Column { get; }
 
         public DataGridViewAutoSizeColumnMode PreviousMode { get; }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeColumnsModeEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewAutoSizeColumnsModeEventArgs.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewAutoSizeColumnsModeEventArgs : EventArgs
     {
-        public DataGridViewAutoSizeColumnsModeEventArgs(DataGridViewAutoSizeColumnMode[] previousModes)
+        public DataGridViewAutoSizeColumnsModeEventArgs(DataGridViewAutoSizeColumnMode[]? previousModes)
         {
             PreviousModes = previousModes;
         }
 
-        public DataGridViewAutoSizeColumnMode[] PreviousModes { get; }
+        public DataGridViewAutoSizeColumnMode[]? PreviousModes { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewAutoSizeColumnModeEventArgs and DataGridViewAutoSizeColumnsModeEventArgs

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5910)