### PR TITLE
[6.0.2] [Servicing]Fixing scaling issue on explicitly set Font containers but still Inherit AustoScaleMode.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -82,6 +82,11 @@ namespace System.Windows.Forms
         private const string FontMeasureString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
         /// <summary>
+        /// True if the container needs scaling as a result of <see cref="DpiChangedEventHandler"/>, irrespective of Font status (explicit set or inherited Font).
+        /// </summary>
+        internal bool _needsDpiChangeScaling;
+
+        /// <summary>
         /// Child Container control that inherit <see cref="AutoScaleMode"/> (and does not store their own) would need
         /// <see cref="AutoScaleFactor"/> from parent to scale them during Dpi changed events. We can not use
         /// <see cref="AutoScaleFactor"/> property as it get computed with already updated Font and Dpi of their parent.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -82,11 +82,6 @@ namespace System.Windows.Forms
         private const string FontMeasureString = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
         /// <summary>
-        /// True if the container needs scaling as a result of <see cref="DpiChangedEventHandler"/>, irrespective of Font status (explicit set or inherited Font).
-        /// </summary>
-        internal bool _needsDpiChangeScaling;
-
-        /// <summary>
         /// Child Container control that inherit <see cref="AutoScaleMode"/> (and does not store their own) would need
         /// <see cref="AutoScaleFactor"/> from parent to scale them during Dpi changed events. We can not use
         /// <see cref="AutoScaleFactor"/> property as it get computed with already updated Font and Dpi of their parent.
@@ -350,6 +345,11 @@ namespace System.Windows.Forms
                 return _currentAutoScaleDimensions;
             }
         }
+
+        /// <summary>
+        /// Gets or sets whether the container needs to be scaled when <see cref="DpiChangedEventHandler" />, irrespective whether the font was inherited or set explicitly.
+        /// </summary>
+        internal bool IsDpiChangeScalingRequired { get; set; }
 
         /// <summary>
         ///  Indicates the form that the scrollable control is assigned to. This property is read-only.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6173


## Proposed changes

Container controls whose Font is explicitly set are not scaled well if they inherit `AutoScaleMode `from parent. Inherited `AutoScaleMode `containers use `AutoScaleFactor `from parents to scale themselves. However, in a `PerMonitorV2 `mode applications, parent receive the `DpiChangedEvent `after all their children receive it and scale themselves. `ContainerControls `that inherit scaling, will end up using `AutoScaleFactor `from parent that was not yet updated to the new Dpi as Parent yet to receive the DPI event. To fix this, we are tracking such containers with `IsDpiChangeScalingRequired `flag and scale them once the Parent `AutoScaleFactor ` is updated.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Customers with PerMonitorV2 mode applications migrating from .NET 5.0 to .NET 60 would experience regression in scaling the Winforms applications on higher DPI settings.

## Regression? 

- Yes from .NET 5.0. Though we do not fully support PerMonitorV2 mode apps in WinForms yet, customers have been developing them and using work arounds where ever needed. 

## Risk

Low. Majority of the changes made are in `Permonv2 `mode code path.

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Customer applications validation.
- Manual validation by CTI for HDPI scenarios.
- Running existing automation with the private binaries shared


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6182)