### PR TITLE
Fixing NullReferenceException when user removes ListViewItem

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6907,4 +6907,7 @@ Stack trace where the illegal operation occurred was:
   <data name="EditDefaultAccessibleName" xml:space="preserve">
     <value>Spinner</value>
   </data>
+  <data name="ListViewItemAccessibilityObjectRequiresListView" xml:space="preserve">
+    <value>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -6571,6 +6571,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Aktuální objekt přístupnosti je určený jenom pro ovládací prvek ListView v zobrazení {0}, {1} nebo {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Událost aktivovaná v případě změny zaškrtnuté vlastnosti položky ListView</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -6571,6 +6571,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Das aktuelle Objekt für Barrierefreiheit gilt nur für ListView in der Ansicht "{0}", "{1}" oder "{2}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Das ausgelöste Ereignis, wenn sich die aktivierte Eigenschaft für ein ListView-Element ändert.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -6571,6 +6571,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">El objeto de accesibilidad actual solo es para la vista ListView en {0}, {1} o {2} Vista</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Evento que se desencadena cuando cambia la propiedad checked de un elemento ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -6571,6 +6571,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">L’objet d’accessibilité actuel est uniquement destiné à ListView dans l’affichage {0}, {1} ou {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Événement déclenché lorsque la propriété Checked d'un élément ListView est modifiée.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -6571,6 +6571,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">L'oggetto accessibilità corrente viene usato solo per il controllo ListView nella visualizzazione {0}, {1} o {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Evento generato quando la proprietà checked di un elemento di ListView cambia.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -6571,6 +6571,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">現在のアクセシビリティ オブジェクトは {0}、{1} または {2} ビューの ListView にのみ使用できます</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView アイテムのチェックされたプロパティが変更するときに発生するイベントです。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -6571,6 +6571,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">현재 접근성 개체는 {0}, {1} 또는 {2} 보기의 ListView에만 해당됩니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView 항목의 Checked 속성이 변경되면 이벤트가 발생합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -6571,6 +6571,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Bieżący obiekt ułatwień dostępu jest przeznaczony tylko dla elementu ListView w widoku {0}, {1} lub {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Zdarzenie wywoływane, gdy zostanie zmieniona zaznaczona właściwość elementu ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -6571,6 +6571,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">O objeto de acessibilidade atual é apenas para ListView no modo de exibição {0}, {1} ou {2}</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Evento gerado quando a propriedade de ativação de um item ListView é alterada.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -6572,6 +6572,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Текущий объект специальных возможностей предназначен только для ListView в представлениях {0}, {1} или {2}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Событие возникает при изменении отмеченного свойства элемента ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -6571,6 +6571,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Geçerli erişilebilirlik nesnesi yalnızca {0}, {1} veya {2} görünümündeki ListView içindir</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView öğesinin Checked özelliği değiştiğinde harekete geçirilen olay.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -6571,6 +6571,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">当前的可访问性对象仅适用于 {0}、{1} 或 {2} 视图中的 ListView</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">当 ListView 项的 Checked 属性更改时引发的事件。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -6571,6 +6571,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">目前的協助工具物件僅適用於 {0}、 {1} 或 {2} 檢視中的 ListView</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
+        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
+        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView 項目的核取屬性變更時引發的事件。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -73,6 +73,8 @@ namespace System.Windows.Forms
         private static bool s_notificationEventAvailable = true;
         private static bool? s_canNotifyClients;
 
+        internal const int InvalidIndex = -1;
+
         internal const int RuntimeIDFirstItem = 0x2a;
 
         public AccessibleObject()
@@ -205,7 +207,7 @@ namespace System.Windows.Forms
         /// </summary>
         public virtual AccessibleObject? GetChild(int index) => null;
 
-        internal virtual int GetChildIndex(AccessibleObject? child) => -1;
+        internal virtual int GetChildIndex(AccessibleObject? child) => InvalidIndex;
 
         /// <summary>
         ///  When overridden in a derived class, gets the number of children

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -102,7 +102,7 @@ namespace System.Windows.Forms
             {
                 if (!_owningListView.IsHandleCreated)
                 {
-                    return -1;
+                    return InvalidIndex;
                 }
 
                 return _owningListView.GroupsDisplayed ? GetVisibleGroups().Count : _owningListView.Items.Count;
@@ -112,23 +112,23 @@ namespace System.Windows.Forms
             {
                 if (child is null)
                 {
-                    return -1;
+                    return InvalidIndex;
                 }
 
                 if (child is ListViewItem.ListViewItemBaseAccessibleObject itemAccessibleObject)
                 {
                     int index = itemAccessibleObject.CurrentIndex;
-                    return index < _owningListView.Items.Count ? index : -1;
+                    return index < _owningListView.Items.Count ? index : InvalidIndex;
                 }
 
-                return -1;
+                return InvalidIndex;
             }
 
             private int GetGroupIndex(AccessibleObject? child)
             {
                 if (child is null)
                 {
-                    return -1;
+                    return InvalidIndex;
                 }
 
                 IReadOnlyList<ListViewGroup> visibleGroups = GetVisibleGroups();
@@ -140,7 +140,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                return -1;
+                return InvalidIndex;
             }
 
             internal override int GetChildIndex(AccessibleObject? child) => _owningListView.GroupsDisplayed ? GetGroupIndex(child) : GetItemIndex(child);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -228,7 +228,9 @@ namespace System.Windows.Forms
                         return _owningListViewAccessibilityObject;
                     case UiaCore.NavigateDirection.NextSibling:
                         int childIndex = _owningListViewAccessibilityObject.GetChildIndex(this);
-                        return childIndex == -1 ? null : _owningListViewAccessibilityObject.GetChild(childIndex + 1);
+                        return childIndex == InvalidIndex
+                            ? null
+                            : _owningListViewAccessibilityObject.GetChild(childIndex + 1);
                     case UiaCore.NavigateDirection.PreviousSibling:
                         return _owningListViewAccessibilityObject.GetChild(_owningListViewAccessibilityObject.GetChildIndex(this) - 1);
                     case UiaCore.NavigateDirection.FirstChild:
@@ -262,7 +264,7 @@ namespace System.Windows.Forms
             {
                 if (child is null || !_owningListView.IsHandleCreated || !_owningListView.GroupsDisplayed)
                 {
-                    return -1;
+                    return InvalidIndex;
                 }
 
                 IReadOnlyList<ListViewItem> visibleItems = GetVisibleItems();
@@ -274,14 +276,14 @@ namespace System.Windows.Forms
                     }
                 }
 
-                return -1;
+                return InvalidIndex;
             }
 
             public override int GetChildCount()
             {
                 if (!_owningListView.IsHandleCreated || !_owningListView.GroupsDisplayed)
                 {
-                    return -1;
+                    return InvalidIndex;
                 }
 
                 return GetVisibleItems().Count;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -63,7 +63,7 @@ namespace System.Windows.Forms
                     || !_owningListView.SupportsListViewSubItems
                     || child is not ListViewSubItem.ListViewSubItemAccessibleObject subItemAccessibleObject)
                 {
-                    return -1;
+                    return InvalidIndex;
                 }
 
                 if (subItemAccessibleObject.OwningSubItem is null)
