### PR TITLE
Add missing feasible file and folder dialog options

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,27 @@
+System.Windows.Forms.FileDialog.AddToRecent.get -> bool
+System.Windows.Forms.FileDialog.AddToRecent.set -> void
+System.Windows.Forms.FileDialog.OkRequiresInteraction.get -> bool
+System.Windows.Forms.FileDialog.OkRequiresInteraction.set -> void
+System.Windows.Forms.FileDialog.ShowHiddenFiles.get -> bool
+System.Windows.Forms.FileDialog.ShowHiddenFiles.set -> void
+System.Windows.Forms.FileDialog.ShowPinnedPlaces.get -> bool
+System.Windows.Forms.FileDialog.ShowPinnedPlaces.set -> void
+System.Windows.Forms.FolderBrowserDialog.AddToRecent.get -> bool
+System.Windows.Forms.FolderBrowserDialog.AddToRecent.set -> void
+System.Windows.Forms.FolderBrowserDialog.OkRequiresInteraction.get -> bool
+System.Windows.Forms.FolderBrowserDialog.OkRequiresInteraction.set -> void
+System.Windows.Forms.FolderBrowserDialog.ShowHiddenFiles.get -> bool
+System.Windows.Forms.FolderBrowserDialog.ShowHiddenFiles.set -> void
+System.Windows.Forms.FolderBrowserDialog.ShowPinnedPlaces.get -> bool
+System.Windows.Forms.FolderBrowserDialog.ShowPinnedPlaces.set -> void
+System.Windows.Forms.OpenFileDialog.SelectReadOnly.get -> bool
+System.Windows.Forms.OpenFileDialog.SelectReadOnly.set -> void
+System.Windows.Forms.OpenFileDialog.ShowPreview.get -> bool
+System.Windows.Forms.OpenFileDialog.ShowPreview.set -> void
+System.Windows.Forms.SaveFileDialog.CheckWriteAccess.get -> bool
+System.Windows.Forms.SaveFileDialog.CheckWriteAccess.set -> void
+System.Windows.Forms.SaveFileDialog.ExpandedMode.get -> bool
+System.Windows.Forms.SaveFileDialog.ExpandedMode.set -> void
 ~override System.Windows.Forms.Panel.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 *REMOVED*override System.Windows.Forms.MonthCalendar.Dispose(bool disposing) -> void
 ~override System.Windows.Forms.ContainerControl.OnResize(System.EventArgs e) -> void

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6862,10 +6862,10 @@ Stack trace where the illegal operation occurred was:
   <data name="CategoryPropertyGridLocalizedControlType" xml:space="preserve">
     <value>PropertyGrid category</value>
   </data>
-  <data name="FDaddToRecentDescr" xml:space="preserve">
+  <data name="FileDialogAddToRecentDescr" xml:space="preserve">
     <value>Controls whether to add the file being opened or saved to the recent list.</value>
   </data>
-  <data name="FDshowHiddenFilesDescr" xml:space="preserve">
+  <data name="FileDialogShowHiddenFilesDescr" xml:space="preserve">
     <value>Controls whether the dialog box displays hidden and system files.</value>
   </data>
   <data name="SaveFileDialogCheckWriteAccess" xml:space="preserve">
@@ -6874,16 +6874,16 @@ Stack trace where the illegal operation occurred was:
   <data name="SaveFileDialogExpandedMode" xml:space="preserve">
     <value>Controls whether the dialog box is always opened in the expanded mode.</value>
   </data>
-  <data name="FDokRequiresInteractionDescr" xml:space="preserve">
+  <data name="FileDialogOkRequiresInteractionDescr" xml:space="preserve">
     <value>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</value>
   </data>
-  <data name="OFDselectReadOnlyDescr" xml:space="preserve">
+  <data name="OpenFileDialogSelectReadOnlyDescr" xml:space="preserve">
     <value>Controls whether the dialog box allows to select read-only files.</value>
   </data>
-  <data name="FDshowPinnedPlacesDescr" xml:space="preserve">
+  <data name="FileDialogShowPinnedPlacesDescr" xml:space="preserve">
     <value>Controls whether the items shown by default in the view's navigation pane are shown.</value>
   </data>
-  <data name="OFDshowPreviewDescr" xml:space="preserve">
+  <data name="OpenFileDialogShowPreviewDescr" xml:space="preserve">
     <value>Controls whether the dialog box shows a preview for selected files.</value>
   </data>
   <data name="FolderBrowserDialogAddToRecent" xml:space="preserve">

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6862,4 +6862,40 @@ Stack trace where the illegal operation occurred was:
   <data name="CategoryPropertyGridLocalizedControlType" xml:space="preserve">
     <value>PropertyGrid category</value>
   </data>
+  <data name="FDaddToRecentDescr" xml:space="preserve">
+    <value>Controls whether to add the file being opened or saved to the recent list.</value>
+  </data>
+  <data name="FDshowHiddenFilesDescr" xml:space="preserve">
+    <value>Controls whether the dialog box displays hidden and system files.</value>
+  </data>
+  <data name="SaveFileDialogCheckWriteAccess" xml:space="preserve">
+    <value>Controls whether the dialog box verifies if the creation of the specified file will be successful.</value>
+  </data>
+  <data name="SaveFileDialogExpandedMode" xml:space="preserve">
+    <value>Controls whether the dialog box is always opened in the expanded mode.</value>
+  </data>
+  <data name="FDokRequiresInteractionDescr" xml:space="preserve">
+    <value>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</value>
+  </data>
+  <data name="OFDselectReadOnlyDescr" xml:space="preserve">
+    <value>Controls whether the dialog box allows to select read-only files.</value>
+  </data>
+  <data name="FDshowPinnedPlacesDescr" xml:space="preserve">
+    <value>Controls whether the items shown by default in the view's navigation pane are shown.</value>
+  </data>
+  <data name="OFDshowPreviewDescr" xml:space="preserve">
+    <value>Controls whether the dialog box shows a preview for selected files.</value>
+  </data>
+  <data name="FolderBrowserDialogAddToRecent" xml:space="preserve">
+    <value>Controls whether the dialog box adds the folder being selected to the recent list.</value>
+  </data>
+  <data name="FolderBrowserDialogOkRequiresInteraction" xml:space="preserve">
+    <value>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</value>
+  </data>
+  <data name="FolderBrowserDialogShowHiddenFiles" xml:space="preserve">
+    <value>Controls whether the dialog box displays hidden and system files.</value>
+  </data>
+  <data name="FolderBrowserDialogShowPinnedPlaces" xml:space="preserve">
+    <value>Controls whether the items shown by default in the view's navigation pane are shown.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -4871,11 +4871,6 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
         <target state="translated">Určuje, zda jsou k názvům souborů automaticky přidávány přípony.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Před návratem z tohoto dialogového okna zkontroluje, zda zadaný soubor existuje.</target>
@@ -4921,11 +4916,6 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
         <target state="translated">Počáteční adresář dialogového okna</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Určuje, zda dialogové okno před zavřením obnoví aktuální adresář.</target>
@@ -4934,16 +4924,6 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Povolí tlačítko Nápověda.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">Určuje, zda dialogové okno zajišťuje, že názvy souborů neobsahují neplatné znaky nebo posloupnosti.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Ověřte, zda byl zadán správný název souboru.</target>
         <target state="translated">Index filtru je neplatný.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">Soubor {0} již existuje.
 Chcete jej nahradit?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Stav zaškrtávacího políčka Jen pro čtení v dialogovém okně.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Určuje, zda má být v dialogovém okně zobrazeno zaškrtávací políčko Jen pro čtení.</target>
@@ -7404,6 +7394,16 @@ Trasování zásobníku, kde došlo k neplatné operaci:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">Položku {0} nelze přidat nebo vložit na více než jedno místo. Musíte ji nejprve odebrat z aktuálního umístění nebo vytvořit její klon.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -4871,6 +4871,11 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
         <target state="translated">Určuje, zda jsou k názvům souborů automaticky přidávány přípony.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Před návratem z tohoto dialogového okna zkontroluje, zda zadaný soubor existuje.</target>
@@ -4916,6 +4921,11 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
         <target state="translated">Počáteční adresář dialogového okna</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Určuje, zda dialogové okno před zavřením obnoví aktuální adresář.</target>
@@ -4924,6 +4934,16 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Povolí tlačítko Nápověda.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Chcete jej nahradit?</target>
         <target state="translated">Určuje, zda má být zobrazeno tlačítko Nápověda.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">Řetězec zobrazený v dialogovém okně nad ovládacím prvkem zobrazení stromu. V řetězci můžete uvést pokyny pro uživatele.</target>
@@ -5095,6 +5120,11 @@ Chcete jej nahradit?</target>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">Kořenovou složku nelze načíst.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Chcete jej nahradit?</target>
         <target state="translated">Cesta ke složce, která byla poprvé vybrána v dialogovém okně nebo naposledy označena uživatelem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">Vloží do dialogového okna tlačítko Nová složka.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Stav zaškrtávacího políčka Jen pro čtení v dialogovém okně.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Určuje, zda má být v dialogovém okně zobrazeno zaškrtávací políčko Jen pro čtení.</target>
@@ -8711,9 +8761,19 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">{1} – {0} – {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">Určuje, zda se při vytváření nového souboru zobrazí výzva uživateli. Použije se pouze v případě, že je vlastnost ValidateNames nastavena na hodnotu True.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -4871,11 +4871,6 @@ Wenn Sie auf "Weiter" klicken, ignoriert die Anwendung den Fehler und setzt den 
         <target state="translated">Steuert, ob Erweiterungen automatisch zu den Dateinamen hinzugefügt werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Überprüft, ob die angegebene Datei vorhanden ist, bevor vom Dialogfeld zurückgekehrt wird.</target>
@@ -4921,11 +4916,6 @@ Wenn Sie auf "Weiter" klicken, ignoriert die Anwendung den Fehler und setzt den 
         <target state="translated">Das anfängliche Verzeichnis für das Dialogfeld.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Steuert, ob das Dialogfeld das aktuelle Verzeichnis vor dem Schließen wiederherstellt.</target>
@@ -4934,16 +4924,6 @@ Wenn Sie auf "Weiter" klicken, ignoriert die Anwendung den Fehler und setzt den 
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Aktiviert die Schaltfläche "Hilfe".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ Wenn Sie auf "Weiter" klicken, ignoriert die Anwendung den Fehler und setzt den 
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">Steuert, ob das Dialogfeld sicherstellt, dass Dateinamen keine ungültigen Zeichen oder Sequenzen enthalten.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Verify that the correct file name was given.</source>
         <target state="translated">Ungültiger Filterindex.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">Die Datei {0} ist bereits vorhanden.
 Möchten Sie sie ersetzen?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Der Zustand des schreibgeschützten Kontrollkästchens im Dialogfeld.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Steuert, ob das schreibgeschützte Kontrollkästchen im Dialogfeld angezeigt wird.</target>
@@ -7404,6 +7394,16 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">Das Element {0} kann nur an einer Stelle hinzugefügt oder eingefügt werden. Entfernen Sie es von der aktuellen Position, oder klonen Sie es.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -4871,6 +4871,11 @@ Wenn Sie auf "Weiter" klicken, ignoriert die Anwendung den Fehler und setzt den 
         <target state="translated">Steuert, ob Erweiterungen automatisch zu den Dateinamen hinzugefügt werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Überprüft, ob die angegebene Datei vorhanden ist, bevor vom Dialogfeld zurückgekehrt wird.</target>
