### PR TITLE
Remove STA thread affinitisation (servicing)

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilder.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilder.cs
@@ -90,10 +90,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {{
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
 {2}
     }}
 }}

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=Tahoma.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=Tahoma.verified.txt
@@ -22,10 +22,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(true);
         Application.SetDefaultFont(new Font(new FontFamily("Tahoma"), 12f, (FontStyle)0, (GraphicsUnit)3));

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=default.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=default.verified.txt
@@ -22,10 +22,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(true);
         Application.SetDefaultFont(new Font(Control.DefaultFont.FontFamily, 12f, (FontStyle)3, (GraphicsUnit)6));

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=null.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=null.verified.txt
@@ -21,10 +21,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
         Application.SetHighDpiMode(HighDpiMode.SystemAware);

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_EnableVisualStyles=false.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_EnableVisualStyles=false.verified.txt
@@ -20,10 +20,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
         Application.SetCompatibleTextRenderingDefault(false);
         Application.SetHighDpiMode(HighDpiMode.SystemAware);
     }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_EnableVisualStyles=true.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_EnableVisualStyles=true.verified.txt
@@ -21,10 +21,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
         Application.SetHighDpiMode(HighDpiMode.SystemAware);

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_UseCompTextRendering=false.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_UseCompTextRendering=false.verified.txt
@@ -21,10 +21,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
         Application.SetHighDpiMode(HighDpiMode.SystemAware);

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_UseCompTextRendering=true.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_UseCompTextRendering=true.verified.txt
@@ -21,10 +21,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(true);
         Application.SetHighDpiMode(HighDpiMode.SystemAware);

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_default_top_level.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_default_top_level.cs
@@ -21,10 +21,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
         Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.SystemAware);

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_user_top_level.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_user_top_level.cs
@@ -22,10 +22,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(true);
         Application.{|CS0117:SetDefaultFont|}(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationInitializeBuilderTests.default_top_level.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationInitializeBuilderTests.default_top_level.cs
@@ -21,10 +21,6 @@ internal static partial class ApplicationConfiguration
     /// </summary>
     public static void Initialize()
     {
-        // Set STAThread
-        Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
-        Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
-
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(false);
         Application.SetHighDpiMode(HighDpiMode.SystemAware);


### PR DESCRIPTION
Application bootstrap was designed and built before the file-scope namespaces became a thing, and supported 
a) the original namespace declarations, and
b) the new top level statements declarations.

In the case of top level statements there is no `Main()` method on to which a developer can apply `STAThreadAttribute`, and to accommodate this use case we added explicit STA thread affinitisation.

The same code gets emitted for file-scope namespace declarations, which is undesirable, as it has overhead and perf implications.

Whilst the top level statements are supported in Windows Forms, those don't represent the main use case, and any developer who wishes to use top level statements in Program.cs can write STA thread affinitisation statements by hand.

* Before
![image](https://user-images.githubusercontent.com/4403806/136911468-9c3552f9-22a0-4c51-943e-fb8771f2bd8e.png)
* After
![image](https://user-images.githubusercontent.com/4403806/136911380-6eb61ea1-501c-4648-b066-2db338a543c0.png)




## Customer Impact

- Improved app start up

## Regression? 

- No,  `Application.Initialize()` is a new feature in .NET 6.0

## Risk

- Minimal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5953)