### PR TITLE
Fixing incorrect rendering of button borders for Windows 11

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonRenderer.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Windows.Forms.VisualStyles;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -26,7 +27,7 @@ namespace System.Windows.Forms
         /// </summary>
         public static bool RenderMatchingApplicationState { get; set; } = true;
 
-        private static bool RenderWithVisualStyles
+        internal static bool RenderWithVisualStyles
         {
             get
             {
@@ -88,6 +89,20 @@ namespace System.Windows.Forms
                     ControlPaint.DrawButton(graphics, bounds, ConvertToButtonState(state));
                 }
             }
+        }
+
+        /// <summary>
+        ///  Method for drawing a button using the VisualStyleRenderer.
+        ///  Should only be used when RenderWithVisualStyles == true
+        /// </summary>
+        internal static void DrawButtonWithVisualStyles(
+            Gdi32.HDC hdc,
+            Rectangle bounds,
+            PushButtonState state,
+            IntPtr hwnd)
+        {
+            InitializeRenderer((int)state);
+            t_visualStyleRenderer.DrawBackground(hdc, bounds, hwnd);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.HLSColor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.HLSColor.cs
@@ -25,6 +25,11 @@ namespace System.Windows.Forms
             private readonly int _saturation;
             private readonly bool _isSystemColors_Control;
 
+            public HLSColor(Color color, bool isSystemColors) : this(color)
+            {
+                _isSystemColors_Control = isSystemColors;
+            }
+
             public HLSColor(Color color)
             {
                 _isSystemColors_Control = color.ToKnownColor() == SystemColors.Control.ToKnownColor();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlPaintTests.cs
@@ -2273,5 +2273,32 @@ namespace System.Windows.Forms.Tests
             // Call again to test caching.
             Assert.Equal(expected, ControlPaint.LightLight(baseColor));
         }
+
+        public static IEnumerable<object[]> ControlPaint_GetRequiredColor_ReturnsExpected_Data()
+        {
+            List<Color> colors = new();
+            foreach (KnownColor knownColor in Enum.GetValues(typeof(KnownColor)))
+            {
+                colors.Add(Color.FromKnownColor((KnownColor)knownColor));
+            }
+
+            foreach (var color1 in colors)
+            {
+                foreach (var color2 in colors)
+                {
+                    yield return new object[] { color1, color2 };
+                }
+            }
+        }
+
+        [WinFormsTheory(Skip = "Designed for manual run")]
+        [MemberData(nameof(ControlPaint_GetRequiredColor_ReturnsExpected_Data))]
+        public void ControlPaint_GetRequiredColor_ReturnsExpected(Color color1, Color color2)
+        {
+            Color сolor = ControlPaint.GetRequiredColor(color1, color2);
+            double contrast = ControlPaint.GetColorContrastRatio(сolor, color2);
+
+            Assert.True(contrast >= 3);
+        }
     }
 }


### PR DESCRIPTION
Fixes #6187

## Proposed changes
- The issue is reproducible because in the original fix we were drawing a rectangle over the border of the button. Unfortunately, Windows 11 uses standard buttons with rounded edges, so the previous fix is not suitable.

- As a fix, logic was added that changes the color of the border using "CompatibleDC". This saves us from having to draw different borders for Windows 10 and Windows 11. In addition, we do not have special methods for drawing a rectangle with rounded edges. 
 
- Added a special `GetRequiredColor` method for working with contrast and getting the required contrast ratio by darkening or lightening the color (documentation: [contrast ratio](https://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef), [relative luminance](https://www.w3.org/TR/WCAG20/#relativeluminancedef))


## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/142198977-e399adbc-bc2d-4087-a0e5-6a15761d6e93.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/142198937-ce14f3f9-83a1-41c7-86e3-11f014442075.png)


## Regression? 
- Yes (from #6059)

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manual testing 
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.22000.318]
- .NET Core SDK: 7.0.0-alpha.1.21562.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6194)