### PR TITLE
Enable nullability in LinkLabelLinkClickedEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2282,9 +2282,9 @@ System.Windows.Forms.ItemCheckedEventArgs.ItemCheckedEventArgs(System.Windows.Fo
 ~System.Windows.Forms.LinkLabel.OverrideCursor.get -> System.Windows.Forms.Cursor
 ~System.Windows.Forms.LinkLabel.OverrideCursor.set -> void
 ~System.Windows.Forms.LinkLabel.PointInLink(int x, int y) -> System.Windows.Forms.LinkLabel.Link
-~System.Windows.Forms.LinkLabelLinkClickedEventArgs.Link.get -> System.Windows.Forms.LinkLabel.Link
-~System.Windows.Forms.LinkLabelLinkClickedEventArgs.LinkLabelLinkClickedEventArgs(System.Windows.Forms.LinkLabel.Link link) -> void
-~System.Windows.Forms.LinkLabelLinkClickedEventArgs.LinkLabelLinkClickedEventArgs(System.Windows.Forms.LinkLabel.Link link, System.Windows.Forms.MouseButtons button) -> void
+System.Windows.Forms.LinkLabelLinkClickedEventArgs.Link.get -> System.Windows.Forms.LinkLabel.Link?
+System.Windows.Forms.LinkLabelLinkClickedEventArgs.LinkLabelLinkClickedEventArgs(System.Windows.Forms.LinkLabel.Link? link) -> void
+System.Windows.Forms.LinkLabelLinkClickedEventArgs.LinkLabelLinkClickedEventArgs(System.Windows.Forms.LinkLabel.Link? link, System.Windows.Forms.MouseButtons button) -> void
 ~System.Windows.Forms.ListBox.CustomTabOffsets.get -> System.Windows.Forms.ListBox.IntegerCollection
 ~System.Windows.Forms.ListBox.FindString(string s) -> int
 ~System.Windows.Forms.ListBox.FindString(string s, int startIndex) -> int

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabelLinkClickedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabelLinkClickedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>
@@ -14,11 +12,12 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Initializes a new instance of the <see cref='LinkLabelLinkClickedEventArgs'/> class, given the link.
         /// </summary>
-        public LinkLabelLinkClickedEventArgs(LinkLabel.Link link) : this(link, MouseButtons.Left)
+        public LinkLabelLinkClickedEventArgs(LinkLabel.Link? link)
+            : this(link, MouseButtons.Left)
         {
         }
 
-        public LinkLabelLinkClickedEventArgs(LinkLabel.Link link, MouseButtons button)
+        public LinkLabelLinkClickedEventArgs(LinkLabel.Link? link, MouseButtons button)
         {
             Link = link;
             Button = button;
@@ -27,7 +26,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Gets the <see cref='LinkLabel.Link'/> that was clicked.
         /// </summary>
-        public LinkLabel.Link Link { get; }
+        public LinkLabel.Link? Link { get; }
 
         /// <summary>
         ///  Gets the mouseButton which causes the link to be clicked


### PR DESCRIPTION
## Proposed changes

- Enable nullability in LinkLabelLinkClickedEventArgs.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6045)