### PR TITLE
Remove 'using' from DrawItemEventArgs_TestData

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -4211,9 +4211,10 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> DrawItemEventArgs_TestData()
         {
-            using var bitmap = new Bitmap(10, 10);
-            using Graphics graphics = Graphics.FromImage(bitmap);
             yield return new object[] { null };
+
+            var bitmap = new Bitmap(10, 10);
+            Graphics graphics = Graphics.FromImage(bitmap);
             yield return new object[] { new DrawItemEventArgs(graphics, null, new Rectangle(1, 2, 3, 4), 0, DrawItemState.Checked) };
         }
 


### PR DESCRIPTION
## Proposed changes

- Remove 'using' from DrawItemEventArgs_TestData

Based on the comments from https://github.com/dotnet/winforms/pull/5899#discussion_r721783556

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5923)