### PR TITLE
Disable Loc on main until servicing branch is updated.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ variables:
   - name: PostBuildSign
     value: true
   - name: EnableLoc
-    value: true
+    value: false
   - name: isPublic
     value: ${{ eq(variables['System.TeamProject'], 'public') }}
   - name: isPR


### PR DESCRIPTION
Disable Loc - We need disable loc here to enable it on servicing. This is still manual process.

Must be reenabled once servicing branch is up to date with loc and disable for loc there.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6118)