### PR TITLE
Fixing `RuntimeId` for system accessible wrapper in AccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -354,6 +354,11 @@ namespace System.Windows.Forms
         {
             get
             {
+                if (systemWrapper)
+                {
+                    return new int[] { RuntimeIDFirstItem, GetHashCode() };
+                }
+
                 string message = string.Format(SR.AccessibleObjectRuntimeIdNotSupported, nameof(AccessibleObject), nameof(RuntimeId));
 
                 Debug.Fail(message);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -2635,6 +2635,15 @@ namespace System.Windows.Forms.Tests
             Assert.Null(pAcc);
         }
 
+        [WinFormsFact]
+        public void AccessibleObject_SystemWrapper_RuntimeId_IsValid()
+        {
+            AccessibleObject accessibleObject =
+                (AccessibleObject)Activator.CreateInstance(typeof(AccessibleObject), BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { null }, null);
+
+            Assert.NotEmpty(accessibleObject.TestAccessor().Dynamic.RuntimeId);
+        }
+
         private class SubAccessibleObject : AccessibleObject
         {
             public new void UseStdAccessibleObjects(IntPtr handle) => base.UseStdAccessibleObjects(handle);


### PR DESCRIPTION
Fixes #6165.


## Proposed changes

- Added a branch for `systemWrapper` in `AccessibleObject.RuntimeId` with an empty array return value

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- There is no impact as release builds don't have assertions compiled

## Regression? 

- Yes (from .NET 6)

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit-tests
- CTI

 

## Test environment(s) <!-- Remove any that don't apply -->

-  Microsoft Windows [Version 10.0.19043.1288]
- .NET 7.0.0-alpha.1.21551.1



<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6192)