### PR TITLE
Adding prevention of label editing when clicking on subitems of ListView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -94,6 +94,7 @@ namespace System.Windows.Forms
         private const int LISTVIEWSTATE1_useCompatibleStateImageBehavior = 0x00000008;
         private const int LISTVIEWSTATE1_selectedIndexChangedSkipped = 0x00000010;
 
+        private const int LVLABELEDITTIMER = 0x2A;
         private const int LVTOOLTIPTRACKING = 0x30;
         private const int MAXTILECOLUMNS = 20;
 
@@ -176,6 +177,8 @@ namespace System.Windows.Forms
         private IComparer listItemSorter;
 
         private ListViewItem prevHoveredItem;
+
+        private bool _blockLabelEdit;
 
         // Background image stuff
         // Because we have to create a temporary file and the OS does not clean up the temporary files from the machine
@@ -2422,6 +2425,21 @@ namespace System.Windows.Forms
                 {
                     savedSelectedItems.Remove(lvi);
                 }
+            }
+        }
+
+        private void CancelPendingLabelEdit()
+        {
+            // Invoke the timer that was already set, this will cause label editing to start (LVN.BEGINLABELEDITW will be sent).
+            // Using _blockLabelEdit will cancel label editing in LVN.BEGINLABELEDITW handler.
+            _blockLabelEdit = true;
+            try
+            {
+                User32.SendMessageW(this, User32.WM.TIMER, LVLABELEDITTIMER);
+            }
+            finally
+            {
+                _blockLabelEdit = false;
             }
         }
 
@@ -6417,11 +6435,21 @@ namespace System.Windows.Forms
 
                 case (int)LVN.BEGINLABELEDITW:
                     {
-                        NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m.LParamInternal;
-                        LabelEditEventArgs e = new LabelEditEventArgs(dispInfo->item.iItem);
-                        OnBeforeLabelEdit(e);
-                        m.ResultInternal = e.CancelEdit ? 1 : 0;
-                        listViewState[LISTVIEWSTATE_inLabelEdit] = !e.CancelEdit;
+                        bool cancelEdit;
+                        if (_blockLabelEdit)
+                        {
+                            cancelEdit = true;
+                        }
+                        else
+                        {
+                            NMLVDISPINFO* dispInfo = (NMLVDISPINFO*)m.LParamInternal;
+                            LabelEditEventArgs e = new(dispInfo->item.iItem);
+                            OnBeforeLabelEdit(e);
+                            cancelEdit = e.CancelEdit;
+                        }
+
+                        m.ResultInternal = cancelEdit ? 1 : 0;
+                        listViewState[LISTVIEWSTATE_inLabelEdit] = !cancelEdit;
                         break;
                     }
 
@@ -6909,10 +6937,23 @@ namespace System.Windows.Forms
 
                 case User32.WM.LBUTTONDOWN:
 
+                    // Check that before click was handled by the ListView code
+                    // because otherwise item will always be selected.
+                    bool cancelLabelEdit =
+                        LabelEdit &&
+                        View == View.Details &&
+                        HitTest(PARAM.ToPoint(m.LParamInternal)) is { SubItem.Index: > 0, Item.Selected: true };
+
                     // Ensure that the itemCollectionChangedInMouseDown is not set
                     // before processing the mousedown event.
                     ItemCollectionChangedInMouseDown = false;
                     WmMouseDown(ref m, MouseButtons.Left, 1);
+
+                    if (cancelLabelEdit)
+                    {
+                        CancelPendingLabelEdit();
+                    }
+
                     downButton = MouseButtons.Left;
                     break;
 


### PR DESCRIPTION
Fixes #4816. ListView allows editing the label by clicking on any subitem of a row. On the other hand, Windows Explorer allows label editing only by clicking on the first subitem (which is actually a label) of a row. Windows Explorer behavior should be more appropriate for a common user. The logic of the label editing is located in ComCtl32.dll which is provided by Windows and therefore can't be changed on our side. In order to change the behavior we can rely on the fact that this internal logic sets a timer before an actual editing begins.

ListView provides a standard way to cancel a pending label edit - `LVM_CANCELEDITLABEL` message. The problem is that this message is only implemented in 6.0 version of ComCtl32.dll. It also doesn't work as expected under 6.0, so it can't be actually used.

Another way is to cancel the timer using `KillTimer`. The problem with this approach is that the timer can be already elapsed at the moment of handling by our code (the message is already on the queue, so `KillTimer` won't help) because of the OS scheduler. Another problem with this approach is that it is not known what side effects may happen when the timer is cancelled by the third-party code.

We can also invoke the timer by pushing `WM_TIMER` message to the queue. This will start label editing immediately, but we need a way to block it. One way is to temporarily change the LabelEdit property - disable it before `WM_TIMER` is sent and enable it after the timer was handled. This works, but may cause redrawing. Another way is to handle `LVN_BEGINLABELEDITW` message which allows to cancel label editing. This is actually the approach which is implemented here, we cancel label editing only when we're sending `WM_TIMER` message. This way we don't have a potential redrawing issue.


## Proposed changes

- Prevention of label editing when clicking on subitems of a row in ListView

## Customer Impact

- Clicking on ListView subitems will no longer start label editing (Windows Explorer behavior)

## Regression? 

- No

## Risk

- Minimal


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![](http://g.recordit.co/zakqSfaw76.gif)

### After

![](http://g.recordit.co/SCi6WVqVzz.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit-tests
- CTI


 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19043.1348]
- .NET 7.0.0-alpha.1.21561.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6188)