### PR TITLE
Ignoring MauiMonthCalendarTests for "SelectedDate" event

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiMonthCalendarTests/MauiMonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/MauiTests/MauiMonthCalendarTests/MauiMonthCalendarTests.cs
@@ -136,7 +136,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return new ScenarioResult(cell != null);
         }
 
-        [Scenario(true)]
+        [Scenario(false)]
         public ScenarioResult MonthCalendar_Click_Date_InvokeEvents(TParams p)
         {
             using var wrapper = new MonthCalendarWrapper(this);
@@ -157,7 +157,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return new ScenarioResult(testData.SelectedDate.Date == newDate.Date, "The selected date has not changed");
         }
 
-        [Scenario(true)]
+        [Scenario(false)]
         public ScenarioResult MonthCalendar_Click_MinimumDate_InvokeEvents(TParams p)
         {
             using var wrapper = new MonthCalendarWrapper(this);
@@ -178,7 +178,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return new ScenarioResult(testData.SelectedDate.Date == newDate.Date, "The selected date has not changed");
         }
 
-        [Scenario(true)]
+        [Scenario(false)]
         public ScenarioResult MonthCalendar_Click_MaximumDate_InvokeEvents(TParams p)
         {
             using var wrapper = new MonthCalendarWrapper(this);
@@ -199,7 +199,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return new ScenarioResult(testData.SelectedDate.Date == newDate.Date, "The selected date has not changed");
         }
 
-        [Scenario(true)]
+        [Scenario(false)]
         public ScenarioResult MonthCalendar_DoubleClick_Date_InvokeEvents(TParams p)
         {
             using var wrapper = new MonthCalendarWrapper(this);
@@ -226,7 +226,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return new ScenarioResult(testData.SelectedDate.Date == newDate.Date, "The selected date has not changed");
         }
 
-        [Scenario(true)]
+        [Scenario(false)]
         public ScenarioResult MonthCalendar_DoubleClick_MinDate_InvokeEvents(TParams p)
         {
             using var wrapper = new MonthCalendarWrapper(this);
@@ -253,7 +253,7 @@ namespace System.Windows.Forms.IntegrationTests.MauiTests
             return new ScenarioResult(testData.SelectedDate.Date == newDate.Date, "The selected date has not changed");
         }
 
-        [Scenario(true)]
+        [Scenario(false)]
         public ScenarioResult MonthCalendar_DoubleClick_MaxDate_InvokeEvents(TParams p)
         {
             using var wrapper = new MonthCalendarWrapper(this);


### PR DESCRIPTION
## Proposed changes
- Ignored `MauiMonthCalendarTests` for `SelectedDate` event

## Regression? 
- Yes

## Risk
- Minimal
## Test methodology <!-- How did you ensure quality? -->
- Unit tests


## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.804]
- .NET Core SDK: 7.0.0-alpha.1.21528.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6092)