### PR TITLE
Fixing IsOffScreenProperty when ListViewItem is in a collapsed ListViewGroup

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -176,7 +176,8 @@ namespace System.Windows.Forms
                     UiaCore.UIA.HasKeyboardFocusPropertyId => OwningListItemFocused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.IsEnabledPropertyId => _owningListView.Enabled,
-                    UiaCore.UIA.IsOffscreenPropertyId => (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
+                    UiaCore.UIA.IsOffscreenPropertyId => OwningGroup?.CollapsedState == ListViewGroupCollapsedState.Collapsed
+                                                        || (State & AccessibleStates.Offscreen) == AccessibleStates.Offscreen,
                     UiaCore.UIA.NativeWindowHandlePropertyId => _owningListView.IsHandleCreated ? _owningListView.Handle : IntPtr.Zero,
                     UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.SelectionItemPatternId),
                     UiaCore.UIA.IsScrollItemPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ScrollItemPatternId),


### PR DESCRIPTION
Fixes #5980


## Proposed changes
- The bug occured because of `GetPropertyValue` method returns value for `IsOffscreenPropertyId` parameter without checking whether owner group is in `CollapsedState` or it doesn't, but when owner group is in `CollapsedState` it should be `OffScreen`.
- The new condition was added. It checks whether owner group is in `CollapsedState` or it doesn't.
- Added unit tests.

## Customer Impact

**Before fix**
![image](https://user-images.githubusercontent.com/74228865/138236284-04cf80d5-a6f8-4b15-bcca-4ba3c8bbd21b.png)

**After fix**
![image](https://user-images.githubusercontent.com/74228865/138236703-c1c0227c-b2cd-42c9-8b90-f96ab6b5a7c8.png)


## Regression? 

- No. `ListViewGroup.CollapsedState` was implemented in .NET Core 5.0 (#3155)

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- CTI Team
- Unit Tests

## Accessibility testing 
- Inspect
- AccessibilityInsights

## Test environments
- Microsoft Windows [Version 10.0.19042.1237]
- .NET Core SDK: 7.0.0-alpha.1.21516.3


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6029)