@@ -72,7 +72,7 @@ namespace System.Windows.Forms
                 }
 
                 int index = _owningItem.SubItems.IndexOf(subItemAccessibleObject.OwningSubItem);
-                return index > _owningListView.Columns.Count - 1 ? -1 : index;
+                return index > _owningListView.Columns.Count - 1 ? InvalidIndex : index;
             }
 
             // This method returns an accessibility object for an existing ListViewSubItem, or creates a fake one

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemListAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemListAccessibleObject.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms
                         return _parentInternal;
                     case UiaCore.NavigateDirection.NextSibling:
                         int childIndex = _parentInternal.GetChildIndex(this);
-                        return childIndex == -1 ? null : _parentInternal.GetChild(childIndex + 1);
+                        return childIndex == InvalidIndex ? null : _parentInternal.GetChild(childIndex + 1);
                     case UiaCore.NavigateDirection.PreviousSibling:
                         return _parentInternal.GetChild(_parentInternal.GetChildIndex(this) - 1);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemTileAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemTileAccessibleObject.cs
@@ -65,7 +65,7 @@ namespace System.Windows.Forms
 
                 if (!_owningListView.IsHandleCreated || !_owningListView.SupportsListViewSubItems)
                 {
-                    return -1;
+                    return InvalidIndex;
                 }
 
                 if (_owningItem.SubItems.Count == 1)
@@ -84,11 +84,11 @@ namespace System.Windows.Forms
                     || child is not ListViewSubItem.ListViewSubItemAccessibleObject subItemAccessibleObject
                     || subItemAccessibleObject.OwningSubItem is null)
                 {
-                    return -1;
+                    return InvalidIndex;
                 }
 
                 int index = _owningItem.SubItems.IndexOf(subItemAccessibleObject.OwningSubItem);
