### PR TITLE
Fixing Color contrast for DataGridViewLinkCell when it is selected

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
@@ -183,7 +183,7 @@ namespace System.Windows.Forms
                 else
                 {
                     // return the default IE Color when cell is not selected
-                    return Selected ? Color.White : LinkUtilities.IELinkColor;
+                    return Selected ? SystemColors.HighlightText : LinkUtilities.IELinkColor;
                 }
             }
             set


### PR DESCRIPTION
Fixes #3883   


## Proposed changes

- Color of the link in the selected cell changed to HighlightText (white as default value)


## Regression? 

- No

## Risk

- Minimal

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
The link is scarcely visible
![image](https://user-images.githubusercontent.com/74228865/139059980-891da197-23ea-43cd-a960-f0f3416ab0a6.png)

### After
The link is clearly visible
![Issue3883](https://user-images.githubusercontent.com/74228865/139060057-0e983534-b8ea-44b6-a7eb-986ec5d0d2fb.gif)

## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- CTI

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19042.1237]
- .NET 6.0.100-rc.2.21505.57
- 
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6237)