### PR TITLE
Implement new readobly (getter only) property of ErrorProvider.HasErrors

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -8071,6 +8071,7 @@ System.Windows.Forms.ErrorProvider.BlinkStyle.get -> System.Windows.Forms.ErrorB
 System.Windows.Forms.ErrorProvider.BlinkStyle.set -> void
 System.Windows.Forms.ErrorProvider.Clear() -> void
 System.Windows.Forms.ErrorProvider.ErrorProvider() -> void
+System.Windows.Forms.ErrorProvider.HasErrors.get -> bool
 System.Windows.Forms.ErrorProvider.RightToLeftChanged -> System.EventHandler
 System.Windows.Forms.ErrorProvider.UpdateBinding() -> void
 System.Windows.Forms.FeatureSupport

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.cs
@@ -804,5 +804,16 @@ namespace System.Windows.Forms
         }
 
         private bool ShouldSerializeIcon() => Icon != DefaultIcon;
+
+        /// <summary>
+        /// Determine if the controls that are linked to this ErrorProvider currently have errors.
+        /// </summary>
+        public bool HasErrors
+        {
+            get
+            {
+                return _items.Count > 0;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5912 


## Proposed changes

- No change, it is a new readonly property to check controls in an ErrorProvider are having errors set (true) or not
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- 
- 

## Regression? 

- No

## Risk

- Should be none, because it is not a breaking change

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->
