### PR TITLE
Removing Windows 8.1 Permonitor mode support.

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms.Primitives/src/PublicAPI.Shipped.txt
@@ -56,9 +56,8 @@ System.Windows.Forms.FileDialogCustomPlacesCollection.Add(System.Guid knownFolde
 System.Windows.Forms.FileDialogCustomPlacesCollection.FileDialogCustomPlacesCollection() -> void
 System.Windows.Forms.HighDpiMode
 System.Windows.Forms.HighDpiMode.DpiUnaware = 0 -> System.Windows.Forms.HighDpiMode
-System.Windows.Forms.HighDpiMode.DpiUnawareGdiScaled = 4 -> System.Windows.Forms.HighDpiMode
-System.Windows.Forms.HighDpiMode.PerMonitor = 2 -> System.Windows.Forms.HighDpiMode
-System.Windows.Forms.HighDpiMode.PerMonitorV2 = 3 -> System.Windows.Forms.HighDpiMode
+System.Windows.Forms.HighDpiMode.DpiUnawareGdiScaled = 3 -> System.Windows.Forms.HighDpiMode
+System.Windows.Forms.HighDpiMode.PerMonitorV2 = 2 -> System.Windows.Forms.HighDpiMode
 System.Windows.Forms.HighDpiMode.SystemAware = 1 -> System.Windows.Forms.HighDpiMode
 System.Windows.Forms.Message
 System.Windows.Forms.Message.GetLParam(System.Type! cls) -> object?

--- a/src/System.Windows.Forms.Primitives/src/Resources/SR.resx
+++ b/src/System.Windows.Forms.Primitives/src/Resources/SR.resx
@@ -129,4 +129,7 @@
   <data name="General_MissingService" xml:space="preserve">
     <value>The service '{0}' must be installed for this feature to work.  Ensure that this service is available.</value>
   </data>
+  <data name="PermonitorModeNotSupported" xml:space="preserve">
+    <value>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Pro využití této funkce musí být nainstalovaná služba {0}. Zkontrolujte, jestli je tato služba dostupná.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Nejméně jedna položka není platná v parametru IDictionary. Ověřte, zda všechny hodnoty odpovídají vlastnostem objektu.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Der Dienst "{0}" muss installiert sein, damit diese Funktion funktioniert. Stellen Sie sicher, dass der Dienst verfügbar ist.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Mindestens ein Eintrag im IDictionary-Parameter ist ungültig. Stellen Sie sicher, dass alle Werte den Eigenschaften des Objekts entsprechen.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Debe instalar el servicio "{0}" para que esta funcionalidad funcione. Asegúrese de que este servicio está disponible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Una o más entradas no son válidas en el parámetro IDictionary. Compruebe que todos los valores coinciden con las propiedades del objeto.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Le service '{0}' doit être installé afin que cette fonctionnalité soit activée. Assurez-vous que ce service est disponible.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Le paramètre IDictionary contient au moins une entrée non valide. Vérifiez que toutes les valeurs correspondent aux propriétés de l'objet.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Per poter usare questa funzionalità, è necessario aver installato il servizio '{0}'. Verificare che il servizio sia disponibile.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Una o più voci non valide nel parametro IDictionary. Verificare che tutti i valori corrispondano alle proprietà dell'oggetto.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">この機能が動作するためにはサービス '{0}' をインストールする必要があります。サービスが利用可能であることを確認してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">1 つ以上の有効ではないエントリが IDictionary パラメーターにあります。すべての値がオブジェクトのプロパティに一致していることを確認してください。</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">이 기능을 제대로 사용하려면 '{0}' 서비스가 설치되어 있어야 합니다.  이 서비스를 사용할 수 있는지 확인하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">IDictionary 매개 변수에 잘못된 항목이 하나 이상 있습니다. 모든 값이 개체의 속성과 일치하는지 확인하십시오.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Usługa „{0}” musi być zainstalowana, aby ta funkcja działała. Sprawdź dostępność usługi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Jeden lub kilka wpisów jest nieprawidłowych w parametrze IDictionary. Sprawdź, czy wszystkie wartości pasują do właściwości obiektu.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">O serviço '{0}' deve estar instalado para que este recurso funcione. Verifique se esse serviço está disponível.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Uma ou mais entradas não são válidas no parâmetro IDictionary. Verifique se todos os valores correspondem às propriedades do objeto.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Для работы этой возможности должна быть установлена служба "{0}". Убедитесь, что эта служба доступна.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">Недействительны одна или больше записей в параметре IDictionary. Проверьте, все ли значения соответствуют свойствам этого объекта.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Bu özelliğin çalışması için '{0}' hizmetinin yüklenmesi gerekiyor. Bu hizmetin kullanılabildiğinden emin olun.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">IDictionary parametresindeki bir veya daha fazla girdi geçerli değil. Tüm değerlerin nesnenin özellikleriyle eşleştiğini doğrulayın.</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">要使此功能工作，必须安装服务“{0}”。 请确保此服务可用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">在 IDictionary 参数中有一个或多个无效项。请验证所有值均与对象的属性匹配。</target>

--- a/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms.Primitives/src/Resources/xlf/SR.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">必須安裝服務 '{0}'，才能讓這項功能運作。請確定這項服務可供使用。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PermonitorModeNotSupported">
+        <source>Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</source>
+        <target state="new">Winforms applications do not support Permonitor mode. Use PermonitorV2 mode instead, on Windows 10 or latest OS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropertyValueInvalidEntry">
         <source>One or more entries are not valid in the IDictionary parameter. Verify that all values match up to the object's properties.</source>
         <target state="translated">IDictionary 參數中有一或多個無效的項目。請確認所有值都符合物件的屬性。</target>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/HighDpiMode.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/HighDpiMode.cs
@@ -39,11 +39,6 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The window checks for DPI when it's created and adjusts scale factor when the DPI changes.
         /// </summary>
-        PerMonitor,
-
-        /// <summary>
-        ///  Similar to <see cref="PerMonitor"/>, but enables child window DPI change notification, improved scaling of comctl32 controls and dialog scaling.
-        /// </summary>
         PerMonitorV2,
 
         /// <summary>

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Windows.Forms.Primitives.Resources;
 using Microsoft.Win32;
 using static Interop;
 
@@ -389,11 +390,6 @@ namespace System.Windows.Forms
                     return HighDpiMode.PerMonitorV2;
                 }
 
