### PR TITLE
Enable nullability in DataGridViewCellContextMenuStripNeededEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1827,8 +1827,8 @@ System.Windows.Forms.DataGridViewAutoSizeColumnsModeEventArgs.PreviousModes.get 
 ~System.Windows.Forms.DataGridViewCellCollection.this[int index].set -> void
 ~System.Windows.Forms.DataGridViewCellCollection.this[string columnName].get -> System.Windows.Forms.DataGridViewCell
 ~System.Windows.Forms.DataGridViewCellCollection.this[string columnName].set -> void
-~System.Windows.Forms.DataGridViewCellContextMenuStripNeededEventArgs.ContextMenuStrip.get -> System.Windows.Forms.ContextMenuStrip
-~System.Windows.Forms.DataGridViewCellContextMenuStripNeededEventArgs.ContextMenuStrip.set -> void
+System.Windows.Forms.DataGridViewCellContextMenuStripNeededEventArgs.ContextMenuStrip.get -> System.Windows.Forms.ContextMenuStrip?
+System.Windows.Forms.DataGridViewCellContextMenuStripNeededEventArgs.ContextMenuStrip.set -> void
 ~System.Windows.Forms.DataGridViewCellErrorTextNeededEventArgs.ErrorText.get -> string
 ~System.Windows.Forms.DataGridViewCellErrorTextNeededEventArgs.ErrorText.set -> void
 ~System.Windows.Forms.DataGridViewCellFormattingEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellContextMenuStripNeededEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellContextMenuStripNeededEventArgs.cs
@@ -2,21 +2,21 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewCellContextMenuStripNeededEventArgs : DataGridViewCellEventArgs
     {
-        public DataGridViewCellContextMenuStripNeededEventArgs(int columnIndex, int rowIndex) : base(columnIndex, rowIndex)
+        public DataGridViewCellContextMenuStripNeededEventArgs(int columnIndex, int rowIndex)
+            : base(columnIndex, rowIndex)
         {
         }
 
-        internal DataGridViewCellContextMenuStripNeededEventArgs(int columnIndex, int rowIndex, ContextMenuStrip contextMenuStrip) : base(columnIndex, rowIndex)
+        internal DataGridViewCellContextMenuStripNeededEventArgs(int columnIndex, int rowIndex, ContextMenuStrip? contextMenuStrip)
+            : base(columnIndex, rowIndex)
         {
             ContextMenuStrip = contextMenuStrip;
         }
 
-        public ContextMenuStrip ContextMenuStrip { get; set; }
+        public ContextMenuStrip? ContextMenuStrip { get; set; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewCellContextMenuStripNeededEventArgs


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5943)