### PR TITLE
[6.0][Servicing]Fix anchored controls mis-alignment when DPI of the display is higher than 100%

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -829,7 +829,15 @@ namespace System.Windows.Forms
             // generator always generates a PerformLayout() right after a
             // ResumeLayout(false), so this seems to be the most opportune place
             // for this.
-            if (!_state[s_stateScalingChild] && !performLayout && AutoScaleMode != AutoScaleMode.None && AutoScaleMode != AutoScaleMode.Inherit && _state[s_stateScalingNeededOnLayout])
+
+            // Skip Scale() when AutoscaleFactor is 100% (evaluated to 1.0F for both width and height) as it is a no-op.
+            // It means the form is designed on the monitor that has same settings as the monitor that
+            // it is being run.
+            if (!_state[s_stateScalingChild]
+                && !performLayout
+                && AutoScaleMode != AutoScaleMode.None && AutoScaleMode != AutoScaleMode.Inherit
+                && _state[s_stateScalingNeededOnLayout]
+                && (AutoScaleFactor.Width != 1.0F || AutoScaleFactor.Height != 1.0F))
             {
                 _state[s_stateScalingChild] = true;
                 try

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -674,10 +674,13 @@ namespace System.Windows.Forms.Layout
                 {
                     if (DpiHelper.IsScalingRequirementMet && (anchorInfo.Right - parentWidth > 0) && (oldAnchorInfo.Right < 0))
                     {
-                        // parent was resized to fit its parent, or screen, we need to reuse old anchor info to prevent losing control beyond right edge
+                        // Parent was resized to fit its parent, or screen, we need to reuse old anchor info to prevent losing control beyond right edge.
                         anchorInfo.Right = oldAnchorInfo.Right;
-                        // control might have been resized, update Left anchor
-                        anchorInfo.Left = oldAnchorInfo.Right - bounds.Width;
+                        if (!IsAnchored(anchor, AnchorStyles.Left))
+                        {
+                            // Control might have been resized, update Left anchor.
+                            anchorInfo.Left = oldAnchorInfo.Right - bounds.Width;
+                        }
                     }
                     else
                     {
@@ -699,10 +702,14 @@ namespace System.Windows.Forms.Layout
                 {
                     if (DpiHelper.IsScalingRequirementMet && (anchorInfo.Bottom - parentHeight > 0) && (oldAnchorInfo.Bottom < 0))
                     {
-                        // parent was resized to fit its parent, or screen, we need to reuse old anchor info to prevent losing control beyond bottom edge
+                        // Parent was resized to fit its parent, or screen, we need to reuse old anchor info to prevent losing control beyond bottom edge.
                         anchorInfo.Bottom = oldAnchorInfo.Bottom;
-                        // control might have been resized, update Top anchor
-                        anchorInfo.Top = oldAnchorInfo.Bottom - bounds.Height;
+
+                        if (!IsAnchored(anchor, AnchorStyles.Top))
+                        {
+                            // Control might have been resized, update Top anchor.
+                            anchorInfo.Top = oldAnchorInfo.Bottom - bounds.Height;
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
* Fixes anchored controls mis-alignment when DPI of the display is higher than 100%. In .NET framework 4.7 timeframe, we made a change to improve the anchoring on higher DPI settings that introduced this bug. As explained in the linked bug below, Applications that anchor controls are currently broken in default SystemAware mode with >100% DPI settings ( which is also a default for most)

Fixes #5774 

## Regression? 

- Yes, from .NET framework 4.6

## Risk
- I would say minimum and associated with only controls that are anchored.  Currently they are broken even in `SystemAware `mode.

## Test methodology <!-- How did you ensure quality? -->

- Manual  CTI validation.
- Running customer provided applications and making sure change fixing them.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6140)