### PR TITLE
Switch to 1ES servicing pools on release/5.0

### DIFF
--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -1,8 +1,8 @@
 parameters:
   # parameters should default to values for running in the External / Public
   # be read from a user-defined variable (Azure DevOps limitation)
-  agentPoolName: NetCorePublic-Pool
-  agentPool: 'BuildPool.Windows.10.Amd64.VS2019.Pre.Open'
+  agentPoolName: NetCore1ESPool-Svc-Public
+  agentPool: 'Build.Windows.10.Amd64.VS2019.Pre.Open'
   repoName: dotnet/winforms
 
 stages:
@@ -23,11 +23,11 @@ stages:
       - job: Windows
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCorePublic-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+            name: NetCore1ESPool-Svc-Public
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre.Open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            name: NetCoreInternal-Pool
-            queue: BuildPool.Windows.10.Amd64.VS2019.Pre
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Pre
 
         variables:
 


### PR DESCRIPTION
Same as https://github.com/dotnet/winforms/pull/5837 but for release/5.0.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6026)