### PR TITLE
Fixing ListView not firing GroupCollapsedStateChanged event from keyboard

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6384,7 +6384,9 @@ namespace System.Windows.Forms
                     targetGroup.CollapsedState = targetGroup.CollapsedState == ListViewGroupCollapsedState.Expanded
                                                 ? ListViewGroupCollapsedState.Collapsed
                                                 : ListViewGroupCollapsedState.Expanded;
+
                     OnGroupCollapsedStateChanged(new ListViewGroupEventArgs(i));
+
                     break;
                 }
             }
@@ -6897,6 +6899,31 @@ namespace System.Windows.Forms
                 case User32.WM.REFLECT_NOTIFY:
                     WmReflectNotify(ref m);
                     break;
+
+                case User32.WM.KEYUP:
+                    int key = (int)m.WParamInternal;
+
+                    if ((key == User32.VK.LEFT || key == User32.VK.RIGHT) && SelectedItems.Count > 0)
+                    {
+                        ListViewGroup group = SelectedItems[0].Group;
+                        ListViewGroupCollapsedState groupCollapsedState = group.CollapsedState;
+
+                        if (group is null || groupCollapsedState == ListViewGroupCollapsedState.Default
+                            || (key == User32.VK.LEFT && groupCollapsedState == ListViewGroupCollapsedState.Collapsed)
+                            || (key == User32.VK.RIGHT && groupCollapsedState == ListViewGroupCollapsedState.Expanded))
+                        {
+                            break;
+                        }
+
+                        group.SetCollapsedStateInternal(group.CollapsedState == ListViewGroupCollapsedState.Expanded
+                                                ? ListViewGroupCollapsedState.Collapsed
+                                                : ListViewGroupCollapsedState.Expanded);
+
+                        OnGroupCollapsedStateChanged(new ListViewGroupEventArgs(Groups.IndexOf(group)));
+                    }
+
+                    break;
+
                 case User32.WM.LBUTTONDBLCLK:
 
                     // Ensure that the itemCollectionChangedInMouseDown is not set

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -404,6 +404,20 @@ namespace System.Windows.Forms
             }
         }
 
+        // Should be used for the cases when sending the message `LVM.SETGROUPINFO` isn't required
+        // (for example, collapsing/expanding groups with keyboard is performed inside the native control already, so this message isn't needed)
+        internal void SetCollapsedStateInternal(ListViewGroupCollapsedState state)
+        {
+            SourceGenerated.EnumValidator.Validate(state);
+
+            if (_collapsedState == state)
+            {
+                return;
+            }
+
+            _collapsedState = state;
+        }
+
         public override string ToString() => Header;
 
         private void UpdateListView()


### PR DESCRIPTION
Fixes #5960

## Proposed changes
- Collapsing/expanding `ListView` groups from a keyboard is handled automatically inside the native control, there's no special code at `.Net Core`. We need only to raise the `GroupCollapsedStateChanged` event and set `CollapsedState` of the `ListViewGroup`
- We need to set `CollapsedState` without sending a Windows message `LVM.SETGROUPINFO` because all collapse/expand handling is already happening automatically, that's why we're adding an internal method `SetCollapsedStateInternal`

## Customer Impact
- No

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests
- CTI team
- Manual testing scenarios:
1. Collapsed and expanded `ListViewGroup` from the keyboard with writing to log at the event handler:
![ListViewGroupEvent](https://user-images.githubusercontent.com/87859299/139688309-7e5d40e2-18b0-4a15-afe0-067cf54e78bc.gif)
2. Examined Narrator's text while collapsing and expanding `ListViewGroup` from the keyboard:
![ListViewGroupNarrator](https://user-images.githubusercontent.com/87859299/139688773-1cfe7822-4714-4b2a-b17f-361c59afd444.gif)
3. Watched the `ExpandCollapse.ExpandCollapseState` property at the `Inspect` tool after expanding/collapsing group from the keyboard:
![image](https://user-images.githubusercontent.com/87859299/139689431-b02b4443-4979-474e-aab2-b0a164d6965b.png)
![image](https://user-images.githubusercontent.com/87859299/139689602-69330249-2442-44c7-a0e7-6c157b330b64.png)

## Test environment(s) <!-- Remove any that don't apply -->
Microsoft Windows [Version 10.0.19043.1288]
.NET SDK 7.0.0-alpha.1.21528.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6097)