### PR TITLE
Enable nullability in ListViewItemSelectionChangedEventArgs and ListViewVirtualItemsSelectionRangeChangedEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2482,8 +2482,8 @@ System.Windows.Forms.Design.IWindowsFormsEditorService.ShowDialog(System.Windows
 ~System.Windows.Forms.ListViewItem.ToolTipText.set -> void
 System.Windows.Forms.ListViewItemMouseHoverEventArgs.Item.get -> System.Windows.Forms.ListViewItem?
 System.Windows.Forms.ListViewItemMouseHoverEventArgs.ListViewItemMouseHoverEventArgs(System.Windows.Forms.ListViewItem? item) -> void
-~System.Windows.Forms.ListViewItemSelectionChangedEventArgs.Item.get -> System.Windows.Forms.ListViewItem
-~System.Windows.Forms.ListViewItemSelectionChangedEventArgs.ListViewItemSelectionChangedEventArgs(System.Windows.Forms.ListViewItem item, int itemIndex, bool isSelected) -> void
+System.Windows.Forms.ListViewItemSelectionChangedEventArgs.Item.get -> System.Windows.Forms.ListViewItem?
+System.Windows.Forms.ListViewItemSelectionChangedEventArgs.ListViewItemSelectionChangedEventArgs(System.Windows.Forms.ListViewItem? item, int itemIndex, bool isSelected) -> void
 ~System.Windows.Forms.MaskedTextBox.Culture.get -> System.Globalization.CultureInfo
 ~System.Windows.Forms.MaskedTextBox.Culture.set -> void
 ~System.Windows.Forms.MaskedTextBox.FormatProvider.get -> System.IFormatProvider

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemSelectionChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemSelectionChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -14,7 +12,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Constructs a ListViewItemSelectionChangedEventArgs object.
         /// </summary>
-        public ListViewItemSelectionChangedEventArgs(ListViewItem item, int itemIndex, bool isSelected)
+        public ListViewItemSelectionChangedEventArgs(ListViewItem? item, int itemIndex, bool isSelected)
         {
             Item = item;
             ItemIndex = itemIndex;
@@ -24,7 +22,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The list view item whose selection changed
         /// </summary>
-        public ListViewItem Item { get; }
+        public ListViewItem? Item { get; }
 
         /// <summary>
         ///  The list view item's index

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewVirtualItemsSelectionRangeChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewVirtualItemsSelectionRangeChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ListViewItemSelectionChangedEventArgs and ListViewVirtualItemsSelectionRangeChangedEventArgs

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5978)