### PR TITLE
Fixing x-thread exception for UI test app

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Program.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Program.cs
@@ -5,6 +5,9 @@
 using System.Windows.Forms;
 using WinformsControlsTest;
 
+// Set STAThread
+Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
+Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
 ApplicationConfiguration.Initialize();
 
 Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);


### PR DESCRIPTION
Set STAThread for our UI test app.
Fixes x-thread exception when using an accessibility tools.
The fix affects our own test app only.

## Customer Impact

- No

## Regression? 

- Yes, from #5952

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- There is the x-thread exception, when using UIA tools:
![image](https://user-images.githubusercontent.com/49272759/137268649-6c90b2a2-0703-420c-8bc2-93af6f83737b.png)

### After

- The UI app works well


## Test methodology <!-- How did you ensure quality? -->

- Manual testing


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0 - alpha1
- Windows 10


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5971)