### PR TITLE
Adding a new localized control type for category of property grid

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6859,4 +6859,7 @@ Stack trace where the illegal operation occurred was:
   <data name="ListViewGroupExpandedStateName" xml:space="preserve">
     <value>{0}, group, expanded</value>
   </data>
+  <data name="CategoryPropertyGridLocalizedControlType" xml:space="preserve">
+    <value>PropertyGrid category</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Styl okna</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">Určuje vzhled zaškrtávacího políčka.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Fensterstil</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">Steuert die Darstellung des Kontrollkästchens.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Estilo de ventana</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">Controla la apariencia de la casilla.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Style de la fenêtre</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">Contrôle l'apparence de la case à cocher.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Stile finestra</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">Determina l'aspetto della casella di controllo.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -822,6 +822,11 @@
         <target state="translated">ウィンドウ スタイル</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">チェック ボックスの外観を設定します。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -822,6 +822,11 @@
         <target state="translated">창 스타일</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">확인란의 모양을 제어합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Styl okna</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">Określa wygląd pola wyboru.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Estilo de Janela</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">Controla a aparência da caixa de seleção.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Стиль окна</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">Определяет внешний вид флажка проверки.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -822,6 +822,11 @@
         <target state="translated">Pencere Stili</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">Onay kutusunun görünümünü denetler.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -822,6 +822,11 @@
         <target state="translated">窗口样式</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">控制复选框的外观。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -822,6 +822,11 @@
         <target state="translated">視窗樣式</target>
         <note />
       </trans-unit>
+      <trans-unit id="CategoryPropertyGridLocalizedControlType">
+        <source>PropertyGrid category</source>
+        <target state="new">PropertyGrid category</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CheckBoxAppearanceDescr">
         <source>Controls the appearance of the check box.</source>
         <target state="translated">控制核取方塊的外觀。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.CategoryGridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/CategoryGridEntry.CategoryGridEntryAccessibleObject.cs
@@ -95,6 +95,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 // To announce expanded collapsed state control type should be appropriate:
                 // https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-controlpatternmapping
                 UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TreeItemControlTypeId,
+                UiaCore.UIA.LocalizedControlTypePropertyId => SR.CategoryPropertyGridLocalizedControlType,
                 _ => base.GetPropertyValue(propertyID),
             };
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CategoryGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CategoryGridEntryAccessibleObjectTests.cs
@@ -146,5 +146,16 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
             Assert.False(button.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void CategoryGridEntryAccessibleObject_LocalizedControlType_ReturnsExpected()
+        {
+            using NoAssertContext context = new();
+            var accessibilityObject = new CategoryGridEntryAccessibleObject(null);
+
+            string expected = SR.CategoryPropertyGridLocalizedControlType;
+
+            Assert.Equal(expected, accessibilityObject.GetPropertyValue(UiaCore.UIA.LocalizedControlTypePropertyId));
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6037


## Proposed changes

- A new localized control type for category of property grid was introduced. Set it for CategoryGridEntryAccessibleObject.
- Added a unit test.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Resolved an accessibility error of the control.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

An error was detected by Accessibility Insights.

![beforeAI](https://user-images.githubusercontent.com/58004471/140714231-455bc7dc-4788-46a0-a8b0-686fddf029f3.png)

A category of property grid has a `tree view` value of `LocalizedControlType` property.

![beforeInsp](https://user-images.githubusercontent.com/58004471/140714664-4d3d014a-5983-4c2e-924d-143673da92cb.png)

In Narrator Buddy

![beforeNB](https://user-images.githubusercontent.com/58004471/140714805-143047ec-b8c0-42cf-9216-1e5e772d595b.png)

### After

No errors were detected by Accessibility Insights.

![afterAI](https://user-images.githubusercontent.com/58004471/140714862-0025328f-015d-4a40-b68d-bec9c1ac8fcc.png)

A category of property grid has a `PropertyGrid category` custom value of `LocalizedControlType` property.

![11](https://user-images.githubusercontent.com/58004471/141956500-3627124b-9045-447a-9d2e-15a4e3855c57.png)

No changes in the Narrator Buddy.

![beforeNB](https://user-images.githubusercontent.com/58004471/140715299-2e61afb6-fa17-40d7-9cd5-bcdc73c48d39.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual
- Unit
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->
- Inspect
- Accessibility Insights
- Narrator
 

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet version: 6.0.100
- OS version: 10.0.19043


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6138)