### PR TITLE
Fixing announcing TextPattern elements by Narrator

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -624,19 +624,17 @@ namespace System.Windows.Forms
 
         UiaCore.IAccessibleEx? UiaCore.IAccessibleEx.GetObjectForChild(int idChild) => null;
 
-        // This method is never called
         unsafe HRESULT UiaCore.IAccessibleEx.GetIAccessiblePair(out object? ppAcc, int* pidChild)
         {
             if (pidChild is null)
             {
                 ppAcc = null;
-                return HRESULT.E_POINTER;
+                return HRESULT.E_INVALIDARG;
             }
 
-            // No need to implement this for patterns and properties
-            ppAcc = null;
-            *pidChild = 0;
-            return HRESULT.E_POINTER;
+            ppAcc = this;
+            *pidChild = NativeMethods.CHILDID_SELF;
+            return HRESULT.S_OK;
         }
 
         int[]? UiaCore.IAccessibleEx.GetRuntimeId() => RuntimeId;

--- a/src/System.Windows.Forms/tests/InteropTests/NativeTests/AccessibleObjectTests.cpp
+++ b/src/System.Windows.Forms/tests/InteropTests/NativeTests/AccessibleObjectTests.cpp
@@ -56,8 +56,8 @@ TEST const WCHAR* WINAPI Test_IAccessibleExGetIAccessiblePair(IUnknown* pUnknown
         long idChild = 1;
         CComPtr<IAccessible> result;
         hr = pAccessibleEx->GetIAccessiblePair(&result, &idChild);
-        assertEqualHr(E_POINTER, hr);
-        assertNull(result.p);
+        assertEqualHr(S_OK, hr);
+        assertNotNull(result.p);
         assertEqualInt(0, idChild);
 
         // Negative tests.
@@ -70,8 +70,9 @@ TEST const WCHAR* WINAPI Test_IAccessibleExGetIAccessiblePair(IUnknown* pUnknown
 #endif
         assertEqualInt(1, idChild);
 
+        result = NULL;
         hr = pAccessibleEx->GetIAccessiblePair(&result, NULL);
-        assertEqualHr(E_POINTER, hr);
+        assertEqualHr(E_INVALIDARG, hr);
         assertNull(result.p);
 
         hr = pAccessibleEx->GetIAccessiblePair(NULL, NULL);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -2606,6 +2606,35 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(type, runtimeIdProperty.DeclaringType);
         }
 
+        [WinFormsFact]
+        public unsafe void AccessibleObject_GetIAccessiblePair_Invoke_ReturnsExpected()
+        {
+            const int expectedIdChild = NativeMethods.CHILDID_SELF;
+
+            AccessibleObject accessibleObject = new();
+
+            // Use some number different from the expected to ensure that the value is changed
+            int idChild = unchecked((int)0xdeadbeef);
+            Assert.NotEqual(expectedIdChild, idChild);
+
+            HRESULT result = ((UiaCore.IAccessibleEx)accessibleObject).GetIAccessiblePair(out object pAcc, &idChild);
+
+            Assert.Equal(HRESULT.S_OK, result);
+            Assert.Equal(accessibleObject, pAcc);
+            Assert.Equal(expectedIdChild, idChild);
+        }
+
+        [WinFormsFact]
+        public unsafe void AccessibleObject_GetIAccessiblePair_InvokeWithInvalidArgument_ReturnsError()
+        {
+            AccessibleObject accessibleObject = new();
+
+            HRESULT result = ((UiaCore.IAccessibleEx)accessibleObject).GetIAccessiblePair(out object pAcc, null);
+
+            Assert.Equal(HRESULT.E_INVALIDARG, result);
+            Assert.Null(pAcc);
+        }
+
         private class SubAccessibleObject : AccessibleObject
         {
             public new void UseStdAccessibleObjects(IntPtr handle) => base.UseStdAccessibleObjects(handle);


### PR DESCRIPTION
Fixes #6020. This regression was introduced by #5404 that removed `InternalAccessibleObject` wrappers around regular accessible objects. The issue appeared because `GetIAccessiblePair` was implemented differently by `InternalAccessibleObject` and `AccessibleObject` classes. `InternalAccessibleObject` had a working implementation whereas `AccessibleObject` basically had a stub which was never called before `InternalAccessibleObject` was removed. The fix is to copy the implementation of `GetIAccessiblePair` from removed `InternalAccessibleObject` to `AccessibleObject` class.


## Proposed changes

- Implemented `AccessibleObject.GetIAccesiblePair` the same as `InternalAccesibleObject.GetIAccessiblePair` was implemented.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Narrator doesn't announce TextPattern stuff like the displayed text, the selected text, moving the cursor inside the text, etc.

## Regression? 

- Yes (from .NET 6)

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Narrator doesn't announce when the cursor is moved inside the text.
![Narrator doesn't announce when the cursor is moved inside the text.](http://g.recordit.co/LXwPNFoX5M.gif)

### After

Narrator announces (and also highlights) the character that goes right after the cursor position when the latter is changed.
![Narrator announces (and also highlights) the character that goes right after the cursor position when the latter is changed.](http://g.recordit.co/MuaKPdVcTD.gif)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit-tests
- CTI
 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19043.1288]
- .NET 7.0.0-alpha.1.21551.1

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6098)