### PR TITLE
Fixing missing default action for combo box

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
@@ -185,6 +185,25 @@ namespace System.Windows.Forms
                 }
             }
 
+            public override string DefaultAction
+            {
+                get
+                {
+                    string defaultAction = _owningComboBox.AccessibleDefaultActionDescription;
+                    if (defaultAction is not null)
+                    {
+                        return defaultAction;
+                    }
+
+                    if (!_owningComboBox.IsHandleCreated || _owningComboBox.DropDownStyle == ComboBoxStyle.Simple)
+                    {
+                        return string.Empty;
+                    }
+
+                    return _owningComboBox.DroppedDown ? SR.AccessibleActionCollapse : SR.AccessibleActionExpand;
+                }
+            }
+
             /// <summary>
             ///  Gets the accessible property value.
             /// </summary>
@@ -289,6 +308,16 @@ namespace System.Windows.Forms
                 _owningComboBox.DropDownStyle == ComboBoxStyle.Simple
                     ? _owningComboBox.ChildEditAccessibleObject
                     : DropDownButtonUiaProvider;
+
+            public override void DoDefaultAction()
+            {
+                if (!_owningComboBox.IsHandleCreated || _owningComboBox.DropDownStyle == ComboBoxStyle.Simple)
+                {
+                    return;
+                }
+
+                _owningComboBox.DroppedDown = !_owningComboBox.DroppedDown;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
@@ -248,5 +248,98 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(comboBox.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void ComboBoxAccessibleObject_DefaultAction_IfAccessibleDefaultActionDescriptionIsNotNull_ReturnsAccessibleDefaultActionDescription()
+        {
+            using ComboBox comboBox = new() { AccessibleDefaultActionDescription = "Test" };
+
+            Assert.Equal(comboBox.AccessibleDefaultActionDescription, comboBox.AccessibilityObject.DefaultAction);
+            Assert.False(comboBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ComboBoxAccessibleObject_DefaultAction_IfHandleIsNotCreated_ReturnsNull()
+        {
+            using ComboBox comboBox = new();
+
+            Assert.Empty(comboBox.AccessibilityObject.DefaultAction);
+            Assert.False(comboBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ComboBoxAccessibleObject_DefaultAction_IfHandleIsCreatedAndDropDownStyleIsSimple_ReturnsNull()
+        {
+            using ComboBox comboBox = new() { DropDownStyle = ComboBoxStyle.Simple };
+            comboBox.CreateControl();
+
+            Assert.True(comboBox.IsHandleCreated);
+            Assert.Empty(comboBox.AccessibilityObject.DefaultAction);
+        }
+
+        public static IEnumerable<object[]> ComboBoxAccessibleObject_DefaultAction_IfHandleIsCreated_ReturnsExpected_TestData()
+        {
+            yield return new object[] { ComboBoxStyle.DropDown, false, SR.AccessibleActionExpand };
+            yield return new object[] { ComboBoxStyle.DropDown, true, SR.AccessibleActionCollapse };
+            yield return new object[] { ComboBoxStyle.DropDownList, false, SR.AccessibleActionExpand };
+            yield return new object[] { ComboBoxStyle.DropDownList, true, SR.AccessibleActionCollapse };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ComboBoxAccessibleObject_DefaultAction_IfHandleIsCreated_ReturnsExpected_TestData))]
+        public void ComboBoxAccessibleObject_DefaultAction_IfHandleIsCreated_ReturnsExpected(ComboBoxStyle style, bool droppedDown, string expectedAction)
+        {
+            using ComboBox comboBox = new() { DropDownStyle = style };
+            comboBox.CreateControl();
+            comboBox.DroppedDown = droppedDown;
+
+            Assert.True(comboBox.IsHandleCreated);
+            Assert.Equal(expectedAction, comboBox.AccessibilityObject.DefaultAction);
+        }
+
+        [WinFormsFact]
+        public void ComboBoxAccessibleObject_DoDefaultAction_IfHandleIsNotCreated_DoesNotExpand()
+        {
+            using ComboBox comboBox = new();
+
+            Assert.False(comboBox.DroppedDown);
+
+            comboBox.AccessibilityObject.DoDefaultAction();
+
+            Assert.False(comboBox.DroppedDown);
+            Assert.False(comboBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ComboBoxAccessibleObject_DoDefaultAction_IfHandleIsCreatedAndDropDownStyleIsSimple_DoesNotCollapse()
+        {
+            using ComboBox comboBox = new() { DropDownStyle = ComboBoxStyle.Simple };
+            comboBox.CreateControl();
+
+            Assert.True(comboBox.IsHandleCreated);
+            Assert.True(comboBox.DroppedDown);
+
+            comboBox.AccessibilityObject.DoDefaultAction();
+
+            Assert.True(comboBox.DroppedDown);
+        }
+
+        [WinFormsTheory]
+        [InlineData(ComboBoxStyle.DropDown, false, true)]
+        [InlineData(ComboBoxStyle.DropDown, true, false)]
+        [InlineData(ComboBoxStyle.DropDownList, false, true)]
+        [InlineData(ComboBoxStyle.DropDownList, true, false)]
+        public void ComboBoxAccessibleObject_DoDefaultAction_IfHandleIsCreated_DoesExpected(ComboBoxStyle style, bool droppedDown, bool expectedDroppedDown)
+        {
+            using ComboBox comboBox = new() { DropDownStyle = style };
+            comboBox.CreateControl();
+            comboBox.DroppedDown = droppedDown;
+
+            Assert.True(comboBox.IsHandleCreated);
+
+            comboBox.AccessibilityObject.DoDefaultAction();
+
+            Assert.Equal(expectedDroppedDown, comboBox.DroppedDown);
+        }
     }
 }


### PR DESCRIPTION
Fixes #3712. Adds the default action description and the default action itself for combo box control with a dropdown list. It can also be achieved by making `LegacyIAccessiblePattern` and `InvokePattern` not supported for the accessible object of combo box (.NET Core 3.1 behavior). This way `UIAutomationCore` will use its own fallback mechanism to support default actions. But it has a drawback of making default action dependent on accessible role property which isn't desirable. Another drawback is that we're depending on `UIAutomationCore` internals/implementation details which is also not desirable. It's better to have our own implementation which is visible to everyone and easy to debug.


## Proposed changes

- Implemented `DefaultAction` and `DoDefaultAction` for `ComboBoxAccessibleObject`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Default action is empty for combo box in accessibility tools.
- Performing default action for combo box does nothing in accessibility tools.

## Regression? 

- Yes, this is a regression from .NET Core 3.x, but not from any version of .NET Framework

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Default action is empty and performing a default action does nothing.](https://recordit.co/Oy7vTGdKFs.gif)

### After

![Default action is expand and performing it expands the list for collapsed combo box and vice versa.](https://recordit.co/9c4vvNYbml.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests
- CTI (planned)

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19043.1237]
- .NET 7.0.0-alpha.1.21480.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5928)