### PR TITLE
Enable nullability in DataGridViewCellToolTipTextNeededEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1857,8 +1857,8 @@ System.Windows.Forms.DataGridViewCellFormattingEventArgs.DataGridViewCellFormatt
 ~System.Windows.Forms.DataGridViewCellStyle.Tag.get -> object
 ~System.Windows.Forms.DataGridViewCellStyle.Tag.set -> void
 ~System.Windows.Forms.DataGridViewCellStyleContentChangedEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
-~System.Windows.Forms.DataGridViewCellToolTipTextNeededEventArgs.ToolTipText.get -> string
-~System.Windows.Forms.DataGridViewCellToolTipTextNeededEventArgs.ToolTipText.set -> void
+System.Windows.Forms.DataGridViewCellToolTipTextNeededEventArgs.ToolTipText.get -> string?
+System.Windows.Forms.DataGridViewCellToolTipTextNeededEventArgs.ToolTipText.set -> void
 ~System.Windows.Forms.DataGridViewCellValidatingEventArgs.FormattedValue.get -> object
 ~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.get -> object
 ~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.set -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellToolTipTextNeededEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellToolTipTextNeededEventArgs.cs
@@ -2,17 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewCellToolTipTextNeededEventArgs : DataGridViewCellEventArgs
     {
-        internal DataGridViewCellToolTipTextNeededEventArgs(int columnIndex, int rowIndex, string toolTipText) : base(columnIndex, rowIndex)
+        internal DataGridViewCellToolTipTextNeededEventArgs(int columnIndex, int rowIndex, string? toolTipText)
+            : base(columnIndex, rowIndex)
         {
             ToolTipText = toolTipText;
         }
 
-        public string ToolTipText { get; set; }
+        public string? ToolTipText { get; set; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewCellToolTipTextNeededEventArgs


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6034)