### PR TITLE
Enable nullability in some DataGridViewCell EventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1841,8 +1841,8 @@ System.Windows.Forms.DataGridViewCellFormattingEventArgs.DataGridViewCellFormatt
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.FormattedValue.get -> object
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.Graphics.get -> System.Drawing.Graphics
 ~System.Windows.Forms.DataGridViewCellPaintingEventArgs.Value.get -> object
-~System.Windows.Forms.DataGridViewCellStateChangedEventArgs.Cell.get -> System.Windows.Forms.DataGridViewCell
-~System.Windows.Forms.DataGridViewCellStateChangedEventArgs.DataGridViewCellStateChangedEventArgs(System.Windows.Forms.DataGridViewCell dataGridViewCell, System.Windows.Forms.DataGridViewElementStates stateChanged) -> void
+System.Windows.Forms.DataGridViewCellStateChangedEventArgs.Cell.get -> System.Windows.Forms.DataGridViewCell!
+System.Windows.Forms.DataGridViewCellStateChangedEventArgs.DataGridViewCellStateChangedEventArgs(System.Windows.Forms.DataGridViewCell! dataGridViewCell, System.Windows.Forms.DataGridViewElementStates stateChanged) -> void
 ~System.Windows.Forms.DataGridViewCellStyle.DataGridViewCellStyle(System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle) -> void
 ~System.Windows.Forms.DataGridViewCellStyle.DataSourceNullValue.get -> object
 ~System.Windows.Forms.DataGridViewCellStyle.DataSourceNullValue.set -> void
@@ -1856,10 +1856,10 @@ System.Windows.Forms.DataGridViewCellFormattingEventArgs.DataGridViewCellFormatt
 ~System.Windows.Forms.DataGridViewCellStyle.NullValue.set -> void
 ~System.Windows.Forms.DataGridViewCellStyle.Tag.get -> object
 ~System.Windows.Forms.DataGridViewCellStyle.Tag.set -> void
-~System.Windows.Forms.DataGridViewCellStyleContentChangedEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
+System.Windows.Forms.DataGridViewCellStyleContentChangedEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle!
 System.Windows.Forms.DataGridViewCellToolTipTextNeededEventArgs.ToolTipText.get -> string?
 System.Windows.Forms.DataGridViewCellToolTipTextNeededEventArgs.ToolTipText.set -> void
-~System.Windows.Forms.DataGridViewCellValidatingEventArgs.FormattedValue.get -> object
+System.Windows.Forms.DataGridViewCellValidatingEventArgs.FormattedValue.get -> object?
 ~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.get -> object
 ~System.Windows.Forms.DataGridViewCheckBoxCell.FalseValue.set -> void
 ~System.Windows.Forms.DataGridViewCheckBoxCell.IndeterminateValue.get -> object

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStateChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStateChangedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewCellStateChangedEventArgs : EventArgs

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleContentChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyleContentChangedEventArgs.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewCellStyleContentChangedEventArgs : EventArgs
     {
         internal DataGridViewCellStyleContentChangedEventArgs(DataGridViewCellStyle dataGridViewCellStyle, bool changeAffectsPreferredSize)
         {
-            CellStyle = dataGridViewCellStyle;
+            CellStyle = dataGridViewCellStyle.OrThrowIfNull();
             ChangeAffectsPreferredSize = changeAffectsPreferredSize;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellValidatingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellValidatingEventArgs.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms
 {
     public class DataGridViewCellValidatingEventArgs : CancelEventArgs
     {
-        internal DataGridViewCellValidatingEventArgs(int columnIndex, int rowIndex, object formattedValue)
+        internal DataGridViewCellValidatingEventArgs(int columnIndex, int rowIndex, object? formattedValue)
         {
             ColumnIndex = columnIndex;
             RowIndex = rowIndex;
@@ -21,6 +19,6 @@ namespace System.Windows.Forms
 
         public int RowIndex { get; }
 
-        public object FormattedValue { get; }
+        public object? FormattedValue { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in some DataGridViewCell EventArgs.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6082)