### PR TITLE
Enable nullability in DataGridViewCellErrorTextNeededEventArgs and DataGridViewCellFormattingEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1829,11 +1829,11 @@ System.Windows.Forms.DataGridViewAutoSizeColumnsModeEventArgs.PreviousModes.get 
 ~System.Windows.Forms.DataGridViewCellCollection.this[string columnName].set -> void
 System.Windows.Forms.DataGridViewCellContextMenuStripNeededEventArgs.ContextMenuStrip.get -> System.Windows.Forms.ContextMenuStrip?
 System.Windows.Forms.DataGridViewCellContextMenuStripNeededEventArgs.ContextMenuStrip.set -> void
-~System.Windows.Forms.DataGridViewCellErrorTextNeededEventArgs.ErrorText.get -> string
-~System.Windows.Forms.DataGridViewCellErrorTextNeededEventArgs.ErrorText.set -> void
-~System.Windows.Forms.DataGridViewCellFormattingEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
-~System.Windows.Forms.DataGridViewCellFormattingEventArgs.CellStyle.set -> void
-~System.Windows.Forms.DataGridViewCellFormattingEventArgs.DataGridViewCellFormattingEventArgs(int columnIndex, int rowIndex, object value, System.Type desiredType, System.Windows.Forms.DataGridViewCellStyle cellStyle) -> void
+System.Windows.Forms.DataGridViewCellErrorTextNeededEventArgs.ErrorText.get -> string?
+System.Windows.Forms.DataGridViewCellErrorTextNeededEventArgs.ErrorText.set -> void
+System.Windows.Forms.DataGridViewCellFormattingEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle?
+System.Windows.Forms.DataGridViewCellFormattingEventArgs.CellStyle.set -> void
+System.Windows.Forms.DataGridViewCellFormattingEventArgs.DataGridViewCellFormattingEventArgs(int columnIndex, int rowIndex, object? value, System.Type? desiredType, System.Windows.Forms.DataGridViewCellStyle? cellStyle) -> void
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.AdvancedBorderStyle.get -> System.Windows.Forms.DataGridViewAdvancedBorderStyle
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.DataGridViewCellPaintingEventArgs(System.Windows.Forms.DataGridView dataGridView, System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, int columnIndex, System.Windows.Forms.DataGridViewElementStates cellState, object value, object formattedValue, string errorText, System.Windows.Forms.DataGridViewCellStyle cellStyle, System.Windows.Forms.DataGridViewAdvancedBorderStyle advancedBorderStyle, System.Windows.Forms.DataGridViewPaintParts paintParts) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellErrorTextNeededEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellErrorTextNeededEventArgs.cs
@@ -2,17 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewCellErrorTextNeededEventArgs : DataGridViewCellEventArgs
     {
-        internal DataGridViewCellErrorTextNeededEventArgs(int columnIndex, int rowIndex, string errorText) : base(columnIndex, rowIndex)
+        internal DataGridViewCellErrorTextNeededEventArgs(int columnIndex, int rowIndex, string? errorText)
+            : base(columnIndex, rowIndex)
         {
             ErrorText = errorText;
         }
 
-        public string ErrorText { get; set; }
+        public string? ErrorText { get; set; }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellFormattingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellFormattingEventArgs.cs
@@ -2,17 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewCellFormattingEventArgs : ConvertEventArgs
     {
-        public DataGridViewCellFormattingEventArgs(int columnIndex,
-                                                   int rowIndex,
-                                                   object value,
-                                                   Type desiredType,
-                                                   DataGridViewCellStyle cellStyle) : base(value, desiredType)
+        public DataGridViewCellFormattingEventArgs(
+            int columnIndex,
+            int rowIndex,
+            object? value,
+            Type? desiredType,
+            DataGridViewCellStyle? cellStyle)
+            : base(value, desiredType)
         {
             if (columnIndex < -1)
             {
@@ -29,7 +29,7 @@ namespace System.Windows.Forms
             CellStyle = cellStyle;
         }
 
-        public DataGridViewCellStyle CellStyle { get; set; }
+        public DataGridViewCellStyle? CellStyle { get; set; }
 
         public int ColumnIndex { get; }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewCellErrorTextNeededEventArgs and DataGridViewCellFormattingEventArgs


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5986)