-                return index == -1 || index > GetLastChildIndex() ? -1 : index;
+                return index == -1 || index > GetLastChildIndex() ? InvalidIndex : index;
             }
 
             private int GetLastChildIndex()
@@ -97,7 +97,7 @@ namespace System.Windows.Forms
                 // Therefore, it is not displayed in the ListViewSubItems list
                 if (_owningItem.SubItems.Count == 1)
                 {
-                    return -1;
+                    return InvalidIndex;
                 }
 
                 // Only ListViewSubItems with the corresponding columns are displayed in the ListView

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -36,7 +36,7 @@ namespace System.Windows.Forms
                     get
                     {
                         int index = ParentInternal.GetChildIndex(this);
-                        if (index == -1)
+                        if (index == InvalidIndex)
                         {
                             return Rectangle.Empty;
                         }
@@ -81,7 +81,10 @@ namespace System.Windows.Forms
                         _ => base.FragmentNavigate(direction)
                     };
 
-                internal override int Column => _owningListView.View == View.Details ? ParentInternal.GetChildIndex(this) : -1;
+                internal override int Column
+                    => _owningListView.View == View.Details
+                        ? ParentInternal.GetChildIndex(this)
+                        : InvalidIndex;
 
                 /// <summary>
                 ///  Gets or sets the accessible name.
@@ -158,7 +161,7 @@ namespace System.Windows.Forms
                 }
 
                 private string AutomationId
-                    => string.Format("{0}-{1}", typeof(ListViewItem.ListViewSubItem).Name, ParentInternal.GetChildIndex(this));
+                    => $"{typeof(ListViewItem.ListViewSubItem).Name}-{ParentInternal.GetChildIndex(this)}";
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.cs
@@ -71,6 +71,8 @@ namespace System.Windows.Forms
                 }
             }
 
