### PR TITLE
Fixing missing expand-collapse pattern for property grid dropdown controls

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
@@ -103,15 +103,13 @@ namespace System.Windows.Forms.PropertyGridInternal
             internal override bool IsIAccessibleExSupported() => true;
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
-            {
-                if (patternId == UiaCore.UIA.ValuePatternId ||
-                    (patternId == UiaCore.UIA.ExpandCollapsePatternId && _owningPropertyDescriptorGridEntry.Enumerable))
+                => patternId switch
                 {
-                    return true;
-                }
-
-                return base.IsPatternSupported(patternId);
-            }
+                    UiaCore.UIA.ValuePatternId => true,
+                    UiaCore.UIA.ExpandCollapsePatternId when
+                        _owningPropertyDescriptorGridEntry.Enumerable || _owningPropertyDescriptorGridEntry.NeedsDropDownButton => true,
+                    _ => base.IsPatternSupported(patternId)
+                };
 
             private void ExpandOrCollapse()
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
 using System.Drawing;
 using Xunit;
 using static Interop;
@@ -82,6 +83,44 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             Assert.Equal(UiaCore.ExpandCollapseState.Expanded, selectedGridEntryAccessibleObject.ExpandCollapseState);
         }
 
+        [WinFormsFact]
+        public void PropertyDescriptorGridEntryAccessibleObject_IsPatternSupported_IfExpandCollapsePatternAndEnumerable_ReturnsTrue()
+        {
+            using PropertyGrid propertyGrid = new();
+            using PropertyGridView propertyGridView = new(serviceProvider: null, propertyGrid);
+
+            TestGridEntry parent = new(propertyGrid, peParent: null, propertyGridView);
+            PropertyDescriptor propertyDescriptor = TypeDescriptor.GetProperties(typeof(TestEntity)).
+                Find(nameof(TestEntity.SizeProperty), ignoreCase: false);
+
+            EnumerablePropertyDescriptorGridEntry gridEntry = new(propertyGrid, parent, propertyDescriptor, hide: false);
+            AccessibleObject accessibleObject = gridEntry.AccessibilityObject;
+
+            Assert.True(gridEntry.Enumerable);
+            Assert.True(accessibleObject.IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId));
+            Assert.False(propertyGrid.IsHandleCreated);
+            Assert.False(propertyGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void PropertyDescriptorGridEntryAccessibleObject_IsPatternSupported_IfExpandCollapsePatternAndDropDownEditable_ReturnsTrue()
+        {
+            using PropertyGrid propertyGrid = new();
+            using PropertyGridView propertyGridView = new(serviceProvider: null, propertyGrid);
+
+            TestGridEntry parent = new(propertyGrid, peParent: null, propertyGridView);
+            PropertyDescriptor propertyDescriptor = TypeDescriptor.GetProperties(typeof(TestEntity)).
+                Find(nameof(TestEntity.SizeProperty), ignoreCase: false);
+
+            DropDownEditablePropertyDescriptorGridEntry gridEntry = new(propertyGrid, parent, propertyDescriptor, hide: false);
+            AccessibleObject accessibleObject = gridEntry.AccessibilityObject;
+
+            Assert.True(gridEntry.NeedsDropDownButton);
+            Assert.True(accessibleObject.IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId));
+            Assert.False(propertyGrid.IsHandleCreated);
+            Assert.False(propertyGridView.IsHandleCreated);
+        }
+
         private class TestGridEntry : GridEntry
         {
             readonly PropertyGridView _propertyGridView;
@@ -134,6 +173,26 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             {
                 get; set;
             }
+        }
+
+        private class EnumerablePropertyDescriptorGridEntry : PropertyDescriptorGridEntry
+        {
+            public EnumerablePropertyDescriptorGridEntry(PropertyGrid ownerGrid, GridEntry parent, PropertyDescriptor propertyDescriptor, bool hide)
+                : base(ownerGrid, parent, propertyDescriptor, hide)
+            {
+            }
+
+            internal override bool Enumerable => true;
+        }
+
+        private class DropDownEditablePropertyDescriptorGridEntry : PropertyDescriptorGridEntry
+        {
+            public DropDownEditablePropertyDescriptorGridEntry(PropertyGrid ownerGrid, GridEntry parent, PropertyDescriptor propertyDescriptor, bool hide)
+                : base(ownerGrid, parent, propertyDescriptor, hide)
+            {
+            }
+
+            public override bool NeedsDropDownButton => true;
         }
     }
 }


### PR DESCRIPTION
Fixes #3672.

`PropertyDescriptorGridEntry` marks `ExpandCollapsePattern` as supported only for enumerable and expandable (in `GridEntry.IsPatternSupported`) entries. Enumerable entries are entries with the predefined set of values such as colors, booleans, etc. Expandable entries are mostly for categories. The other entries with the dropdowns are treated as `DropDownEditable` which can be checked by `NeedsDropDownButton` property. The fix is to check not only `Enumerable` but also `NeedsDropDownButton` property in `PropertyDescriptorGridEntryAccessibleObject.IsPatternSupported` for `ExpandCollapsePattern`. `ExpandCollapseState` is already correctly treated by using `DropDownVisible` property. `Expand` and `Collapse` methods also correctly perform the corresponding actions. This fixes `ExpandCollapsePattern` for `MultilineStringEditor` and `DateTimeEditor`.


## Proposed changes

- Add `NeedsDropDownButton` check to `IsPatternSupported` condition for `ExpandCollapsePatternId`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Narrator can read expand-collapse state of dropdown controls (`MultilineStringEditor` and `DateTimeEditor`) on property grid.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/5282741/136638967-49082a01-e29b-45e6-bc47-c559a3ee2672.png)


### After

![image](https://user-images.githubusercontent.com/5282741/136638972-0fa0c413-5866-4a45-8c04-0c22d3116f77.png)
![image](https://user-images.githubusercontent.com/5282741/136640445-35712438-6475-4a9a-acd8-9c33f80fb478.png)




## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests
- CTI (planned)



## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19043.1237]
- .NET 7.0.0-alpha.1.21480.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5938)