### PR TITLE
Enable nullability in SelectedGridItemChangedEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2645,9 +2645,9 @@ System.Windows.Forms.RetrieveVirtualItemEventArgs.Item.set -> void
 ~System.Windows.Forms.ScrollableControl.HorizontalScroll.get -> System.Windows.Forms.HScrollProperties
 ~System.Windows.Forms.ScrollableControl.ScrollControlIntoView(System.Windows.Forms.Control activeControl) -> void
 ~System.Windows.Forms.ScrollableControl.VerticalScroll.get -> System.Windows.Forms.VScrollProperties
-~System.Windows.Forms.SelectedGridItemChangedEventArgs.NewSelection.get -> System.Windows.Forms.GridItem
-~System.Windows.Forms.SelectedGridItemChangedEventArgs.OldSelection.get -> System.Windows.Forms.GridItem
-~System.Windows.Forms.SelectedGridItemChangedEventArgs.SelectedGridItemChangedEventArgs(System.Windows.Forms.GridItem oldSel, System.Windows.Forms.GridItem newSel) -> void
+System.Windows.Forms.SelectedGridItemChangedEventArgs.NewSelection.get -> System.Windows.Forms.GridItem?
+System.Windows.Forms.SelectedGridItemChangedEventArgs.OldSelection.get -> System.Windows.Forms.GridItem?
+System.Windows.Forms.SelectedGridItemChangedEventArgs.SelectedGridItemChangedEventArgs(System.Windows.Forms.GridItem? oldSel, System.Windows.Forms.GridItem? newSel) -> void
 ~System.Windows.Forms.SelectionRange.SelectionRange(System.Windows.Forms.SelectionRange range) -> void
 ~System.Windows.Forms.SplitContainer.Controls.get -> System.Windows.Forms.Control.ControlCollection
 ~System.Windows.Forms.SplitContainer.OnSplitterMoved(System.Windows.Forms.SplitterEventArgs e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SelectedGridItemChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SelectedGridItemChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -14,7 +12,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Constructs a SelectedGridItemChangedEventArgs object.
         /// </summary>
-        public SelectedGridItemChangedEventArgs(GridItem oldSel, GridItem newSel)
+        public SelectedGridItemChangedEventArgs(GridItem? oldSel, GridItem? newSel)
         {
             OldSelection = oldSel;
             NewSelection = newSel;
@@ -23,11 +21,11 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The previously selected GridItem object. This can be null.
         /// </summary>
-        public GridItem OldSelection { get; }
+        public GridItem? OldSelection { get; }
 
         /// <summary>
         ///  The newly selected GridItem object
         /// </summary>
-        public GridItem NewSelection { get; }
+        public GridItem? NewSelection { get; }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SelectedGridItemChangedEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SelectedGridItemChangedEventArgsTests.cs
@@ -13,6 +13,8 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> Ctor_GridItem_Object_TestData()
         {
             yield return new object[] { null, null };
+            yield return new object[] { new SubGridItem(), null };
+            yield return new object[] { null, new SubGridItem() };
             yield return new object[] { new SubGridItem(), new SubGridItem() };
         }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in SelectedGridItemChangedEventArgs


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5977)