### PR TITLE
Enable nullability in ToolStripItemClickedEventArgs and ToolStripItemEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2862,8 +2862,8 @@ System.Windows.Forms.ToolStripGripRenderEventArgs.ToolStripGripRenderEventArgs(S
 ~System.Windows.Forms.ToolStripItem.ToolStripItemAccessibleObject.ToolStripItemAccessibleObject(System.Windows.Forms.ToolStripItem ownerItem) -> void
 ~System.Windows.Forms.ToolStripItem.ToolTipText.get -> string
 ~System.Windows.Forms.ToolStripItem.ToolTipText.set -> void
-~System.Windows.Forms.ToolStripItemClickedEventArgs.ClickedItem.get -> System.Windows.Forms.ToolStripItem
-~System.Windows.Forms.ToolStripItemClickedEventArgs.ToolStripItemClickedEventArgs(System.Windows.Forms.ToolStripItem clickedItem) -> void
+System.Windows.Forms.ToolStripItemClickedEventArgs.ClickedItem.get -> System.Windows.Forms.ToolStripItem?
+System.Windows.Forms.ToolStripItemClickedEventArgs.ToolStripItemClickedEventArgs(System.Windows.Forms.ToolStripItem? clickedItem) -> void
 ~System.Windows.Forms.ToolStripItemCollection.Add(string text) -> System.Windows.Forms.ToolStripItem
 ~System.Windows.Forms.ToolStripItemCollection.Add(string text, System.Drawing.Image image) -> System.Windows.Forms.ToolStripItem
 ~System.Windows.Forms.ToolStripItemCollection.Add(string text, System.Drawing.Image image, System.EventHandler onClick) -> System.Windows.Forms.ToolStripItem
@@ -2878,8 +2878,8 @@ System.Windows.Forms.ToolStripGripRenderEventArgs.ToolStripGripRenderEventArgs(S
 ~System.Windows.Forms.ToolStripItemCollection.Insert(int index, System.Windows.Forms.ToolStripItem value) -> void
 ~System.Windows.Forms.ToolStripItemCollection.Remove(System.Windows.Forms.ToolStripItem value) -> void
 ~System.Windows.Forms.ToolStripItemCollection.ToolStripItemCollection(System.Windows.Forms.ToolStrip owner, System.Windows.Forms.ToolStripItem[] value) -> void
-~System.Windows.Forms.ToolStripItemEventArgs.Item.get -> System.Windows.Forms.ToolStripItem
-~System.Windows.Forms.ToolStripItemEventArgs.ToolStripItemEventArgs(System.Windows.Forms.ToolStripItem item) -> void
+System.Windows.Forms.ToolStripItemEventArgs.Item.get -> System.Windows.Forms.ToolStripItem?
+System.Windows.Forms.ToolStripItemEventArgs.ToolStripItemEventArgs(System.Windows.Forms.ToolStripItem? item) -> void
 ~System.Windows.Forms.ToolStripItemImageRenderEventArgs.Image.get -> System.Drawing.Image
 ~System.Windows.Forms.ToolStripItemImageRenderEventArgs.ToolStripItemImageRenderEventArgs(System.Drawing.Graphics g, System.Windows.Forms.ToolStripItem item, System.Drawing.Image image, System.Drawing.Rectangle imageRectangle) -> void
 ~System.Windows.Forms.ToolStripItemImageRenderEventArgs.ToolStripItemImageRenderEventArgs(System.Drawing.Graphics g, System.Windows.Forms.ToolStripItem item, System.Drawing.Rectangle imageRectangle) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemClickedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemClickedEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class ToolStripItemClickedEventArgs : EventArgs
@@ -11,7 +9,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents event args a ToolStrip can use when an item has been clicked.
         /// </summary>
-        public ToolStripItemClickedEventArgs(ToolStripItem clickedItem)
+        public ToolStripItemClickedEventArgs(ToolStripItem? clickedItem)
         {
             ClickedItem = clickedItem;
         }
@@ -19,6 +17,6 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Represents the item that was clicked on the toolStrip.
         /// </summary>
-        public ToolStripItem ClickedItem { get; }
+        public ToolStripItem? ClickedItem { get; }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemEventArgs.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class ToolStripItemEventArgs : EventArgs
     {
-        public ToolStripItemEventArgs(ToolStripItem item)
+        public ToolStripItemEventArgs(ToolStripItem? item)
         {
             Item = item;
         }
 
-        public ToolStripItem Item { get; }
+        public ToolStripItem? Item { get; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripItemClickedEventArgs and ToolStripItemEventArgs

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6088)