### PR TITLE
Remove 'using' from OnDrawItem_TestData

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxTests.cs
@@ -5519,9 +5519,10 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> OnDrawItem_TestData()
         {
-            using var bitmap = new Bitmap(10, 10);
-            using Graphics graphics = Graphics.FromImage(bitmap);
             yield return new object[] { null };
+
+            var bitmap = new Bitmap(10, 10);
+            Graphics graphics = Graphics.FromImage(bitmap);
             yield return new object[] { new DrawItemEventArgs(graphics, null, new Rectangle(1, 2, 3, 4), 0, DrawItemState.Checked) };
         }
 


### PR DESCRIPTION
## Proposed changes

- Similar change to https://github.com/dotnet/winforms/pull/5923


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5946)