### PR TITLE
Enable nullability in ToolStripItemImageRenderEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2880,9 +2880,9 @@ System.Windows.Forms.ToolStripItemClickedEventArgs.ToolStripItemClickedEventArgs
 ~System.Windows.Forms.ToolStripItemCollection.ToolStripItemCollection(System.Windows.Forms.ToolStrip owner, System.Windows.Forms.ToolStripItem[] value) -> void
 System.Windows.Forms.ToolStripItemEventArgs.Item.get -> System.Windows.Forms.ToolStripItem?
 System.Windows.Forms.ToolStripItemEventArgs.ToolStripItemEventArgs(System.Windows.Forms.ToolStripItem? item) -> void
-~System.Windows.Forms.ToolStripItemImageRenderEventArgs.Image.get -> System.Drawing.Image
-~System.Windows.Forms.ToolStripItemImageRenderEventArgs.ToolStripItemImageRenderEventArgs(System.Drawing.Graphics g, System.Windows.Forms.ToolStripItem item, System.Drawing.Image image, System.Drawing.Rectangle imageRectangle) -> void
-~System.Windows.Forms.ToolStripItemImageRenderEventArgs.ToolStripItemImageRenderEventArgs(System.Drawing.Graphics g, System.Windows.Forms.ToolStripItem item, System.Drawing.Rectangle imageRectangle) -> void
+System.Windows.Forms.ToolStripItemImageRenderEventArgs.Image.get -> System.Drawing.Image?
+System.Windows.Forms.ToolStripItemImageRenderEventArgs.ToolStripItemImageRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem? item, System.Drawing.Image? image, System.Drawing.Rectangle imageRectangle) -> void
+System.Windows.Forms.ToolStripItemImageRenderEventArgs.ToolStripItemImageRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem? item, System.Drawing.Rectangle imageRectangle) -> void
 System.Windows.Forms.ToolStripItemRenderEventArgs.Graphics.get -> System.Drawing.Graphics!
 System.Windows.Forms.ToolStripItemRenderEventArgs.Item.get -> System.Windows.Forms.ToolStripItem?
 System.Windows.Forms.ToolStripItemRenderEventArgs.ToolStrip.get -> System.Windows.Forms.ToolStrip?

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemImageRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemImageRenderEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 using System.Drawing.Imaging;
 
@@ -11,7 +9,8 @@ namespace System.Windows.Forms
 {
     public class ToolStripItemImageRenderEventArgs : ToolStripItemRenderEventArgs
     {
-        public ToolStripItemImageRenderEventArgs(Graphics g, ToolStripItem item, Rectangle imageRectangle) : base(g, item)
+        public ToolStripItemImageRenderEventArgs(Graphics g, ToolStripItem? item, Rectangle imageRectangle)
+            : base(g, item)
         {
             Image = (item is not null && item.RightToLeftAutoMirrorImage && item.RightToLeft == RightToLeft.Yes) ? item.MirroredImage : item?.Image;
             ImageRectangle = imageRectangle;
@@ -20,7 +19,12 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents all the information to render the ToolStrip
         /// </summary>
-        public ToolStripItemImageRenderEventArgs(Graphics g, ToolStripItem item, Image image, Rectangle imageRectangle) : base(g, item)
+        public ToolStripItemImageRenderEventArgs(
+            Graphics g,
+            ToolStripItem? item,
+            Image? image,
+            Rectangle imageRectangle)
+            : base(g, item)
         {
             Image = image;
             ImageRectangle = imageRectangle;
@@ -29,7 +33,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The image to draw
         /// </summary>
-        public Image Image { get; }
+        public Image? Image { get; }
 
         /// <summary>
         ///  The rectangle to draw the Image in
@@ -44,6 +48,6 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Not public as it currently pertains to ToolStripRenderer.
         /// </summary>
-        internal ImageAttributes ImageAttributes { get; set; }
+        internal ImageAttributes? ImageAttributes { get; set; }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripItemImageRenderEventArgs

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6279)