### PR TITLE
Fixing scaling issue on explicitly set Font containers but Inherit AutoScaleMode

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -347,6 +347,11 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        /// Gets or sets whether the container needs to be scaled when <see cref="DpiChangedEventHandler" />, irrespective whether the font was inherited or set explicitly.
+        /// </summary>
+        internal bool IsDpiChangeScalingRequired { get; set; }
+
+        /// <summary>
         ///  Indicates the form that the scrollable control is assigned to. This property is read-only.
         /// </summary>
         [SRCategory(nameof(SR.CatAppearance))]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2099,48 +2099,7 @@ namespace System.Windows.Forms
             [param: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(ActiveXFontMarshaler))]
             set
             {
-                Font local = (Font)Properties.GetObject(s_fontProperty);
-                bool localChanged = false;
-                if (value is null)
-                {
-                    if (local is not null)
-                    {
-                        localChanged = true;
-                    }
-                }
-                else
-                {
-                    if (local is null)
-                    {
-                        localChanged = true;
-                    }
-                    else
-                    {
-                        localChanged = !value.Equals(local);
-                    }
-                }
-
-                if (localChanged)
-                {
-                    // Store new local value
-                    Properties.SetObject(s_fontProperty, value);
-
-                    // Cleanup any font handle wrapper...
-                    DisposeFontHandle();
-
-                    if (Properties.ContainsInteger(s_fontHeightProperty))
-                    {
-                        Properties.SetInteger(s_fontHeightProperty, (value is null) ? -1 : value.Height);
-                    }
-
-                    // Font is an ambient property.  We need to layout our parent because Font may
-                    // change our size.  We need to layout ourselves because our children may change
-                    // size by inheriting the new value.
-                    using (new LayoutTransaction(ParentInternal, this, PropertyNames.Font))
-                    {
-                        OnFontChanged(EventArgs.Empty);
-                    }
-                }
+                SetFont(value);
             }
         }
 
@@ -7476,9 +7435,23 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual void OnParentFontChanged(EventArgs e)
         {
-            if (!IsFontSet())
+            // Container controls that were marked IsDpiChangeScalingRequired had to go through OnFontChanged event
+            // Irrespective of the Font status (explicit set or inherit Font). See "WmDpiChangedBeforeParent" for more info.
+            var container = this as ContainerControl;
+
+            try
             {
-                OnFontChanged(e);
+                if (!IsFontSet() || (container is not null && container.IsDpiChangeScalingRequired))
+                {
+                    OnFontChanged(e);
+                }
+            }
+            finally
+            {
+                if (container is not null)
+                {
+                    container.IsDpiChangeScalingRequired = false;
+                }
             }
         }
 
@@ -11417,6 +11390,57 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        /// Sets the new font value with the option to control whether <see cref="OnFontChanged(EventArgs)"/> event is raised.
+        /// </summary>
+        /// <param name="font">The <see cref="Font"/> value to be set.</param>
+        /// <param name="raiseOnFontChangedEvent">Indicates whether to raise <see cref="OnFontChanged(EventArgs)"/> event.</param>
+        private void SetFont(Font font, bool raiseOnFontChangedEvent = true)
+        {
+            var local = (Font)Properties.GetObject(s_fontProperty);
+            bool localChanged = false;
+            if (font is null)
+            {
+                if (local is not null)
+                {
+                    localChanged = true;
+                }
+            }
+            else
+            {
+                localChanged = local is null ? true : !font.Equals(local);
+            }
+
+            if (localChanged)
+            {
+                // Store new local value
+                Properties.SetObject(s_fontProperty, font);
+
+                // Cleanup any font handle wrapper...
+                DisposeFontHandle();
+
+                ScaledControlFont = font;
+
+                if (Properties.ContainsInteger(s_fontHeightProperty))
+                {
+                    Properties.SetInteger(s_fontHeightProperty, (font is null) ? -1 : font.Height);
+                }
+
+                if (!raiseOnFontChangedEvent)
+                {
+                    return;
+                }
+
+                // Font is an ambient property.  We need to layout our parent because Font may
+                // change our size.  We need to layout ourselves because our children may change
+                // size by inheriting the new value.
+                using (new LayoutTransaction(ParentInternal, this, PropertyNames.Font))
+                {
+                    OnFontChanged(EventArgs.Empty);
+                }
+            }
+        }
+
+        /// <summary>
         ///  Stops listening for the mouse leave event.
         /// </summary>
         private void UnhookMouseEvent()
@@ -12260,11 +12284,29 @@ namespace System.Windows.Forms
             // If it is a container control that inherit Font and is scaled by parent, we simply scale Font
             // and wait for OnFontChangedEvent caused by its parent. Otherwise, we scale Font and trigger
             // 'OnFontChanged' event explicitly. ex: winforms designer in VS.
-            if (TryGetExplicitlySetFont(out Font local) || this is not ContainerControl || !IsScaledByParent(this))
+            var container = this as ContainerControl;
+            if (TryGetExplicitlySetFont(out Font local) || container is null || !IsScaledByParent(this))
             {
                 if (local is not null)
                 {
-                    Font = ScaledControlFont;
+                    // Container controls with the font set explicitly have their fonts scaled according to the current dpi (i.e. set to ScaledFont).
+                    // For container control with  AutoscaleMode=Inherit we'd like to avoid raising OnFontChanged event that would trigger
+                    // PerformAutoscale with the parent's AutoscaleFactor. This is because the parent control is yet to receive DpiChanged event
+                    // and, thus, neither scaled nor updated its AutoscaleFactor value.
+                    // Mark the containers as required scaling, so they are scaled when their parents update AutoscaleFactor value and ready to scale.
+                    bool raiseOnFontChangedEvent = container is null || container.AutoScaleMode != AutoScaleMode.Inherit;
+                    SetFont(scaledFont, raiseOnFontChangedEvent);
+                }
+                else
+                {
+                    ScaledControlFont = scaledFont;
+                }
+
+                // Mark the container as needing to rescale when its parent is scaled.
+                // This flag is reset when scaling is done on Container in "OnParentFontChanged".
+                if (container is not null)
+                {
+                    container.IsDpiChangeScalingRequired = true;
                 }
 
                 RescaleConstantsForDpi(_oldDeviceDpi, _deviceDpi);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12295,11 +12295,7 @@ namespace System.Windows.Forms
                     // and, thus, neither scaled nor updated its AutoscaleFactor value.
                     // Mark the containers as required scaling, so they are scaled when their parents update AutoscaleFactor value and ready to scale.
                     bool raiseOnFontChangedEvent = container is null || container.AutoScaleMode != AutoScaleMode.Inherit;
-                    SetFont(scaledFont, raiseOnFontChangedEvent);
-                }
-                else
-                {
-                    ScaledControlFont = scaledFont;
+                    SetFont(ScaledControlFont, raiseOnFontChangedEvent);
                 }
 
                 // Mark the container as needing to rescale when its parent is scaled.


### PR DESCRIPTION
Fixes #6173


## Proposed changes

Container controls whose Font is explicitly set are not scaled well if they inherit `AutoScaleMode `from parent. Inherited `AutoScaleMode `containers use `AutoScaleFactor `from parents to scale themselves. However, in a `PerMonitorV2 `mode applications, parent receive the `DpiChangedEvent `after all their children receive it and scale themselves. `ContainerControls `that inherit scaling, will end up using `AutoScaleFactor `from parent that was not yet updated to the new Dpi as Parent yet to receive the DPI event. To fix this, we are tracking such containers with `IsDpiChangeScalingRequired `flag and scale them once the Parent `AutoScaleFactor ` is updated.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6198)