### PR TITLE
Fixing dotline rectangle for focused `Button` with `Standard` FlatStyle

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonStandardAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonStandardAdapter.cs
@@ -177,7 +177,7 @@ namespace System.Windows.Forms.ButtonInternal
             PaintImage(e, layout);
 
             // Inflate the focus rectangle to be consistent with the behavior of Win32 app
-            if (Application.RenderWithVisualStyles)
+            if (Application.RenderWithVisualStyles && Control.FlatStyle != FlatStyle.Standard)
             {
                 layout.Focus.Inflate(1, 1);
             }


### PR DESCRIPTION
Fixes #4538

## Proposed changes

- After zooming in it's visible that dotline rectangle for the focused `Button` with FlatStyle set to `Standard` is still there, but it intersects with the blue border:
![image](https://user-images.githubusercontent.com/87859299/145019536-bad5bd4a-5b7f-490c-9ab5-ef73f01ca1d8.png)
- At .Net 5.0 there's no such intersection:
![image](https://user-images.githubusercontent.com/87859299/145019583-5b987914-f5cb-443e-bc1b-c9a29543291a.png)
- This intersection happens because the focus rectangle is inflated for one pixel, and to fix this issue we should add a condition on this inflating to exclude the `Standard` FlatStyle case

## Before the fix
- ![image](https://user-images.githubusercontent.com/87859299/145019797-713ff86e-9bf3-46de-bf17-01c5e5658ef6.png)
- ![buttonsBeforeFix](https://user-images.githubusercontent.com/87859299/145020580-a20358f8-562b-4991-9387-7ed5dddb1e1c.gif)


## After the fix
- ![image](https://user-images.githubusercontent.com/87859299/145019827-55050b73-15c6-4b02-9b88-36b8bcf0a4ea.png)
- ![buttonsAfterFix](https://user-images.githubusercontent.com/87859299/145020609-0ff118b3-ea04-4485-a06f-6f51832e009e.gif)

## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- Manual testing (see the `After the fix` section)
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
Microsoft Windows [Version 10.0.19043.1348]
.NET SDK 7.0.100-alpha.1.21606.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6305)