### PR TITLE
Enable nullability in ToolStripItemTextRenderEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2887,12 +2887,12 @@ System.Windows.Forms.ToolStripItemRenderEventArgs.Graphics.get -> System.Drawing
 System.Windows.Forms.ToolStripItemRenderEventArgs.Item.get -> System.Windows.Forms.ToolStripItem?
 System.Windows.Forms.ToolStripItemRenderEventArgs.ToolStrip.get -> System.Windows.Forms.ToolStrip?
 System.Windows.Forms.ToolStripItemRenderEventArgs.ToolStripItemRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem? item) -> void
-~System.Windows.Forms.ToolStripItemTextRenderEventArgs.Text.get -> string
-~System.Windows.Forms.ToolStripItemTextRenderEventArgs.Text.set -> void
-~System.Windows.Forms.ToolStripItemTextRenderEventArgs.TextFont.get -> System.Drawing.Font
-~System.Windows.Forms.ToolStripItemTextRenderEventArgs.TextFont.set -> void
-~System.Windows.Forms.ToolStripItemTextRenderEventArgs.ToolStripItemTextRenderEventArgs(System.Drawing.Graphics g, System.Windows.Forms.ToolStripItem item, string text, System.Drawing.Rectangle textRectangle, System.Drawing.Color textColor, System.Drawing.Font textFont, System.Drawing.ContentAlignment textAlign) -> void
-~System.Windows.Forms.ToolStripItemTextRenderEventArgs.ToolStripItemTextRenderEventArgs(System.Drawing.Graphics g, System.Windows.Forms.ToolStripItem item, string text, System.Drawing.Rectangle textRectangle, System.Drawing.Color textColor, System.Drawing.Font textFont, System.Windows.Forms.TextFormatFlags format) -> void
+System.Windows.Forms.ToolStripItemTextRenderEventArgs.Text.get -> string?
+System.Windows.Forms.ToolStripItemTextRenderEventArgs.Text.set -> void
+System.Windows.Forms.ToolStripItemTextRenderEventArgs.TextFont.get -> System.Drawing.Font?
+System.Windows.Forms.ToolStripItemTextRenderEventArgs.TextFont.set -> void
+System.Windows.Forms.ToolStripItemTextRenderEventArgs.ToolStripItemTextRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem! item, string? text, System.Drawing.Rectangle textRectangle, System.Drawing.Color textColor, System.Drawing.Font? textFont, System.Drawing.ContentAlignment textAlign) -> void
+System.Windows.Forms.ToolStripItemTextRenderEventArgs.ToolStripItemTextRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem! item, string? text, System.Drawing.Rectangle textRectangle, System.Drawing.Color textColor, System.Drawing.Font? textFont, System.Windows.Forms.TextFormatFlags format) -> void
 ~System.Windows.Forms.ToolStripLabel.ToolStripLabel(string text) -> void
 ~System.Windows.Forms.ToolStripLabel.ToolStripLabel(string text, System.Drawing.Image image) -> void
 ~System.Windows.Forms.ToolStripLabel.ToolStripLabel(string text, System.Drawing.Image image, bool isLink) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemTextRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemTextRenderEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms
@@ -19,7 +17,15 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents all the information to render the ToolStrip
         /// </summary>
-        public ToolStripItemTextRenderEventArgs(Graphics g, ToolStripItem item, string text, Rectangle textRectangle, Color textColor, Font textFont, TextFormatFlags format) : base(g, item)
+        public ToolStripItemTextRenderEventArgs(
+            Graphics g,
+            ToolStripItem item,
+            string? text,
+            Rectangle textRectangle,
+            Color textColor,
+            Font? textFont,
+            TextFormatFlags format)
+            : base(g, item)
         {
             ArgumentNullException.ThrowIfNull(item);
 
@@ -34,7 +40,15 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents all the information to render the ToolStrip
         /// </summary>
-        public ToolStripItemTextRenderEventArgs(Graphics g, ToolStripItem item, string text, Rectangle textRectangle, Color textColor, Font textFont, ContentAlignment textAlign) : base(g, item)
+        public ToolStripItemTextRenderEventArgs(
+            Graphics g,
+            ToolStripItem item,
+            string? text,
+            Rectangle textRectangle,
+            Color textColor,
+            Font? textFont,
+            ContentAlignment textAlign)
+            : base(g, item)
         {
             ArgumentNullException.ThrowIfNull(item);
 
@@ -50,7 +64,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The string to draw
         /// </summary>
-        public string Text { get; set; }
+        public string? Text { get; set; }
 
         /// <summary>
         ///  The color to draw the text
@@ -70,7 +84,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The font to draw the text
         /// </summary>
-        public Font TextFont { get; set; }
+        public Font? TextFont { get; set; }
 
         /// <summary>
         ///  The rectangle to draw the text in


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripItemTextRenderEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6134)