### PR TITLE
Filling empty test files for missing ao (part 7 - final)

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObjectTests.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using static System.Windows.Forms.ColumnHeader;
+using static Interop.UiaCore;
 
 namespace System.Windows.Forms.Tests
 {
@@ -13,6 +14,27 @@ namespace System.Windows.Forms.Tests
         public void ListViewColumnHeaderAccessibleObject_Ctor_OwnerColumnHeaderCannotBeNull()
         {
             Assert.Throws<ArgumentNullException>(() => new ListViewColumnHeaderAccessibleObject(null));
+        }
+
+        [WinFormsFact]
+        public void ListViewColumnHeaderAccessibleObject_GetPropertyValue_ControlType_ReturnsExpected()
+        {
+            using ColumnHeader columnHeader = new();
+
+            ListViewColumnHeaderAccessibleObject accessibleObject = new(columnHeader);
+
+            Assert.Equal(UIA.HeaderItemControlTypeId, accessibleObject.GetPropertyValue(UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsFact]
+        public void ListViewColumnHeaderAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        {
+            string testText = "This is a simple text for testing.";
+            using ColumnHeader columnHeader = new() { Text = testText };
+
+            ListViewColumnHeaderAccessibleObject accessibleObject = new(columnHeader);
+
+            Assert.Equal(testText, accessibleObject.GetPropertyValue(UIA.NamePropertyId));
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static System.Windows.Forms.ListViewItem;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -13,6 +16,312 @@ namespace System.Windows.Forms.Tests
         public void ListViewItemBaseAccessibleObject_Ctor_OwnerListViewItemCannotBeNull()
         {
             Assert.Throws<ArgumentNullException>(() => new ListViewItemBaseAccessibleObject(null));
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_Role_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            Assert.Equal(AccessibleRole.ListItem, item.AccessibilityObject.Role);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_DefaultAction_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            Assert.Equal(SR.AccessibleActionDoubleClick, item.AccessibilityObject.DefaultAction);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_CurrentIndex_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            var accessibleObject = (ListViewItemBaseAccessibleObject)item.AccessibilityObject;
+
+            Assert.Equal(item.Index, accessibleObject.CurrentIndex);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_FragmentRoot_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            Assert.Equal(control.AccessibilityObject, item.AccessibilityObject.FragmentRoot);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ListViewItemBaseAccessibleObject_IsItemSelected_ReturnsExpected(bool isSelected)
+        {
+            using ListView control = new();
+            ListViewItem item = new() { Selected = isSelected };
+            control.Items.Add(item);
+
+            Assert.Equal(isSelected, item.AccessibilityObject.IsItemSelected);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_DoDefaultAction_DoesNothing_IfControlIsNotCreated()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.False((accessibleObject.State & AccessibleStates.Selected) != 0);
+
+            accessibleObject.DoDefaultAction();
+
+            Assert.False((accessibleObject.State & AccessibleStates.Selected) != 0);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_AddToSelection_WorksExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+            control.CreateControl();
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.False(accessibleObject.IsItemSelected);
+
+            accessibleObject.AddToSelection();
+
+            Assert.True(accessibleObject.IsItemSelected);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_DoDefaultAction_IfControlIsNotCreated()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.False((accessibleObject.State & AccessibleStates.Selected) != 0);
+
+            accessibleObject.DoDefaultAction();
+
+            Assert.False((accessibleObject.State & AccessibleStates.Selected) != 0);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_DoDefaultAction_WorksExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+            control.CreateControl();
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.False((accessibleObject.State & AccessibleStates.Selected) != 0);
+
+            accessibleObject.DoDefaultAction();
+
+            Assert.True((accessibleObject.State & AccessibleStates.Selected) != 0);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+            var actual = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent);
+
+            Assert.Equal(control.AccessibilityObject, actual);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_FragmentNavigate_ToSibling_ReturnsNull()
+        {
+            using ListView control = new();
+            control.Items.AddRange(new ListViewItem[] { new(), new(), new() });
+
+            AccessibleObject accessibleObject1 = control.Items[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Items[1].AccessibilityObject;
+
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_FragmentNavigate_Child_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.Tile)]
+        [InlineData(View.List)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.LargeIcon)]
+        public void ListViewItemBaseAccessibleObject_GetChild_ReturnsNull_IfViewIsNotDetailsOrTile(View view)
+        {
+            using ListView control = new() { View = view };
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.Null(item.AccessibilityObject.GetChild(0));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.Details)]
+        [InlineData(View.Tile)]
+        [InlineData(View.List)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.LargeIcon)]
+        public void ListViewItemBaseAccessibleObject_GetChildCount_ReturnsNull_IfViewIsNotDetailsOrTile(View view)
+        {
+            using ListView control = new() { View = view };
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.Equal(-1, item.AccessibilityObject.GetChildCount());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_GetSubItemBounds_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            var accessibleObject = (ListViewItemBaseAccessibleObject)item.AccessibilityObject;
+
+            Assert.Equal(Rectangle.Empty, accessibleObject.GetSubItemBounds(0));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_GetPropertyValue_ControlType_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            var actual = item.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
+
+            Assert.Equal(UiaCore.UIA.ListItemControlTypeId, actual);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_GetPropertyValue_FrameworkProperty_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            var actual = item.AccessibilityObject.GetPropertyValue(UiaCore.UIA.FrameworkIdPropertyId);
+
+            Assert.Equal(NativeMethods.WinFormFrameworkId, actual);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.ScrollItemPatternId)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        [InlineData((int)UiaCore.UIA.SelectionItemPatternId)]
+        [InlineData((int)UiaCore.UIA.InvokePatternId)]
+        [InlineData((int)UiaCore.UIA.TogglePatternId)]
+        public void ListViewItemBaseAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
+        {
+            using ListView control = new() { CheckBoxes = true };
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            Assert.True(item.AccessibilityObject.IsPatternSupported((UiaCore.UIA) patternId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_ItemSelectionContainer_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            Assert.Equal(control.AccessibilityObject, item.AccessibilityObject.ItemSelectionContainer);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, (int)UiaCore.ToggleState.On)]
+        [InlineData(false, (int)UiaCore.ToggleState.Off)]
+        public void ListViewItemBaseAccessibleObject_ToggleState_ReturnsExpected(bool isChecked, int expected)
+        {
+            using ListView control = new();
+            ListViewItem item = new() { Checked = isChecked };
+            control.Items.Add(item);
+
+            Assert.Equal((UiaCore.ToggleState)expected, item.AccessibilityObject.ToggleState);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(false, (int)UiaCore.ToggleState.Off, (int)UiaCore.ToggleState.On)]
+        [InlineData(true, (int)UiaCore.ToggleState.On, (int)UiaCore.ToggleState.Off)]
+        public void ListViewItemBaseAccessibleObject_Toggle_WorksExpected(bool isChecked, int before, int expected)
+        {
+            using ListView control = new();
+            ListViewItem item = new() { Checked = isChecked };
+            control.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.Equal((UiaCore.ToggleState)before, accessibleObject.ToggleState);
+
+            accessibleObject.Toggle();
+
+            Assert.Equal((UiaCore.ToggleState)expected, accessibleObject.ToggleState);
+            Assert.False(control.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using static System.Windows.Forms.ListViewItem;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -13,6 +14,99 @@ namespace System.Windows.Forms.Tests
         public void ListViewItemDetailsAccessibleObject_Ctor_OwnerListViewItemCannotBeNull()
         {
             Assert.Throws<ArgumentNullException>(() => new ListViewItemDetailsAccessibleObject(null));
+        }
+
+        [WinFormsFact]
+        public void ListViewItemDetailsAccessibleObject_FragmentNavigate_FirstChild_ReturnsExpected()
+        {
+            using ListView control = new() { View = View.Details};
+            ListViewItem item = new();
+            control.Columns.Add(new ColumnHeader());
+            control.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+            AccessibleObject expected = item.SubItems[0].AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemDetailsAccessibleObject_FragmentNavigate_LastChild_ReturnsExpected()
+        {
+            using ListView control = new() { View = View.Details };
+            ListViewItem item = new();
+            control.Items.Add(item);
+            control.Columns.AddRange(new ColumnHeader[] { new(), new(), new() });
+            item.SubItems.AddRange(new ListViewSubItem[] { new(), new(), new(), new(), new() });
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+            AccessibleObject expected = item.SubItems[control.Columns.Count - 1].AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemDetailsAccessibleObject_GetChild_ReturnsNull_IfIndexInvalid()
+        {
+            using ListView control = new() { View = View.Details };
+            ListViewItem item = new();
+            control.Columns.AddRange(new ColumnHeader[] { new(), new(), new() });
+            int outRangeIndex = control.Columns.Count + 1;
+            control.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.Null(accessibleObject.GetChild(-1));
+            Assert.Null(accessibleObject.GetChild(outRangeIndex));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemDetailsAccessibleObject_GetChild_ReturnsExpected()
+        {
+            using ListView control = new() { View = View.Details };
+            ListViewItem item = new();
+            control.Items.Add(item);
+            control.Columns.AddRange(new ColumnHeader[] { new(), new(), new() });
+            item.SubItems.AddRange(new ListViewSubItem[] { new(), new(), new(), new() });
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.Equal(item.SubItems[0].AccessibilityObject, accessibleObject.GetChild(0));
+            Assert.Equal(item.SubItems[1].AccessibilityObject, accessibleObject.GetChild(1));
+            Assert.Equal(item.SubItems[2].AccessibilityObject, accessibleObject.GetChild(2));
+            Assert.Null(accessibleObject.GetChild(3));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemDetailsAccessibleObject_GetChildCount_ReturnsExpected_IfControlIsNotCreated()
+        {
+            using ListView control = new() { View = View.Details };
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.Equal(-1, accessibleObject.GetChildCount());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemDetailsAccessibleObject_GetChildCount_ReturnsExpected()
+        {
+            using ListView control = new() { View = View.Details };
+            ListViewItem item = new();
+            control.Items.Add(item);
+            control.Columns.AddRange(new ColumnHeader[] { new(), new(), new() });
+            control.CreateControl();
+
+            AccessibleObject accessibleObject = item.AccessibilityObject;
+
+            Assert.Equal(control.Columns.Count, accessibleObject.GetChildCount());
+            Assert.True(control.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSplitButton.ToolStripSplitButtonExAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSplitButton.ToolStripSplitButtonExAccessibleObjectTests.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using static System.Windows.Forms.ToolStripSplitButton;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -13,6 +14,37 @@ namespace System.Windows.Forms.Tests
         public void ToolStripSplitButtonExAccessibleObject_Ctor_OwnerToolStripSplitButtonCannotBeNull()
         {
             Assert.Throws<ArgumentNullException>(() => new ToolStripSplitButtonExAccessibleObject(null));
+        }
+
+        [WinFormsFact]
+        public void ToolStripSplitButtonExAccessibleObject_ControlType_ReturnsExpected()
+        {
+            using ToolStripSplitButton toolStripSplitButton = new();
+
+            ToolStripSplitButtonExAccessibleObject accessibleObject = new(toolStripSplitButton);
+
+            Assert.Equal(UiaCore.UIA.ButtonControlTypeId, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsFact]
+        public void ToolStripSplitButtonExAccessibleObject_IsIAccessibleExSupported_ReturnsExpected()
+        {
+            using ToolStripSplitButton toolStripSplitButton = new();
+
+            ToolStripSplitButtonExAccessibleObject accessibleObject = new(toolStripSplitButton);
+
+            Assert.True(accessibleObject.IsIAccessibleExSupported());
+        }
+
+        [WinFormsFact]
+        public void ToolStripSplitButtonExAccessibleObject_DropDownItemsCount_ReturnsExpected_IfDropDownCollapsed()
+        {
+            using ToolStripSplitButton toolStripSplitButton = new();
+
+            ToolStripSplitButtonExAccessibleObject accessibleObject = new(toolStripSplitButton);
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+            Assert.Equal(0, accessibleObject.TestAccessor().Dynamic.DropDownItemsCount);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSplitButton.ToolStripSplitButtonUiaProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSplitButton.ToolStripSplitButtonUiaProviderTests.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -13,6 +13,16 @@ namespace System.Windows.Forms.Tests
         public void ToolStripSplitButtonUiaProvider_Ctor_OwnerToolStripSplitButtonCannotBeNull()
         {
             Assert.Throws<ArgumentNullException>(() => new ToolStripSplitButtonUiaProvider(null));
+        }
+
+        [WinFormsFact]
+        public void ToolStripSplitButtonUiaProvider_IsIAccessibleExSupported_ReturnsExpected()
+        {
+            using ToolStripSplitButton toolStripSplitButton = new();
+
+            ToolStripSplitButtonUiaProvider accessibleObject = new(toolStripSplitButton);
+
+            Assert.True(accessibleObject.IsIAccessibleExSupported());
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

This opportunity appears after creating test files for missing ao classes in pr #5731.
Added unit tests for the following classes:
- `ListViewColumnHeaderAccessibleObject`
- `ListViewItemBaseAccessibleObject`
- `ListViewItemDetailsAccessibleObject`
- `ToolStripSplitButtonExAccessibleObject`
- `ToolStripSplitButtonUiaProvider`


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->