### PR TITLE
Fixing NotSupportedException from "AccessibleObject.RuntimeId" property

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6850,9 +6850,6 @@ Stack trace where the illegal operation occurred was:
   <data name="ControlsCollectionShouldNotBeEmptyInGetNextControl" xml:space="preserve">
     <value>{0} collection shouldn't be empty for {1}.</value>
   </data>
-  <data name="AccessibleObjectRuntimeIdNotSupported" xml:space="preserve">
-    <value>{0} doesn't support {1} property. It must be overriden in the derived class.</value>
-  </data>
   <data name="ListViewGroupCollapsedStateName" xml:space="preserve">
     <value>{0}, group, collapsed</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -217,11 +217,6 @@
         <target state="translated">Odpovídající prvek uživatelského rozhraní není aktivní oblast.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} nepodporuje vlastnost {1}. Musí to být přepsáno v odvozené třídě.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">Ovládací prvky vytvořené v jednom vlákně nelze nadřadit ovládacím prvkům v jiném vlákně.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -217,11 +217,6 @@
         <target state="translated">Das entsprechende Element der Benutzeroberfläche ist kein dynamischer Bereich.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} unterstützt {1} Eigenschaft nicht. Sie muss in der abgeleiteten Klasse überschrieben werden.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">Steuerelemente, die für einen Thread erstellt wurden, können nicht einem Steuerelement in einem anderen Thread übergeordnet werden.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -217,11 +217,6 @@
         <target state="translated">El elemento de interfaz de usuario correspondiente no es una región activa.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} no admite {1} propiedad. Debe reemplazarse en la clase derivada.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">Los controles creados en un subproceso no pueden tener controles primarios en un control en un subproceso diferente.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -217,11 +217,6 @@
         <target state="translated">L'élément d'interface utilisateur correspondant n'est pas une zone dynamique.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} ne prend pas en charge {1} la propriété. Il doit être remplacé dans la classe dérivée.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">Les contrôles créés sur un thread ne peuvent pas être parents d'un contrôle d'un autre thread.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -217,11 +217,6 @@
         <target state="translated">L'elemento dell'interfaccia utente corrispondente non è un'area dinamica.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} non supporta la proprietà {1}. È necessario eseguire l'override sulla classe derivata.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">I controlli creati su un thread non possono avere come elemento padre un controllo su un thread diverso.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -217,11 +217,6 @@
         <target state="translated">対応する UI 要素が、ライブ リージョンではありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} は {1} プロパティをサポートしていません。派生クラスでオーバーライドする必要があります。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">あるスレッドで作成されたコントロールに対して、別のスレッドのコントロールを親にすることはできません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -217,11 +217,6 @@
         <target state="translated">해당 UI 요소는 라이브 영역이 아닙니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0}에서 {1} 속성을 지원하지 않습니다. 파생 클래스에서 재정의해야 합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">한 스레드에 만든 컨트롤은 다른 스레드에 있는 컨트롤의 부모가 될 수 없습니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -217,11 +217,6 @@
         <target state="translated">Odpowiadający element interfejsu użytkownika nie jest regionem dynamicznym.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} nie obsługuje właściwości {1}. Musi zostać zastąpiona w klasie pochodnej.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">Formanty utworzone w jednym wątku nie mogą być nadrzędne w stosunku do formantów w innym wątku.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -217,11 +217,6 @@
         <target state="translated">O elemento de interface do usuário correspondente não é uma região dinâmica.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} não dá suporte à propriedade {1}. Ele deve ser substituído na classe derivada.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">Os controles criados em um thread não podem ser controles pai de um controle em um outro thread.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -217,11 +217,6 @@
         <target state="translated">Соответствующий элемент пользовательского интерфейса не является динамической областью.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} не поддерживает свойство {1}. Его необходимо переопределить в производном классе.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">Элементы управления, созданные в одном потоке, не могут быть родительскими для элемента управления в другом потоке.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -217,11 +217,6 @@
         <target state="translated">Karşılık gelen kullanıcı arabirimi öğesi canlı bir bölge değil.</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0}, {1} özelliğini desteklemez. Türetilmiş sınıfta geçersiz kılınmalıdır.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">Bir iş parçacığında oluşturulan denetimler, farklı bir iş parçacığındaki denetimin üst öğesi yapılamaz.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -217,11 +217,6 @@
         <target state="translated">相应的 UI 元素不是实时区域。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} 不支持 {1} 属性。必须在派生类中重写它。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">在某个线程上创建的控件不能成为在另一个线程上创建的控件的父级。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -217,11 +217,6 @@
         <target state="translated">對應的 UI 元素不是即時區域。</target>
         <note />
       </trans-unit>