@@ -4916,6 +4921,11 @@ Wenn Sie auf "Weiter" klicken, ignoriert die Anwendung den Fehler und setzt den 
         <target state="translated">Das anfängliche Verzeichnis für das Dialogfeld.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Steuert, ob das Dialogfeld das aktuelle Verzeichnis vor dem Schließen wiederherstellt.</target>
@@ -4924,6 +4934,16 @@ Wenn Sie auf "Weiter" klicken, ignoriert die Anwendung den Fehler und setzt den 
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Aktiviert die Schaltfläche "Hilfe".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Möchten Sie sie ersetzen?</target>
         <target state="translated">Steuert, ob die Schaltfläche "Hilfe" angezeigt wird.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">Die Zeichenfolge, die im Dialogfeld über dem Strukturansicht-Steuerelement angezeigt wird. Sie kann zum Angeben von Benutzeranweisungen verwendet werden.</target>
@@ -5095,6 +5120,11 @@ Möchten Sie sie ersetzen?</target>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">Der Stammordner kann nicht abgerufen werden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Möchten Sie sie ersetzen?</target>
         <target state="translated">Der Pfad für den Ordner, der im Dialogfeld zuerst ausgewählt war oder vom Benutzer zuletzt gewählt wurde.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">Fügen Sie die Schaltfläche "Neuer Ordner" zum Dialogfeld hinzu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Der Zustand des schreibgeschützten Kontrollkästchens im Dialogfeld.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Steuert, ob das schreibgeschützte Kontrollkästchen im Dialogfeld angezeigt wird.</target>
@@ -8711,9 +8761,19 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">Steuert, ob der Benutzer zum Bestätigen aufgefordert wird, bevor eine neue Datei erstellt wird. Nur zutreffend, wenn ValidateNames auf "true" festgelegt ist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -4871,11 +4871,6 @@ Si hace clic en Continuar, la aplicación pasará por alto este error e intentar
         <target state="translated">Controla si las extensiones se agregan automáticamente a los nombres de archivo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Comprueba que el archivo especificado existe antes de volver del cuadro de diálogo.</target>
@@ -4921,11 +4916,6 @@ Si hace clic en Continuar, la aplicación pasará por alto este error e intentar
         <target state="translated">Directorio inicial del cuadro de diálogo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Controla si el cuadro de diálogo restaura el directorio actual antes de cerrar.</target>
@@ -4934,16 +4924,6 @@ Si hace clic en Continuar, la aplicación pasará por alto este error e intentar
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Habilita el botón Ayuda.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ Si hace clic en Continuar, la aplicación pasará por alto este error e intentar
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">Controla si el cuadro de diálogo comprueba que los nombres de archivo no contienen caracteres o secuencias no válidas.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Compruebe que ha proporcionado el nombre correcto del archivo.</target>
         <target state="translated">Índice de filtro no válido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">El archivo '{0}' ya existe.
 ¿Desea reemplazarlo?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Estado de la casilla de solo lectura en el cuadro de diálogo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Controla si se muestra la casilla de solo lectura en el cuadro de diálogo.</target>
@@ -7404,6 +7394,16 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">No se puede agregar o insertar el elemento '{0}' en más de un sitio. Debe quitarlo primero de su ubicación actual o clonarlo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -4871,6 +4871,11 @@ Si hace clic en Continuar, la aplicación pasará por alto este error e intentar
         <target state="translated">Controla si las extensiones se agregan automáticamente a los nombres de archivo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Comprueba que el archivo especificado existe antes de volver del cuadro de diálogo.</target>
@@ -4916,6 +4921,11 @@ Si hace clic en Continuar, la aplicación pasará por alto este error e intentar
         <target state="translated">Directorio inicial del cuadro de diálogo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Controla si el cuadro de diálogo restaura el directorio actual antes de cerrar.</target>
@@ -4924,6 +4934,16 @@ Si hace clic en Continuar, la aplicación pasará por alto este error e intentar
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Habilita el botón Ayuda.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Do you want to replace it?</source>
         <target state="translated">Controla si debe mostrar el botón Ayuda.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">Cadena que aparece encima del control de vista de árbol en el cuadro de diálogo. Esta cadena se utiliza para especificar instrucciones al usuario.</target>
@@ -5095,6 +5120,11 @@ Do you want to replace it?</source>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">No se puede recuperar la carpeta raíz.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Do you want to replace it?</source>
         <target state="translated">Ruta de acceso de la carpeta que primero se seleccionó en el cuadro de diálogo o la última que seleccionó el usuario.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">Incluir el botón Nueva carpeta en el cuadro de diálogo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Estado de la casilla de solo lectura en el cuadro de diálogo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Controla si se muestra la casilla de solo lectura en el cuadro de diálogo.</target>
@@ -8711,9 +8761,19 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">Controla si se debe avisar al usuario cuando se va a crear un nuevo archivo. Sólo es aplicable si 'ValidateNames' está establecida en true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -4871,11 +4871,6 @@ Si vous cliquez sur Continuer, l'application va ignorer cette erreur et tenter d
         <target state="translated">Contrôle si les extensions sont automatiquement ajoutées aux noms de fichiers.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Vérifie que le fichier spécifié existe avant le retour à partir de cette boîte de dialogue.</target>
@@ -4921,11 +4916,6 @@ Si vous cliquez sur Continuer, l'application va ignorer cette erreur et tenter d
         <target state="translated">Le répertoire d'origine pour cette boîte de dialogue.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Contrôle si la boîte de dialogue rétablit le répertoire actif avant de se fermer.</target>
@@ -4934,16 +4924,6 @@ Si vous cliquez sur Continuer, l'application va ignorer cette erreur et tenter d
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Active le bouton d'aide.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ Si vous cliquez sur Continuer, l'application va ignorer cette erreur et tenter d
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">Contrôle si la boîte de dialogue s'assure que les noms de fichiers ne contiennent pas de caractères ou de séquences non valides.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Vérifiez que le nom de fichier correct a été indiqué.</target>
         <target state="translated">Index de filtre non valide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">Le fichier {0} existe déjà.
 Voulez-vous le remplacer ?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">L'état de la case à cocher "lecture seule" dans la boîte de dialogue.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Contrôle si la case à cocher "lecture seule" s'affiche dans la boîte de dialogue.</target>
@@ -7404,6 +7394,16 @@ Cette opération non conforme s'est produite sur la trace de la pile :
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">Impossible d'ajouter ou d'insérer l'élément '{0}' à plusieurs emplacements. Vous devez tout d'abord le supprimer de son emplacement actuel ou le cloner.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -4871,6 +4871,11 @@ Si vous cliquez sur Continuer, l'application va ignorer cette erreur et tenter d
         <target state="translated">Contrôle si les extensions sont automatiquement ajoutées aux noms de fichiers.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Vérifie que le fichier spécifié existe avant le retour à partir de cette boîte de dialogue.</target>
@@ -4916,6 +4921,11 @@ Si vous cliquez sur Continuer, l'application va ignorer cette erreur et tenter d
         <target state="translated">Le répertoire d'origine pour cette boîte de dialogue.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Contrôle si la boîte de dialogue rétablit le répertoire actif avant de se fermer.</target>
@@ -4924,6 +4934,16 @@ Si vous cliquez sur Continuer, l'application va ignorer cette erreur et tenter d
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Active le bouton d'aide.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Voulez-vous le remplacer ?</target>
         <target state="translated">Contrôle l'affichage du bouton Aide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">Chaîne affichée au-dessus du contrôle TreeView dans la boîte de dialogue. Cette chaîne peut être utilisée pour spécifier des instructions à l'utilisateur.</target>
@@ -5095,6 +5120,11 @@ Voulez-vous le remplacer ?</target>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">Impossible de récupérer le dossier racine.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Voulez-vous le remplacer ?</target>
         <target state="translated">Chemin du dossier sélectionné en premier dans la boîte de dialogue ou le dernier sélectionné par l'utilisateur.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">Inclure le bouton Nouveau dossier dans la boîte de dialogue.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">L'état de la case à cocher "lecture seule" dans la boîte de dialogue.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Contrôle si la case à cocher "lecture seule" s'affiche dans la boîte de dialogue.</target>
@@ -8711,9 +8761,19 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">Contrôle si l'utilisateur doit confirmer la création d'un nouveau fichier. Applicable uniquement si 'ValidateNames' a la valeur true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -4871,11 +4871,6 @@ Se si sceglie Continua, l'errore verrà ignorato e l'applicazione proverà a con
         <target state="translated">Determina se le estensioni vengono automaticamente aggiunte ai nomi di file.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Controlla che il file specificato esista prima di chiudere la finestra di dialogo.</target>
@@ -4921,11 +4916,6 @@ Se si sceglie Continua, l'errore verrà ignorato e l'applicazione proverà a con
         <target state="translated">La directory iniziale della finestra di dialogo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Determina se la finestra di dialogo ripristina la directory corrente prima della chiusura.</target>
@@ -4934,16 +4924,6 @@ Se si sceglie Continua, l'errore verrà ignorato e l'applicazione proverà a con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Abilita il pulsante ?.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ Se si sceglie Continua, l'errore verrà ignorato e l'applicazione proverà a con
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">Determina se la finestra di dialogo ha il compito di verificare che i nomi di file non contengano caratteri o sequenze non valide.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Verificare che si sia specificato il nome di file corretto.</target>
         <target state="translated">Indice del filtro non valido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">Il file {0} esiste già.
 Sostituirlo?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Lo stato della casella di controllo in sola lettura nella finestra di dialogo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Determina se visualizzare la casella di controllo in sola lettura nella finestra di dialogo.</target>
@@ -7404,6 +7394,16 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">Non è possibile aggiungere o inserire l'elemento '{0}' in più di una posizione. Rimuoverlo prima dalla posizione corrente oppure clonarlo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -4871,6 +4871,11 @@ Se si sceglie Continua, l'errore verrà ignorato e l'applicazione proverà a con
         <target state="translated">Determina se le estensioni vengono automaticamente aggiunte ai nomi di file.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Controlla che il file specificato esista prima di chiudere la finestra di dialogo.</target>
@@ -4916,6 +4921,11 @@ Se si sceglie Continua, l'errore verrà ignorato e l'applicazione proverà a con
         <target state="translated">La directory iniziale della finestra di dialogo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Determina se la finestra di dialogo ripristina la directory corrente prima della chiusura.</target>
@@ -4924,6 +4934,16 @@ Se si sceglie Continua, l'errore verrà ignorato e l'applicazione proverà a con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Abilita il pulsante ?.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Sostituirlo?</target>
         <target state="translated">Determina se visualizzare il pulsante ?.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">Stringa visualizzata sopra il controllo TreeView nella finestra di dialogo. Può essere utilizzata per specificare istruzioni all'utente.</target>
@@ -5095,6 +5120,11 @@ Sostituirlo?</target>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">Impossibile recuperare la cartella radice.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Sostituirlo?</target>
         <target state="translated">Percorso della cartella selezionata nella finestra di dialogo o dell'ultima cartella selezionata dall'utente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">Include il pulsante Nuova cartella nella finestra di dialogo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Lo stato della casella di controllo in sola lettura nella finestra di dialogo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Determina se visualizzare la casella di controllo in sola lettura nella finestra di dialogo.</target>
