### PR TITLE
Enable nullability in TreeNodeMouseHoverEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -3044,8 +3044,8 @@ System.Windows.Forms.ToolStripContentPanelRenderEventArgs.ToolStripContentPanelR
 ~System.Windows.Forms.TreeNodeCollection.GetEnumerator() -> System.Collections.IEnumerator
 ~System.Windows.Forms.TreeNodeCollection.IndexOf(System.Windows.Forms.TreeNode node) -> int
 ~System.Windows.Forms.TreeNodeCollection.Remove(System.Windows.Forms.TreeNode node) -> void
-~System.Windows.Forms.TreeNodeMouseHoverEventArgs.Node.get -> System.Windows.Forms.TreeNode
-~System.Windows.Forms.TreeNodeMouseHoverEventArgs.TreeNodeMouseHoverEventArgs(System.Windows.Forms.TreeNode node) -> void
+System.Windows.Forms.TreeNodeMouseHoverEventArgs.Node.get -> System.Windows.Forms.TreeNode?
+System.Windows.Forms.TreeNodeMouseHoverEventArgs.TreeNodeMouseHoverEventArgs(System.Windows.Forms.TreeNode? node) -> void
 ~System.Windows.Forms.TreeView.GetItemRenderStyles(System.Windows.Forms.TreeNode node, int state) -> System.Windows.Forms.OwnerDrawPropertyBag
 ~System.Windows.Forms.TreeView.GetNodeAt(int x, int y) -> System.Windows.Forms.TreeNode
 ~System.Windows.Forms.TreeView.GetNodeAt(System.Drawing.Point pt) -> System.Windows.Forms.TreeNode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeMouseHoverEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeMouseHoverEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -11,11 +9,11 @@ namespace System.Windows.Forms
     /// </summary>
     public class TreeNodeMouseHoverEventArgs : EventArgs
     {
-        public TreeNodeMouseHoverEventArgs(TreeNode node)
+        public TreeNodeMouseHoverEventArgs(TreeNode? node)
         {
             Node = node;
         }
 
-        public TreeNode Node { get; }
+        public TreeNode? Node { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in TreeNodeMouseHoverEventArgs


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/5991)