### PR TITLE
Fixing highlighting of property grid item dropdown in the Inspect

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1490,6 +1490,16 @@ namespace System.Windows.Forms.PropertyGridInternal
                 _dropDownHolder.ResizeUp = false;
             }
 
+            var gridEntry = GetGridEntryFromRow(_selectedRow);
+            if (gridEntry is not null && IsAccessibilityObjectCreated)
+            {
+                gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
+                gridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
+                    UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
+                    UiaCore.ExpandCollapseState.Collapsed,
+                    UiaCore.ExpandCollapseState.Expanded);
+            }
+
             // Control is a top level window. Standard way of setting parent on the control is prohibited for top-level controls.
             // It is unknown why this control was created as a top-level control. Windows does not recommend this way of setting parent.
             // We are not touching this for this release. We may revisit it in next release.
@@ -1501,16 +1511,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             _dropDownHolder.Visible = true;
             _dropDownHolder.FocusComponent();
             EditTextBox.SelectAll();
-
-            var gridEntry = GetGridEntryFromRow(_selectedRow);
-            if (gridEntry is not null && IsAccessibilityObjectCreated)
-            {
-                gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
-                gridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
-                    UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
-                    UiaCore.ExpandCollapseState.Collapsed,
-                    UiaCore.ExpandCollapseState.Expanded);
-            }
 
             try
             {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3796 


## Proposed changes

- Refactored `DropDownControl` method: set sending a focus and change expand-collapse state events before focusing on dropdown control.  

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Has a correct highlighting of opened and focused dropdown in the Inspect.

## Regression? 

- No

## Risk

- No

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

No highlighting on the focused dropdown of property grid item in the Inspect.

![gifBefore](https://user-images.githubusercontent.com/62929087/91526420-28c92c80-e936-11ea-8c84-e8d889d0efb8.gif)

### After

Has highlighting on the focused dropdown of property grid item in the Inspect.

![HighlightDropdown](https://user-images.githubusercontent.com/58004471/141765369-e0015d1a-9f1c-44f5-8dfb-6ac56f542df8.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual
- Unit
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Inspect
- Accessibility Insights
- Narrator
 

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet version: 6.0.100
- OS version: 10.0.19043


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6179)