### PR TITLE
[3.1] WinForms .NET designer freezes when JAWS is narrating

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -400,6 +400,11 @@ namespace System.Windows.Forms
 
             public void NotifyClients(AccessibleEvents accEvent)
             {
+                if (!CanNotifyClients())
+                {
+                    return;
+                }
+
                 Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo,
                     $"Control.NotifyClients: this = {ToString()}, accEvent = {accEvent}, childID = self");
 
@@ -408,6 +413,11 @@ namespace System.Windows.Forms
 
             public void NotifyClients(AccessibleEvents accEvent, int childID)
             {
+                if (!CanNotifyClients())
+                {
+                    return;
+                }
+
                 Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo,
                     $"Control.NotifyClients: this = {ToString()}, accEvent = {accEvent}, childID = {childID}");
 
@@ -416,6 +426,11 @@ namespace System.Windows.Forms
 
             public void NotifyClients(AccessibleEvents accEvent, int objectID, int childID)
             {
+                if (!CanNotifyClients())
+                {
+                    return;
+                }
+
                 Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo,
                     $"Control.NotifyClients: this = {ToString()}, accEvent = {accEvent}, childID = {childID}");
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -4623,7 +4623,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected void AccessibilityNotifyClients(AccessibleEvents accEvent, int objectID, int childID)
         {
-            if (IsHandleCreated)
+            if (IsHandleCreated && AccessibleObject.CanNotifyClients())
             {
                 UnsafeNativeMethods.NotifyWinEvent((int)accEvent, new HandleRef(this, Handle), objectID, childID + 1);
             }


### PR DESCRIPTION
.NET designer bug - https://github.com/dotnet/winforms-designer/issues/3399 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1419310

## Impact:
Winforms designer is not usable with accessible tech. 

## Fix:
This change prevents client notifications from being sent from the designer server process, where we will be setting the opt-out switch. These notifications are problematics as clients might send messages to the server process and cause a deadlock.

This is ported from the 6.0 GA change - https://github.com/dotnet/winforms/pull/6035. I then searched for all instances of the problematic API - `UIARaise`* and `NotifyWinEvent` to ensure that they are hidden under this switch.

## Testing:
Tested controls that send WinEvents in the common design-time scenarios under JAWS, Narrator, NVDA, AI and Inspect.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6048)