### PR TITLE
Fixing UI test app x-thread exception (port 6.0)

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Program.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Program.cs
@@ -5,6 +5,9 @@
 using System.Windows.Forms;
 using WinformsControlsTest;
 
+// Set STAThread
+Thread.CurrentThread.SetApartmentState(ApartmentState.Unknown);
+Thread.CurrentThread.SetApartmentState(ApartmentState.STA);
 ApplicationConfiguration.Initialize();
 
 Application.SetUnhandledExceptionMode(UnhandledExceptionMode.ThrowException);


### PR DESCRIPTION
7.0 related PR #5971.
Fixes x-thread exception when using an accessibility tools.
The fix affects our own test app only.

(cherry picked from commit 523db5be78a6251d7b13f4cd4fbaf96cbebc6e0e)


## Customer Impact

- No 

## Regression? 

- Yes, from #5953

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- There is the x-thread exception, when using UIA tools:
![image](https://user-images.githubusercontent.com/49272759/137278809-ef61f40d-08e8-4079-8a38-5ca16970a04a.png)

<!-- TODO -->

### After
- The UI app works well
<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual

## Test environment(s) <!-- Remove any that don't apply -->
- .NET 6.0
- Windows 10


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5972)