@@ -8711,9 +8761,19 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">Determina se visualizzare una richiesta all'utente al momento della creazione di un nuovo file. Applicabile solo se 'ValidateNames' è impostato su true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -4871,11 +4871,6 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">拡張子が自動的にファイル名に追加されるかどうかを設定します。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">ダイアログから戻る前に、指定されたファイルが存在することを確認します。</target>
@@ -4921,11 +4916,6 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">ダイアログ ボックスの初期ディレクトリです。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">閉じる前に、ダイアログ ボックスが現在のディレクトリを復元するかどうかを制御します。</target>
@@ -4934,16 +4924,6 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">ヘルプ ボタンを有効にします。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">無効な文字やシーケンスがファイル名に含まれていないことをダイアログ ボックスが確認するかどうかを設定します。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Verify that the correct file name was given.</source>
         <target state="translated">フィルター インデックスが有効ではありません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">ファイル {0} は既に存在します。
 置き換えますか?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ダイアログの読み取り専用チェック ボックスの状態です。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">ダイアログに読み取り専用のチェック ボックスを表示するかどうかを制御します。</target>
@@ -7404,6 +7394,16 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">複数の場所にアイテム '{0}' を追加または挿入することはできません。最初に現在の場所から削除するか、クローンを作成しなければなりません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -4871,6 +4871,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">拡張子が自動的にファイル名に追加されるかどうかを設定します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">ダイアログから戻る前に、指定されたファイルが存在することを確認します。</target>
@@ -4916,6 +4921,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">ダイアログ ボックスの初期ディレクトリです。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">閉じる前に、ダイアログ ボックスが現在のディレクトリを復元するかどうかを制御します。</target>
@@ -4924,6 +4934,16 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">ヘルプ ボタンを有効にします。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Do you want to replace it?</source>
         <target state="translated">ヘルプ ボタンを表示するかどうかを設定します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">ダイアログ ボックスのツリー ビュー コントロールの上に表示される文字列です。この文字列は、ユーザーに手順を指定するのに使用されます。</target>
@@ -5095,6 +5120,11 @@ Do you want to replace it?</source>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">ルート フォルダーを取得できません。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Do you want to replace it?</source>
         <target state="translated">ダイアログで最初に、またはユーザーによって最後に選択されたフォルダーのパスです。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">[新しいフォルダー] をダイアログ ボックスに含めます。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ダイアログの読み取り専用チェック ボックスの状態です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">ダイアログに読み取り専用のチェック ボックスを表示するかどうかを制御します。</target>
@@ -8711,9 +8761,19 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">新しいファイルを作成しようとしているときに、ユーザーに確認メッセージを表示するかどうかを設定します。'ValidateNames' が true に設定されているときのみ有効です。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -4871,11 +4871,6 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">파일 이름에 자동으로 확장명을 추가할지 여부를 제어합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">대화 상자에서 반환하기 전에 지정한 파일이 있는지 확인합니다.</target>
@@ -4921,11 +4916,6 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">대화 상자의 초기 디렉터리입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">대화 상자를 닫기 전에 현재 디렉터리를 복원할지 여부를 제어합니다.</target>
@@ -4934,16 +4924,6 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">[도움말] 단추를 사용합니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">대화 상자에서 파일 이름에 잘못된 문자나 시퀀스가 없는지 확인할지 여부를 제어합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Verify that the correct file name was given.</source>
         <target state="translated">필터 인덱스가 잘못되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">{0} 파일이 이미 있습니다.
 바꾸시겠습니까?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">대화 상자에서 읽기 전용 확인란의 상태입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">대화 상자의 읽기 전용 확인란을 표시할지 여부를 제어합니다.</target>
@@ -7404,6 +7394,16 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">두 개 이상의 위치에 '{0}' 항목을 추가하거나 삽입할 수 없습니다. 먼저 항목의 현재 위치에서 항목을 제거하거나 복제해야 합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -4871,6 +4871,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">파일 이름에 자동으로 확장명을 추가할지 여부를 제어합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">대화 상자에서 반환하기 전에 지정한 파일이 있는지 확인합니다.</target>
@@ -4916,6 +4921,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">대화 상자의 초기 디렉터리입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">대화 상자를 닫기 전에 현재 디렉터리를 복원할지 여부를 제어합니다.</target>
@@ -4924,6 +4934,16 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">[도움말] 단추를 사용합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Do you want to replace it?</source>
         <target state="translated">[도움말] 단추의 표시 여부를 제어합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">대화 상자의 tree view 컨트롤 위에 표시되는 문자열입니다. 이 문자열을 사용하여 사용자에게 표시될 지시 사항을 지정할 수 있습니다.</target>
@@ -5095,6 +5120,11 @@ Do you want to replace it?</source>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">루트 폴더를 검색할 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Do you want to replace it?</source>
         <target state="translated">대화 상자에 처음 선택되어 있거나 사용자가 마지막에 선택한 폴더의 경로입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">대화 상자에 새 폴더 단추를 넣습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">대화 상자에서 읽기 전용 확인란의 상태입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">대화 상자의 읽기 전용 확인란을 표시할지 여부를 제어합니다.</target>
@@ -8711,9 +8761,19 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">새 파일을 만들려고 할 때 사용자에게 프롬프트를 표시할지 여부를 제어합니다. 'ValidateNames'를 true로 설정한 경우에만 적용됩니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -4871,11 +4871,6 @@ Jeśli klikniesz pozycję Kontynuuj, aplikacja zignoruje ten błąd i będzie pr
         <target state="translated">Wskazuje, czy rozszerzenia są automatycznie dodawane do nazw plików.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Przed powrotem z okna dialogowego sprawdza, czy istnieje określony plik.</target>
@@ -4921,11 +4916,6 @@ Jeśli klikniesz pozycję Kontynuuj, aplikacja zignoruje ten błąd i będzie pr
         <target state="translated">Początkowy katalog dla okna dialogowego.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Wskazuje, czy przed zamknięciem okna dialogowego jest przywracany bieżący katalog.</target>
@@ -4934,16 +4924,6 @@ Jeśli klikniesz pozycję Kontynuuj, aplikacja zignoruje ten błąd i będzie pr
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Włącza przycisk Pomoc.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ Jeśli klikniesz pozycję Kontynuuj, aplikacja zignoruje ten błąd i będzie pr
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">Kontroluje, czy w oknie dialogowym nazwy plików nie zawierają nieprawidłowych znaków ani sekwencji.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Sprawdź, czy podano prawidłową nazwę pliku.</target>
         <target state="translated">Nieprawidłowy indeks filtru.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">Plik {0} już istnieje.
 Czy chcesz go zamienić?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Stan pola wyboru tylko do odczytu w oknie dialogowym.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Określa, czy pokazywać pola wyboru tylko do odczytu w oknie dialogowym.</target>
@@ -7404,6 +7394,16 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">Nie można dodać lub wstawić elementu '{0}' w więcej niż jedno miejsce. Musisz najpierw usunąć element z jego bieżącej lokalizacji lub sklonować go.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -4871,6 +4871,11 @@ Jeśli klikniesz pozycję Kontynuuj, aplikacja zignoruje ten błąd i będzie pr
         <target state="translated">Wskazuje, czy rozszerzenia są automatycznie dodawane do nazw plików.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Przed powrotem z okna dialogowego sprawdza, czy istnieje określony plik.</target>
@@ -4916,6 +4921,11 @@ Jeśli klikniesz pozycję Kontynuuj, aplikacja zignoruje ten błąd i będzie pr
         <target state="translated">Początkowy katalog dla okna dialogowego.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Wskazuje, czy przed zamknięciem okna dialogowego jest przywracany bieżący katalog.</target>
@@ -4924,6 +4934,16 @@ Jeśli klikniesz pozycję Kontynuuj, aplikacja zignoruje ten błąd i będzie pr
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Włącza przycisk Pomoc.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Czy chcesz go zamienić?</target>
         <target state="translated">Określa, czy wyświetlać przycisk Pomoc.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">Ciąg wyświetlony w oknie dialogowym nad formantem widoku drzewa. Ten ciąg może posłużyć do określenia instrukcji dla użytkownika.</target>
@@ -5095,6 +5120,11 @@ Czy chcesz go zamienić?</target>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">Nie można pobrać folderu głównego.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Czy chcesz go zamienić?</target>
         <target state="translated">Ścieżka do folderu wybranego jako pierwszy w tym oknie dialogowym lub wybranego ostatnio przez użytkownika.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">Dołącz w oknie dialogowym przycisk Nowy folder.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Stan pola wyboru tylko do odczytu w oknie dialogowym.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Określa, czy pokazywać pola wyboru tylko do odczytu w oknie dialogowym.</target>
@@ -8711,9 +8761,19 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">Określa, czy wyświetlać monit, gdy ma zostać utworzony nowy plik. Ma zastosowanie tylko wtedy, gdy element „ValidateNames” ma wartość true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -4871,11 +4871,6 @@ Se você clicar em Continuar, o aplicativo ignorará esse erro e tentará contin
         <target state="translated">Controla se as extensões são automaticamente adicionadas aos nomes de arquivos.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Verifica se o arquivo especificado existe antes de retornar da caixa de diálogo.</target>
@@ -4921,11 +4916,6 @@ Se você clicar em Continuar, o aplicativo ignorará esse erro e tentará contin
         <target state="translated">O diretório inicial para a caixa de diálogo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Controla se a caixa de diálogo restaura o diretório atual antes de fechar.</target>
@@ -4934,16 +4924,6 @@ Se você clicar em Continuar, o aplicativo ignorará esse erro e tentará contin
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Ativa o botão Ajuda.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ Se você clicar em Continuar, o aplicativo ignorará esse erro e tentará contin
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">Controla se a caixa de diálogo assegura que os nomes de arquivos não contém cadeias ou caracteres inválidos.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Verifique se o nome de arquivo correto foi fornecido.</target>
         <target state="translated">Índice de filtro inválido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">O arquivo {0} já existe.
 Deseja substituí-lo?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">O estado da caixa de seleção de somente leitura na caixa de diálogo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Controla se a caixa de seleção de somente leitura deve ser exibida na caixa de diálogo.</target>
@@ -7404,6 +7394,16 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">Não é possível adicionar ou inserir o item '{0}' em mais de um local. Primeiro você precisa removê-lo do local atual ou cloná-lo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -4871,6 +4871,11 @@ Se você clicar em Continuar, o aplicativo ignorará esse erro e tentará contin
         <target state="translated">Controla se as extensões são automaticamente adicionadas aos nomes de arquivos.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Verifica se o arquivo especificado existe antes de retornar da caixa de diálogo.</target>
@@ -4916,6 +4921,11 @@ Se você clicar em Continuar, o aplicativo ignorará esse erro e tentará contin
         <target state="translated">O diretório inicial para a caixa de diálogo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Controla se a caixa de diálogo restaura o diretório atual antes de fechar.</target>
@@ -4924,6 +4934,16 @@ Se você clicar em Continuar, o aplicativo ignorará esse erro e tentará contin
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Ativa o botão Ajuda.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Deseja substituí-lo?</target>
         <target state="translated">Controla se o botão Ajuda deve ser mostrado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">A cadeia de caracteres exibida acima do controle do modo de exibição de árvore na caixa de diálogo. Esta cadeia de caracteres pode ser utilizada para especificar instruções para o usuário.</target>
@@ -5095,6 +5120,11 @@ Deseja substituí-lo?</target>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">Não é possível recuperar a pasta raiz.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Deseja substituí-lo?</target>
         <target state="translated">O caminho da pasta selecionado primeiro no diálogo ou o último caminho selecionado pelo usuário.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">Inclua o botão Nova Pasta na caixa de diálogo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">O estado da caixa de seleção de somente leitura na caixa de diálogo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Controla se a caixa de seleção de somente leitura deve ser exibida na caixa de diálogo.</target>
