### PR TITLE
Removing exception throwing from RuntimeId property type

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
@@ -140,28 +140,12 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 internal override int[] RuntimeId
-                {
-                    get
+                    => new int[]
                     {
-                        int[]? selectedGridEntryAccessibleRuntimeId =
-                            _owningPropertyGridView.SelectedGridEntry?.AccessibilityObject.RuntimeId;
-
-                        if (selectedGridEntryAccessibleRuntimeId is null)
-                        {
-                            throw new InvalidOperationException();
-                        }
-
-                        int[] runtimeId = new int[selectedGridEntryAccessibleRuntimeId.Length + 1];
-                        for (int i = 0; i < selectedGridEntryAccessibleRuntimeId.Length; i++)
-                        {
-                            runtimeId[i] = selectedGridEntryAccessibleRuntimeId[i];
-                        }
-
-                        runtimeId[^1] = 1;
-
-                        return runtimeId;
-                    }
-                }
+                        RuntimeIDFirstItem,
+                        PARAM.ToInt(Owner.InternalHandle),
+                        GetHashCode()
+                    };
 
                 internal override bool IsReadOnly
                     => _owningPropertyGridView.SelectedGridEntry is not PropertyDescriptorGridEntry propertyDescriptorGridEntry

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObjectTests.cs
@@ -172,5 +172,25 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             Assert.Equal(expectedRole, actual);
             Assert.False(propertyGrid.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void GridViewTextBoxAccessibleObject_RuntimeId_ReturnsNull()
+        {
+            using PropertyGrid propertyGrid = new() { SelectedObject = new TestEntityWithTextField() { TextProperty = "Test" } };
+
+            PropertyGridView propertyGridView = propertyGrid.TestAccessor().GridView;
+            int firstPropertyIndex = 1; // Index 0 corresponds to the category grid entry.
+            PropertyDescriptorGridEntry gridEntry = (PropertyDescriptorGridEntry)propertyGridView.AccessibilityGetGridEntries()[firstPropertyIndex];
+
+            // Force the entry edit control Handle creation.
+            // GridViewEditAccessibleObject exists, if its control is already created.
+            // In UI case an entry edit control is created when an PropertyGridView gets focus.
+            Assert.NotEqual(IntPtr.Zero, propertyGridView.TestAccessor().Dynamic.EditTextBox.Handle);
+
+            AccessibleObject editFieldAccessibleObject = (AccessibleObject)gridEntry.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
+            propertyGridView.TestAccessor().Dynamic._selectedGridEntry = null;
+
+            Assert.NotNull(editFieldAccessibleObject.RuntimeId);
+        }
     }
 }


### PR DESCRIPTION
Fixes #6069

## Proposed changes

- Remove exception throwing when `RuntimeId is null`

## Regression? 

- Yes (from #5638)

## Risk

- Minimal

### Before

![138625661-c3fd93c6-5887-4b07-8882-c47efa9bd6fd](https://user-images.githubusercontent.com/74228865/138891940-4928c907-2ae4-4e84-9a98-aa8ec8389958.gif)


### After

![Issue6069](https://user-images.githubusercontent.com/74228865/138891899-136adbfb-6be4-402e-abdd-6f59664fb4dc.gif)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- CTI
 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19042.1237]
- .NET 6.0.100-rc.2.21505.57


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6070)