### PR TITLE
Filling empty test files for missing ao (part 6)

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CategoryGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CategoryGridEntryAccessibleObjectTests.cs
@@ -5,23 +5,146 @@
 using System.Windows.Forms.PropertyGridInternal;
 using Xunit;
 using static System.Windows.Forms.PropertyGridInternal.CategoryGridEntry;
+using static System.Windows.Forms.PropertyGridInternal.PropertyGridView;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
     public class CategoryGridEntryAccessibleObjectTests
     {
         [WinFormsFact]
-        public void CategoryGridEntryAccessibleObject_Ctor_OwnerCategoryGridEntryCannotBeNull()
+        public void CategoryGridEntryAccessibleObject_Ctor_Default()
         {
             using NoAssertContext context = new();
             var accessibilityObject = new CategoryGridEntryAccessibleObject(null);
+
             Assert.Null(accessibilityObject.TestAccessor().Dynamic._owningCategoryGridEntry);
         }
 
-        private class SubGridEntry: GridEntry
+        [WinFormsFact]
+        public void CategoryGridEntryAccessibleObject_Role_ReturnsExpected()
         {
-            public SubGridEntry(PropertyGrid ownerGrid, GridEntry parent) : base(ownerGrid, parent)
-            { }
+            using NoAssertContext context = new();
+            var accessibilityObject = new CategoryGridEntryAccessibleObject(null);
+
+            Assert.Equal(AccessibleRole.ButtonDropDownGrid, accessibilityObject.Role);
+        }
+
+        [WinFormsFact]
+        public void CategoryGridEntryAccessibleObject_Column_ReturnsExpected()
+        {
+            using NoAssertContext context = new();
+            var accessibilityObject = new CategoryGridEntryAccessibleObject(null);
+
+            Assert.Equal(0, accessibilityObject.Column);
+        }
+
+        [WinFormsFact]
+        public void CategoryGridEntryAccessibleObject_ControlType_ReturnsExpected()
+        {
+            using NoAssertContext context = new();
+            var accessibilityObject = new CategoryGridEntryAccessibleObject(null);
+
+            UiaCore.UIA expected = UiaCore.UIA.TreeItemControlTypeId;
+
+            Assert.Equal(expected, accessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.GridItemPatternId)]
+        [InlineData((int)UiaCore.UIA.TableItemPatternId)]
+        public void CategoryGridEntryAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
+        {
+            using NoAssertContext context = new();
+            var accessibilityObject = new CategoryGridEntryAccessibleObject(null);
+
+            Assert.True(accessibilityObject.IsPatternSupported((UiaCore.UIA)patternId));
+        }
+
+        [WinFormsFact]
+        public void CategoryGridEntryAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using PropertyGrid control = new();
+            using Button button = new();
+            control.SelectedObject = button;
+            PropertyGridView gridView = control.TestAccessor().Dynamic._gridView;
+
+            AccessibleObject accessibilityObject = gridView.TopLevelGridEntries[0].AccessibilityObject;
+
+            Assert.Equal(gridView.AccessibilityObject, accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+            Assert.False(button.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CategoryGridEntryAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected()
+        {
+            using PropertyGrid control = new();
+            using Button button = new();
+            control.SelectedObject = button;
+            PropertyGridView gridView = control.TestAccessor().Dynamic._gridView;
+
+            AccessibleObject accessibilityObjectCategory1 = gridView.TopLevelGridEntries[0].AccessibilityObject;
+            AccessibleObject accessibilityObjectCategory2 = gridView.TopLevelGridEntries[1].AccessibilityObject;
+            AccessibleObject accessibilityObjectLastCategory = gridView.TopLevelGridEntries[^1].AccessibilityObject;
+
+            Assert.Equal(accessibilityObjectCategory2, accessibilityObjectCategory1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibilityObjectLastCategory.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+            Assert.False(button.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CategoryGridEntryAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        {
+            using PropertyGrid control = new();
+            using Button button = new();
+            control.SelectedObject = button;
+            PropertyGridView gridView = control.TestAccessor().Dynamic._gridView;
+
+            AccessibleObject accessibilityObjectCategory1 = gridView.TopLevelGridEntries[0].AccessibilityObject;
+            AccessibleObject accessibilityObjectCategory2 = gridView.TopLevelGridEntries[1].AccessibilityObject;
+
+            Assert.Null(accessibilityObjectCategory1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibilityObjectCategory1, accessibilityObjectCategory2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+            Assert.False(button.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CategoryGridEntryAccessibleObject_FragmentNavigate_FirstChild_ReturnsExpected()
+        {
+            using PropertyGrid control = new();
+            using Button button = new();
+            control.SelectedObject = button;
+            PropertyGridView gridView = control.TestAccessor().Dynamic._gridView;
+            var category = (CategoryGridEntry)gridView.TopLevelGridEntries[0];
+            var gridViewAccessibilityObject = (PropertyGridViewAccessibleObject)gridView.AccessibilityObject;
+
+            AccessibleObject accessibilityObject = category.AccessibilityObject;
+            AccessibleObject accessibilityObjectFirstItem = gridViewAccessibilityObject.GetFirstChildProperty(category);
+
+            Assert.Equal(accessibilityObjectFirstItem, accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.False(control.IsHandleCreated);
+            Assert.False(button.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CategoryGridEntryAccessibleObject_FragmentNavigate_LastChild_ReturnsExpected()
+        {
+            using PropertyGrid control = new();
+            using Button button = new();
+            control.SelectedObject = button;
+            PropertyGridView gridView = control.TestAccessor().Dynamic._gridView;
+            var category = (CategoryGridEntry)gridView.TopLevelGridEntries[0];
+            var gridViewAccessibilityObject = (PropertyGridViewAccessibleObject)gridView.AccessibilityObject;
+
+            AccessibleObject accessibilityObject = category.AccessibilityObject;
+            AccessibleObject accessibilityObjectLastItem = gridViewAccessibilityObject.GetLastChildProperty(category);
+
+            Assert.Equal(accessibilityObjectLastItem, accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+            Assert.False(button.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopLeftHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopLeftHeaderCellAccessibleObjectTests.cs
@@ -2,7 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+using System.Windows.Forms.TestUtilities;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -12,7 +15,184 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewTopLeftHeaderCellAccessibleObject_Ctor_Default()
         {
             var accessibleObject = new DataGridViewTopLeftHeaderCellAccessibleObject(null);
+
             Assert.Null(accessibleObject.Owner);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_Bounds_ThrowsException_IfOwnerIsNull()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                new DataGridViewTopLeftHeaderCellAccessibleObject(null).Bounds);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_Bounds_ReturnsEmptyRectangle_IfDataGridViewIsNull()
+        {
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            Assert.Null(cell.DataGridView);
+            Assert.Equal(Rectangle.Empty, cell.AccessibilityObject.Bounds);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_Bounds_ReturnsEmptyRectangle_IfDataGridViewIsNotCreated()
+        {
+            using DataGridView control = new();
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            control.TopLeftHeaderCell = cell;
+
+            Assert.Equal(Rectangle.Empty, cell.AccessibilityObject.Bounds);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_Bounds_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            control.TopLeftHeaderCell = cell;
+            control.CreateControl();
+
+            Assert.NotEqual(Rectangle.Empty, cell.AccessibilityObject.Bounds);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> DataGridViewTopLeftHeaderCellAccessibleObject_DefaultAction_TestData()
+        {
+            yield return new object[] { true, SR.DataGridView_AccTopLeftColumnHeaderCellDefaultAction };
+            yield return new object[] { false, string.Empty };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DataGridViewTopLeftHeaderCellAccessibleObject_DefaultAction_TestData))]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_DefaultAction_ReturnsExpected(bool isMultiSelect, string expected)
+        {
+            using DataGridView control = new();
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            control.TopLeftHeaderCell = cell;
+            control.MultiSelect = isMultiSelect;
+
+            Assert.Equal(expected, cell.AccessibilityObject.DefaultAction);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_Value_ReturnsExpected()
+        {
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            Assert.Equal(string.Empty, cell.AccessibilityObject.Value);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_ControlType_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewTopLeftHeaderCellAccessibleObject(null);
+
+            UiaCore.UIA expected = UiaCore.UIA.HeaderControlTypeId;
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_IsEnabled_ReturnsExpected(bool isEnabled)
+        {
+            using DataGridView control = new();
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            control.TopLeftHeaderCell = cell;
+            control.Enabled = isEnabled;
+
+            Assert.Equal(isEnabled, cell.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsEnabledPropertyId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> DataGridViewTopLeftHeaderCellAccessibleObject_Name_TestData()
+        {
+            yield return new object[] { RightToLeft.No, SR.DataGridView_AccTopLeftColumnHeaderCellName };
+            yield return new object[] { RightToLeft.Yes, SR.DataGridView_AccTopLeftColumnHeaderCellNameRTL };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DataGridViewTopLeftHeaderCellAccessibleObject_Name_TestData))]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_Name_ReturnsExpected(RightToLeft value, string expected)
+        {
+            using DataGridView control = new();
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            control.TopLeftHeaderCell = cell;
+            control.RightToLeft = value;
+
+            Assert.Equal(expected, cell.AccessibilityObject.Name);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_Name_ReturnsEmptyString_IfOwnerValueIsNotEmptySring()
+        {
+            using DataGridView control = new();
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            cell.Value = "It is not empty string";
+            control.TopLeftHeaderCell = cell;
+
+            Assert.Equal(string.Empty, cell.AccessibilityObject.Name);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            control.TopLeftHeaderCell = cell;
+            AccessibleObject expected = control.AccessibilityObject.GetChild(0);
+
+            Assert.Equal(expected, cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            control.TopLeftHeaderCell = cell;
+
+            Assert.Null(cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            control.TopLeftHeaderCell = cell;
+            AccessibleObject expected = control.AccessibilityObject.GetChild(0)?.GetChild(1);
+
+            Assert.Equal(expected, cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsNull_IfDataGridViewHasNoVisibleCollumns()
+        {
+            using DataGridView control = new();
+            using DataGridViewTopLeftHeaderCell cell = new();
+
+            control.TopLeftHeaderCell = cell;
+
+            Assert.Null(cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

This opportunity appears after creating test files for missing ao classes in pr #5731.
Added unit tests for the following classes:
- `CategoryGridEntryAccessibleObject`
- `DataGridViewTopLeftHeaderCellAccessibleObject`


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5913)