@@ -8711,9 +8761,19 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">Controla se o usuário deve ser avisado quando um novo arquivo estiver prestes a ser criado. Aplicável somente se 'ValidateNames' estiver definido como true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -4872,11 +4872,6 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">Определяет, добавляются ли расширения к именам файлов автоматически.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Перед возвратом из диалогового окна проверяет, что заданный файл существует.</target>
@@ -4922,11 +4917,6 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">Исходный каталог диалогового окна.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Определяет, восстанавливает ли диалоговое окно текущий каталог перед закрытием.</target>
@@ -4935,16 +4925,6 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Активирует кнопку 'Справка'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4960,6 +4940,11 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">Определяет, проверяет ли диалоговое окно имена файлов на наличие недопустимых символов или последовательностей.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4996,11 +4981,26 @@ Verify that the correct file name was given.</source>
         <target state="translated">Недопустимый индекс фильтра.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">Файл {0} уже существует.
 Заменить его?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7372,16 +7372,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Состояние доступного только для чтения флажка проверки в данном диалоговом окне.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Задает, отображается ли доступный только для чтения флажок проверки в данном диалоговом окне.</target>
@@ -7405,6 +7395,16 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">Невозможно добавить или вставить элемент '{0}' в несколько позиций. Сначала удалите его из текущей позиции или создайте его клон.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -4872,6 +4872,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">Определяет, добавляются ли расширения к именам файлов автоматически.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">Перед возвратом из диалогового окна проверяет, что заданный файл существует.</target>
@@ -4917,6 +4922,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">Исходный каталог диалогового окна.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">Определяет, восстанавливает ли диалоговое окно текущий каталог перед закрытием.</target>
@@ -4925,6 +4935,16 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Активирует кнопку 'Справка'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5088,6 +5108,11 @@ Do you want to replace it?</source>
         <target state="translated">Определяет, отображать ли кнопку 'Справка'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">Строка, отображаемая над иерархическим представлением структуры дерева в данном диалоговом окне. Эта строка служит для задания инструкций для пользователя.</target>
@@ -5096,6 +5121,11 @@ Do you want to replace it?</source>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">Не удалось извлечь корневую папку.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5108,9 +5138,19 @@ Do you want to replace it?</source>
         <target state="translated">Путь к папке, которая первой выбрана в данном диалоговом окне, или к последней папке, выбранной пользователем.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">Отображать кнопку 'Создать папку' в диалоговом окне.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7332,6 +7372,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Состояние доступного только для чтения флажка проверки в данном диалоговом окне.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">Задает, отображается ли доступный только для чтения флажок проверки в данном диалоговом окне.</target>
@@ -8712,9 +8762,19 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">Определяет, получает ли пользователь запрос перед созданием нового файла. Действует только в том случае, если ValidateNames имеет значение true (истина).</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -4871,11 +4871,6 @@ Devam'a tıkladığınızda uygulama bu hatayı yoksayar ve işlemi sürdürmeye
         <target state="translated">Dosya adlarına otomatik olarak uzantıların eklenip eklenmediğini denetler.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">İletişim kutusundan dönmeden önce belirtilen dosyanın var olduğunu denetler.</target>
@@ -4921,11 +4916,6 @@ Devam'a tıkladığınızda uygulama bu hatayı yoksayar ve işlemi sürdürmeye
         <target state="translated">İletişim kutusu için başlangıç dizini.</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">İletişim kutusunun kapanmadan önce geçerli dizini geri getirip getirmeyeceğini denetler.</target>
@@ -4934,16 +4924,6 @@ Devam'a tıkladığınızda uygulama bu hatayı yoksayar ve işlemi sürdürmeye
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Yardım düğmesini etkinleştirir.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ Devam'a tıkladığınızda uygulama bu hatayı yoksayar ve işlemi sürdürmeye
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">İletişim kutusunun dosya adlarında geçersiz karakterler ve sıralar içermediğinden emin olup olmayacağını denetler.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Doğru dosya adının verildiğinden emin olun.</target>
         <target state="translated">Filtre dizini geçerli değil.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">{0} dosyası zaten var.
 Bunu değiştirmek istiyor musunuz?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">İletişim kutusundaki salt okunur onay kutusunun durumu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">İletişim kutusunda salt okunur onay kutusunun gösterilip gösterilmeyeceğini denetler.</target>
@@ -7404,6 +7394,16 @@ Geçersiz işlemin gerçekleştiği yığın izi:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">'{0}' öğesi birden fazla yere eklenemez. Öğeyi önce bulunduğu yerden kaldırmalı veya kopyasını oluşturmalısınız.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -4871,6 +4871,11 @@ Devam'a tıkladığınızda uygulama bu hatayı yoksayar ve işlemi sürdürmeye
         <target state="translated">Dosya adlarına otomatik olarak uzantıların eklenip eklenmediğini denetler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">İletişim kutusundan dönmeden önce belirtilen dosyanın var olduğunu denetler.</target>
@@ -4916,6 +4921,11 @@ Devam'a tıkladığınızda uygulama bu hatayı yoksayar ve işlemi sürdürmeye
         <target state="translated">İletişim kutusu için başlangıç dizini.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">İletişim kutusunun kapanmadan önce geçerli dizini geri getirip getirmeyeceğini denetler.</target>
@@ -4924,6 +4934,16 @@ Devam'a tıkladığınızda uygulama bu hatayı yoksayar ve işlemi sürdürmeye
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">Yardım düğmesini etkinleştirir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Bunu değiştirmek istiyor musunuz?</target>
         <target state="translated">Yardım düğmesinin gösterilip gösterilmeyeceğini denetler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">İletişim kutusundaki ağaç görünümü denetiminin üstünde görüntülenen dize. Bu dize kullanıcıya yönergeleri bildirmek için kullanılabilir.</target>
@@ -5095,6 +5120,11 @@ Bunu değiştirmek istiyor musunuz?</target>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">Kök klasör alınamıyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Bunu değiştirmek istiyor musunuz?</target>
         <target state="translated">İletişim kutusunda ilk seçili olan klasörün veya kullanıcı tarafından son seçilen klasörün yolu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">İletişim kutusuna Yeni Klasör düğmesini ekle.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">İletişim kutusundaki salt okunur onay kutusunun durumu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">İletişim kutusunda salt okunur onay kutusunun gösterilip gösterilmeyeceğini denetler.</target>
@@ -8711,9 +8761,19 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">Yeni bir dosya oluşturulmak üzere olduğunda kullanıcıya sorulup sorulmayacağını denetler. Bu yalnızca 'ValidateNames' True olarak ayarlanmışsa geçerlidir.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -4871,11 +4871,6 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">控制是否将扩展名自动添加到文件名上。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">在从对话框返回之前，检查指定的文件是否存在。</target>
@@ -4921,11 +4916,6 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">对话框的初始目录。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">控制对话框在关闭之前是否恢复当前目录。</target>
@@ -4934,16 +4924,6 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">启用“帮助”按钮。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">控制对话框是否确保文件名中不包含无效的字符或序列。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Verify that the correct file name was given.</source>
         <target state="translated">筛选器索引无效。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">文件 {0} 已存在。
 是否替换文件?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">该对话框中只读复选框的状态。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">控制是否在该对话框中显示只读复选框。</target>
@@ -7404,6 +7394,16 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">不能在多处添加或插入项“{0}”。必须首先将其从当前位置移除或将其克隆。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -4871,6 +4871,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">控制是否将扩展名自动添加到文件名上。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">在从对话框返回之前，检查指定的文件是否存在。</target>
@@ -4916,6 +4921,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">对话框的初始目录。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">控制对话框在关闭之前是否恢复当前目录。</target>
@@ -4924,6 +4934,16 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">启用“帮助”按钮。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Do you want to replace it?</source>
         <target state="translated">控制是否显示“帮助”按钮。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">显示在对话框的树视图控件上方的字符串。该字符串可用来指定显示给用户的指导信息。</target>
@@ -5095,6 +5120,11 @@ Do you want to replace it?</source>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">无法检索根文件夹。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Do you want to replace it?</source>
         <target state="translated">对话框中最先选择的文件夹或用户最后选择的文件夹的路径。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">在对话框中包括“新建文件夹”按钮。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">该对话框中只读复选框的状态。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">控制是否在该对话框中显示只读复选框。</target>
@@ -8711,9 +8761,19 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">控制在将要创建新文件时是否提示用户。仅在“ValidateNames”设置为 true 时才适用。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -4871,11 +4871,6 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">控制是否自動在檔名之後加上副檔名。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDaddToRecentDescr">
-        <source>Controls whether to add the file being opened or saved to the recent list.</source>
-        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">從對話方塊傳回前，檢查指定的檔案是否存在。</target>
@@ -4921,11 +4916,6 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">對話方塊的初始目錄。</target>
         <note />
       </trans-unit>
-      <trans-unit id="FDokRequiresInteractionDescr">
-        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
-        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">控制對話方塊於關閉前是否還原目前的目錄。</target>
@@ -4934,16 +4924,6 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">啟用 [說明] 按鈕。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowHiddenFilesDescr">
-        <source>Controls whether the dialog box displays hidden and system files.</source>
-        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FDshowPinnedPlacesDescr">
-        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
-        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -4959,6 +4939,11 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDvalidateNamesDescr">
         <source>Controls whether the dialog box ensures that file names do not contain invalid characters or sequences.</source>
         <target state="translated">控制對話方塊是否要確認檔名並未包含無效的字元或逸出字元。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogAddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogBufferTooSmall">
@@ -4995,11 +4980,26 @@ Verify that the correct file name was given.</source>
         <target state="translated">篩選條件索引無效。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FileDialogOkRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FileDialogOverwritePrompt">
         <source>File {0} already exists.
 Do you want to replace it?</source>
         <target state="translated">檔案 {0} 已經存在。
 您要取代它嗎?</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FileDialogShowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FileDialogSubLassFailure">
@@ -7371,16 +7371,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">對話方塊中唯讀核取方塊的狀態。</target>
         <note />
       </trans-unit>
-      <trans-unit id="OFDselectReadOnlyDescr">
-        <source>Controls whether the dialog box allows to select read-only files.</source>
-        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="OFDshowPreviewDescr">
-        <source>Controls whether the dialog box shows a preview for selected files.</source>
-        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">控制是否在對話方塊中顯示唯讀核取方塊。</target>
@@ -7404,6 +7394,16 @@ Stack trace where the illegal operation occurred was:
       <trans-unit id="OnlyOneControl">
         <source>Cannot add or insert the item '{0}' in more than one place. You must first remove it from its current location or clone it.</source>
         <target state="translated">無法將項目 '{0}' 加入或插入一個以上的位置。必須先將其從目前位置移除或複製。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogSelectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OpenFileDialogShowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperationRequiresIBindingList">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -4871,6 +4871,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">控制是否自動在檔名之後加上副檔名。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDaddToRecentDescr">
+        <source>Controls whether to add the file being opened or saved to the recent list.</source>
+        <target state="new">Controls whether to add the file being opened or saved to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDcheckFileExistsDescr">
         <source>Checks that the specified file exists before returning from the dialog.</source>
         <target state="translated">從對話方塊傳回前，檢查指定的檔案是否存在。</target>
