### PR TITLE
Fixing missing ControlBox buttons at maximized MDI child window for UIA

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.ToolStripAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.ToolStripAccessibleObject.cs
@@ -183,11 +183,20 @@ namespace System.Windows.Forms
                     }
                 }
 
-                items = _owningToolStrip.Items;
-
-                if (fragmentIndex < items.Count)
+                List<ToolStripItem> orderedItems = new();
+                for (int i = 0, current = 0; i < _owningToolStrip.Items.Count; i++)
                 {
-                    ToolStripItem item = items[fragmentIndex];
+                    ToolStripItem item = _owningToolStrip.Items[i];
+                    orderedItems.Insert(current, item);
+                    if (item.Alignment == ToolStripItemAlignment.Left)
+                    {
+                        current++;
+                    }
+                }
+
+                if (fragmentIndex < orderedItems.Count)
+                {
+                    ToolStripItem item = orderedItems[fragmentIndex];
                     if (item.Available && item.Alignment == ToolStripItemAlignment.Right)
                     {
                         return GetItemAccessibleObject(item);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel;
 using System.Drawing;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -189,6 +190,96 @@ namespace System.Windows.Forms.Tests
             {
                 Assert.NotNull(item.Image);
             }
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void MdiControlStrip_MaximizedChildWindow_NextSibling_ReturnsControlBoxButtonsAsExpected(RightToLeft rightToLeft)
+        {
+            using ToolStripMenuItem toolStripMenuItem1 = new() { Text = "&Test1" };
+            using ToolStripMenuItem toolStripMenuItem2 = new() { Text = "&Test2" };
+            using MenuStrip menuStrip = new() { RightToLeft = rightToLeft };
+            menuStrip.Items.AddRange(new ToolStripItem[] { toolStripMenuItem1, toolStripMenuItem2 });
+            using Form mdiParent = new()
+            {
+                IsMdiContainer = true,
+                MainMenuStrip = menuStrip
+            };
+
+            mdiParent.Controls.Add(menuStrip);
+            using Form mdiChild = new()
+            {
+                MdiParent = mdiParent,
+                WindowState = FormWindowState.Maximized
+            };
+
+            mdiParent.Show();
+            mdiChild.Show();
+            AccessibleObject accessibleObject = mdiParent.MainMenuStrip.AccessibilityObject;
+            ToolStripItem.ToolStripItemAccessibleObject systemItem = (ToolStripItem.ToolStripItemAccessibleObject)accessibleObject.TestAccessor().Dynamic.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
+            ToolStripItem.ToolStripItemAccessibleObject test1Item = (ToolStripItem.ToolStripItemAccessibleObject)systemItem.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            ToolStripItem.ToolStripItemAccessibleObject test2Item = (ToolStripItem.ToolStripItemAccessibleObject)test1Item.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            ToolStripItem.ToolStripItemAccessibleObject minimizeItem = (ToolStripItem.ToolStripItemAccessibleObject)test2Item.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            ToolStripItem.ToolStripItemAccessibleObject restoreItem = (ToolStripItem.ToolStripItemAccessibleObject)minimizeItem.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            ToolStripItem.ToolStripItemAccessibleObject closeItem = (ToolStripItem.ToolStripItemAccessibleObject)restoreItem.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+            ToolStripItem.ToolStripItemAccessibleObject nullItem = (ToolStripItem.ToolStripItemAccessibleObject)closeItem.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
+
+            Assert.Equal("System", systemItem.Name);
+            Assert.Equal("Test1", test1Item.Name);
+            Assert.Equal("Test2", test2Item.Name);
+            Assert.Equal("Minimize", minimizeItem.Name);
+            Assert.Equal("Restore", restoreItem.Name);
+            Assert.Equal("Close", closeItem.Name);
+            Assert.Null(nullItem);
+            Assert.True(mdiChild.IsHandleCreated);
+            Assert.True(mdiParent.IsHandleCreated);
+            Assert.True(menuStrip.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void MdiControlStrip_MaximizedChildWindow_PreviousSibling_ReturnsControlBoxButtonsAsExpected(RightToLeft rightToLeft)
+        {
+            using ToolStripMenuItem toolStripMenuItem1 = new() { Text = "&Test1" };
+            using ToolStripMenuItem toolStripMenuItem2 = new() { Text = "&Test2" };
+            using MenuStrip menuStrip = new() { RightToLeft = rightToLeft };
+            menuStrip.Items.AddRange(new ToolStripItem[] { toolStripMenuItem1, toolStripMenuItem2 });
+            using Form mdiParent = new()
+            {
+                IsMdiContainer = true,
+                MainMenuStrip = menuStrip
+            };
+
+            mdiParent.Controls.Add(menuStrip);
+            using Form mdiChild = new()
+            {
+                MdiParent = mdiParent,
+                WindowState = FormWindowState.Maximized
+            };
+
+            mdiParent.Show();
+            mdiChild.Show();
+            AccessibleObject accessibleObject = mdiParent.MainMenuStrip.AccessibilityObject;
+            ToolStripItem.ToolStripItemAccessibleObject closeItem = (ToolStripItem.ToolStripItemAccessibleObject)accessibleObject.TestAccessor().Dynamic.FragmentNavigate(UiaCore.NavigateDirection.LastChild);
+            ToolStripItem.ToolStripItemAccessibleObject restoreItem = (ToolStripItem.ToolStripItemAccessibleObject)closeItem.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+            ToolStripItem.ToolStripItemAccessibleObject minimizeItem = (ToolStripItem.ToolStripItemAccessibleObject)restoreItem.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+            ToolStripItem.ToolStripItemAccessibleObject test2Item = (ToolStripItem.ToolStripItemAccessibleObject)minimizeItem.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+            ToolStripItem.ToolStripItemAccessibleObject test1Item = (ToolStripItem.ToolStripItemAccessibleObject)test2Item.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+            ToolStripItem.ToolStripItemAccessibleObject systemItem = (ToolStripItem.ToolStripItemAccessibleObject)test1Item.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+            ToolStripItem.ToolStripItemAccessibleObject nullItem = (ToolStripItem.ToolStripItemAccessibleObject)systemItem.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
+
+            Assert.Equal("Close", closeItem.Name);
+            Assert.Equal("Restore", restoreItem.Name);
+            Assert.Equal("Minimize", minimizeItem.Name);
+            Assert.Equal("Test2", test2Item.Name);
+            Assert.Equal("Test1", test1Item.Name);
+            Assert.Equal("System", systemItem.Name);
+            Assert.Null(nullItem);
+            Assert.True(mdiChild.IsHandleCreated);
+            Assert.True(mdiParent.IsHandleCreated);
+            Assert.True(menuStrip.IsHandleCreated);
         }
 
         private class SubMdiControlStrip : MdiControlStrip


### PR DESCRIPTION
Fixes #6231

## Proposed changes
- `MdiControlStrip` is the class that implements merged `MenuStrip` when an MDI child is maximized and the `MainMenuStrip` property of the `Form` is set. 
- `MdiControlStrip` has three `ControlBoxMenuItems` with `Alignment` property set to `Right`: `_minimize`, `_restore` and `_close`.
- The item collection of `MdiControlStrip` after merging will look like this:
![image](https://user-images.githubusercontent.com/87859299/143578415-d8fc2e1c-587d-4915-9c5d-1c678655455c.png)
for this menu bar:
![image](https://user-images.githubusercontent.com/87859299/143578222-0332ce32-0914-42c4-8ee8-d8ebbab7ec77.png)
- That's okay for the `MenuStrip` rendering because the right-aligned items will be placed on the right side correctly, but not okay for the `ToolStripAccessibleObject`, which picks the item by its sequential `fragmentIndex` at the `GetChildFragment` method. 
- To fix this issue we need to re-order the local item collection at `GetChildFragment` to make it consistent with the visual layout.

## Customer Impact
**Before the fix**
- 
![image](https://user-images.githubusercontent.com/87859299/143578778-cb1f0714-6db5-4285-98e7-7a5b69f3c9c3.png)
- 
![image](https://user-images.githubusercontent.com/87859299/143578816-16d3171c-9f09-4e09-b93b-099ba5d51d17.png)

**After the fix**
- 
![image](https://user-images.githubusercontent.com/87859299/143579107-fa352ab1-ac12-4d77-86eb-d94cca5034eb.png)
- 
![image](https://user-images.githubusercontent.com/87859299/143579188-19403a1b-eefb-40f1-9ae3-d254e459cf21.png) 

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests
- CTI team
- Manual testing:
1. The case when parent MDI form has 6 MenuStrip items (see the screenshots at the `After the fix` section)
2. The case when parent MDI form has 6 MenuStrip items and child MDI form has 2 MenuStrip items:
![image](https://user-images.githubusercontent.com/87859299/143579959-e486a9e6-e97d-4393-82bb-6e826545f22d.png)
3. The case when child MDI form has 2 MenuStrip items:
![image](https://user-images.githubusercontent.com/87859299/143580161-02ce2553-5b0d-4e97-9f1c-ed4ddb6437fb.png)
4. The case when both parent and child MDI forms have no MenuStrip items at all:
![image](https://user-images.githubusercontent.com/87859299/143580367-1c279c02-91a9-45ed-89b4-d6986303effa.png)
5. The case when the `RightToLeft` mode is set to `Yes` for parent MDI form (at the Accessibility Insights tool it look the same as for `RightToLeft` turned off because when the `RightToLeft` is on the first item is still the `System` item, then `Test1`, `Test2`, etc.):
![image](https://user-images.githubusercontent.com/87859299/143581858-88611b82-a652-40c3-9433-6920ebf59218.png)
6. The case when child MDI form isn't maximized - the code from the fix won't even be called because the item will be returned by the code above, and Accessibility Insights will show correct menu bars both for parent and child MDI forms.

## Accessibility testing
- Accessibility Insights
- Inspect

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19043.1348]
- .Net SDK 7.0.100-alpha.1.21526.13

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6239)