### PR TITLE
Fixing DPiAwarenessContext cache value for the controls in mixed Dpi mode applications.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -385,6 +385,7 @@ namespace System.Windows.Forms
             // Initialize Dpi to the value on the primary screen, we will have the correct value when the Handle is created.
             _deviceDpi = _oldDeviceDpi = DpiHelper.DeviceDpi;
             _window = new ControlNativeWindow(this);
+            DpiAwarenessContext = _window.DpiAwarenessContext;
             RequiredScalingEnabled = true;
             RequiredScaling = BoundsSpecified.All;
             _tabIndex = -1;
@@ -482,7 +483,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Gets control Dpi awareness context value.
         /// </summary>
-        internal IntPtr DpiAwarenessContext => _window.DpiAwarenessContext;
+        internal readonly IntPtr DpiAwarenessContext;
 
         /// <summary>
         ///  The Accessibility Object for this Control

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -69,12 +69,15 @@ namespace System.Windows.Forms
         public NativeWindow()
         {
             _weakThisPtr = new WeakReference(this);
+
+            // Set DpiAwarenessContext of the control. Control handle will be created with this DpiAwarenessContext.
+            DpiAwarenessContext = User32.GetThreadDpiAwarenessContext();
         }
 
         /// <summary>
         /// Cache window DpiContext awareness information that helps to create handle with right context at the later time.
         /// </summary>
-        internal IntPtr DpiAwarenessContext { get; } = User32.GetThreadDpiAwarenessContext();
+        internal readonly IntPtr DpiAwarenessContext;
 
         /// <summary>
         ///  Override's the base object's finalize method.


### PR DESCRIPTION
Currently, we are evaluating the `DpiAwarenessContext `on the fly thus could result in incorrect
evaluation if the application is running in a mixed Dpi mode and we call this property from a wrong thread.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6223)