@@ -4916,6 +4921,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">對話方塊的初始目錄。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FDokRequiresInteractionDescr">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FDrestoreDirectoryDescr">
         <source>Controls whether the dialog box restores the current directory before closing.</source>
         <target state="translated">控制對話方塊於關閉前是否還原目前的目錄。</target>
@@ -4924,6 +4934,16 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="FDshowHelpDescr">
         <source>Enables the Help button.</source>
         <target state="translated">啟用 [說明] 按鈕。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowHiddenFilesDescr">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FDshowPinnedPlacesDescr">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FDsupportMultiDottedExtensionsDescr">
@@ -5087,6 +5107,11 @@ Do you want to replace it?</source>
         <target state="translated">控制是否顯示 [說明] 按鈕。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogAddToRecent">
+        <source>Controls whether the dialog box adds the folder being selected to the recent list.</source>
+        <target state="new">Controls whether the dialog box adds the folder being selected to the recent list.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogDescription">
         <source>The string that is displayed above the tree view control in the dialog box. This string can be used to specify instructions to the user.</source>
         <target state="translated">顯示在對話方塊中樹狀檢視控制項上方的字串。這個字串可以用來指定對使用者的指示。</target>
@@ -5095,6 +5120,11 @@ Do you want to replace it?</source>
       <trans-unit id="FolderBrowserDialogNoRootFolder">
         <source>Unable to retrieve the root folder.</source>
         <target state="translated">無法擷取根資料夾。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogOkRequiresInteraction">
+        <source>Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</source>
+        <target state="new">Controls whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogRootFolder">
@@ -5107,9 +5137,19 @@ Do you want to replace it?</source>
         <target state="translated">對話方塊中第一個選取的資料夾或使用者選取的最後一個資料夾的路徑。</target>
         <note />
       </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowHiddenFiles">
+        <source>Controls whether the dialog box displays hidden and system files.</source>
+        <target state="new">Controls whether the dialog box displays hidden and system files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FolderBrowserDialogShowNewFolderButton">
         <source>Include the New Folder button in the dialog box.</source>
         <target state="translated">在對話方塊中包括 [新增資料夾] 按鈕。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FolderBrowserDialogShowPinnedPlaces">
+        <source>Controls whether the items shown by default in the view's navigation pane are shown.</source>
+        <target state="new">Controls whether the items shown by default in the view's navigation pane are shown.</target>
         <note />
       </trans-unit>
       <trans-unit id="FolderBrowserDialogUseDescriptionForTitle">
@@ -7331,6 +7371,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">對話方塊中唯讀核取方塊的狀態。</target>
         <note />
       </trans-unit>
+      <trans-unit id="OFDselectReadOnlyDescr">
+        <source>Controls whether the dialog box allows to select read-only files.</source>
+        <target state="new">Controls whether the dialog box allows to select read-only files.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OFDshowPreviewDescr">
+        <source>Controls whether the dialog box shows a preview for selected files.</source>
+        <target state="new">Controls whether the dialog box shows a preview for selected files.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OFDshowReadOnlyDescr">
         <source>Controls whether to show the read-only check box in the dialog.</source>
         <target state="translated">控制是否在對話方塊中顯示唯讀核取方塊。</target>
@@ -8711,9 +8761,19 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">{1} - {0} - {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="SaveFileDialogCheckWriteAccess">
+        <source>Controls whether the dialog box verifies if the creation of the specified file will be successful.</source>
+        <target state="new">Controls whether the dialog box verifies if the creation of the specified file will be successful.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SaveFileDialogCreatePrompt">
         <source>Controls whether to prompt the user when a new file is about to be created. It is only applicable if 'ValidateNames' is set to true.</source>
         <target state="translated">控制在建立新檔案時是否要提示使用者。只有當 'ValidateNames' 設定為 true 時才適用。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="SaveFileDialogExpandedMode">
+        <source>Controls whether the dialog box is always opened in the expanded mode.</source>
+        <target state="new">Controls whether the dialog box is always opened in the expanded mode.</target>
         <note />
       </trans-unit>
       <trans-unit id="SaveFileDialogOverWritePrompt">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -280,7 +280,7 @@ namespace System.Windows.Forms
         /// </remarks>
         [SRCategory(nameof(SR.CatBehavior))]
         [DefaultValue(false)]
