### PR TITLE
Fixing switching focus between ToolStrips where TabStop=true with Shift-Tab (port to 7.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6039,41 +6039,57 @@ namespace System.Windows.Forms
                     int targetIndex = ctl._tabIndex;
                     bool hitCtl = false;
                     Control found = null;
-                    Control p = ctl._parent;
+                    Control parent = ctl._parent;
+
+                    if (parent is null)
+                    {
+                        throw new InvalidOperationException(
+                            string.Format(SR.ParentPropertyNotSetInGetNextControl, nameof(Control.Parent), ctl));
+                    }
+
+                    ControlCollection siblings = GetControlCollection(parent);
+
+                    if (siblings is null)
+                    {
+                        throw new InvalidOperationException(
+                            string.Format(SR.ControlsPropertyNotSetInGetNextControl,
+                                nameof(Control.Controls), parent));
+                    }
+
+                    int siblingCount = siblings.Count;
+
+                    if (siblingCount == 0)
+                    {
+                        throw new InvalidOperationException(
+                            string.Format(SR.ControlsCollectionShouldNotBeEmptyInGetNextControl,
+                                nameof(Control.Controls), parent));
+                    }
 
                     // Cycle through the controls in reverse z-order looking for the next lowest tab index.  We must
                     // start with the same tab index as ctl, because there can be dups.
-                    int parentControlCount = 0;
-
-                    ControlCollection parentControls = (ControlCollection)p.Properties.GetObject(s_controlsCollectionProperty);
-
-                    if (parentControls is not null)
+                    for (int c = siblingCount - 1; c >= 0; c--)
                     {
-                        parentControlCount = parentControls.Count;
-                    }
-
-                    for (int c = parentControlCount - 1; c >= 0; c--)
-                    {
+                        Control sibling = siblings[c];
                         // The logic for this is a bit lengthy, so I have broken it into separate
                         // clauses:
 
                         // We are not interested in ourself.
-                        if (parentControls[c] != ctl)
+                        if (sibling != ctl)
                         {
                             // We are interested in controls with <= tab indexes to ctl.  We must include those
                             // controls with equal indexes to account for duplicate indexes.
-                            if (parentControls[c]._tabIndex <= targetIndex)
+                            if (sibling._tabIndex <= targetIndex)
                             {
                                 // Check to see if this control replaces the "best match" we've already
                                 // found.
-                                if (found is null || found._tabIndex < parentControls[c]._tabIndex)
+                                if (found is null || found._tabIndex < sibling._tabIndex)
                                 {
                                     // Finally, check to make sure that if this tab index is the same as ctl,
                                     // that we've already encountered ctl in the z-order.  If it isn't the same,
                                     // than we're more than happy with it.
-                                    if (parentControls[c]._tabIndex != targetIndex || hitCtl)
+                                    if (sibling._tabIndex != targetIndex || hitCtl)
                                     {
-                                        found = parentControls[c];
+                                        found = sibling;
                                     }
                                 }
                             }
@@ -6094,27 +6110,35 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        if (p == this)
+                        if (parent == this)
                         {
                             return null;
                         }
                         else
                         {
-                            return p;
+                            // If we don't found any siblings, and the control is a ToolStripItem that hosts a control itself,
+                            // then we shouldn't return its parent, because it would be the same ToolStrip we're currently at.
+                            // Instead, we should return the control that is previous to the current ToolStrip
+                            if (ctl.ToolStripControlHost is not null)
+                            {
+                                return GetNextControl(ctl._parent, forward: false);
+                            }
+
+                            return parent;
                         }
                     }
                 }
 
-                // We found a control.  Walk into this control to find the proper sub control within it to select.
-                ControlCollection ctlControls = (ControlCollection)ctl.Properties.GetObject(s_controlsCollectionProperty);
+                // We found a control.  Walk into this control to find the proper child control within it to select.
+                ControlCollection children = GetControlCollection(ctl);
 
-                while (ctlControls is not null && ctlControls.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
+                while (children is not null && children.Count > 0 && (ctl == this || !IsFocusManagingContainerControl(ctl)))
                 {
-                    Control found = ctl.GetFirstChildControlInTabOrder(/*forward=*/false);
+                    Control found = ctl.GetFirstChildControlInTabOrder(forward: false);
                     if (found is not null)
                     {
                         ctl = found;
-                        ctlControls = (ControlCollection)ctl.Properties.GetObject(s_controlsCollectionProperty);
+                        children = GetControlCollection(ctl);
                     }
                     else
                     {
@@ -6124,6 +6148,9 @@ namespace System.Windows.Forms
             }
 
             return ctl == this ? null : ctl;
+
+            static ControlCollection GetControlCollection(Control control)
+               => (ControlCollection)control.Properties.GetObject(s_controlsCollectionProperty);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #5795

## Proposed changes

- If we don't found any siblings, and the control is a ToolStripItem that hosts a control itself, then we shouldn't return its parent, because it would be the same ToolStrip we're currently at. Instead, we should return the control that is previous to the current ToolStrip. Run unit tests, manually tested switching between ToolStrips, CTI testing is in progress now.
- `Debug.Assert` replaced for throwing `InvalidOperationException` with localized string
- Ported from PR in 6.0: #5924
- Obsolete PR in 7.0: #5842 

## Customer Impact

- Before the fix (focus was trapped at the last ToolStrip item while pressing `Shift`+`Tab`):
![shiftTabNotWorking](https://user-images.githubusercontent.com/87859299/134381259-94979eae-2232-4a84-a9a8-5c25ad10e628.gif)

- After the fix (focus isn't trapped at the last ToolStrip item while pressing `Shift`+`Tab`):
![shiftTabWorking](https://user-images.githubusercontent.com/87859299/134379122-84de599d-f9cb-4999-b75d-fecfe7d24f3e.gif)

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manual testing (tested moving focus backward with `Shift`+`Tab` inside the `ToolStrip` (`TabStop`=`false`) and between the `ToolStrips` (`TabStop`=`true`) in both RTL modes for both states of `TabStop`)
- Unit tests
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
Microsoft Windows [Version 10.0.19043.1237]
.NET SDK 7.0.100-alpha.1.21512.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5964)