### PR TITLE
Fixing no focus border on the empty DGV in the Narrator

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -239,7 +239,9 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.NamePropertyId:
                         return Name;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
-                        return false; // Only inner cell should be announced as focused by Narrator but not entire DGV.
+                        // If no inner cell entire DGV should be announced as focused by Narrator.
+                        // Else only inner cell should be announced as focused by Narrator but not entire DGV.
+                        return RowCount == 0;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return _ownerDataGridView.CanFocus;
                     case UiaCore.UIA.IsEnabledPropertyId:
@@ -284,13 +286,9 @@ namespace System.Windows.Forms
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
             {
-                if (patternId == UiaCore.UIA.TablePatternId ||
-                    patternId == UiaCore.UIA.GridPatternId)
-                {
-                    return true;
-                }
-
-                return base.IsPatternSupported(patternId);
+                return (patternId == UiaCore.UIA.TablePatternId && RowCount > 0) ||
+                    patternId == UiaCore.UIA.GridPatternId ||
+                    base.IsPatternSupported(patternId);
             }
 
             internal override UiaCore.IRawElementProviderSimple[]? GetRowHeaders()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAccessibleObjectTests.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_Ctor_Default()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
 
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             Assert.NotNull(accessibleObject);
@@ -26,10 +26,12 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_ItemStatus_ReturnsAsSorted()
         {
-            using DataGridView dataGridView = new DataGridView();
-            DataGridViewTextBoxColumn column = new DataGridViewTextBoxColumn();
-            column.SortMode = DataGridViewColumnSortMode.Programmatic;
-            column.HeaderText = "Some column";
+            using DataGridView dataGridView = new();
+            DataGridViewTextBoxColumn column = new()
+            {
+                SortMode = DataGridViewColumnSortMode.Programmatic,
+                HeaderText = "Some column"
+            };
 
             dataGridView.Columns.Add(column);
             dataGridView.Sort(dataGridView.Columns[0], ListSortDirection.Ascending);
@@ -42,7 +44,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_EmptyGrid_GetChildCount_ReturnsCorrectValue()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             Assert.Equal(0, accessibleObject.GetChildCount()); // dataGridView doesn't have items
         }
@@ -50,7 +52,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_GridWithFirstRowOnly_GetChildCount_ReturnsCorrectValue()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             dataGridView.ColumnHeadersVisible = false;
@@ -60,7 +62,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_GridWithColumnHeadersAndFirstRow_GetChildCount_ReturnsCorrectValue()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             Assert.Equal(2, accessibleObject.GetChildCount()); // Column headers and a first Row
@@ -69,7 +71,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_EmptyGrid_GetChild_ReturnsCorrectValue()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             Assert.Equal(0, accessibleObject.GetChildCount()); // dataGridView doesn't have an item
             Assert.Null(accessibleObject.GetChild(0)); // GetChild method should not throw an exception
@@ -78,7 +80,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_GridWithFirstRowOnly_GetChild_ReturnsCorrectValue()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             dataGridView.ColumnHeadersVisible = false;
@@ -89,7 +91,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_GridWithColumnHeadersAndFirstRow_GetChild_ReturnsCorrectValue()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             Assert.NotNull(accessibleObject.GetChild(0)); // dataGridView column headers
@@ -99,7 +101,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_Bounds_ReturnsCorrectValue_IfHandleIsCreated()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             dataGridView.CreateControl();
             dataGridView.Size = new Size(500, 300);
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
@@ -122,7 +124,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_Bounds_ReturnsCorrectValue_IfHandleIsNotCreated()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             dataGridView.Size = new Size(500, 300);
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
 
@@ -142,7 +144,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_ControlType_IsDataGrid_IfAccessibleRoleIsDefault()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
             UiaCore.UIA expected = UiaCore.UIA.DataGridControlTypeId;
