### PR TITLE
Fix 1ES hosted pool name in richnav pipeline

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -16,7 +16,7 @@ stages:
         enableRichCodeNavigation: true
         richCodeNavigationEnvironment: 'production'
         pool:
-          name: NetCorePublic-Pool
+          name: NetCore1ESPool-Public
           demands: ImageOverride -equals Build.Windows.10.Amd64.VS2019.Open
 
         steps:


### PR DESCRIPTION
We have missed one pool when migrating to 1ES hosted pools.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6066)