### PR TITLE
Enable nullability in CheckableControlBaseAdapter

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
@@ -18,7 +18,8 @@ namespace System.Windows.Forms.ButtonInternal
         // SystemInformation.Border3DSize + 2 pixels for focus rect
         protected const int ButtonBorderSize = 4;
 
-        internal ButtonBaseAdapter(ButtonBase control) => Control = control;
+        internal ButtonBaseAdapter(ButtonBase control) =>
+            Control = control.OrThrowIfNull();
 
         protected ButtonBase Control { get; }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckableControlBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckableControlBaseAdapter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Drawing;
 
@@ -15,9 +13,12 @@ namespace System.Windows.Forms.ButtonInternal
     internal abstract class CheckableControlBaseAdapter : ButtonBaseAdapter
     {
         private const int StandardCheckSize = 13;
-        private ButtonBaseAdapter _buttonAdapter;
+        private ButtonBaseAdapter? _buttonAdapter;
 
-        internal CheckableControlBaseAdapter(ButtonBase control) : base(control) { }
+        internal CheckableControlBaseAdapter(ButtonBase control)
+            : base(control)
+        {
+        }
 
         protected ButtonBaseAdapter ButtonAdapter
         {
@@ -39,7 +40,7 @@ namespace System.Windows.Forms.ButtonInternal
                 return ButtonAdapter.GetPreferredSizeCore(proposedSize);
             }
 
-            LayoutOptions options = default;
+            LayoutOptions? options = default;
             using (var screen = GdiCache.GetScreenHdc())
             using (PaintEventArgs pe = new PaintEventArgs(screen, new Rectangle()))
             {
@@ -87,7 +88,7 @@ namespace System.Windows.Forms.ButtonInternal
             return GetDpiScaleRatio(Control);
         }
 
-        internal static double GetDpiScaleRatio(Control control)
+        internal static double GetDpiScaleRatio(Control? control)
         {
             if (DpiHelper.IsPerMonitorV2Awareness
                 && control is not null && control.IsHandleCreated)


### PR DESCRIPTION
## Proposed changes

- Enable nullability in CheckableControlBaseAdapter.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6046)