@@ -152,7 +154,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_GetFocused_ReturnsCorrectFocusedCell()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             User32.SetFocus(new HandleRef(dataGridView, dataGridView.Handle));
@@ -171,7 +173,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_GetItem_ReturnsCorrectValue()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             dataGridView.Rows.Add();
@@ -190,8 +192,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_ItemStatus_IsCorrectWhenSorted()
         {
-            using DataGridView dataGridView = new DataGridView();
-            using DataGridViewTextBoxColumn column = new DataGridViewTextBoxColumn();
+            using DataGridView dataGridView = new();
+            using DataGridViewTextBoxColumn column = new();
             column.SortMode = DataGridViewColumnSortMode.Programmatic;
             column.HeaderText = "Some column";
 
@@ -208,7 +210,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(false, AccessibleStates.None)]
         public void DataGridViewAccessibleObject_State_IsFocusable(bool createControl, AccessibleStates expectedAccessibleStates)
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             if (createControl)
             {
                 dataGridView.CreateControl();
@@ -223,7 +225,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_Ctor_NullOwnerParameter_ThrowsArgumentNullException()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             Type type = dataGridView.AccessibilityObject.GetType();
             ConstructorInfo ctor = type.GetConstructor(new Type[] { typeof(DataGridView) });
             Assert.NotNull(ctor);
@@ -233,7 +235,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_FirstAndLastChildren_AreNotNull()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
 
@@ -251,7 +253,7 @@ namespace System.Windows.Forms.Tests
         [InlineData((int)UiaCore.UIA.IsTablePatternAvailablePropertyId)]
         public void DataGridViewAccessibleObject_Pattern_IsAvailable(int propertyId)
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             AccessibleObject accessibilityObject = dataGridView.AccessibilityObject;
             Assert.True((bool)accessibilityObject.GetPropertyValue((UiaCore.UIA)propertyId));
         }
@@ -261,7 +263,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(false)]
         public void DataGridViewAccessibleObject_Cell_IsOffscreen_ReturnsCorrectValue(bool createControl)
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
 
             if (createControl)
             {
@@ -290,7 +292,7 @@ namespace System.Windows.Forms.Tests
         [InlineData((int)UiaCore.UIA.GridPatternId)]
         public void DataGridViewAccessibleObject_IsPatternSupported(int patternId)
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
         }
@@ -300,7 +302,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(false)]
         public void DataGridViewAccessibleObject_Cell_IsReadOnly_ReturnsCorrectValue(bool isReadOnly)
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
 
             dataGridView.Rows[0].Cells[0].ReadOnly = isReadOnly;
@@ -323,7 +325,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(false)]
         public void DataGridViewAccessibleObject_Row_IsReadOnly_ReturnsCorrectValue(bool isReadOnly)
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
 
             dataGridView.Rows[0].ReadOnly = isReadOnly;
@@ -346,7 +348,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(false)]
         public void DataGridViewAccessibleObject_Grid_IsReadOnly_ReturnsCorrectValue(bool isReadOnly)
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
 
             dataGridView.ReadOnly = isReadOnly;
@@ -367,7 +369,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_Owner_IsNotNull()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             Control.ControlAccessibleObject accessibleObject = (Control.ControlAccessibleObject)dataGridView.AccessibilityObject;
             Assert.NotNull(accessibleObject.Owner);
         }
@@ -375,7 +377,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_Parent_IsNotNull_IfHandleIsCreated()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             dataGridView.CreateControl();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             Assert.NotNull(accessibleObject.Parent);
@@ -385,7 +387,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewAccessibleObject_Parent_IsNotNull_IfHandleIsNotCreated()
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             Assert.Null(accessibleObject.Parent);
             Assert.False(dataGridView.IsHandleCreated);
