### PR TITLE
Fix nested container controls scaling that have AutoscaleMode as Inherit

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -688,7 +688,12 @@ namespace System.Windows.Forms
         private SizeF GetParentAutoScaleFactor()
         {
             Control parentControl = Parent;
-            while (parentControl is not null and not ContainerControl)
+
+            // Traverse thorugh parent hierarchy untill we get a ContainerControl whose AutoScaleMode is not Inherit.
+            // AutoscaleFactor from this parent is used to scale the child controls within its hierarchy.
+            while (parentControl is not null
+                && (parentControl is not ContainerControl containerControl
+                    || containerControl.AutoScaleMode == AutoScaleMode.Inherit))
             {
                 parentControl = parentControl.Parent;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -689,7 +689,7 @@ namespace System.Windows.Forms
         {
             Control parentControl = Parent;
 
-            // Traverse thorugh parent hierarchy untill we get a ContainerControl whose AutoScaleMode is not Inherit.
+            // Traverse through parent hierarchy until we get a ContainerControl whose AutoScaleMode is not Inherit.
             // AutoscaleFactor from this parent is used to scale the child controls within its hierarchy.
             while (parentControl is not null
                 && (parentControl is not ContainerControl containerControl


### PR DESCRIPTION
Fix nested `Container Controls` scaling that have `AutoscaleMode` as `Inherit`.  In this change we are making sure to traverse hierarchy all the way up until we get a container parent whose `AutoScaleMode `is not Inherit and use it s `AutoScaleFactor `to scale children.

Fixes #5957.

fixes #6152 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6130)