### PR TITLE
[6.0][Servicing] Fix nested container controls scaling that have AutoscaleMode as Inherit

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -688,7 +688,12 @@ namespace System.Windows.Forms
         private SizeF GetParentAutoScaleFactor()
         {
             Control parentControl = Parent;
-            while (parentControl is not null and not ContainerControl)
+
+            // Traverse through parent hierarchy until we get a ContainerControl whose AutoScaleMode is not Inherit.
+            // AutoscaleFactor from this parent is used to scale the child controls within its hierarchy.
+            while (parentControl is not null
+                && (parentControl is not ContainerControl containerControl
+                    || containerControl.AutoScaleMode == AutoScaleMode.Inherit))
             {
                 parentControl = parentControl.Parent;
             }


### PR DESCRIPTION
* Fix nested ContainerControls that have `AutoscaleMode `as `Inherit`.

A change in supporting scaling for `MDI `child windows in PermonV2 mode applications regressed this. Issue impact Winforms applications that are running in `PerMonV2 `mode. While winforms not yet fully support  PerMonV2 mode, customers are creating and using this mode for their applications, since .NET Framework 4.7.3, and get it working for less complex winforms applications with some work arounds. 

Fixes #6152.


## Regression? 

- Yes, from .NET 5.0. 

## Risk
- Low. Fix is already in 7.0 and tested for `PermonV2 `mode.
- 
## Test methodology <!-- How did you ensure quality? -->

- Manual  CTI validation.
- Running customer provided applications and making sure change fixing them.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6158)