-      <trans-unit id="AccessibleObjectRuntimeIdNotSupported">
-        <source>{0} doesn't support {1} property. It must be overriden in the derived class.</source>
-        <target state="translated">{0} 不支援 {1} 屬性。必須在衍生類別中加以覆寫。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddDifferentThreads">
         <source>Controls created on one thread cannot be parented to a control on a different thread.</source>
         <target state="translated">不可以在不同執行緒上建立控制項的父項。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -350,17 +350,7 @@ namespace System.Windows.Forms
             return false;
         }
 
-        internal virtual int[] RuntimeId
-        {
-            get
-            {
-                string message = string.Format(SR.AccessibleObjectRuntimeIdNotSupported, nameof(AccessibleObject), nameof(RuntimeId));
-
-                Debug.Fail(message);
-
-                throw new NotSupportedException(message);
-            }
-        }
+        internal virtual int[] RuntimeId => Array.Empty<int>();
 
         internal virtual int ProviderOptions
             => (int)(UiaCore.ProviderOptions.ServerSideProvider | UiaCore.ProviderOptions.UseComThreading);

--- a/src/System.Windows.Forms/tests/InteropTests/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/InteropTests/AccessibleObjectTests.cs
@@ -29,11 +29,8 @@ namespace System.Windows.Forms.InteropTests
         [WinFormsFact]
         public unsafe void AccessibleObject_IAccessibleExGetRuntimeId_Invoke_ReturnsExpected()
         {
-            using (new NoAssertContext())
-            {
-                var o = new AccessibleObject();
-                AssertSuccess(Test_IAccessibleExGetRuntimeId(o, null));
-            }
+            var o = new AccessibleObject();
+            AssertSuccess(Test_IAccessibleExGetRuntimeId(o));
         }
 
         [WinFormsTheory]
@@ -180,11 +177,8 @@ namespace System.Windows.Forms.InteropTests
         [WinFormsFact]
         public unsafe void AccessibleObject_IRawElementProviderFragmentGetRuntimeId_Invoke_ReturnsExpected()
         {
-            using (new NoAssertContext())
-            {
-                var o = new AccessibleObject();
-                AssertSuccess(Test_IRawElementProviderFragmentGetRuntimeId(o, null));
-            }
+            var o = new AccessibleObject();
+            AssertSuccess(Test_IRawElementProviderFragmentGetRuntimeId(o));
         }
 
         [WinFormsTheory]
