### PR TITLE
Fix disabled ToolStripItem selected bits when ToolStrip fires MouseLeave

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -2198,10 +2198,12 @@ namespace System.Windows.Forms
                     break;
                 case ToolStripItemEventType.MouseLeave:
                     // disabled toolstrip items should also clear tooltips.
+                    // disabled toolstrip items should also handle leave.
                     // we won't raise mouse events though.
                     if (!Enabled && ParentInternal is not null)
                     {
                         ParentInternal.UpdateToolTip(null);
+                        HandleLeave();
                     }
                     else
                     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -5772,6 +5772,32 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
         }
 
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ToolStrip_OnMouseLeave_UnselectsToolStripItem(bool toolStripItemEnabled)
+        {
+            using var toolStrip = new SubToolStrip()
+            {
+                GripStyle = ToolStripGripStyle.Hidden
+            };
+            using var item = new SubToolStripItem()
+            {
+                Enabled = toolStripItemEnabled,
+                Parent = toolStrip,
+                SupportsDisabledHotTracking = true
+            };
+
+            item.SetPlacement(ToolStripItemPlacement.Main);
+            toolStrip.Items.Add(item);
+            toolStrip.SetDisplayedItems();
+
+            toolStrip.OnMouseMove(new MouseEventArgs(MouseButtons.Left, 1, item.Bounds.X, item.Bounds.Y, 0));
+            Assert.True(item.Selected);
+
+            toolStrip.OnMouseLeave(new EventArgs());
+            Assert.False(item.Selected);
+        }
+
         [WinFormsFact]
         public void ToolStrip_OnPaint_NullE_ThrowsNullReferenceException()
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5493 

## Proposed changes

- Remove the disabled `ToolStripItem` selected bits when the `ToolStrip` fires `MouseLeave`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A consistent ToolStripItem selected behavior experience after the mouse leaves, whether the item is enabled or not.

## Regression? 

- No.

## Risk

- Possible risk if customers depend on and/or have implemented workarounds, those could break.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

https://user-images.githubusercontent.com/5017479/138641139-8f4c037b-6604-4c2e-ba00-146caf813ce3.mp4

### After

<!-- TODO -->

https://user-images.githubusercontent.com/5017479/138641152-2344e92f-6f11-4300-a367-2ec1dace7f71.mp4

## Test methodology <!-- How did you ensure quality? -->

- Wrote a unit test to demonstrate the bug. The proposed fix causes the test to pass.
- Manually tested the changes and have provided videos to demonstrate the before and after.
- Ran unit and integration tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

Accessbility Insights for Windows

![FastPassAutomatedChecks](https://user-images.githubusercontent.com/5017479/138819845-57133114-5d63-45c6-b31b-d5696688ee10.PNG)
 
## Test environment(s) <!-- Remove any that don't apply -->

<!-- use `dotnet --info` -->

Windows 10.0.19043
.NET Core SDK: 7.0.0-alpha.1.21522.9

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6055)