### PR TITLE
Fixing DGV sort glyph color contrast

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.cs
@@ -1031,7 +1031,21 @@ namespace System.Windows.Forms
 
             if (paint && displaySortGlyph && PaintContentBackground(paintParts))
             {
+                static Color Darker(Color color)
+                {
+                    // Get a color 10% darker
+                    const float Offset = 0.9f; // 90%
+                    return Color.FromArgb(color.A, (int)(color.R * Offset), (int)(color.G * Offset), (int)(color.B * Offset));
+                }
+
                 (Color darkColor, Color lightColor) = GetContrastedColors(cellStyle.BackColor);
+
+                if (!SystemInformation.HighContrast)
+                {
+                    // Colors in HighContrast modes have own value with a correct constrast
+                    darkColor = Darker(darkColor);
+                }
+
                 using var penControlDark = darkColor.GetCachedPenScope();
                 using var penControlLightLight = lightColor.GetCachedPenScope();
 


### PR DESCRIPTION
Fixes #5933

## Proposed changes

- Make the dark color of a DGV sort glyph darker 10%
- Alternative way: use `darkColor = ControlPaint.Dark(darkColor, 0.01f);`, but the result is darker than 10% and looks worse.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A DGV sort glyph is more contrast

## Regression? 

- No

## Risk

- Minimal

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- Color contrast is incorrect:
![image](https://user-images.githubusercontent.com/49272759/137725036-78d50758-9752-428a-8f42-8a40076bdbfc.png)

### After
- Color contrast is correct:
![image](https://user-images.githubusercontent.com/49272759/137724529-cde5a61b-f0d8-46b4-a77c-b5d301d868c1.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Accessibility Insights

## Test environment(s)
- .NET 7.0-alpha1
- Win10
