### PR TITLE
WinForms .NET designer might hang when JAWS is narrating

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -74,6 +74,7 @@ namespace System.Windows.Forms
         // If we learn that the UIA Notification event is not available,
         // controls should not attempt to raise it.
         private static bool s_notificationEventAvailable = true;
+        private static bool? s_canNotifyClients;
 
         internal const int RuntimeIDFirstItem = 0x2a;
 
@@ -99,6 +100,24 @@ namespace System.Windows.Forms
                 _systemIAccessible.accLocation(out int left, out int top, out int width, out int height, NativeMethods.CHILDID_SELF);
                 return new Rectangle(left, top, width, height);
             }
+        }
+
+        internal static bool CanNotifyClients => s_canNotifyClients ??= InitializeCanNotifyClients();
+
+        private static bool InitializeCanNotifyClients()
+        {
+            // While handling accessibility events, accessibility clients (JAWS, Inspect),
+            // can access AccessibleObject associated with the event. In the designer scenario, controls are not
+            // receiving messages directly and might not respond to messages while in the notification call.
+            // This will make the server process unresponsive and will cause VisualStudio to become unresponsive.
+            //
+            // The following compat switch is set in the designer server process to prevent controls from sending notification.
+            if (AppContext.TryGetSwitch("Switch.System.Windows.Forms.AccessibleObject.NoClientNotifications", out bool isEnabled))
+            {
+                return !isEnabled;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -1987,7 +2006,7 @@ namespace System.Windows.Forms
             AutomationNotificationProcessing notificationProcessing,
             string notificationText)
         {
-            if (!s_notificationEventAvailable)
+            if (!s_notificationEventAvailable || !CanNotifyClients)
             {
                 return false;
             }
@@ -2023,7 +2042,7 @@ namespace System.Windows.Forms
 
         internal virtual bool RaiseAutomationEvent(UiaCore.UIA eventId)
         {
-            if (UiaCore.UiaClientsAreListening().IsTrue())
+            if (UiaCore.UiaClientsAreListening().IsTrue() && CanNotifyClients)
             {
                 HRESULT result = UiaCore.UiaRaiseAutomationEvent(this, eventId);
                 return result == HRESULT.S_OK;
@@ -2034,7 +2053,7 @@ namespace System.Windows.Forms
 
         internal virtual bool RaiseAutomationPropertyChangedEvent(UiaCore.UIA propertyId, object oldValue, object newValue)
         {
-            if (UiaCore.UiaClientsAreListening().IsTrue())
+            if (UiaCore.UiaClientsAreListening().IsTrue() && CanNotifyClients)
             {
                 HRESULT result = UiaCore.UiaRaiseAutomationPropertyChangedEvent(this, propertyId, oldValue, newValue);
                 return result == HRESULT.S_OK;
@@ -2058,7 +2077,7 @@ namespace System.Windows.Forms
 
         internal bool RaiseStructureChangedEvent(UiaCore.StructureChangeType structureChangeType, int[] runtimeId)
         {
-            if (UiaCore.UiaClientsAreListening().IsTrue())
+            if (UiaCore.UiaClientsAreListening().IsTrue() && CanNotifyClients)
             {
                 HRESULT result = UiaCore.UiaRaiseStructureChangedEvent(this, structureChangeType, runtimeId, runtimeId is null ? 0 : runtimeId.Length);
                 return result == HRESULT.S_OK;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -396,7 +396,7 @@ namespace System.Windows.Forms
 
             public void NotifyClients(AccessibleEvents accEvent)
             {
-                if (HandleInternal == IntPtr.Zero)
+                if (HandleInternal == IntPtr.Zero || !CanNotifyClients)
                 {
                     return;
                 }
@@ -409,7 +409,7 @@ namespace System.Windows.Forms
 
             public void NotifyClients(AccessibleEvents accEvent, int childID)
             {
-                if (HandleInternal == IntPtr.Zero)
+                if (HandleInternal == IntPtr.Zero || !CanNotifyClients)
                 {
                     return;
                 }
@@ -422,7 +422,7 @@ namespace System.Windows.Forms
 
             public void NotifyClients(AccessibleEvents accEvent, int objectID, int childID)
             {
-                if (HandleInternal == IntPtr.Zero)
+                if (HandleInternal == IntPtr.Zero || !CanNotifyClients)
                 {
                     return;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -4553,7 +4553,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected void AccessibilityNotifyClients(AccessibleEvents accEvent, int objectID, int childID)
         {
-            if (IsHandleCreated)
+            if (IsHandleCreated && AccessibleObject.CanNotifyClients)
             {
                 User32.NotifyWinEvent((uint)accEvent, new HandleRef(this, Handle), objectID, childID + 1);
             }


### PR DESCRIPTION
This change prevents client notifications from being sent from the designer server process, where we will be setting the opt-out switch. These notifications are problematics as clients might send messages to the server process and cause a deadlock.

This is ported from #6035. I then searched for all instances of the problematic API - `UIARaise`* and `NotifyWinEvent` to ensure that they are hidden under this switch.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6050)