-                if (User32.AreDpiAwarenessContextsEqual(dpiAwareness, User32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE))
-                {
-                    return HighDpiMode.PerMonitor;
-                }
-
                 if (User32.AreDpiAwarenessContextsEqual(dpiAwareness, User32.DPI_AWARENESS_CONTEXT.UNAWARE_GDISCALED))
                 {
                     return HighDpiMode.DpiUnawareGdiScaled;
@@ -409,7 +405,7 @@ namespace System.Windows.Forms
                     case SHCore.PROCESS_DPI_AWARENESS.SYSTEM_AWARE:
                         return HighDpiMode.SystemAware;
                     case SHCore.PROCESS_DPI_AWARENESS.PER_MONITOR_AWARE:
-                        return HighDpiMode.PerMonitor;
+                        throw new InvalidOperationException(SR.PermonitorModeNotSupported);
                 }
             }
             else
@@ -438,9 +434,6 @@ namespace System.Windows.Forms
                 {
                     case HighDpiMode.SystemAware:
                         rs2AndAboveDpiFlag = User32.DPI_AWARENESS_CONTEXT.SYSTEM_AWARE;
-                        break;
-                    case HighDpiMode.PerMonitor:
-                        rs2AndAboveDpiFlag = User32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE;
                         break;
                     case HighDpiMode.PerMonitorV2:
                         // Necessary for RS1, since this SetProcessIntPtr IS available here.
@@ -474,7 +467,6 @@ namespace System.Windows.Forms
                     case HighDpiMode.SystemAware:
                         dpiFlag = SHCore.PROCESS_DPI_AWARENESS.SYSTEM_AWARE;
                         break;
-                    case HighDpiMode.PerMonitor:
                     case HighDpiMode.PerMonitorV2:
                         dpiFlag = SHCore.PROCESS_DPI_AWARENESS.PER_MONITOR_AWARE;
                         break;
@@ -496,7 +488,6 @@ namespace System.Windows.Forms
                         // We can return, there is nothing to set if we assume we're already in DpiUnaware.
                         return true;
                     case HighDpiMode.SystemAware:
-                    case HighDpiMode.PerMonitor:
                     case HighDpiMode.PerMonitorV2:
                         dpiFlag = SHCore.PROCESS_DPI_AWARENESS.SYSTEM_AWARE;
                         break;


### PR DESCRIPTION
Permonitor mode was introduced in Windows 8.1 and was upgraded to PermonitorV2 mode in Windows 10. WinForms in .NET never fully supported this mode and given that Windows 8.1 is out of support, its time to remove this reference and
keep it clean with PermonitorV2 mode for Windows 10 and latest OSes.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6212)