### PR TITLE
Enable nullability in DataGridViewEditingControlShowingEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1923,10 +1923,10 @@ System.Windows.Forms.DataGridViewColumnStateChangedEventArgs.DataGridViewColumnS
 ~System.Windows.Forms.DataGridViewComboBoxColumn.ValueMember.set -> void
 ~System.Windows.Forms.DataGridViewDataErrorEventArgs.DataGridViewDataErrorEventArgs(System.Exception exception, int columnIndex, int rowIndex, System.Windows.Forms.DataGridViewDataErrorContexts context) -> void
 ~System.Windows.Forms.DataGridViewDataErrorEventArgs.Exception.get -> System.Exception
-~System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
-~System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.CellStyle.set -> void
-~System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.Control.get -> System.Windows.Forms.Control
-~System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.DataGridViewEditingControlShowingEventArgs(System.Windows.Forms.Control control, System.Windows.Forms.DataGridViewCellStyle cellStyle) -> void
+System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.CellStyle.get -> System.Windows.Forms.DataGridViewCellStyle!
+System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.CellStyle.set -> void
+System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.Control.get -> System.Windows.Forms.Control!
+System.Windows.Forms.DataGridViewEditingControlShowingEventArgs.DataGridViewEditingControlShowingEventArgs(System.Windows.Forms.Control! control, System.Windows.Forms.DataGridViewCellStyle! cellStyle) -> void
 ~System.Windows.Forms.DataGridViewImageCell.Description.get -> string
 ~System.Windows.Forms.DataGridViewImageCell.Description.set -> void
 ~System.Windows.Forms.DataGridViewImageColumn.Description.get -> string

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewEditingControlShowingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewEditingControlShowingEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewEditingControlShowingEventArgs : EventArgs
@@ -12,8 +10,8 @@ namespace System.Windows.Forms
 
         public DataGridViewEditingControlShowingEventArgs(Control control, DataGridViewCellStyle cellStyle)
         {
-            Control = control;
-            _cellStyle = cellStyle;
+            Control = control.OrThrowIfNull();
+            _cellStyle = cellStyle.OrThrowIfNull();
         }
 
         public Control Control { get; }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewEditingControlShowingEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewEditingControlShowingEventArgsTests.cs
@@ -35,7 +35,8 @@ namespace System.Windows.Forms.Tests
         [Fact]
         public void CellStyle_SetNull_ThrowsArgumentNullException()
         {
-            var e = new DataGridViewEditingControlShowingEventArgs(new Button(), new DataGridViewCellStyle());
+            using var button = new Button();
+            var e = new DataGridViewEditingControlShowingEventArgs(button, new DataGridViewCellStyle());
             Assert.Throws<ArgumentNullException>("value", () => e.CellStyle = null);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewEditingControlShowingEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewEditingControlShowingEventArgsTests.cs
@@ -11,31 +11,31 @@ namespace System.Windows.Forms.Tests
     {
         public static IEnumerable<object[]> Ctor_Control_DataGridViewCellStyle_TestData()
         {
-            yield return new object[] { null, null };
-            yield return new object[] { new Button(), new DataGridViewCellStyle() };
+            yield return new object[] { null, new DataGridViewCellStyle() };
+            yield return new object[] { new Button(), null };
         }
 
         [WinFormsTheory]
         [MemberData(nameof(Ctor_Control_DataGridViewCellStyle_TestData))]
-        public void Ctor_Control_DataGridViewCellStyle(Control control, DataGridViewCellStyle cellStyle)
+        public void DataGridViewEditingControlShowingEventArgs_NullArg_ThrowsArgumentNullException(Control control, DataGridViewCellStyle cellStyle)
         {
-            var e = new DataGridViewEditingControlShowingEventArgs(control, cellStyle);
-            Assert.Equal(control, e.Control);
-            Assert.Equal(cellStyle, e.CellStyle);
+            Assert.Throws<ArgumentNullException>(() => new DataGridViewEditingControlShowingEventArgs(control, cellStyle));
         }
 
         [Fact]
-        public void CellStyle_SetNonNull_GetReturnsExpected()
+        public void Ctor_Control_DataGridViewCellStyle()
         {
-            var value = new DataGridViewCellStyle();
-            var e = new DataGridViewEditingControlShowingEventArgs(null, null) { CellStyle = value };
-            Assert.Equal(value, e.CellStyle);
+            using var button = new Button();
+            var cellStyle = new DataGridViewCellStyle();
+            var e = new DataGridViewEditingControlShowingEventArgs(button, cellStyle);
+            Assert.Equal(button, e.Control);
+            Assert.Equal(cellStyle, e.CellStyle);
         }
 
         [Fact]
         public void CellStyle_SetNull_ThrowsArgumentNullException()
         {
-            var e = new DataGridViewEditingControlShowingEventArgs(null, null);
+            var e = new DataGridViewEditingControlShowingEventArgs(new Button(), new DataGridViewCellStyle());
             Assert.Throws<ArgumentNullException>("value", () => e.CellStyle = null);
         }
     }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewEditingControlShowingEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6135)