@@ -410,13 +412,46 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(DataGridViewAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData))]
         public void DataGridViewAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole(AccessibleRole role)
         {
-            using DataGridView dataGridView = new DataGridView();
+            using DataGridView dataGridView = new();
             dataGridView.AccessibleRole = role;
 
             object actual = dataGridView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
             UiaCore.UIA expected = AccessibleRoleControlTypeMap.GetControlType(role);
 
             Assert.Equal(expected, actual);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForEmptyDGV()
+        {
+            using DataGridView dataGridView = new();
+
+            Assert.True((bool)dataGridView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForNotEmptyDGV()
+        {
+            using DataGridView dataGridView = new();
+
+            dataGridView.Columns.Add(new DataGridViewButtonColumn());
+
+            Assert.False((bool)dataGridView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForNonEditableDGV()
+        {
+            using DataGridView dataGridView = new()
+            {
+                ReadOnly = true,
+                AllowUserToAddRows = false
+            };
+
+            Assert.True((bool)dataGridView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
             Assert.False(dataGridView.IsHandleCreated);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAccessibleObjectTests.cs
@@ -251,11 +251,21 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData((int)UiaCore.UIA.IsGridPatternAvailablePropertyId)]
         [InlineData((int)UiaCore.UIA.IsTablePatternAvailablePropertyId)]
-        public void DataGridViewAccessibleObject_Pattern_IsAvailable(int propertyId)
+        public void DataGridViewAccessibleObject_Pattern_IsAvailable_IfDGVIsNotEmpty(int propertyId)
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            AccessibleObject accessibilityObject = dataGridView.AccessibilityObject;
+            Assert.True((bool)accessibilityObject.GetPropertyValue((UiaCore.UIA)propertyId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_TablePattern_IsNotAvailable_IfDGVIsEmpty()
         {
             using DataGridView dataGridView = new();
             AccessibleObject accessibilityObject = dataGridView.AccessibilityObject;
-            Assert.True((bool)accessibilityObject.GetPropertyValue((UiaCore.UIA)propertyId));
+            Assert.False((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsTablePatternAvailablePropertyId));
+            Assert.False(dataGridView.IsHandleCreated);
         }
 
         [WinFormsTheory]
@@ -290,11 +300,21 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData((int)UiaCore.UIA.TablePatternId)]
         [InlineData((int)UiaCore.UIA.GridPatternId)]
-        public void DataGridViewAccessibleObject_IsPatternSupported(int patternId)
+        public void DataGridViewAccessibleObject_IsPatternSupported_IfDGVIsNotEmpty(int patternId)
         {
             using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             AccessibleObject accessibleObject = dataGridView.AccessibilityObject;
             Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_TablePattern_IsNotSupported_IfDGVIsEmpty()
+        {
+            using DataGridView dataGridView = new();
+            AccessibleObject accessibilityObject = dataGridView.AccessibilityObject;
+            Assert.False(accessibilityObject.IsPatternSupported(UiaCore.UIA.IsTablePatternAvailablePropertyId));
+            Assert.False(dataGridView.IsHandleCreated);
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2178  


## Proposed changes

- Reworked the property `HasKeyboardFocusPropertyId` of DGV AO. If no inner item then focus on the entire DGV else focus on the inner cell instead of entire DGV. This works also for DGV in Virtual mode. This doesn't break focusing border on the cell if DGV is not empty. It works also when form doesn't have any row (e.g. row for edit) see this case in after screens below.
- Turned off `TablePattern` support for DGV without rows. It needs to avoid incorrect announcement of the control:
if focus on empty DGV then it has no message "enter table", although if leave then it has message "exit table". So we turn off "enter table" and "exit table" messages for the empty DGV. This approach doesn't make a new accessibility problems in Accessibility Insights.
- Added unit tests for it.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The Narrator has correct focus on empty DGV. 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

No a blue border focus on the empty DGV (only dashed border).

![before](https://user-images.githubusercontent.com/58004471/139853919-c9ce7d29-7e02-474a-9e2b-7d13da0bc40a.png)

### After

The focusing blue border is set on the empty DGV.

![after fix](https://user-images.githubusercontent.com/58004471/139854541-5ba1a182-c4bf-427d-ac9a-ab978643abb7.png)

If DGV is non editable e.g. DGV has `ReadOnly = true` and `AllowUserToAddRows = false` properties and DGV has no rows then the Narrator set the blue border on the entire DGV.

![3](https://user-images.githubusercontent.com/58004471/140025795-9c4e3364-ea74-4b13-beba-27719fa5558d.png)

## Test methodology

- Manually
- Unit
- CTI

## Test environment(s) <!-- Remove any that don't apply -->

- Dotnet version 6.0.100
- OS Version 10.0.19043

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6102)