### PR TITLE
Fix anchored controls mis-alignment when DPI of the display is higher than 100%

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -829,7 +829,11 @@ namespace System.Windows.Forms
             // generator always generates a PerformLayout() right after a
             // ResumeLayout(false), so this seems to be the most opportune place
             // for this.
-            if (!_state[s_stateScalingChild] && !performLayout && AutoScaleMode != AutoScaleMode.None && AutoScaleMode != AutoScaleMode.Inherit && _state[s_stateScalingNeededOnLayout])
+            if (!_state[s_stateScalingChild]
+                && !performLayout
+                && AutoScaleMode != AutoScaleMode.None && AutoScaleMode != AutoScaleMode.Inherit
+                && _state[s_stateScalingNeededOnLayout]
+                && (AutoScaleFactor.Width != 1.0F || AutoScaleFactor.Height != 1.0F))
             {
                 _state[s_stateScalingChild] = true;
                 try

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -829,6 +829,10 @@ namespace System.Windows.Forms
             // generator always generates a PerformLayout() right after a
             // ResumeLayout(false), so this seems to be the most opportune place
             // for this.
+
+            // Skip Scale() when AutoscaleFactor is 100% (evaluated to 1.0F for both width and height).
+            // It means the form is designed on the monitor that has same settings as the monitor that
+            // it is being run.
             if (!_state[s_stateScalingChild]
                 && !performLayout
                 && AutoScaleMode != AutoScaleMode.None && AutoScaleMode != AutoScaleMode.Inherit

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -830,7 +830,7 @@ namespace System.Windows.Forms
             // ResumeLayout(false), so this seems to be the most opportune place
             // for this.
 
-            // Skip Scale() when AutoscaleFactor is 100% (evaluated to 1.0F for both width and height).
+            // Skip Scale() when AutoscaleFactor is 100% (evaluated to 1.0F for both width and height) as it is a no-op.
             // It means the form is designed on the monitor that has same settings as the monitor that
             // it is being run.
             if (!_state[s_stateScalingChild]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -676,8 +676,11 @@ namespace System.Windows.Forms.Layout
                     {
                         // parent was resized to fit its parent, or screen, we need to reuse old anchor info to prevent losing control beyond right edge
                         anchorInfo.Right = oldAnchorInfo.Right;
-                        // control might have been resized, update Left anchor
-                        anchorInfo.Left = oldAnchorInfo.Right - bounds.Width;
+                        if (!IsAnchored(anchor, AnchorStyles.Left))
+                        {
+                            // control might have been resized, update Left anchor
+                            anchorInfo.Left = oldAnchorInfo.Right - bounds.Width;
+                        }
                     }
                     else
                     {
@@ -701,8 +704,12 @@ namespace System.Windows.Forms.Layout
                     {
                         // parent was resized to fit its parent, or screen, we need to reuse old anchor info to prevent losing control beyond bottom edge
                         anchorInfo.Bottom = oldAnchorInfo.Bottom;
-                        // control might have been resized, update Top anchor
-                        anchorInfo.Top = oldAnchorInfo.Bottom - bounds.Height;
+
+                        if (!IsAnchored(anchor, AnchorStyles.Top))
+                        {
+                            // control might have been resized, update Top anchor
+                            anchorInfo.Top = oldAnchorInfo.Bottom - bounds.Height;
+                        }
                     }
                     else
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -674,11 +674,11 @@ namespace System.Windows.Forms.Layout
                 {
                     if (DpiHelper.IsScalingRequirementMet && (anchorInfo.Right - parentWidth > 0) && (oldAnchorInfo.Right < 0))
                     {
-                        // parent was resized to fit its parent, or screen, we need to reuse old anchor info to prevent losing control beyond right edge
+                        // Parent was resized to fit its parent, or screen, we need to reuse old anchor info to prevent losing control beyond right edge.
                         anchorInfo.Right = oldAnchorInfo.Right;
                         if (!IsAnchored(anchor, AnchorStyles.Left))
                         {
-                            // control might have been resized, update Left anchor
+                            // Control might have been resized, update Left anchor.
                             anchorInfo.Left = oldAnchorInfo.Right - bounds.Width;
                         }
                     }
@@ -702,12 +702,12 @@ namespace System.Windows.Forms.Layout
                 {
                     if (DpiHelper.IsScalingRequirementMet && (anchorInfo.Bottom - parentHeight > 0) && (oldAnchorInfo.Bottom < 0))
                     {
-                        // parent was resized to fit its parent, or screen, we need to reuse old anchor info to prevent losing control beyond bottom edge
+                        // Parent was resized to fit its parent, or screen, we need to reuse old anchor info to prevent losing control beyond bottom edge.
                         anchorInfo.Bottom = oldAnchorInfo.Bottom;
 
                         if (!IsAnchored(anchor, AnchorStyles.Top))
                         {
-                            // control might have been resized, update Top anchor
+                            // Control might have been resized, update Top anchor.
                             anchorInfo.Top = oldAnchorInfo.Bottom - bounds.Height;
                         }
                     }


### PR DESCRIPTION
This issue was introduced in .NET Framework 4.8.  Control `AnchorInfo `is used in the determination of `Location `of the `Control`.  AnchorInfo was miscalculated (ignored `AnchorStyle `property) when controls scaled on higher DPI settings and thus location OFF as demonstrated in the linked issue.  In this change, we will be checking the `AnchorStyles `before overriding the `AnchorInfo`.

Fixes #5774
Fixes #4838 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6122)