### PR TITLE
(Servicing) Resume invocation of OnParentHandleRecreated for child control when form recreates handle

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -9835,6 +9835,9 @@ namespace System.Windows.Forms
                     // the call shouldn't fail.
                     // However, it could fail if this.CreateParams.Parent is changed outside our control.
                     CreateHandle();
+
+                    // DestroyHandle resets the state, but CreateHandle doesn't set the state back.
+                    SetState(States.Created, true);
                 }
                 catch (Exception)
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
@@ -730,7 +730,7 @@ namespace System.Windows.Forms.Tests
             using Button button1 = new();
             using Button button2 = new();
             using Button button3 = new();
-            control.Controls.AddRange(new Button[] { button1, button2, button3});
+            control.Controls.AddRange(new Button[] { button1, button2, button3 });
             Control nextControl1 = control.GetNextControl(button1, forward: true);
             Control nextControl2 = control.GetNextControl(button2, forward: true);
             Control nextControl3 = control.GetNextControl(button3, forward: true);
@@ -972,6 +972,62 @@ namespace System.Windows.Forms.Tests
             Assert.True(form.IsHandleCreated);
             Assert.True(toolStrip1.IsHandleCreated);
             Assert.True(toolStrip2.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void Control_RecreateHandleCore_invokes_OnParentHandleRecreated_for_children()
+        {
+            using Form form = new();
+            SubCheckedListBox checkedListBox1 = new();
+            SubButton button1 = new();
+            SubListBox listBox1 = new();
+            SubListView listView1 = new();
+
+            checkedListBox1.Items.AddRange(new object[] { "Foo", "Foo", "Foo" });
+            checkedListBox1.Location = new Point(10, 10);
+            checkedListBox1.Size = new Size(103, 64);
+
+            button1.Location = new Point(12, 166);
+            button1.Size = new Size(213, 20);
+
+            listBox1.Items.AddRange(new object[] { "Foo", "Foo", "Foo" });
+            listBox1.Location = new Point(12, 80);
+            listBox1.Size = new Size(101, 69);
+
+            listView1.Items.AddRange(new ListViewItem[] { new("Foo"), new("Foo"), new("Foo") });
+            listView1.Location = new Point(130, 10);
+            listView1.Size = new Size(121, 64);
+            listView1.View = View.List;
+
+            form.Controls.Add(checkedListBox1);
+            form.Controls.Add(button1);
+            form.Controls.Add(listBox1);
+            form.Controls.Add(listView1);
+
+            form.Show();
+
+            // This will recreate the handle.
+            form.ShowInTaskbar = false;
+
+            try
+            {
+                AssertHandler(button1);
+                AssertHandler(listView1);
+                AssertHandler(checkedListBox1);
+                AssertHandler(listBox1);
+            }
+            finally
+            {
+                form.Close();
+            }
+
+            return;
+
+            static void AssertHandler(IParentHandleRecreationHandler handler)
+            {
+                Assert.Equal(1, handler.OnParentHandleRecreatedCalled);
+                Assert.Equal(1, handler.OnParentHandleRecreatingCalled);
+            }
         }
 
         private class SubControl : Control
@@ -1300,6 +1356,84 @@ namespace System.Windows.Forms.Tests
             public new void UpdateZOrder() => base.UpdateZOrder();
 
             public new void WndProc(ref Message m) => base.WndProc(ref m);
+        }
+
+        private class SubCheckedListBox : CheckedListBox, IParentHandleRecreationHandler
+        {
+            public int OnParentHandleRecreatedCalled { get; private set; }
+            public int OnParentHandleRecreatingCalled { get; private set; }
+
+            internal override void OnParentHandleRecreated()
+            {
+                OnParentHandleRecreatedCalled++;
+                base.OnParentHandleRecreated();
+            }
+
+            internal override void OnParentHandleRecreating()
+            {
+                OnParentHandleRecreatingCalled++;
+                base.OnParentHandleRecreating();
+            }
+        }
+
+        private class SubListBox : ListBox, IParentHandleRecreationHandler
+        {
+            public int OnParentHandleRecreatedCalled { get; private set; }
+            public int OnParentHandleRecreatingCalled { get; private set; }
+
+            internal override void OnParentHandleRecreated()
+            {
+                OnParentHandleRecreatedCalled++;
+                base.OnParentHandleRecreated();
+            }
+
+            internal override void OnParentHandleRecreating()
+            {
+                OnParentHandleRecreatingCalled++;
+                base.OnParentHandleRecreating();
+            }
+        }
+
+        private class SubButton : Button, IParentHandleRecreationHandler
+        {
+            public int OnParentHandleRecreatedCalled { get; private set; }
+            public int OnParentHandleRecreatingCalled { get; private set; }
+
+            internal override void OnParentHandleRecreated()
+            {
+                OnParentHandleRecreatedCalled++;
+                base.OnParentHandleRecreated();
+            }
+
+            internal override void OnParentHandleRecreating()
+            {
+                OnParentHandleRecreatingCalled++;
+                base.OnParentHandleRecreating();
+            }
+        }
+
+        private class SubListView : ListView, IParentHandleRecreationHandler
+        {
+            public int OnParentHandleRecreatedCalled { get; private set; }
+            public int OnParentHandleRecreatingCalled { get; private set; }
+
+            internal override void OnParentHandleRecreated()
+            {
+                OnParentHandleRecreatedCalled++;
+                base.OnParentHandleRecreated();
+            }
+
+            internal override void OnParentHandleRecreating()
+            {
+                OnParentHandleRecreatingCalled++;
+                base.OnParentHandleRecreating();
+            }
+        }
+
+        private interface IParentHandleRecreationHandler
+        {
+            int OnParentHandleRecreatedCalled { get; }
+            int OnParentHandleRecreatingCalled { get; }
         }
     }
 }


### PR DESCRIPTION
Fixes #6093, the regression introduced in #2262.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

Restore the required state after the handle was re-created.

#2262 has added a check to the method handling recreation of a control handle to verify that the control is created before any child controls can be re-parented on to it.
![image](https://user-images.githubusercontent.com/4403806/140240606-fb377ca0-dc30-4e8f-a66c-80a16e92b201.png)

However it was missed that `DestroyHandle()` method resets the state (i.e. removes `Created` state), but `CreateHandle()` method doesn't set the state back. 


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Child controls sited on a form that recreates its handle while shown (e.g. while changing the value of `ShowInTaskbar` property) will be correctly rendered.

## Regression? 

- Yes, introduced in https://github.com/dotnet/winforms/pull/2262 in .NET 5.0 Preview1.

## Risk

- Small

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/4403806/139774029-1f175a1d-f3db-46cc-84c6-9da7faea3b23.png)
On the left `ListBox` and `CheckedListBox` controls, on the right `ListView` controls.

### After
![image](https://user-images.githubusercontent.com/4403806/140017467-ffa88ec3-fd2b-4654-86b2-632be8f73210.png)

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- git bisect to establish the commit that regressed the behaviour
- manual
- unit tests



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6114)