+            internal bool IsAccessibilityObjectCreated => _accessibilityObject is not null;
+
             public Color BackColor
             {
                 get

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -973,5 +973,17 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId) ?? false);
             Assert.False(listView.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_State_ReturnsFocusable()
+        {
+            using ListView listview = new();
+            ListViewItem listViewItem = new();
+            ListViewItem.ListViewSubItem listViewSubItem = new();
+            listViewItem.SubItems.Add(listViewSubItem);
+            listview.Items.Add(listViewItem);
+
+            Assert.Equal(AccessibleStates.Focusable, listViewSubItem.AccessibilityObject.State);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemTests.cs
@@ -1071,11 +1071,11 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
-        public void ListViewItem_AccessibilityObject_ReturnsNull_IfListViewNotExists()
+        public void ListViewItem_AccessibilityObject_ThrowsInvalidOperationException_IfListViewNotExists()
         {
             ListViewItem item = new();
 
-            Assert.Null(item.AccessibilityObject);
+            Assert.Throws<InvalidOperationException>(() => item.AccessibilityObject);
         }
 
         [WinFormsFact]
@@ -1086,6 +1086,34 @@ namespace System.Windows.Forms.Tests
             listView.Items.Add(item);
 
             Assert.NotNull(item.AccessibilityObject);
+        }
+
+        [WinFormsFact]
+        public void ListViewItem_AccessibilityObject_ThrowsInvalidOperationException_IfRemoved()
+        {
+            using ListView listView = new();
+            ListViewItem item = new();
+            listView.Items.Add(item);
+
+            Assert.NotNull(item.AccessibilityObject);
+
+            listView.Items.RemoveAt(0);
+
+            Assert.Throws<InvalidOperationException>(() => item.AccessibilityObject);
+        }
+
+        [WinFormsFact]
+        public void ListViewItem_AccessibilityObject_ThrowsInvalidOperationException_IfCleared()
+        {
+            using ListView listView = new();
+            ListViewItem item = new();
+            listView.Items.Add(item);
+
+            Assert.NotNull(item.AccessibilityObject);
+
+            listView.Items.Clear();
+
+            Assert.Throws<InvalidOperationException>(() => item.AccessibilityObject);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -4400,6 +4400,8 @@ namespace System.Windows.Forms.Tests
             listView.CreateControl();
             listItem1.SetItemIndex(listView, 0);
 
+            Assert.NotNull(listView.AccessibilityObject);
+
             SubListViewItemAccessibleObject customAccessibleObject = new SubListViewItemAccessibleObject(listItem1);
             listItem1.CustomAccessibleObject = customAccessibleObject;
 
@@ -4792,6 +4794,8 @@ namespace System.Windows.Forms.Tests
             {
                 Assert.NotEqual(IntPtr.Zero, listView.Handle);
             }
+
+            Assert.NotNull(listView.AccessibilityObject);
 
             SubListViewItemAccessibleObject customAccessibleObject = new SubListViewItemAccessibleObject(listItem);
             listItem.CustomAccessibleObject = customAccessibleObject;
@@ -5259,6 +5263,7 @@ namespace System.Windows.Forms.Tests
             using SubListView listView = GetSubListViewWithData(view, virtualMode, showGroups, withinGroup, createControl: true);
             ListViewItem listViewItem = listView.Items[0];
 
+            Assert.NotNull(listView.AccessibilityObject);
             Assert.NotNull(listViewItem.AccessibilityObject);
 
             SubListViewItemAccessibleObject accessibleObject = new SubListViewItemAccessibleObject(listViewItem);
@@ -5691,6 +5696,70 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(selectedCount, listView.CheckedItems.Count);
                 Assert.Equal(selectedCount, listView.CheckedIndices.Count);
             }
+        }
+
+        [WinFormsFact]
+        public void ListView_FocusedItem_Reset_Remove()
+        {
+            using ListView listView = new();
+            listView.CreateControl();
+            listView.Items.Add(new ListViewItem("Test 1"));
+            listView.Items.Add(new ListViewItem("Test 2"));
+            listView.Items[0].Focused = true;
+
+            Assert.NotNull(listView.FocusedItem);
+
+            listView.Items.Remove(listView.Items[0]);
+
+            Assert.Null(listView.FocusedItem);
+        }
+
+        [WinFormsFact]
+        public void ListView_FocusedItem_Reset_RemoveAt()
+        {
+            using ListView listView = new();
+            listView.CreateControl();
+            listView.Items.Add(new ListViewItem("Test 1"));
+            listView.Items.Add(new ListViewItem("Test 2"));
+            listView.Items[0].Focused = true;
+
+            Assert.NotNull(listView.FocusedItem);
+
+            listView.Items.RemoveAt(0);
+
+            Assert.Null(listView.FocusedItem);
+        }
+
+        [WinFormsFact]
+        public void ListView_FocusedItem_Reset_RemoveByKey()
+        {
+            using ListView listView = new();
+            listView.CreateControl();
+            listView.Items.Add(new ListViewItem("Test 1") { Name = "Test 1" });
+            listView.Items.Add(new ListViewItem("Test 2"));
+            listView.Items[0].Focused = true;
+
+            Assert.NotNull(listView.FocusedItem);
+
+            listView.Items.RemoveByKey("Test 1");
+
+            Assert.Null(listView.FocusedItem);
+        }
+
+        [WinFormsFact]
+        public void ListView_FocusedItem_Reset_Clear()
+        {
+            using ListView listView = new();
+            listView.CreateControl();
+            listView.Items.Add(new ListViewItem("Test 1"));
+            listView.Items.Add(new ListViewItem("Test 2"));
+            listView.Items[0].Focused = true;
+
+            Assert.NotNull(listView.FocusedItem);
+
+            listView.Items.Clear();
+
+            Assert.Null(listView.FocusedItem);
         }
 
         private class SubListViewItem : ListViewItem


### PR DESCRIPTION
Fixes #6230 

## Proposed changes
- The issue is reproduced because we believed that if an `ListViewItem` does not have a `ListView`, then it is inaccessible to the user and has no interaction with the Accessibility tool (Inspect, Narrator).
- Unfortunately, after deleting an `ListViewItem`, the Accessibility tool still tries to get information about it, although the `ListViewItem` no longer has a `ListView`. Therefore, the logic has been updated to work with an `ListViewItem` that does not have a `ListView`.
- Also, after the focused `ListViewItem` is removed, it remains cached in the `FocusedItem` property. It also forces the Accessibility tool to try to retrieve the data of the `ListViewItem` that is not displayed. As a fix, a logic was added to reset the `Focused` flag from the `ListViewItem`.

## Customer Impact
**Before fix:**
![Issue-6230-before](https://user-images.githubusercontent.com/23376742/144040481-714f76ab-e33b-46dc-bdcc-d98e00346f1d.gif)

**After fix:**
![Issue-6230](https://user-images.githubusercontent.com/23376742/144039475-a8f96143-e35c-4741-921e-81c771413686.gif)

## Regression? 
- Yes.

## Risk
- Minimal.

## Test methodology <!-- How did you ensure quality? -->
-  CTI team;
- Unit tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Accessibility Insights;
- Inspect;
- Narrator.

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.1348]
- .NET Core SDK: 7.0.0-alpha.1.21576.4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6249)