-        [SRDescription(nameof(SR.FDokRequiresInteractionDescr))]
+        [SRDescription(nameof(SR.FileDialogOkRequiresInteractionDescr))]
         public bool OkRequiresInteraction
         {
             get => GetOption((int)FOS.OKBUTTONNEEDSINTERACTION);
@@ -293,7 +293,7 @@ namespace System.Windows.Forms
         /// </summary>
         [SRCategory(nameof(SR.CatBehavior))]
         [DefaultValue(true)]
-        [SRDescription(nameof(SR.FDshowPinnedPlacesDescr))]
+        [SRDescription(nameof(SR.FileDialogShowPinnedPlacesDescr))]
         public bool ShowPinnedPlaces
         {
             get => !GetOption((int)FOS.HIDEPINNEDPLACES);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -106,7 +106,15 @@ namespace System.Windows.Forms
               | FOS.PATHMUSTEXIST
               | FOS.FILEMUSTEXIST
               | FOS.CREATEPROMPT
-              | FOS.NODEREFERENCELINKS;
+              | FOS.NODEREFERENCELINKS
+              | FOS.DONTADDTORECENT
+              | FOS.NOREADONLYRETURN
+              | FOS.NOTESTFILECREATE
+              | FOS.FORCESHOWHIDDEN
+              | FOS.DEFAULTNOMINIMODE
+              | FOS.OKBUTTONNEEDSINTERACTION
+              | FOS.HIDEPINNEDPLACES
+              | FOS.FORCEPREVIEWPANEON;
 
             const int UnexpectedOptions =
                 (int)(Comdlg32.OFN.SHOWHELP // If ShowHelp is true, we don't use the Vista Dialog
@@ -117,9 +125,6 @@ namespace System.Windows.Forms
             Debug.Assert((UnexpectedOptions & _options) == 0, "Unexpected FileDialog options");
 
             FOS ret = (FOS)_options & BlittableOptions;
-
-            // Force no mini mode for the SaveFileDialog
-            ret |= FOS.DEFAULTNOMINIMODE;
 
             // Make sure that the Open dialog allows the user to specify
             // non-file system locations. This flag will cause the dialog to copy the resource
@@ -263,5 +268,36 @@ namespace System.Windows.Forms
         /// </summary>
         [DefaultValue(true)]
         public bool AutoUpgradeEnabled { get; set; } = true;
+
+        /// <summary>
+        ///  Gets or sets a value indicating whether the OK button of the dialog box is
+        ///  disabled until the user navigates the view or edits the filename (if applicable).
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///  Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.
+        ///  </para>
+        /// </remarks>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(false)]
+        [SRDescription(nameof(SR.FDokRequiresInteractionDescr))]
+        public bool OkRequiresInteraction
+        {
+            get => GetOption((int)FOS.OKBUTTONNEEDSINTERACTION);
+            set => SetOption((int)FOS.OKBUTTONNEEDSINTERACTION, value);
+        }
+
+        /// <summary>
+        ///  Gets or sets a value indicating whether the items shown by default in the view's
+        ///  navigation pane are shown.
+        /// </summary>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(true)]
+        [SRDescription(nameof(SR.FDshowPinnedPlacesDescr))]
+        public bool ShowPinnedPlaces
+        {
+            get => !GetOption((int)FOS.HIDEPINNEDPLACES);
+            set => SetOption((int)FOS.HIDEPINNEDPLACES, !value);
+        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -65,7 +65,7 @@ namespace System.Windows.Forms
         /// </summary>
         [SRCategory(nameof(SR.CatBehavior))]
         [DefaultValue(true)]
-        [SRDescription(nameof(SR.FDaddToRecentDescr))]
+        [SRDescription(nameof(SR.FileDialogAddToRecentDescr))]
         public bool AddToRecent
         {
             get => !GetOption((int)Comdlg32.OFN.DONTADDTORECENT);
@@ -344,7 +344,7 @@ namespace System.Windows.Forms
         /// </summary>
         [SRCategory(nameof(SR.CatBehavior))]
         [DefaultValue(false)]
-        [SRDescription(nameof(SR.FDshowHiddenFilesDescr))]
+        [SRDescription(nameof(SR.FileDialogShowHiddenFilesDescr))]
         public bool ShowHiddenFiles
         {
             get => GetOption((int)Comdlg32.OFN.FORCESHOWHIDDEN);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -60,6 +60,19 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///  Gets or sets a value indicating whether the dialog box adds the file being opened
+        ///  or saved to the recent list.
+        /// </summary>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(true)]
+        [SRDescription(nameof(SR.FDaddToRecentDescr))]
+        public bool AddToRecent
+        {
+            get => !GetOption((int)Comdlg32.OFN.DONTADDTORECENT);
+            set => SetOption((int)Comdlg32.OFN.DONTADDTORECENT, !value);
+        }
+
+        /// <summary>
         ///  Gets or sets a value indicating whether the dialog box displays a warning
         ///  if the user specifies a file name that does not exist.
         /// </summary>
@@ -283,16 +296,20 @@ namespace System.Windows.Forms
         protected virtual IntPtr Instance => Kernel32.GetModuleHandleW(null);
 
         /// <summary>
-        ///  Gets the Win32 common Open File Dialog OFN_* option flags.
+        ///  Gets the Win32 common Open File Dialog OFN_* and FOS_* option flags.
         /// </summary>
         protected int Options
         {
             get
             {
-                return _options & (int)(Comdlg32.OFN.READONLY | Comdlg32.OFN.HIDEREADONLY |
+                return _options & ((int)(Comdlg32.OFN.READONLY | Comdlg32.OFN.HIDEREADONLY |
                                   Comdlg32.OFN.NOCHANGEDIR | Comdlg32.OFN.SHOWHELP | Comdlg32.OFN.NOVALIDATE |
                                   Comdlg32.OFN.ALLOWMULTISELECT | Comdlg32.OFN.PATHMUSTEXIST |
-                                  Comdlg32.OFN.NODEREFERENCELINKS);
+                                  Comdlg32.OFN.NODEREFERENCELINKS | Comdlg32.OFN.DONTADDTORECENT |
+                                  Comdlg32.OFN.NOREADONLYRETURN | Comdlg32.OFN.NOTESTFILECREATE |
+                                  Comdlg32.OFN.FORCESHOWHIDDEN) | (int)(Shell32.FOS.OKBUTTONNEEDSINTERACTION |
+                                  Shell32.FOS.HIDEPINNEDPLACES | Shell32.FOS.DEFAULTNOMINIMODE |
+                                  Shell32.FOS.FORCEPREVIEWPANEON));
             }
         }
 
@@ -320,6 +337,18 @@ namespace System.Windows.Forms
         {
             get => GetOption((int)Comdlg32.OFN.SHOWHELP);
             set => SetOption((int)Comdlg32.OFN.SHOWHELP, value);
+        }
+
+        /// <summary>
+        ///  Gets or sets a value indicating whether the dialog box displays hidden and system files.
+        /// </summary>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(false)]
+        [SRDescription(nameof(SR.FDshowHiddenFilesDescr))]
+        public bool ShowHiddenFiles
+        {
+            get => GetOption((int)Comdlg32.OFN.FORCESHOWHIDDEN);
+            set => SetOption((int)Comdlg32.OFN.FORCESHOWHIDDEN, value);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -36,12 +36,27 @@ namespace System.Windows.Forms
         // Initial folder.
         private string _initialDirectory;
 
+        // Win32 file dialog FOS_* option flags.
+        private int _options;
+
         /// <summary>
         ///  Initializes a new instance of the <see cref='FolderBrowserDialog'/> class.
         /// </summary>
         public FolderBrowserDialog()
         {
             Reset();
+        }
+
+        /// <summary>
+        ///  Gets or sets a value indicating whether the dialog box adds the folder being selected to the recent list.
+        /// </summary>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(true)]
+        [SRDescription(nameof(SR.FolderBrowserDialogAddToRecent))]
+        public bool AddToRecent
+        {
+            get => !GetOption((int)FOS.DONTADDTORECENT);
+            set => SetOption((int)FOS.DONTADDTORECENT, !value);
         }
 
         /// <summary>
@@ -56,6 +71,49 @@ namespace System.Windows.Forms
         {
             add => base.HelpRequest += value;
             remove => base.HelpRequest -= value;
+        }
+
+        /// <summary>
+        ///  Gets or sets a value indicating whether the OK button of the dialog box is
+        ///  disabled until the user navigates the view or edits the filename (if applicable).
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///  Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.
+        ///  </para>
+        /// </remarks>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(false)]
+        [SRDescription(nameof(SR.FolderBrowserDialogOkRequiresInteraction))]
+        public bool OkRequiresInteraction
+        {
+            get => GetOption((int)FOS.OKBUTTONNEEDSINTERACTION);
+            set => SetOption((int)FOS.OKBUTTONNEEDSINTERACTION, value);
+        }
+
+        /// <summary>
+        ///  Gets or sets a value indicating whether the dialog box displays hidden and system files.
+        /// </summary>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(false)]
+        [SRDescription(nameof(SR.FolderBrowserDialogShowHiddenFiles))]
+        public bool ShowHiddenFiles
+        {
+            get => GetOption((int)FOS.FORCESHOWHIDDEN);
+            set => SetOption((int)FOS.FORCESHOWHIDDEN, value);
+        }
+
+        /// <summary>
+        ///  Gets or sets a value indicating whether the items shown by default in the view's
+        ///  navigation pane are shown.
+        /// </summary>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(true)]
+        [SRDescription(nameof(SR.FolderBrowserDialogShowPinnedPlaces))]
+        public bool ShowPinnedPlaces
+        {
+            get => !GetOption((int)FOS.HIDEPINNEDPLACES);
+            set => SetOption((int)FOS.HIDEPINNEDPLACES, !value);
         }
 
         /// <summary>
@@ -177,6 +235,7 @@ namespace System.Windows.Forms
         /// </summary>
         public override void Reset()
         {
+            _options = (int)(FOS.PICKFOLDERS | FOS.FORCEFILESYSTEM | FOS.FILEMUSTEXIST);
             _rootFolder = Environment.SpecialFolder.Desktop;
             _descriptionText = string.Empty;
             _selectedPath = string.Empty;
@@ -279,7 +338,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            dialog.SetOptions(FOS.PICKFOLDERS | FOS.FORCEFILESYSTEM | FOS.FILEMUSTEXIST);
+            dialog.SetOptions((FOS)_options);
 
             if (!string.IsNullOrEmpty(_initialDirectory))
             {
@@ -321,6 +380,23 @@ namespace System.Windows.Forms
             }
 
             return (IShellItem)item;
+        }
+
+        private bool GetOption(int option) => (_options & option) != 0;
+
+        /// <summary>
+        ///  Sets the given option to the given boolean value.
+        /// </summary>
+        private void SetOption(int option, bool value)
+        {
+            if (value)
+            {
+                _options |= option;
+            }
+            else
+            {
+                _options &= ~option;
+            }
         }
 
         private void GetResult(IFileDialog dialog)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -62,7 +62,7 @@ namespace System.Windows.Forms
         /// </summary>
         [SRCategory(nameof(SR.CatBehavior))]
         [DefaultValue(true)]
-        [SRDescription(nameof(SR.OFDselectReadOnlyDescr))]
+        [SRDescription(nameof(SR.OpenFileDialogSelectReadOnlyDescr))]
         public bool SelectReadOnly
         {
             get => !GetOption((int)Comdlg32.OFN.NOREADONLYRETURN);
@@ -74,7 +74,7 @@ namespace System.Windows.Forms
         /// </summary>
         [SRCategory(nameof(SR.CatBehavior))]
         [DefaultValue(false)]
-        [SRDescription(nameof(SR.OFDshowPreviewDescr))]
+        [SRDescription(nameof(SR.OpenFileDialogShowPreviewDescr))]
         public bool ShowPreview
         {
             get => GetOption((int)FOS.FORCEPREVIEWPANEON);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -58,6 +58,30 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the dialog box allows to select read-only files.
+        /// </summary>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(true)]
+        [SRDescription(nameof(SR.OFDselectReadOnlyDescr))]
+        public bool SelectReadOnly
+        {
+            get => !GetOption((int)Comdlg32.OFN.NOREADONLYRETURN);
+            set => SetOption((int)Comdlg32.OFN.NOREADONLYRETURN, !value);
+        }
+
+        /// <summary>
+        ///  Gets or sets a value indicating whether the dialog box shows a preview for selected files.
+        /// </summary>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(false)]
+        [SRDescription(nameof(SR.OFDshowPreviewDescr))]
+        public bool ShowPreview
+        {
+            get => GetOption((int)FOS.FORCEPREVIEWPANEON);
+            set => SetOption((int)FOS.FORCEPREVIEWPANEON, value);
+        }
+
+        /// <summary>
         ///  Gets or sets a value indicating whether the dialog contains a read-only check box.
         /// </summary>
         [SRCategory(nameof(SR.CatBehavior))]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
@@ -16,12 +16,23 @@ namespace System.Windows.Forms
     ///  a common dialog box that allows the user to specify options for saving a
     ///  file. This class cannot be inherited.
     /// </summary>
-    [
-    Designer("System.Windows.Forms.Design.SaveFileDialogDesigner, " + AssemblyRef.SystemDesign)]
-    [SRDescription(nameof(SR.DescriptionSaveFileDialog))
-    ]
+    [Designer("System.Windows.Forms.Design.SaveFileDialogDesigner, " + AssemblyRef.SystemDesign)]
+    [SRDescription(nameof(SR.DescriptionSaveFileDialog))]
     public sealed partial class SaveFileDialog : FileDialog
     {
+        /// <summary>
+        ///  Gets or sets a value indicating whether the dialog box verifies if the creation of the specified file will be successful.
+        ///  If this flag is not set, the calling application must handle errors, such as denial of access, discovered when the item is created.
+        /// </summary>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(true)]
+        [SRDescription(nameof(SR.SaveFileDialogCheckWriteAccess))]
+        public bool CheckWriteAccess
+        {
+            get => !GetOption((int)Comdlg32.OFN.NOTESTFILECREATE);
+            set => SetOption((int)Comdlg32.OFN.NOTESTFILECREATE, !value);
+        }
+
         /// <summary>
         ///  Gets or sets a value indicating whether the dialog box prompts the user for
         ///  permission to create a file if the user specifies a file that does not exist.
@@ -33,6 +44,18 @@ namespace System.Windows.Forms
         {
             get => GetOption((int)Comdlg32.OFN.CREATEPROMPT);
             set => SetOption((int)Comdlg32.OFN.CREATEPROMPT, value);
+        }
+
+        /// <summary>
+        ///  Gets or sets a value indicating whether the dialog box is always opened in the expanded mode.
+        /// </summary>
+        [SRCategory(nameof(SR.CatBehavior))]
+        [DefaultValue(true)]
+        [SRDescription(nameof(SR.SaveFileDialogExpandedMode))]
+        public bool ExpandedMode
+        {
+            get => GetOption((int)FOS.DEFAULTNOMINIMODE);
+            set => SetOption((int)FOS.DEFAULTNOMINIMODE, value);
         }
 
         /// <summary>
@@ -120,6 +143,7 @@ namespace System.Windows.Forms
         public override void Reset()
         {
             base.Reset();
+            SetOption((int)FOS.DEFAULTNOMINIMODE, true);
             SetOption((int)Comdlg32.OFN.OVERWRITEPROMPT, true);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
@@ -17,6 +17,7 @@ namespace System.Windows.Forms.Tests
         {
             using var dialog = new SubFileDialog();
             Assert.True(dialog.AddExtension);
+            Assert.True(dialog.AddToRecent);
             Assert.True(dialog.AutoUpgradeEnabled);
             Assert.True(dialog.CanRaiseEvents);
             Assert.False(dialog.CheckFileExists);
@@ -35,10 +36,13 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, dialog.FilterIndex);
             Assert.Empty(dialog.InitialDirectory);
             Assert.NotEqual(IntPtr.Zero, dialog.Instance);
+            Assert.False(dialog.OkRequiresInteraction);
             Assert.Equal(2052, dialog.Options);
             Assert.False(dialog.RestoreDirectory);
             Assert.False(dialog.ShowHelp);
+            Assert.False(dialog.ShowHiddenFiles);
             Assert.False(dialog.SupportMultiDottedExtensions);
+            Assert.True(dialog.ShowPinnedPlaces);
             Assert.Null(dialog.Site);
             Assert.Null(dialog.Tag);
             Assert.Empty(dialog.Title);
@@ -51,6 +55,7 @@ namespace System.Windows.Forms.Tests
         {
             using var dialog = new EmptyResetFileDialog();
             Assert.False(dialog.AddExtension);
+            Assert.True(dialog.AddToRecent);
             Assert.True(dialog.AutoUpgradeEnabled);
             Assert.True(dialog.CanRaiseEvents);
             Assert.False(dialog.CheckFileExists);
@@ -69,9 +74,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, dialog.FilterIndex);
             Assert.Empty(dialog.InitialDirectory);
             Assert.NotEqual(IntPtr.Zero, dialog.Instance);
+            Assert.False(dialog.OkRequiresInteraction);
             Assert.Equal(0, dialog.Options);
             Assert.False(dialog.RestoreDirectory);
             Assert.False(dialog.ShowHelp);
+            Assert.False(dialog.ShowHiddenFiles);
+            Assert.True(dialog.ShowPinnedPlaces);
             Assert.False(dialog.SupportMultiDottedExtensions);
             Assert.Null(dialog.Site);
             Assert.Null(dialog.Tag);
@@ -107,6 +115,29 @@ namespace System.Windows.Forms.Tests
             dialog.AddExtension = !value;
             Assert.Equal(!value, dialog.AddExtension);
             Assert.Equal(2052, dialog.Options);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, 2052, 33556484)]
+        [InlineData(false, 33556484, 2052)]
+        public void FileDialog_AddToRecent_Set_GetReturnsExpected(bool value, int expectedOptions, int expectedOptionsAfter)
+        {
+            using var dialog = new SubFileDialog
+            {
+                AddToRecent = value
+            };
+            Assert.Equal(value, dialog.AddToRecent);
+            Assert.Equal(expectedOptions, dialog.Options);
+
+            // Set same.
+            dialog.AddToRecent = value;
+            Assert.Equal(value, dialog.AddToRecent);
+            Assert.Equal(expectedOptions, dialog.Options);
+
+            // Set different.
+            dialog.AddToRecent = !value;
+            Assert.Equal(!value, dialog.AddToRecent);
+            Assert.Equal(expectedOptionsAfter, dialog.Options);
         }
 
         [WinFormsTheory]
@@ -340,6 +371,29 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(true, 2099204, 2052)]
+        [InlineData(false, 2052, 2099204)]
+        public void FileDialog_OkRequiresInteraction_Set_GetReturnsExpected(bool value, int expectedOptions, int expectedOptionsAfter)
+        {
+            using var dialog = new SubFileDialog
+            {
+                OkRequiresInteraction = value
+            };
+            Assert.Equal(value, dialog.OkRequiresInteraction);
+            Assert.Equal(expectedOptions, dialog.Options);
+
+            // Set same.
+            dialog.OkRequiresInteraction = value;
+            Assert.Equal(value, dialog.OkRequiresInteraction);
+            Assert.Equal(expectedOptions, dialog.Options);
+
+            // Set different.
+            dialog.OkRequiresInteraction = !value;
+            Assert.Equal(!value, dialog.OkRequiresInteraction);
+            Assert.Equal(expectedOptionsAfter, dialog.Options);
+        }
+
+        [WinFormsTheory]
         [InlineData(true, 2060, 2052)]
         [InlineData(false, 2052, 2060)]
         public void FileDialog_RestoreDirectory_Set_GetReturnsExpected(bool value, int expectedOptions, int expectedOptionsAfter)
@@ -382,6 +436,52 @@ namespace System.Windows.Forms.Tests
             // Set different.
             dialog.ShowHelp = !value;
             Assert.Equal(!value, dialog.ShowHelp);
+            Assert.Equal(expectedOptionsAfter, dialog.Options);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, 268437508, 2052)]
+        [InlineData(false, 2052, 268437508)]
+        public void FileDialog_ShowHiddenFiles_Set_GetReturnsExpected(bool value, int expectedOptions, int expectedOptionsAfter)
+        {
+            using var dialog = new SubFileDialog
+            {
+                ShowHiddenFiles = value
+            };
+            Assert.Equal(value, dialog.ShowHiddenFiles);
+            Assert.Equal(expectedOptions, dialog.Options);
+
+            // Set same.
+            dialog.ShowHiddenFiles = value;
+            Assert.Equal(value, dialog.ShowHiddenFiles);
+            Assert.Equal(expectedOptions, dialog.Options);
+
+            // Set different.
+            dialog.ShowHiddenFiles = !value;
+            Assert.Equal(!value, dialog.ShowHiddenFiles);
+            Assert.Equal(expectedOptionsAfter, dialog.Options);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, 2052, 264196)]
+        [InlineData(false, 264196, 2052)]
+        public void FileDialog_ShowPinnedPlaces_Set_GetReturnsExpected(bool value, int expectedOptions, int expectedOptionsAfter)
+        {
+            using var dialog = new SubFileDialog
+            {
+                ShowPinnedPlaces = value
+            };
+            Assert.Equal(value, dialog.ShowPinnedPlaces);
+            Assert.Equal(expectedOptions, dialog.Options);
+
+            // Set same.
+            dialog.ShowPinnedPlaces = value;
+            Assert.Equal(value, dialog.ShowPinnedPlaces);
+            Assert.Equal(expectedOptions, dialog.Options);
+
+            // Set different.
+            dialog.ShowPinnedPlaces = !value;
+            Assert.Equal(!value, dialog.ShowPinnedPlaces);
             Assert.Equal(expectedOptionsAfter, dialog.Options);
         }
 
@@ -487,6 +587,7 @@ namespace System.Windows.Forms.Tests
             using var dialog = new SubFileDialog
             {
                 AddExtension = false,
+                AddToRecent = false,
                 AutoUpgradeEnabled = false,
                 CheckFileExists = true,
                 CheckPathExists = false,
@@ -496,8 +597,11 @@ namespace System.Windows.Forms.Tests
                 FileName = "FileName",
                 FilterIndex = 2,
                 InitialDirectory = "InitialDirectory",
+                OkRequiresInteraction = true,
                 RestoreDirectory = true,
                 ShowHelp = true,
+                ShowHiddenFiles = true,
+                ShowPinnedPlaces = false,
                 SupportMultiDottedExtensions = true,
                 Tag = "Tag",
                 Title = "Title",
@@ -507,6 +611,7 @@ namespace System.Windows.Forms.Tests
 
             dialog.Reset();
             Assert.True(dialog.AddExtension);
+            Assert.True(dialog.AddToRecent);
             Assert.False(dialog.AutoUpgradeEnabled);
             Assert.True(dialog.CanRaiseEvents);
             Assert.False(dialog.CheckFileExists);
@@ -525,9 +630,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, dialog.FilterIndex);
             Assert.Empty(dialog.InitialDirectory);
             Assert.NotEqual(IntPtr.Zero, dialog.Instance);
+            Assert.False(dialog.OkRequiresInteraction);
             Assert.Equal(2052, dialog.Options);
             Assert.False(dialog.RestoreDirectory);
             Assert.False(dialog.ShowHelp);
+            Assert.False(dialog.ShowHiddenFiles);
+            Assert.True(dialog.ShowPinnedPlaces);
             Assert.False(dialog.SupportMultiDottedExtensions);
             Assert.Null(dialog.Site);
             Assert.Equal("Tag", dialog.Tag);
@@ -581,6 +689,7 @@ namespace System.Windows.Forms.Tests
             using var dialog = new SubFileDialog
             {
                 AddExtension = result,
+                AddToRecent = false,
                 AutoUpgradeEnabled = false,
                 CheckFileExists = true,
                 CheckPathExists = false,
@@ -589,8 +698,11 @@ namespace System.Windows.Forms.Tests
                 FileName = "FileName",
                 FilterIndex = 2,
                 InitialDirectory = "InitialDirectory",
+                OkRequiresInteraction = true,
                 RestoreDirectory = true,
                 ShowHelp = true,
+                ShowHiddenFiles = true,
+                ShowPinnedPlaces = false,
                 SupportMultiDottedExtensions = true,
                 Tag = "Tag",
                 Title = "Title",
@@ -611,7 +723,7 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(260, o.nMaxFileTitle);
                 Assert.Equal("InitialDirectory", o.lpstrInitialDir);
                 Assert.Equal("Title", o.lpstrTitle);
-                Assert.Equal(9961788, o.Flags);
+                Assert.Equal(314310972, o.Flags);
                 Assert.Equal(0, o.nFileOffset);
                 Assert.Equal(0, o.nFileExtension);
                 Assert.Equal(result ? "DefaultExt" : null, o.lpstrDefExt);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FolderBrowserDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FolderBrowserDialogTests.cs
@@ -14,17 +14,40 @@ namespace System.Windows.Forms.Tests
         public void FolderBrowserDialog_Ctor_Default()
         {
             using var dialog = new FolderBrowserDialog();
+            Assert.True(dialog.AddToRecent);
             Assert.True(dialog.AutoUpgradeEnabled);
             Assert.Null(dialog.Container);
             Assert.Empty(dialog.Description);
             Assert.Equal(Environment.SpecialFolder.Desktop, dialog.RootFolder);
             Assert.Empty(dialog.InitialDirectory);
+            Assert.False(dialog.OkRequiresInteraction);
             Assert.Empty(dialog.SelectedPath);
+            Assert.False(dialog.ShowHiddenFiles);
+            Assert.True(dialog.ShowPinnedPlaces);
             Assert.True(dialog.ShowNewFolderButton);
             Assert.Null(dialog.Site);
             Assert.Null(dialog.Tag);
             Assert.False(dialog.UseDescriptionForTitle);
             Assert.Null(dialog.ClientGuid);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void FolderBrowserDialog_AddToRecent_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new FolderBrowserDialog
+            {
+                AddToRecent = value
+            };
+            Assert.Equal(value, dialog.AddToRecent);
+
+            // Set same.
+            dialog.AddToRecent = value;
+            Assert.Equal(value, dialog.AddToRecent);
+
+            // Set different.
+            dialog.AddToRecent = !value;
+            Assert.Equal(!value, dialog.AddToRecent);
         }
 
         [WinFormsTheory]
@@ -59,6 +82,25 @@ namespace System.Windows.Forms.Tests
             // Set same.
             dialog.Description = value;
             Assert.Equal(value ?? string.Empty, dialog.Description);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void FolderBrowserDialog_OkRequiresInteraction_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new FolderBrowserDialog
+            {
+                OkRequiresInteraction = value
+            };
+            Assert.Equal(value, dialog.OkRequiresInteraction);
+
+            // Set same.
+            dialog.OkRequiresInteraction = value;
+            Assert.Equal(value, dialog.OkRequiresInteraction);
+
+            // Set different.
+            dialog.OkRequiresInteraction = !value;
+            Assert.Equal(!value, dialog.OkRequiresInteraction);
         }
 
         [WinFormsTheory]
@@ -117,6 +159,44 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void FolderBrowserDialog_ShowHiddenFiles_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new FolderBrowserDialog
+            {
+                ShowHiddenFiles = value
+            };
+            Assert.Equal(value, dialog.ShowHiddenFiles);
+
+            // Set same.
+            dialog.ShowHiddenFiles = value;
+            Assert.Equal(value, dialog.ShowHiddenFiles);
+
+            // Set different.
+            dialog.ShowHiddenFiles = !value;
+            Assert.Equal(!value, dialog.ShowHiddenFiles);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void FileDialog_ShowPinnedPlaces_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new FolderBrowserDialog
+            {
+                ShowPinnedPlaces = value
+            };
+            Assert.Equal(value, dialog.ShowPinnedPlaces);
+
+            // Set same.
+            dialog.ShowPinnedPlaces = value;
+            Assert.Equal(value, dialog.ShowPinnedPlaces);
+
+            // Set different.
+            dialog.ShowPinnedPlaces = !value;
+            Assert.Equal(!value, dialog.ShowPinnedPlaces);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
         public void FolderBrowserDialog_ShowNewFolderButton_Set_GetReturnsExpected(bool value)
         {
             using var dialog = new FolderBrowserDialog
@@ -158,11 +238,15 @@ namespace System.Windows.Forms.Tests
         {
             using var dialog = new FolderBrowserDialog
             {
+                AddToRecent = false,
                 AutoUpgradeEnabled = false,
                 Description = "A description",
                 RootFolder = Environment.SpecialFolder.CommonAdminTools,
                 InitialDirectory = @"C:\",
+                OkRequiresInteraction = true,
                 SelectedPath = @"C:\",
+                ShowHiddenFiles = true,
+                ShowPinnedPlaces = false,
                 ShowNewFolderButton = false,
                 UseDescriptionForTitle = true,
                 ClientGuid = new Guid("ad6e2857-4659-4791-aa59-efffa61d4594"),
@@ -170,12 +254,16 @@ namespace System.Windows.Forms.Tests
 
             dialog.Reset();
 
+            Assert.True(dialog.AddToRecent);
             Assert.False(dialog.AutoUpgradeEnabled);
             Assert.Null(dialog.Container);
             Assert.Empty(dialog.Description);
             Assert.Equal(Environment.SpecialFolder.Desktop, dialog.RootFolder);
             Assert.Empty(dialog.InitialDirectory);
+            Assert.False(dialog.OkRequiresInteraction);
             Assert.Empty(dialog.SelectedPath);
+            Assert.False(dialog.ShowHiddenFiles);
+            Assert.True(dialog.ShowPinnedPlaces);
             Assert.True(dialog.ShowNewFolderButton);
             Assert.Null(dialog.Site);
             Assert.Null(dialog.Tag);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OpenFileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/OpenFileDialogTests.cs
@@ -1,0 +1,160 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms.TestUtilities;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class OpenFileDialogTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void OpenFileDialog_Ctor_Default()
+        {
+            using var dialog = new OpenFileDialog();
+            Assert.True(dialog.CheckFileExists);
+            Assert.False(dialog.Multiselect);
+            Assert.False(dialog.ReadOnlyChecked);
+            Assert.True(dialog.SelectReadOnly);
+            Assert.False(dialog.ShowPreview);
+            Assert.False(dialog.ShowReadOnly);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void OpenFileDialog_CheckFileExists_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new OpenFileDialog
+            {
+                CheckFileExists = value
+            };
+            Assert.Equal(value, dialog.CheckFileExists);
+
+            // Set same.
+            dialog.CheckFileExists = value;
+            Assert.Equal(value, dialog.CheckFileExists);
+
+            // Set different.
+            dialog.CheckFileExists = !value;
+            Assert.Equal(!value, dialog.CheckFileExists);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void OpenFileDialog_Multiselect_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new OpenFileDialog
+            {
+                Multiselect = value
+            };
+            Assert.Equal(value, dialog.Multiselect);
+
+            // Set same.
+            dialog.Multiselect = value;
+            Assert.Equal(value, dialog.Multiselect);
+
+            // Set different.
+            dialog.Multiselect = !value;
+            Assert.Equal(!value, dialog.Multiselect);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void OpenFileDialog_ReadOnlyChecked_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new OpenFileDialog
+            {
+                ReadOnlyChecked = value
+            };
+            Assert.Equal(value, dialog.ReadOnlyChecked);
+
+            // Set same.
+            dialog.ReadOnlyChecked = value;
+            Assert.Equal(value, dialog.ReadOnlyChecked);
+
+            // Set different.
+            dialog.ReadOnlyChecked = !value;
+            Assert.Equal(!value, dialog.ReadOnlyChecked);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void OpenFileDialog_SelectReadOnly_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new OpenFileDialog
+            {
+                SelectReadOnly = value
+            };
+            Assert.Equal(value, dialog.SelectReadOnly);
+
+            // Set same.
+            dialog.SelectReadOnly = value;
+            Assert.Equal(value, dialog.SelectReadOnly);
+
+            // Set different.
+            dialog.SelectReadOnly = !value;
+            Assert.Equal(!value, dialog.SelectReadOnly);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void OpenFileDialog_ShowPreview_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new OpenFileDialog
+            {
+                ShowPreview = value
+            };
+            Assert.Equal(value, dialog.ShowPreview);
+
+            // Set same.
+            dialog.ShowPreview = value;
+            Assert.Equal(value, dialog.ShowPreview);
+
+            // Set different.
+            dialog.ShowPreview = !value;
+            Assert.Equal(!value, dialog.ShowPreview);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void OpenFileDialog_ShowReadOnly_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new OpenFileDialog
+            {
+                ShowReadOnly = value
+            };
+            Assert.Equal(value, dialog.ShowReadOnly);
+
+            // Set same.
+            dialog.ShowReadOnly = value;
+            Assert.Equal(value, dialog.ShowReadOnly);
+
+            // Set different.
+            dialog.ShowReadOnly = !value;
+            Assert.Equal(!value, dialog.ShowReadOnly);
+        }
+
+        [WinFormsFact]
+        public void OpenFileDialog_Reset_Invoke_Success()
+        {
+            using var dialog = new OpenFileDialog
+            {
+                CheckFileExists = false,
+                Multiselect = true,
+                ReadOnlyChecked = true,
+                SelectReadOnly = false,
+                ShowPreview = true,
+                ShowReadOnly = true
+            };
+
+            dialog.Reset();
+            Assert.True(dialog.CheckFileExists);
+            Assert.False(dialog.Multiselect);
+            Assert.False(dialog.ReadOnlyChecked);
+            Assert.True(dialog.SelectReadOnly);
+            Assert.False(dialog.ShowPreview);
+            Assert.False(dialog.ShowReadOnly);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SaveFileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SaveFileDialogTests.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms.TestUtilities;
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class SaveFileDialogTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void SaveFileDialog_Ctor_Default()
+        {
+            using var dialog = new SaveFileDialog();
+            Assert.True(dialog.CheckWriteAccess);
+            Assert.False(dialog.CreatePrompt);
+            Assert.True(dialog.ExpandedMode);
+            Assert.True(dialog.OverwritePrompt);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void SaveFileDialog_CheckWriteAccess_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new SaveFileDialog
+            {
+                CheckWriteAccess = value
+            };
+            Assert.Equal(value, dialog.CheckWriteAccess);
+
+            // Set same.
+            dialog.CheckWriteAccess = value;
+            Assert.Equal(value, dialog.CheckWriteAccess);
+
+            // Set different.
+            dialog.CheckWriteAccess = !value;
+            Assert.Equal(!value, dialog.CheckWriteAccess);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void SaveFileDialog_CreatePrompt_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new SaveFileDialog
+            {
+                CreatePrompt = value
+            };
+            Assert.Equal(value, dialog.CreatePrompt);
+
+            // Set same.
+            dialog.CreatePrompt = value;
+            Assert.Equal(value, dialog.CreatePrompt);
+
+            // Set different.
+            dialog.CreatePrompt = !value;
+            Assert.Equal(!value, dialog.CreatePrompt);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void SaveFileDialog_ExpandedMode_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new SaveFileDialog
+            {
+                ExpandedMode = value
+            };
+            Assert.Equal(value, dialog.ExpandedMode);
+
+            // Set same.
+            dialog.ExpandedMode = value;
+            Assert.Equal(value, dialog.ExpandedMode);
+
+            // Set different.
+            dialog.ExpandedMode = !value;
+            Assert.Equal(!value, dialog.ExpandedMode);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void SaveFileDialog_OverwritePrompt_Set_GetReturnsExpected(bool value)
+        {
+            using var dialog = new SaveFileDialog
+            {
+                OverwritePrompt = value
+            };
+            Assert.Equal(value, dialog.OverwritePrompt);
+
+            // Set same.
+            dialog.OverwritePrompt = value;
+            Assert.Equal(value, dialog.OverwritePrompt);
+
+            // Set different.
+            dialog.OverwritePrompt = !value;
+            Assert.Equal(!value, dialog.OverwritePrompt);
+        }
+
+        [WinFormsFact]
+        public void SaveFileDialog_Reset_Invoke_Success()
+        {
+            using var dialog = new SaveFileDialog
+            {
+                CheckWriteAccess = false,
+                CreatePrompt = true,
+                ExpandedMode = false,
+                OverwritePrompt = false
+            };
+
+            dialog.Reset();
+            Assert.True(dialog.CheckWriteAccess);
+            Assert.False(dialog.CreatePrompt);
+            Assert.True(dialog.ExpandedMode);
+            Assert.True(dialog.OverwritePrompt);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #5405 

## Proposed changes

Add missing feasible file and folder dialog options and expose them via public properties.

- AddToRecent
- CheckWriteAccess
- ExpandedMode
- OkRequiresInteraction
- SelectReadOnly
- ShowHiddenFiles
- ShowPinnedPlaces
- ShowPreview

```csharp

namespace System.Windows.Forms
{
    public partial class FileDialog
    {
        [DefaultValue(true)]
        public bool AddToRecent { get; set; } = true;

        [DefaultValue(false)]
        public bool ShowHiddenFiles { get; set; }

        [DefaultValue(true)]
        public bool ShowPinnedPlaces { get; set; } = true;

        [DefaultValue(false)]
        public bool OkRequiresInteraction { get; set; }
    }

    public partial class OpenFileDialog
    {
        [DefaultValue(false)]
        public bool ShowPreview { get; set; }

        [DefaultValue(true)]
        public bool SelectReadOnly { get; set; } = true;
    }

    public partial class SaveFileDialog
    {
        [DefaultValue(true)]
        public bool ExpandedMode { get; set; } = true;

        [DefaultValue(true)]
        public bool CheckWriteAccess { get; set; } = true;
    }

    public partial class FolderBrowserDialog
    {
        [DefaultValue(true)]
        public bool AddToRecent { get; set; } = true;

        [DefaultValue(false)]
        public bool ShowHiddenFiles { get; set; }

        [DefaultValue(true)]
        public bool ShowPinnedPlaces { get; set; } = true;

        [DefaultValue(false)]
        public bool OkRequiresInteraction { get; set; }
    }
}

```

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improved file and folder dialog experience.

## Regression? 

- No.

## Risk

- I could use some guidance analyzing the risk for this change.
- I don't know if I've included everything that is necessary for the VS Designer to support this feature.

<!-- end TELL-MODE -->

## Videos <!-- Remove this section if PR does not change UI -->

<details><summary>AddToRecent</summary>

Gets or sets a value indicating whether the dialog box adds the folder being selected to the recent list.

https://user-images.githubusercontent.com/5017479/137843944-f00e8399-dd5b-41b8-8943-bfd0be76de10.mp4

</details>

<details><summary>CheckWriteAccess</summary>

Gets or sets a value indicating whether the dialog box verifies whether creation of the specified file will be successful. If this flag is not set, the calling application must handle errors, such as denial of access, discovered when the item is created.

https://user-images.githubusercontent.com/5017479/137844713-1ab80c5b-1d1b-4de1-971d-705fe0074c8d.mp4

</details>

<details><summary>ExpandedMode</summary>

Gets or sets a value indicating whether the dialog box is always opened in the expanded mode.

https://user-images.githubusercontent.com/5017479/137844642-7765180b-0a23-4248-b350-76a7c55c6626.mp4

</details>

<details><summary>OkRequiresInteraction</summary>

Gets or sets a value indicating whether the OK button of the dialog box is disabled until the user navigates the view or edits the filename (if applicable). Note: Disabling of the OK button does not prevent the dialog from being submitted by the Enter key.

https://user-images.githubusercontent.com/5017479/137844523-a2b15923-c496-4481-9941-6518909b46ea.mp4

</details>

<details><summary>SelectReadOnly</summary>

Gets or sets a value indicating whether the dialog box allows to select read-only files.

https://user-images.githubusercontent.com/5017479/137844790-4e40ba95-ef1f-459e-819f-a2900e99b452.mp4

</details>

<details><summary>ShowHiddenFiles</summary>

Gets or sets a value indicating whether the dialog box displays hidden and system files.

https://user-images.githubusercontent.com/5017479/137844598-8fe5334d-7d29-4c25-acca-58f5d3bfbda4.mp4

</details>

<details><summary>ShowPinnedPlaces</summary>

Gets or sets a value indicating whether the items shown by default in the view's navigation pane are hidden.

https://user-images.githubusercontent.com/5017479/137844557-575f1bba-7e47-4db0-b0a5-dd7c6d61cea7.mp4

</details>

<details><summary>ShowPreview</summary>

Gets or sets a value indicating whether the dialog box shows a preview for selected files.

https://user-images.githubusercontent.com/5017479/137844744-c93c7007-9411-41cb-b01a-2b8acb9a62b3.mp4

</details>

## Test methodology <!-- How did you ensure quality? -->

- Added unit tests.
- Manually tested the changes using WinformsControlsTest -> Dialogs Test (see videos).
- Ran unit and integration tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

Accessibility Insights for Windows

I'm seeing FastPass automated check failures for the `FolderBrowserDialog`, `OpenFileDialog`, and `SaveFileDialog` prior to making this change. Based on my tests this change does not increase the number of failures detected.

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10.0.22000
- .NET Core SDK 6.0.100

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6244)