### PR TITLE
Fixing ListViewGroupAccessibleObject.ExpandCollapsePattern when ListViewGroup.CollapsedState == Default

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -95,7 +95,8 @@ namespace System.Windows.Forms
                     ? UiaCore.ExpandCollapseState.Collapsed
                     : UiaCore.ExpandCollapseState.Expanded;
 
-            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => _owningListView.AccessibilityObject;
+            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
+                => _owningListView.AccessibilityObject;
 
             public override string Name
                 => _owningGroup.Header;
@@ -298,15 +299,12 @@ namespace System.Windows.Forms
             }
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
-            {
-                if (patternId == UiaCore.UIA.LegacyIAccessiblePatternId ||
-                    patternId == UiaCore.UIA.ExpandCollapsePatternId)
+                => patternId switch
                 {
-                    return true;
-                }
-
-                return base.IsPatternSupported(patternId);
-            }
+                    UiaCore.UIA.LegacyIAccessiblePatternId => true,
+                    UiaCore.UIA.ExpandCollapsePatternId => _owningGroup.CollapsedState != ListViewGroupCollapsedState.Default,
+                    _ => base.IsPatternSupported(patternId),
+                };
 
             internal override unsafe void SetFocus()
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -1124,6 +1124,55 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(createHandle, listView.IsHandleCreated);
         }
 
+        public static IEnumerable<object[]> ListViewGroupAccessibleObject_IsPatternSupported_TestData()
+        {
+            foreach (View view in Enum.GetValues(typeof(View)))
+            {
+                foreach (bool showGroups in new[] { true, false })
+                {
+                    foreach (bool createHandle in new[] { true, false })
+                    {
+                        foreach (ListViewGroupCollapsedState listViewGroupCollapsedState in Enum.GetValues(typeof(ListViewGroupCollapsedState)))
+                        {
+                            yield return new object[] { view, showGroups, createHandle, listViewGroupCollapsedState };
+                        }
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ListViewGroupAccessibleObject_IsPatternSupported_TestData))]
+        public void ListViewGroupAccessibleObject_IsPatternSupported_ReturnFalse_ForCollapsedStateDefault(View view, bool showGroups, bool createHandle, ListViewGroupCollapsedState listViewGroupCollapsedState)
+        {
+            using ListView listView = new()
+            {
+                View = view,
+                ShowGroups = showGroups,
+            };
+
+            ListViewGroup listGroup = new("Test")
+            {
+                CollapsedState = listViewGroupCollapsedState,
+            };
+
+            listView.Groups.Add(listGroup);
+            ListViewItem item = new("Test");
+            item.Group = listGroup;
+            listView.Items.Add(item);
+            ListViewGroupAccessibleObject accessibleObject = new(listGroup, false);
+
+            if (createHandle)
+            {
+                listView.CreateControl();
+            }
+
+            bool expectedPatternSupported = listViewGroupCollapsedState != ListViewGroupCollapsedState.Default;
+
+            Assert.Equal(expectedPatternSupported, accessibleObject.IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId));
+            Assert.Equal(createHandle, listView.IsHandleCreated);
+        }
+
         private ListView GetListViewItemWithInvisibleItems(View view)
         {
             ListView listView = new ListView() { View = view };


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5981


## Proposed changes
- The bug occured because of in case of `ExpandCollapsePatternId` parameter presence in the `IsPatternSupported` method we're always returned `true`, but `ListViewGroupAccessibleObject` component doesn't support such functionality under the following condition: `ListViewGroup.CollapsedState != ListViewGroupCollapsedState.Default`
- The new condition was added. It checks whether component supports `ExpandCollapsePattern` or doesn't.
- Added unit tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

**Before fix:**
![image](https://user-images.githubusercontent.com/74228865/137779337-bacf8b0d-95d1-4740-8b8e-fc2c2a9ba43e.png)

**After fix:**
![image](https://user-images.githubusercontent.com/74228865/137944325-78c3384d-83b6-4253-ba9e-04fcd2f4ceb5.png)



## Regression? 

- No. ListViewGroup.CollapsedState was implemented in .NET Core 5.0 (#3155)

## Risk

- Minimal

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- CTI Team
- Unit Tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect
- Accessibility Insights

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19042.1237]
- .NET Core SDK: 7.0.0-alpha.1.21516.3


<!-- Mention language, UI scaling, or anything else that might be relevant -->
