### PR TITLE
Fixing of the DataGridViewComboBoxColumn in "Nothing" display mode

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewComboBoxCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewComboBoxCellAccessibleObjectTests.cs
@@ -9,18 +9,69 @@ namespace System.Windows.Forms.Tests
 {
     public class DataGridViewComboBoxCellAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
+        public static IEnumerable<object[]> DataGridViewComboBoxCellAccessibleObject_SupportExpandCollapsePattern_TestData()
+        {
+            foreach (DataGridViewComboBoxDisplayStyle displayStyle in Enum.GetValues(typeof(DataGridViewComboBoxDisplayStyle)))
+            {
+                foreach (bool cellIsEdited in new[] { true, false })
+                {
+                    bool expectedValue = displayStyle != DataGridViewComboBoxDisplayStyle.Nothing || cellIsEdited;
+                    yield return new object[] { displayStyle, cellIsEdited, expectedValue };
+                }
+            }
+        }
+
         [WinFormsTheory]
-        [InlineData((int)UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId, true)]
-        public void GetPropertyValue_Returns_Correct_Value(int propertyID, object expectedPropertyValue)
+        [MemberData(nameof(DataGridViewComboBoxCellAccessibleObject_SupportExpandCollapsePattern_TestData))]
+        public void DataGridViewComboBoxCellAccessibleObject_SupportExpandCollapsePattern_ReturnExpected(DataGridViewComboBoxDisplayStyle displayStyle, bool cellIsEdited, bool expectedValue)
         {
             using var dataGridView = new DataGridView();
-            DataGridViewComboBoxColumn column = new DataGridViewComboBoxColumn();
-            dataGridView.Columns.Add(column);
+            dataGridView.Columns.Add(new DataGridViewComboBoxColumn() { DisplayStyle = displayStyle });
             dataGridView.Rows.Add();
+            dataGridView.CurrentCell = dataGridView.Rows[0].Cells[0];
 
-            object actualPropertyValue = dataGridView.Rows[0].Cells[0].AccessibilityObject.GetPropertyValue((UiaCore.UIA)propertyID);
+            if (cellIsEdited)
+            {
+                dataGridView.BeginEdit(false);
+            }
 
-            Assert.Equal(expectedPropertyValue, actualPropertyValue);
+            object actualPropertyValue = dataGridView.Rows[0].Cells[0].AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId);
+
+            Assert.Equal(expectedValue, actualPropertyValue);
+        }
+
+        public static IEnumerable<object[]> DataGridViewComboBoxCellAccessibleObject_ControlType_TestData()
+        {
+            foreach (DataGridViewComboBoxDisplayStyle displayStyle in Enum.GetValues(typeof(DataGridViewComboBoxDisplayStyle)))
+            {
+                foreach (bool cellIsEdited in new[] { true, false })
+                {
+                    int expectedControlType = displayStyle != DataGridViewComboBoxDisplayStyle.Nothing || cellIsEdited
+                                        ? (int)UiaCore.UIA.ComboBoxControlTypeId
+                                        : (int)UiaCore.UIA.DataItemControlTypeId;
+
+                    yield return new object[] { displayStyle, cellIsEdited, expectedControlType };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DataGridViewComboBoxCellAccessibleObject_ControlType_TestData))]
+        public void DataGridViewComboBoxCellAccessibleObject_ControlType_ReturnExpected(DataGridViewComboBoxDisplayStyle displayStyle, bool cellIsEdited, int expectedControlType)
+        {
+            using var dataGridView = new DataGridView();
+            dataGridView.Columns.Add(new DataGridViewComboBoxColumn() { DisplayStyle = displayStyle });
+            dataGridView.Rows.Add();
+            dataGridView.CurrentCell = dataGridView.Rows[0].Cells[0];
+
+            if (cellIsEdited)
+            {
+                dataGridView.BeginEdit(false);
+            }
+
+            int actualPropertyValue = (int)dataGridView.Rows[0].Cells[0].AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
+
+            Assert.Equal(expectedControlType, actualPropertyValue);
         }
     }
 }


### PR DESCRIPTION
Fixes #1587

## Proposed changes
- Since the `ComboBox` in the `Nothing` display style and view mode is displayed as a normal cell, a condition was added so that for this case it would return the `DataItem` control type instead of the `ComboBox` control type. Support for the `ExpandCollapse` pattern is also disabled for this case

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/139260046-f6ba1818-1693-414d-96e2-4eff13a0e759.png)

**After fix:** 
![image](https://user-images.githubusercontent.com/23376742/139259142-544262ac-abf2-4c6f-a7e0-90e2897e045c.png)
![image](https://user-images.githubusercontent.com/23376742/139258581-ac92af06-6074-4801-8b1e-6b52d94f8a84.png)

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests
- Manually

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.804]
- .NET Core SDK: 7.0.0-alpha.1.21526.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6081)