### PR TITLE
[5.0] WinForms .NET designer freezes when JAWS is narrating 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -412,7 +412,7 @@ namespace System.Windows.Forms
 
             public void NotifyClients(AccessibleEvents accEvent)
             {
-                if (HandleInternal == IntPtr.Zero)
+                if (HandleInternal == IntPtr.Zero || !CanNotifyClients())
                 {
                     return;
                 }
@@ -425,7 +425,7 @@ namespace System.Windows.Forms
 
             public void NotifyClients(AccessibleEvents accEvent, int childID)
             {
-                if (HandleInternal == IntPtr.Zero)
+                if (HandleInternal == IntPtr.Zero || !CanNotifyClients())
                 {
                     return;
                 }
@@ -438,7 +438,7 @@ namespace System.Windows.Forms
 
             public void NotifyClients(AccessibleEvents accEvent, int objectID, int childID)
             {
-                if (HandleInternal == IntPtr.Zero)
+                if (HandleInternal == IntPtr.Zero || !CanNotifyClients())
                 {
                     return;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -4501,7 +4501,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected void AccessibilityNotifyClients(AccessibleEvents accEvent, int objectID, int childID)
         {
-            if (IsHandleCreated)
+            if (IsHandleCreated && AccessibleObject.CanNotifyClients())
             {
                 User32.NotifyWinEvent((uint)accEvent, new HandleRef(this, Handle), objectID, childID + 1);
             }


### PR DESCRIPTION
This fixes .NET designer issue - https://github.com/dotnet/winforms-designer/issues/3399 and https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1419310

## Impact:
.NET Winforms designer is not usable with accessible tech. 

## Fix:
This change prevents client notifications from being sent from the designer server process, where we will be setting the opt-out switch. These notifications are problematics as clients might send messages to the server process and cause a deadlock.

This is ported from the 6.0 GA change -  https://github.com/dotnet/winforms/pull/6035. I then searched for all instances of the problematic API - `UIARaise`* and `NotifyWinEvent` to ensure that they are hidden under this switch.

## Testing:
Tested controls that send WinEvents in the common design-time scenarios under JAWS, Narrator, NVDA, AI and Inspect.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6049)