### PR TITLE
Set the font after we set the DPI scaling, as it affects how we scale the font

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilder.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilder.cs
@@ -29,13 +29,16 @@ namespace System.Windows.Forms.Generators
 
                 code.AppendLine($"{indent}Application.SetCompatibleTextRenderingDefault({projectConfig.UseCompatibleTextRendering.ToString().ToLowerInvariant()});");
 
+                code.AppendLine($"{indent}Application.SetHighDpiMode(HighDpiMode.{projectConfig.HighDpiMode});");
+
+                // Note: we need to set the font _after_ we set the DPI scaling, as it affects how we scale the font.
                 if (!string.IsNullOrWhiteSpace(defaultFont))
                 {
                     code.AppendLine($"{indent}Application.SetDefaultFont({defaultFont});");
                 }
 
                 // Don't append line as we don't need the trailing \r\n!
-                code.Append($"{indent}Application.SetHighDpiMode(HighDpiMode.{projectConfig.HighDpiMode});");
+                code.Remove(code.Length - Environment.NewLine.Length, Environment.NewLine.Length);
 
                 return code.ToString();
             }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=SansSerif.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=SansSerif.verified.txt
@@ -16,15 +16,15 @@ internal static partial class ApplicationConfiguration
     ///  <code>
     ///  Application.EnableVisualStyles();
     ///  Application.SetCompatibleTextRenderingDefault(true);
-    ///  Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)3));
     ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)3));
     /// </code>
     /// </summary>
     public static void Initialize()
     {
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(true);
-        Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)3));
         Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)3));
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=Tahoma.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=Tahoma.verified.txt
@@ -16,15 +16,15 @@ internal static partial class ApplicationConfiguration
     ///  <code>
     ///  Application.EnableVisualStyles();
     ///  Application.SetCompatibleTextRenderingDefault(true);
-    ///  Application.SetDefaultFont(new Font(new FontFamily("Tahoma"), 12f, (FontStyle)0, (GraphicsUnit)3));
     ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  Application.SetDefaultFont(new Font(new FontFamily("Tahoma"), 12f, (FontStyle)0, (GraphicsUnit)3));
     /// </code>
     /// </summary>
     public static void Initialize()
     {
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(true);
-        Application.SetDefaultFont(new Font(new FontFamily("Tahoma"), 12f, (FontStyle)0, (GraphicsUnit)3));
         Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        Application.SetDefaultFont(new Font(new FontFamily("Tahoma"), 12f, (FontStyle)0, (GraphicsUnit)3));
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=default.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=default.verified.txt
@@ -16,15 +16,15 @@ internal static partial class ApplicationConfiguration
     ///  <code>
     ///  Application.EnableVisualStyles();
     ///  Application.SetCompatibleTextRenderingDefault(true);
-    ///  Application.SetDefaultFont(new Font(Control.DefaultFont.FontFamily, 12f, (FontStyle)3, (GraphicsUnit)6));
     ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  Application.SetDefaultFont(new Font(Control.DefaultFont.FontFamily, 12f, (FontStyle)3, (GraphicsUnit)6));
     /// </code>
     /// </summary>
     public static void Initialize()
     {
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(true);
-        Application.SetDefaultFont(new Font(Control.DefaultFont.FontFamily, 12f, (FontStyle)3, (GraphicsUnit)6));
         Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        Application.SetDefaultFont(new Font(Control.DefaultFont.FontFamily, 12f, (FontStyle)3, (GraphicsUnit)6));
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_user_settings_boilerplate.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_user_settings_boilerplate.cs
@@ -17,16 +17,16 @@ namespace MyProject
         ///  <code>
         ///  Application.EnableVisualStyles();
         ///  Application.SetCompatibleTextRenderingDefault(true);
-        ///  Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
         ///  Application.SetHighDpiMode(HighDpiMode.DpiUnawareGdiScaled);
+        ///  Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
         /// </code>
         /// </summary>
         public static void Initialize()
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(true);
-            Application.{|CS0117:SetDefaultFont|}(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
             Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.DpiUnawareGdiScaled);
+            Application.{|CS0117:SetDefaultFont|}(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
         }
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_user_top_level.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_user_top_level.cs
@@ -16,15 +16,15 @@ internal static partial class ApplicationConfiguration
     ///  <code>
     ///  Application.EnableVisualStyles();
     ///  Application.SetCompatibleTextRenderingDefault(true);
-    ///  Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
     ///  Application.SetHighDpiMode(HighDpiMode.DpiUnawareGdiScaled);
+    ///  Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
     /// </code>
     /// </summary>
     public static void Initialize()
     {
         Application.EnableVisualStyles();
         Application.SetCompatibleTextRenderingDefault(true);
-        Application.{|CS0117:SetDefaultFont|}(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
         Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.DpiUnawareGdiScaled);
+        Application.{|CS0117:SetDefaultFont|}(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
     }
 }


### PR DESCRIPTION


Resolves #6191

<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

-  Set the font after we set the DPI scaling, as it affects how we scale the font.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customer using DPI scaling can use the new [application bootstrap functionality](https://aka.ms/applicationconfiguration) introduced in .NET 6.0.

## Regression? 

- No

## Risk

- Minimal


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6202)