@@ -697,8 +691,7 @@ namespace System.Windows.Forms.InteropTests
 
         [DllImport(NativeTests, ExactSpelling = true, CharSet = CharSet.Unicode)]
         private unsafe static extern string Test_IAccessibleExGetRuntimeId(
-            [MarshalAs(UnmanagedType.IUnknown)] object pUnk,
-            int* expected);
+            [MarshalAs(UnmanagedType.IUnknown)] object pUnk);
 
         [DllImport(NativeTests, ExactSpelling = true, CharSet = CharSet.Unicode)]
         private unsafe static extern string Test_IAccessibleExGetObjectForChild(
@@ -781,8 +774,7 @@ namespace System.Windows.Forms.InteropTests
 
         [DllImport(NativeTests, ExactSpelling = true, CharSet = CharSet.Unicode)]
         private unsafe static extern string Test_IRawElementProviderFragmentGetRuntimeId(
-            [MarshalAs(UnmanagedType.IUnknown)] object pUnk,
-            int* expected);
+            [MarshalAs(UnmanagedType.IUnknown)] object pUnk);
 
         [DllImport(NativeTests, ExactSpelling = true, CharSet = CharSet.Unicode)]
         private static extern string Test_IRawElementProviderFragmentNavigate(

--- a/src/System.Windows.Forms/tests/InteropTests/NativeTests/AccessibleObjectTests.cpp
+++ b/src/System.Windows.Forms/tests/InteropTests/NativeTests/AccessibleObjectTests.cpp
@@ -8,8 +8,6 @@
 #include <atlbase.h>
 using namespace ATL;
 
-#define COR_E_NOTSUPPORTED 0x80131515
-
 TEST const WCHAR* WINAPI Test_IAccessibleExConvertReturnedElement(IUnknown* pUnknown)
 {
     return RunTest([&](std::wstringstream& output)
@@ -85,7 +83,7 @@ TEST const WCHAR* WINAPI Test_IAccessibleExGetIAccessiblePair(IUnknown* pUnknown
     });
 }
 
-TEST const WCHAR* WINAPI Test_IAccessibleExGetRuntimeId(IUnknown* pUnknown, int* expected)
+TEST const WCHAR* WINAPI Test_IAccessibleExGetRuntimeId(IUnknown* pUnknown)
 {
     return RunTest([&](std::wstringstream& output)
     {
@@ -97,12 +95,13 @@ TEST const WCHAR* WINAPI Test_IAccessibleExGetRuntimeId(IUnknown* pUnknown, int*
 
         SAFEARRAY *result = (SAFEARRAY*)(long)0xdeadbeef;
         hr = pAccessibleEx->GetRuntimeId(&result);
-        assertEqualHr(COR_E_NOTSUPPORTED, hr);
+        assertEqualHr(S_OK, hr);
+        assertNotNull(result);
         SafeArrayDestroy(result);
 
         // Negative tests.
         hr = pAccessibleEx->GetRuntimeId(NULL);
-        assertEqualHr(COR_E_NOTSUPPORTED, hr);
+        assertEqualHr(S_OK, hr);
 
         return S_OK;
     });
@@ -342,7 +341,7 @@ TEST const WCHAR* WINAPI Test_IRawElementProviderFragmentGetEmbeddedFragmentRoot
     });
 }
 
-TEST const WCHAR* WINAPI Test_IRawElementProviderFragmentGetRuntimeId(IUnknown* pUnknown, int* expected)
+TEST const WCHAR* WINAPI Test_IRawElementProviderFragmentGetRuntimeId(IUnknown* pUnknown)
 {
     return RunTest([&](std::wstringstream& output)
     {
@@ -354,12 +353,13 @@ TEST const WCHAR* WINAPI Test_IRawElementProviderFragmentGetRuntimeId(IUnknown* 
 
         SAFEARRAY *result = (SAFEARRAY*)(long)0xdeadbeef;
         hr = pRawElementProviderFragment->GetRuntimeId(&result);
-        assertEqualHr(COR_E_NOTSUPPORTED, hr);
+        assertEqualHr(S_OK, hr);
+        assertNotNull(result);
         SafeArrayDestroy(result);
 
         // Negative tests.
         hr = pRawElementProviderFragment->GetRuntimeId(NULL);
-        assertEqualHr(COR_E_NOTSUPPORTED, hr);
+        assertEqualHr(S_OK, hr);
 
         return S_OK;
     });


### PR DESCRIPTION
Fixes #6165

## Proposed changes
- The issue is reproduced because we throw an `NotSupportedException` when user tries to get the `RuntimeId` properties for the base `AccessibleObject`.
- Added return of `Array.Empty` for base class
- Remove `AccessibleObjectRuntimeIdNotSupported` from string resources

## Customer Impact
**Before fix:** 
![Issue-6165](https://user-images.githubusercontent.com/23376742/141281075-9d567d01-06e6-470f-8987-a80368ad7b85.gif)

**After fix:**
![Issue-6165-fixed](https://user-images.githubusercontent.com/23376742/141285880-6fab234d-3e33-48cb-a2d0-0d9bfec85e98.gif)

## Regression? 
- Yes (from #5638)

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manual testing 


## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect

## Test environment(s) <!-- Remove any that don't apply -->
- .NET Core SDK: 7.0.0-alpha.1.21558.10
- Microsoft Windows [Version 10.0.19041.804]

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6166)