### PR TITLE
Fixing color contrast for DataGridViewLinkCell active link when cell is selected

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewLinkCell.cs
@@ -59,8 +59,8 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    // return the default IE Color
-                    return LinkUtilities.IEActiveLinkColor;
+                    // return the default IE Color if cell is not not selected
+                    return Selected ? SystemColors.HighlightText : LinkUtilities.IEActiveLinkColor;
                 }
             }
             set
@@ -183,7 +183,7 @@ namespace System.Windows.Forms
                 else
                 {
                     // return the default IE Color when cell is not selected
-                    return Selected ? Color.White : LinkUtilities.IELinkColor;
+                    return Selected ? SystemColors.HighlightText : LinkUtilities.IELinkColor;
                 }
             }
             set
@@ -379,8 +379,8 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    // return the default IE Color
-                    return LinkUtilities.IEVisitedLinkColor;
+                    // return the default IE Color if cell is not not selected
+                    return Selected ? SystemColors.HighlightText : LinkUtilities.IEVisitedLinkColor;
                 }
             }
             set
@@ -1019,8 +1019,9 @@ namespace System.Windows.Forms
 
                 Font getLinkFont = null;
                 Font getHoverFont = null;
+                bool isActive = (LinkState & LinkState.Active) == LinkState.Active;
 
-                LinkUtilities.EnsureLinkFonts(cellStyle.Font, LinkBehavior, ref getLinkFont, ref getHoverFont);
+                LinkUtilities.EnsureLinkFonts(cellStyle.Font, LinkBehavior, ref getLinkFont, ref getHoverFont, isActive);
                 TextFormatFlags flags = DataGridViewUtilities.ComputeTextFormatFlagsForCellStyleAlignment(
                     DataGridView.RightToLeftInternal,
                     cellStyle.Alignment,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkUtilities.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkUtilities.cs
@@ -161,7 +161,7 @@ namespace System.Windows.Forms
             return LinkBehavior.AlwaysUnderline;
         }
 
-        public static void EnsureLinkFonts(Font baseFont, LinkBehavior link, ref Font linkFont, ref Font hoverLinkFont)
+        public static void EnsureLinkFonts(Font baseFont, LinkBehavior link, ref Font linkFont, ref Font hoverLinkFont, bool isActive = false)
         {
             if (linkFont is not null && hoverLinkFont is not null)
             {
@@ -207,6 +207,15 @@ namespace System.Windows.Forms
                 else
                 {
                     style &= ~FontStyle.Underline;
+                }
+
+                if (isActive)
+                {
+                    style |= FontStyle.Bold;
+                }
+                else
+                {
+                    style &= ~FontStyle.Bold;
                 }
 
                 hoverLinkFont = new Font(f, style);


### PR DESCRIPTION
Fixes #6116


## Proposed changes

- Color for link in the selected cell switched to `SystemColors.HighLightText`
- Font for the active link inside selected cell switched to bold

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Before fix:

![image](https://user-images.githubusercontent.com/74228865/144044156-948de530-deac-4637-84fb-b6b83132ddbb.png)

![image](https://user-images.githubusercontent.com/74228865/144044177-e0e69774-c7e1-4886-8ddb-237013718beb.png)

- After fix:

![DataGridViewLinkCellColor](https://user-images.githubusercontent.com/74228865/144043837-716e9b7b-0d01-49b7-bb27-08807623b483.gif)

## Regression? 

- No

## Risk

- Minimal

## Test methodology

- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Accesssibility Insights

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19042.1237]
- .NET 6.0.100-rc.2.21505.57


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6250)