### PR TITLE
Improving accessible object for label edit in ListView

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWinEventHook.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWinEventHook.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        public static extern nint SetWinEventHook(
+            uint eventMin, uint eventMax, nint hmodWinEventProc, WINEVENTPROC pfnWinEventProc, uint idProcess, uint idThread, WINEVENT dwFlags);
+
+        public static nint SetWinEventHook(uint eventId, WINEVENTPROC pfnWinEventProc)
+            => SetWinEventHook(
+                eventId, eventId, Kernel32.GetModuleHandleW(null), pfnWinEventProc, (uint)Environment.ProcessId, Kernel32.GetCurrentThreadId(), WINEVENT.INCONTEXT);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWinEventHook.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWinEventHook.cs
@@ -9,11 +9,11 @@ internal static partial class Interop
     internal static partial class User32
     {
         [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern nint SetWinEventHook(
-            uint eventMin, uint eventMax, nint hmodWinEventProc, WINEVENTPROC pfnWinEventProc, uint idProcess, uint idThread, WINEVENT dwFlags);
+        private static extern nint SetWinEventHook(uint eventMin, uint eventMax, nint hmodWinEventProc,
+            WINEVENTPROC pfnWinEventProc, uint idProcess, uint idThread, WINEVENT dwFlags);
 
         public static nint SetWinEventHook(uint eventId, WINEVENTPROC pfnWinEventProc)
-            => SetWinEventHook(
-                eventId, eventId, Kernel32.GetModuleHandleW(null), pfnWinEventProc, (uint)Environment.ProcessId, Kernel32.GetCurrentThreadId(), WINEVENT.INCONTEXT);
+            => SetWinEventHook(eventId, eventId, Kernel32.GetModuleHandleW(null), pfnWinEventProc,
+                (uint)Environment.ProcessId, Kernel32.GetCurrentThreadId(), WINEVENT.INCONTEXT);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.UnhookWinEvent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.UnhookWinEvent.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
+        public static extern BOOL UnhookWinEvent(nint hWinEventHook);
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WINEVENT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WINEVENT.cs
@@ -6,7 +6,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        public enum WINEVENT : int
+        public enum WINEVENT : uint
         {
             OUTOFCONTEXT   = 0,
             SKIPOWNTHREAD  = 1,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WINEVENT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WINEVENT.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public enum WINEVENT : int
+        {
+            OUTOFCONTEXT   = 0,
+            SKIPOWNTHREAD  = 1,
+            SKIPOWNPROCESS = 2,
+            INCONTEXT      = 4,
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WINEVENTPROC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WINEVENTPROC.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class User32
+    {
+        public delegate void WINEVENTPROC(nint hWinEventHook, uint eventId, nint hwnd, int idObject, int idChild, uint idEventThread, uint dwmsEventTime);
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -89,6 +89,11 @@ namespace System.Windows.Forms
                     return null;
                 }
 
+                if (_owningListView._labelEdit is {} labelEdit && index == GetChildCount() - 1)
+                {
+                    return labelEdit.AccessibilityObject;
+                }
+
                 if (_owningListView.GroupsDisplayed)
                 {
                     IReadOnlyList<ListViewGroup> visibleGroups = GetVisibleGroups();
@@ -105,7 +110,13 @@ namespace System.Windows.Forms
                     return InvalidIndex;
                 }
 
-                return _owningListView.GroupsDisplayed ? GetVisibleGroups().Count : _owningListView.Items.Count;
+                int count = _owningListView.GroupsDisplayed ? GetVisibleGroups().Count : _owningListView.Items.Count;
+                if (_owningListView._labelEdit is not null)
+                {
+                    count++;
+                }
+
+                return count;
             }
 
             private int GetItemIndex(AccessibleObject? child)
@@ -143,7 +154,10 @@ namespace System.Windows.Forms
                 return InvalidIndex;
             }
 
-            internal override int GetChildIndex(AccessibleObject? child) => _owningListView.GroupsDisplayed ? GetGroupIndex(child) : GetItemIndex(child);
+            internal override int GetChildIndex(AccessibleObject? child)
+                => _owningListView._labelEdit is {} labelEdit && child == labelEdit.AccessibilityObject
+                    ? GetChildCount() - 1
+                    : _owningListView.GroupsDisplayed ? GetGroupIndex(child) : GetItemIndex(child);
 
             private string GetItemStatus()
                 => _owningListView.Sorting switch
@@ -195,6 +209,11 @@ namespace System.Windows.Forms
 
             private AccessibleObject? GetLastChild()
             {
+                if (_owningListView._labelEdit is {} labelEdit)
+                {
+                    return labelEdit.AccessibilityObject;
+                }
+
                 if (_owningListView.GroupsDisplayed)
                 {
                     IReadOnlyList<ListViewGroup> visibleGroups = GetVisibleGroups();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -179,7 +179,7 @@ namespace System.Windows.Forms
 
         private bool _blockLabelEdit;
 
-        private ListViewLabelEditNativeWindow _labelEdit;
+        private ListViewLabelEditNativeWindow? _labelEdit;
 
         // Background image stuff
         // Because we have to create a temporary file and the OS does not clean up the temporary files from the machine
@@ -6468,9 +6468,12 @@ namespace System.Windows.Forms
 
                 case (int)LVN.BEGINLABELEDITW:
                     {
+                        Debug.Assert(_labelEdit is null,
+                            "A new label editing shouldn't start before the previous one ended");
                         if (_labelEdit is not null)
                         {
-                            throw new InvalidOperationException("A new label editing can't be started before the previous one was ended.");
+                            _labelEdit.ReleaseHandle();
+                            _labelEdit = null;
                         }
 
                         bool cancelEdit;
@@ -6524,9 +6527,10 @@ namespace System.Windows.Forms
 
                 case (int)LVN.ENDLABELEDITW:
                     {
+                        Debug.Assert(_labelEdit is not null, "There is no active label edit to end");
                         if (_labelEdit is null)
                         {
-                            throw new InvalidOperationException("There is no active label edit to end");
+                            break;
                         }
 
                         _labelEdit.ReleaseHandle();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
+using System.Drawing;
 using System.Runtime.InteropServices;
 using static Interop;
 
@@ -12,57 +12,57 @@ namespace System.Windows.Forms
     {
         private const string LIST_VIEW_LABEL_EDIT_AUTOMATION_ID = "1";
 
-        private ListView _owner;
-        private IntPtr _handle;
+        private readonly ListView _owningListView;
+        private readonly IntPtr _handle;
+        private readonly ListViewLabelEditUiaTextProvider _textProvider;
         private int[]? _runtimeId;
 
-        public ListViewLabelEditAccessibleObject(ListView owner, IHandle handle)
+        public ListViewLabelEditAccessibleObject(ListView owningListView, IHandle handle)
         {
-            _owner = owner;
+            _owningListView = owningListView.OrThrowIfNull();
             _handle = handle.Handle;
             UseStdAccessibleObjects(_handle);
-
-            ListViewLabelEditUiaTextProvider textProvider = new(owner, handle, this);
-            UseTextProviders(textProvider, textProvider);
+            _textProvider = new ListViewLabelEditUiaTextProvider(owningListView, handle, this);
         }
 
-        internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-            => propertyID switch
-            {
-                UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
-                UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
-                UiaCore.UIA.ProcessIdPropertyId => Environment.ProcessId,
-                UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.EditControlTypeId,
-                UiaCore.UIA.NamePropertyId => Name,
-                UiaCore.UIA.AccessKeyPropertyId => string.Empty,
-                UiaCore.UIA.HasKeyboardFocusPropertyId => true,
-                UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
-                UiaCore.UIA.IsEnabledPropertyId => Enabled,
-                UiaCore.UIA.AutomationIdPropertyId => LIST_VIEW_LABEL_EDIT_AUTOMATION_ID,
-                UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
-                UiaCore.UIA.IsContentElementPropertyId => true,
-                UiaCore.UIA.IsPasswordPropertyId => false,
-                UiaCore.UIA.NativeWindowHandlePropertyId => _handle,
-                UiaCore.UIA.IsOffscreenPropertyId => false,
-                UiaCore.UIA.IsTextPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPatternId),
-                UiaCore.UIA.IsTextPattern2AvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPattern2Id),
-                UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
-                UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
-                _ => base.GetPropertyValue(propertyID),
-            };
+        private protected override string AutomationId => LIST_VIEW_LABEL_EDIT_AUTOMATION_ID;
 
         internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
         {
-            AccessibleObject parent = _owner.AccessibilityObject;
+            AccessibleObject parent = _owningListView.AccessibilityObject;
 
             return direction switch
             {
                 UiaCore.NavigateDirection.Parent => parent,
                 UiaCore.NavigateDirection.NextSibling => parent.GetChildIndex(this) is int childId and >= 0 ? parent.GetChild(childId + 1) : null,
                 UiaCore.NavigateDirection.PreviousSibling => parent.GetChildIndex(this) is int childId and >= 0 ? parent.GetChild(childId - 1) : null,
-                UiaCore.NavigateDirection.FirstChild or UiaCore.NavigateDirection.LastChild => null,
                 _ => base.FragmentNavigate(direction),
             };
+        }
+
+        internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => _owningListView.AccessibilityObject;
+
+        internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+            => propertyID switch
+            {
+                UiaCore.UIA.ProcessIdPropertyId => Environment.ProcessId,
+                UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.EditControlTypeId,
+                UiaCore.UIA.AccessKeyPropertyId => string.Empty,
+                UiaCore.UIA.HasKeyboardFocusPropertyId => true,
+                UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                UiaCore.UIA.IsEnabledPropertyId => _owningListView.Enabled,
+                UiaCore.UIA.IsContentElementPropertyId => true,
+                UiaCore.UIA.NativeWindowHandlePropertyId => _handle,
+                _ => base.GetPropertyValue(propertyID),
+            };
+
+        internal override UiaCore.IRawElementProviderSimple? HostRawElementProvider
+        {
+            get
+            {
+                UiaCore.UiaHostProviderFromHwnd(new HandleRef(this, _handle), out UiaCore.IRawElementProviderSimple provider);
+                return provider;
+            }
         }
 
         internal override bool IsPatternSupported(UiaCore.UIA patternId) => patternId switch
@@ -74,28 +74,32 @@ namespace System.Windows.Forms
             _ => base.IsPatternSupported(patternId),
         };
 
-        internal override int[] RuntimeId => _runtimeId ??= new int[] { RuntimeIDFirstItem, PARAM.ToInt(_handle) };
-
-        internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot => _owner.AccessibilityObject;
-
-        internal override UiaCore.IRawElementProviderSimple? HostRawElementProvider
-        {
-            get
-            {
-                UiaCore.UiaHostProviderFromHwnd(new HandleRef(this, _handle), out UiaCore.IRawElementProviderSimple provider);
-                return provider;
-            }
-        }
-
         public override string Name => User32.GetWindowText(_handle);
 
-        private bool Enabled
-        {
-            get
-            {
-                Debug.Assert(_owner.Enabled);
-                return _owner.Enabled;
-            }
-        }
+        internal override int[] RuntimeId => _runtimeId ??= new int[] { RuntimeIDFirstItem, PARAM.ToInt(_handle) };
+
+        internal override UiaCore.ITextRangeProvider DocumentRangeInternal
+            => _textProvider.DocumentRange;
+
+        internal override UiaCore.ITextRangeProvider[]? GetTextSelection()
+            => _textProvider.GetSelection();
+
+        internal override UiaCore.ITextRangeProvider[]? GetTextVisibleRanges()
+            => _textProvider.GetVisibleRanges();
+
+        internal override UiaCore.ITextRangeProvider? GetTextRangeFromChild(UiaCore.IRawElementProviderSimple childElement)
+            => _textProvider.RangeFromChild(childElement);
+
+        internal override UiaCore.ITextRangeProvider? GetTextRangeFromPoint(Point screenLocation)
+            => _textProvider.RangeFromPoint(screenLocation);
+
+        internal override UiaCore.SupportedTextSelection SupportedTextSelectionInternal
+            => _textProvider.SupportedTextSelection;
+
+        internal override UiaCore.ITextRangeProvider? GetTextCaretRange(out BOOL isActive)
+            => _textProvider.GetCaretRange(out isActive);
+
+        internal override UiaCore.ITextRangeProvider GetRangeFromAnnotation(UiaCore.IRawElementProviderSimple annotationElement)
+            => _textProvider.RangeFromAnnotation(annotationElement);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditAccessibleObject.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    internal class ListViewLabelEditAccessibleObject : AccessibleObject
+    {
+        private const string LIST_VIEW_LABEL_EDIT_AUTOMATION_ID = "1";
+
+        private ListView _owner;
+        private IntPtr _handle;
+        private int[]? _runtimeId;
+
+        public ListViewLabelEditAccessibleObject(ListView owner, IHandle handle)
+        {
+            _owner = owner;
+            _handle = handle.Handle;
+            UseStdAccessibleObjects(_handle);
+
+            ListViewLabelEditUiaTextProvider textProvider = new(owner, handle, this);
+            UseTextProviders(textProvider, textProvider);
+        }
+
+        internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+            => propertyID switch
+            {
+                UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
+                UiaCore.UIA.BoundingRectanglePropertyId => Bounds,
+                UiaCore.UIA.ProcessIdPropertyId => Environment.ProcessId,
+                UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.EditControlTypeId,
+                UiaCore.UIA.NamePropertyId => Name,
+                UiaCore.UIA.AccessKeyPropertyId => string.Empty,
+                UiaCore.UIA.HasKeyboardFocusPropertyId => true,
+                UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                UiaCore.UIA.IsEnabledPropertyId => Enabled,
+                UiaCore.UIA.AutomationIdPropertyId => LIST_VIEW_LABEL_EDIT_AUTOMATION_ID,
+                UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
+                UiaCore.UIA.IsContentElementPropertyId => true,
+                UiaCore.UIA.IsPasswordPropertyId => false,
+                UiaCore.UIA.NativeWindowHandlePropertyId => _handle,
+                UiaCore.UIA.IsOffscreenPropertyId => false,
+                UiaCore.UIA.IsTextPatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPatternId),
+                UiaCore.UIA.IsTextPattern2AvailablePropertyId => IsPatternSupported(UiaCore.UIA.TextPattern2Id),
+                UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
+                UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId),
+                _ => base.GetPropertyValue(propertyID),
+            };
+
+        internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+        {
+            AccessibleObject parent = _owner.AccessibilityObject;
+
+            return direction switch
+            {
+                UiaCore.NavigateDirection.Parent => parent,
+                UiaCore.NavigateDirection.NextSibling => parent.GetChildIndex(this) is int childId and >= 0 ? parent.GetChild(childId + 1) : null,
+                UiaCore.NavigateDirection.PreviousSibling => parent.GetChildIndex(this) is int childId and >= 0 ? parent.GetChild(childId - 1) : null,
+                UiaCore.NavigateDirection.FirstChild or UiaCore.NavigateDirection.LastChild => null,
+                _ => base.FragmentNavigate(direction),
+            };
+        }
+
+        internal override bool IsPatternSupported(UiaCore.UIA patternId) => patternId switch
+        {
+            UiaCore.UIA.TextPatternId => true,
+            UiaCore.UIA.TextPattern2Id => true,
+            UiaCore.UIA.ValuePatternId => true,
+            UiaCore.UIA.LegacyIAccessiblePatternId => true,
+            _ => base.IsPatternSupported(patternId),
+        };
+
+        internal override int[] RuntimeId => _runtimeId ??= new int[] { RuntimeIDFirstItem, PARAM.ToInt(_handle) };
+
+        internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot => _owner.AccessibilityObject;
+
+        internal override UiaCore.IRawElementProviderSimple? HostRawElementProvider
+        {
+            get
+            {
+                UiaCore.UiaHostProviderFromHwnd(new HandleRef(this, _handle), out UiaCore.IRawElementProviderSimple provider);
+                return provider;
+            }
+        }
+
+        public override string Name => User32.GetWindowText(_handle);
+
+        private bool Enabled
+        {
+            get
+            {
+                Debug.Assert(_owner.Enabled);
+                return _owner.Enabled;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditNativeWindow.cs
@@ -1,0 +1,183 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    internal class ListViewLabelEditNativeWindow : NativeWindow
+    {
+        private const uint TextSelectionChanged = 0x8014;
+
+        private ListView _owner;
+
+        private AccessibleObject? _accessibilityObject;
+
+        private User32.WINEVENTPROC? _winEventProc;
+
+        private nint _valueChangeHook;
+        private nint _textSelectionChangedHook;
+
+        private bool _winEventHooksInstalled;
+
+        public ListViewLabelEditNativeWindow(ListView owner)
+        {
+            _owner = owner.OrThrowIfNull();
+        }
+
+        public AccessibleObject AccessibilityObject => _accessibilityObject ??= new ListViewLabelEditAccessibleObject(_owner, this);
+
+        public override void ReleaseHandle()
+        {
+            if (_winEventHooksInstalled)
+            {
+                User32.UnhookWinEvent(_valueChangeHook);
+                User32.UnhookWinEvent(_textSelectionChangedHook);
+
+                _winEventHooksInstalled = false;
+            }
+
+            if (_accessibilityObject is not null)
+            {
+                // When a window that previously returned providers has been destroyed,
+                // you should notify UI Automation by calling the UiaReturnRawElementProvider
+                // as follows: UiaReturnRawElementProvider(hwnd, 0, 0, NULL). This call tells
+                // UI Automation that it can safely remove all map entries that refer to the specified window.
+                UiaCore.UiaReturnRawElementProvider(Handle, 0, 0, null);
+
+                if (OsVersion.IsWindows8OrGreater)
+                {
+                    UiaCore.UiaDisconnectProvider(AccessibilityObject);
+                }
+            }
+
+            base.ReleaseHandle();
+        }
+
+        protected override void OnHandleChange()
+        {
+            base.OnHandleChange();
+
+            if (Handle == IntPtr.Zero)
+            {
+                return;
+            }
+
+            // Install winevent hooks only in the case when the parent listview already has an accessible object created.
+            // If we won't install hooks at the label edit startup then Narrator won't announce the text pattern for it.
+            // If we will just check for UiaClientsAreListening then we will have hooks installed even if Narrator isn't currently run.
+            if (!_owner.IsAccessibilityObjectCreated)
+            {
+                return;
+            }
+
+            InstallWinEventHooks();
+        }
+
+        protected override void WndProc(ref Message m)
+        {
+            switch (m.MsgInternal)
+            {
+                case User32.WM.GETOBJECT:
+                    WmGetObject(ref m);
+                    return;
+                default:
+                    base.WndProc(ref m);
+                    return;
+            }
+        }
+
+        private void InstallWinEventHooks()
+        {
+            if (UiaCore.UiaClientsAreListening().IsFalse())
+            {
+                return;
+            }
+
+            _winEventProc = new User32.WINEVENTPROC(WinEventProc);
+            _valueChangeHook = User32.SetWinEventHook((uint)AccessibleEvents.ValueChange, _winEventProc);
+            _textSelectionChangedHook = User32.SetWinEventHook(TextSelectionChanged, _winEventProc);
+
+            _winEventHooksInstalled = true;
+        }
+
+        private AccessibleObject RequestAccessibilityObject()
+        {
+            AccessibleObject result = AccessibilityObject;
+
+            // Accessibility object was likely requested by some accessibility tool (because of WM_GETOBJECT message).
+            // The tool that requested the object may be Narrator in which case we may need to install winevent hooks to
+            // produce the automation events related to the text pattern.
+            if (!_winEventHooksInstalled)
+            {
+                InstallWinEventHooks();
+            }
+
+            return result;
+        }
+
+        private void WinEventProc(nint hWinEventHook, uint eventId, nint hwnd, int idObject, int idChild, uint idEventThread, uint dwmsEventTime)
+        {
+            if (hwnd != Handle || idObject != User32.OBJID.CLIENT)
+            {
+                return;
+            }
+
+            switch (eventId)
+            {
+                case (uint)AccessibleEvents.ValueChange:
+                    AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextChangedEventId);
+                    break;
+                case TextSelectionChanged:
+                    AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextSelectionChangedEventId);
+                    break;
+            }
+        }
+
+        private void WmGetObject(ref Message m)
+        {
+            if (m.LParamInternal == NativeMethods.UiaRootObjectId)
+            {
+                // If the requested object identifier is UiaRootObjectId,
+                // we should return an UI Automation provider using the UiaReturnRawElementProvider function.
+                m.ResultInternal = UiaCore.UiaReturnRawElementProvider(
+                    this,
+                    m.WParamInternal,
+                    m.LParamInternal,
+                    RequestAccessibilityObject());
+
+                return;
+            }
+
+            if ((int)m.LParamInternal != User32.OBJID.CLIENT)
+            {
+                DefWndProc(ref m);
+
+                return;
+            }
+
+            // https://docs.microsoft.com/windows/win32/winauto/how-to-handle-wm-getobject
+            // Get an Lresult for the accessibility Object for this control.
+            try
+            {
+                // Obtain the Lresult.
+                IntPtr pUnknown = Marshal.GetIUnknownForObject(RequestAccessibilityObject());
+
+                try
+                {
+                    m.ResultInternal = Oleacc.LresultFromObject(ref IID.IAccessible, m.WParamInternal, new HandleRef(this, pUnknown));
+                }
+                finally
+                {
+                    Marshal.Release(pUnknown);
+                }
+            }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException(SR.RichControlLresult, e);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditUiaTextProvider.cs
@@ -1,0 +1,339 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Drawing;
+using System.Windows.Forms.Automation;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    internal class ListViewLabelEditUiaTextProvider : UiaTextProvider2
+    {
+        /// <summary>
+        ///  Since the label edit inside the ListView is always single-line, for optimization
+        ///  we always return 0 as the index of lines
+        /// </summary>
+        private const int OwnerChildEditLineIndex = 0;
+
+        /// <summary>
+        ///  Since the label edit inside the ListView is always single-line, for optimization
+        ///  we always return 1 as the number of lines
+        /// </summary>
+        private const int OwnerChildEditLinesCount = 1;
+
+        private readonly IHandle _owningChildEdit;
+
+        private readonly AccessibleObject _owningChildEditAccessibilityObject;
+
+        private readonly ListView _owningListView;
+
+        public ListViewLabelEditUiaTextProvider(ListView owner, IHandle childEdit, AccessibleObject childEditAccessibilityObject)
+        {
+            _owningListView = owner.OrThrowIfNull();
+            _owningChildEdit = childEdit;
+            _owningChildEditAccessibilityObject = childEditAccessibilityObject;
+        }
+
+        public override Rectangle BoundingRectangle => GetFormattingRectangle();
+
+        public override UiaCore.ITextRangeProvider DocumentRange => new UiaTextRange(_owningChildEditAccessibilityObject, this, start: 0, TextLength);
+
+        public override User32.ES EditStyle => GetEditStyle(_owningChildEdit);
+
+        public override int FirstVisibleLine => 0;
+
+        public override bool IsMultiline => false;
+
+        public override bool IsReadingRTL => WindowExStyle.HasFlag(User32.WS_EX.RTLREADING);
+
+        public override bool IsReadOnly => false;
+
+        public override bool IsScrollable
+        {
+            get
+            {
+                User32.ES extendedStyle = (User32.ES)User32.GetWindowLong(_owningChildEdit, User32.GWL.STYLE);
+                return extendedStyle.HasFlag(User32.ES.AUTOHSCROLL);
+            }
+        }
+
+        public override int LinesCount => OwnerChildEditLinesCount;
+
+        public override int LinesPerPage => _owningChildEditAccessibilityObject.BoundingRectangle.IsEmpty ? 0 : OwnerChildEditLinesCount;
+
+        public override User32.LOGFONTW Logfont => User32.LOGFONTW.FromFont(_owningListView.Font);
+
+        public override UiaCore.SupportedTextSelection SupportedTextSelection => UiaCore.SupportedTextSelection.Single;
+
+        public override string Text => User32.GetWindowText(_owningChildEdit);
+
+        public override int TextLength => (int)User32.SendMessageW(_owningChildEdit, User32.WM.GETTEXTLENGTH);
+
+        public override User32.WS_EX WindowExStyle => GetWindowExStyle(_owningChildEdit);
+
+        public override User32.WS WindowStyle => GetWindowStyle(_owningChildEdit);
+
+        public override UiaCore.ITextRangeProvider? GetCaretRange(out BOOL isActive)
+        {
+            isActive = BOOL.FALSE;
+
+            object? hasKeyboardFocus = _owningChildEditAccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId);
+            if (hasKeyboardFocus is true)
+            {
+                isActive = BOOL.TRUE;
+            }
+
+            // First caret position of a selected text
+            int start = 0;
+            // Last caret position of a selected text
+            int end = 0;
+
+            // Returns info about the selected text range.
+            // If there is no selection, start and end parameters are the position of the caret.
+            User32.SendMessageW(_owningChildEdit, (User32.WM)User32.EM.GETSEL, ref start, ref end);
+
+            return new UiaTextRange(_owningChildEditAccessibilityObject, this, start, start);
+        }
+
+        public override int GetLineFromCharIndex(int charIndex) => OwnerChildEditLineIndex;
+
+        public override int GetLineIndex(int line) => OwnerChildEditLineIndex;
+
+        public override Point GetPositionFromChar(int charIndex) => GetPositionFromCharIndex(charIndex);
+
+        // A variation on EM_POSFROMCHAR that returns the upper-right corner instead of upper-left.
+        public override Point GetPositionFromCharForUpperRightCorner(int startCharIndex, string text)
+        {
+            if (startCharIndex < 0 || startCharIndex >= text.Length)
+            {
+                return Point.Empty;
+            }
+
+            char ch = text[startCharIndex];
+            Point pt;
+
+            if (char.IsControl(ch))
+            {
+                if (ch == '\t')
+                {
+                    // for tabs the calculated width of the character is no help so we use the
+                    // UL corner of the following character if it is on the same line.
+                    bool useNext = startCharIndex < TextLength - 1 && GetLineFromCharIndex(startCharIndex + 1) == GetLineFromCharIndex(startCharIndex);
+                    return GetPositionFromCharIndex(useNext ? startCharIndex + 1 : startCharIndex);
+                }
+
+                pt = GetPositionFromCharIndex(startCharIndex);
+
+                if (ch == '\r' || ch == '\n')
+                {
+                    pt.X += EndOfLineWidth; // add 2 px to show the end of line
+                }
+
+                // return the UL corner of the rest characters because these characters have no width
+                return pt;
+            }
+
+            // get the UL corner of the character
+            pt = GetPositionFromCharIndex(startCharIndex);
+
+            // add the width of the character at that position.
+            if (GetTextExtentPoint32(ch, out Size size))
+            {
+                pt.X += size.Width;
+            }
+
+            return pt;
+        }
+
+        public override UiaCore.ITextRangeProvider[]? GetSelection()
+        {
+            // First caret position of a selected text
+            int start = 0;
+            // Last caret position of a selected text
+            int end = 0;
+
+            // Returns info about the selected text range.
+            // If there is no selection, start and end parameters are the position of the caret.
+            User32.SendMessageW(_owningChildEdit, (User32.WM)User32.EM.GETSEL, ref start, ref end);
+
+            return new UiaCore.ITextRangeProvider[] { new UiaTextRange(_owningChildEditAccessibilityObject, this, start, end) };
+        }
+
+        public override void GetVisibleRangePoints(out int visibleStart, out int visibleEnd)
+        {
+            visibleStart = 0;
+            visibleEnd = 0;
+
+            if (IsDegenerate(_owningListView.ClientRectangle))
+            {
+                return;
+            }
+
+            Rectangle rectangle = GetFormattingRectangle();
+            if (IsDegenerate(rectangle))
+            {
+                return;
+            }
+
+            // Formatting rectangle is the boundary, which we need to inflate by 1
+            // in order to read characters within the rectangle
+            Point ptStart = new Point(rectangle.X + 1, rectangle.Y + 1);
+            Point ptEnd = new Point(rectangle.Right - 1, rectangle.Bottom - 1);
+
+            visibleStart = GetCharIndexFromPosition(ptStart);
+            visibleEnd = GetCharIndexFromPosition(ptEnd) + 1; // Add 1 to get a caret position after received character
+
+            return;
+
+            bool IsDegenerate(Rectangle rect)
+                => rect.IsEmpty || rect.Width <= 0 || rect.Height <= 0;
+        }
+
+        public override UiaCore.ITextRangeProvider[]? GetVisibleRanges()
+        {
+            GetVisibleRangePoints(out int start, out int end);
+
+            return new UiaCore.ITextRangeProvider[] { new UiaTextRange(_owningChildEditAccessibilityObject, this, start, end) };
+        }
+
+        public override bool LineScroll(int charactersHorizontal, int linesVertical)
+            // If the EM_LINESCROLL message is sent to a single-line edit control, the return value is FALSE.
+            => false;
+
+        public override Point PointToScreen(Point pt)
+        {
+            User32.MapWindowPoint(_owningChildEdit, IntPtr.Zero, ref pt);
+            return pt;
+        }
+
+        /// <summary>
+        ///  Exposes a text range that contains the text that is the target of the annotation associated with the specified annotation element.
+        /// </summary>
+        /// <param name="annotationElement">
+        ///  The provider for an element that implements the IAnnotationProvider interface.
+        ///  The annotation element is a sibling of the element that implements the <see cref="UiaCore.ITextProvider2"/> interface for the document.
+        /// </param>
+        /// <returns>
+        ///  A text range that contains the annotation target text.
+        /// </returns>
+        public override UiaCore.ITextRangeProvider RangeFromAnnotation(UiaCore.IRawElementProviderSimple annotationElement)
+        {
+            return new UiaTextRange(_owningChildEditAccessibilityObject, this, start: 0, end: 0);
+        }
+
+        public override UiaCore.ITextRangeProvider? RangeFromChild(UiaCore.IRawElementProviderSimple childElement)
+        {
+            // We don't have any children so this call returns null.
+            Debug.Fail("Label edit control cannot have a child element.");
+            return null;
+        }
+
+        /// <summary>
+        ///  Returns the degenerate (empty) text range nearest to the specified screen coordinates.
+        /// </summary>
+        /// <param name="screenLocation">The location in screen coordinates.</param>
+        /// <returns>A degenerate range nearest the specified location. Null is never returned.</returns>
+        public override UiaCore.ITextRangeProvider? RangeFromPoint(Point screenLocation)
+        {
+            Point clientLocation = screenLocation;
+
+            // Convert screen to client coordinates.
+            // (Essentially ScreenToClient but MapWindowPoints accounts for window mirroring using WS_EX_LAYOUTRTL.)
+            if (User32.MapWindowPoint(IntPtr.Zero, _owningChildEdit, ref clientLocation) == 0)
+            {
+                return new UiaTextRange(_owningChildEditAccessibilityObject, this, start: 0, end: 0);
+            }
+
+            // We have to deal with the possibility that the coordinate is inside the window rect
+            // but outside the client rect. In that case we just scoot it over so it is at the nearest
+            // point in the client rect.
+            RECT clientRectangle = _owningChildEditAccessibilityObject.BoundingRectangle;
+
+            clientLocation.X = Math.Max(clientLocation.X, clientRectangle.left);
+            clientLocation.X = Math.Min(clientLocation.X, clientRectangle.right);
+            clientLocation.Y = Math.Max(clientLocation.Y, clientRectangle.top);
+            clientLocation.Y = Math.Min(clientLocation.Y, clientRectangle.bottom);
+
+            // Get the character at those client coordinates.
+            int start = GetCharIndexFromPosition(clientLocation);
+
+            return new UiaTextRange(_owningChildEditAccessibilityObject, this, start, start);
+        }
+
+        public override void SetSelection(int start, int end)
+        {
+            if (start < 0 || start > TextLength)
+            {
+                Debug.Fail("SetSelection start is out of text range.");
+                return;
+            }
+
+            if (end < 0 || end > TextLength)
+            {
+                Debug.Fail("SetSelection end is out of text range.");
+                return;
+            }
+
+            User32.SendMessageW(_owningChildEdit, (User32.WM)User32.EM.SETSEL, start, end);
+        }
+
+        private int GetCharIndexFromPosition(Point pt)
+        {
+            int index = PARAM.LOWORD(User32.SendMessageW(_owningChildEdit, (User32.WM)User32.EM.CHARFROMPOS, 0, PARAM.FromPoint(pt)));
+
+            if (index < 0)
+            {
+                index = 0;
+            }
+            else
+            {
+                string t = Text;
+                // EM_CHARFROMPOS will return an invalid number if the last character in the RichEdit
+                // is a newline.
+                if (index >= t.Length)
+                {
+                    index = Math.Max(t.Length - 1, 0);
+                }
+            }
+
+            return index;
+        }
+
+        private RECT GetFormattingRectangle()
+        {
+            // Send an EM_GETRECT message to find out the bounding rectangle.
+            RECT rectangle = new RECT();
+            User32.SendMessageW(_owningChildEdit, (User32.WM)User32.EM.GETRECT, 0, ref rectangle);
+
+            return rectangle;
+        }
+
+        private Point GetPositionFromCharIndex(int index)
+        {
+            if (index < 0 || index >= Text.Length)
+            {
+                return Point.Empty;
+            }
+
+            int i = (int)User32.SendMessageW(_owningChildEdit, (User32.WM)User32.EM.POSFROMCHAR, index);
+
+            return new Point(PARAM.SignedLOWORD(i), PARAM.SignedHIWORD(i));
+        }
+
+        private bool GetTextExtentPoint32(char item, out Size size)
+        {
+            size = new Size();
+
+            using var hdc = new User32.GetDcScope(_owningChildEdit.Handle);
+            if (hdc.IsNull)
+            {
+                return false;
+            }
+
+            // Add the width of the character at that position.
+            return Gdi32.GetTextExtentPoint32W(hdc, item.ToString(), 1, ref size).IsTrue();
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditUiaTextProvider.cs
@@ -24,16 +24,14 @@ namespace System.Windows.Forms
         private const int OwnerChildEditLinesCount = 1;
 
         private readonly IHandle _owningChildEdit;
-
         private readonly AccessibleObject _owningChildEditAccessibilityObject;
-
         private readonly ListView _owningListView;
 
         public ListViewLabelEditUiaTextProvider(ListView owner, IHandle childEdit, AccessibleObject childEditAccessibilityObject)
         {
             _owningListView = owner.OrThrowIfNull();
             _owningChildEdit = childEdit;
-            _owningChildEditAccessibilityObject = childEditAccessibilityObject;
+            _owningChildEditAccessibilityObject = childEditAccessibilityObject.OrThrowIfNull();
         }
 
         public override Rectangle BoundingRectangle => GetFormattingRectangle();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewLabelEditAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewLabelEditAccessibleObjectTests.cs
@@ -28,6 +28,7 @@ public class ListViewLabelEditAccessibleObjectTests : IClassFixture<ThreadExcept
         Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
         Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsKeyboardFocusablePropertyId));
         Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsEnabledPropertyId));
+        Assert.Equal(listView.Enabled, (bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsEnabledPropertyId));
         Assert.Equal("1", accessibilityObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
         Assert.Empty((string)accessibilityObject.GetPropertyValue(UiaCore.UIA.HelpTextPropertyId));
         Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsContentElementPropertyId));
@@ -38,6 +39,8 @@ public class ListViewLabelEditAccessibleObjectTests : IClassFixture<ThreadExcept
         Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsTextPattern2AvailablePropertyId));
         Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsValuePatternAvailablePropertyId));
         Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+        Assert.True(listView.IsHandleCreated);
+        Assert.True(labelEdit.IsHandleCreated);
     }
 
     [WinFormsFact]
@@ -111,6 +114,39 @@ public class ListViewLabelEditAccessibleObjectTests : IClassFixture<ThreadExcept
         ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
 
         Assert.Equal(listView.Items[0].Text, accessibilityObject.Name);
+    }
+
+    [WinFormsFact]
+    public void ListViewLabelEditAccessibleObject_Ctor_NullOwningListView_ThrowsArgumentNullException()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+
+        Assert.Throws<ArgumentNullException>(() => new ListViewLabelEditAccessibleObject(null, labelEdit));
+    }
+
+    [WinFormsFact]
+    public void ListViewLabelEditNativeWindow_Ctor_NullOwningListView_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ListViewLabelEditNativeWindow(null));
+    }
+
+    [WinFormsFact]
+    public void ListViewLabelEditUiaTextProvider_Ctor_NullOwningListView_ThrowsArgumentNullException()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+
+        Assert.Throws<ArgumentNullException>(() => new ListViewLabelEditUiaTextProvider(null, labelEdit, labelEdit.AccessibilityObject));
+    }
+
+    [WinFormsFact]
+    public void ListViewLabelEditUiaTextProvider_Ctor_NullChildEditAccessibilityObject_ThrowsArgumentNullException()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+
+        Assert.Throws<ArgumentNullException>(() => new ListViewLabelEditUiaTextProvider(listView, labelEdit, null));
     }
 
     private ListView CreateListViewAndStartEditing()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewLabelEditAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewLabelEditAccessibleObjectTests.cs
@@ -1,0 +1,152 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using Xunit;
+using static Interop;
+using static Interop.ComCtl32;
+
+namespace System.Windows.Forms.Tests;
+
+public class ListViewLabelEditAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+{
+    [WinFormsFact]
+    public void ListViewLabelEditAccessibleObject_GetPropertyValue_ReturnsExpected()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+        ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
+
+        Assert.Equal(accessibilityObject.RuntimeId, accessibilityObject.GetPropertyValue(UiaCore.UIA.RuntimeIdPropertyId));
+        Assert.Equal(User32.GetWindowRect(labelEdit), accessibilityObject.GetPropertyValue(UiaCore.UIA.BoundingRectanglePropertyId));
+        Assert.Equal(Environment.ProcessId, accessibilityObject.GetPropertyValue(UiaCore.UIA.ProcessIdPropertyId));
+        Assert.Equal(UiaCore.UIA.EditControlTypeId, accessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        Assert.Equal(accessibilityObject.Name, accessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
+        Assert.Empty((string)accessibilityObject.GetPropertyValue(UiaCore.UIA.AccessKeyPropertyId));
+        Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+        Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsKeyboardFocusablePropertyId));
+        Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsEnabledPropertyId));
+        Assert.Equal("1", accessibilityObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
+        Assert.Empty((string)accessibilityObject.GetPropertyValue(UiaCore.UIA.HelpTextPropertyId));
+        Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsContentElementPropertyId));
+        Assert.False((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsPasswordPropertyId));
+        Assert.Equal(labelEdit.Handle, accessibilityObject.GetPropertyValue(UiaCore.UIA.NativeWindowHandlePropertyId));
+        Assert.False((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId));
+        Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsTextPatternAvailablePropertyId));
+        Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsTextPattern2AvailablePropertyId));
+        Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsValuePatternAvailablePropertyId));
+        Assert.True((bool)accessibilityObject.GetPropertyValue(UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+    }
+
+    [WinFormsFact]
+    public void ListViewLabelEditAccessibleObject_FragmentNavigate_ReturnsExpected()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+        ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
+
+        Assert.Equal(listView.AccessibilityObject, accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+        Assert.Equal(listView.Items[0].AccessibilityObject, accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+        Assert.Null(accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+        Assert.Null(accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+        Assert.Null(accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+    }
+
+    [WinFormsFact]
+    public void ListViewLabelEditAccessibleObject_IsPatternSupported_ReturnsExpected()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+        ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
+
+        Assert.True(accessibilityObject.IsPatternSupported(UiaCore.UIA.TextPatternId));
+        Assert.True(accessibilityObject.IsPatternSupported(UiaCore.UIA.TextPattern2Id));
+        Assert.True(accessibilityObject.IsPatternSupported(UiaCore.UIA.ValuePatternId));
+        Assert.True(accessibilityObject.IsPatternSupported(UiaCore.UIA.LegacyIAccessiblePatternId));
+    }
+
+    [WinFormsFact]
+    public void ListViewLabelEditAccessibleObject_RuntimeId_ReturnsExpected()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+        ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
+
+        Assert.Equal(new int[] { AccessibleObject.RuntimeIDFirstItem, PARAM.ToInt(labelEdit.Handle) }, accessibilityObject.RuntimeId);
+    }
+
+    [WinFormsFact]
+    public void ListViewLabelEditAccessibleObject_FragmentRoot_ReturnsExpected()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+        ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
+
+        Assert.Equal(listView.AccessibilityObject, accessibilityObject.FragmentRoot);
+    }
+
+    [WinFormsFact]
+    public void ListViewLabelEditAccessibleObject_HostRawElementProvider_ReturnsExpected()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+        ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
+
+        Assert.NotNull(accessibilityObject.HostRawElementProvider);
+    }
+
+    [WinFormsFact]
+    public void ListViewLabelEditAccessibleObject_Name_ReturnsExpected()
+    {
+        using ListView listView = CreateListViewAndStartEditing();
+
+        ListViewLabelEditNativeWindow labelEdit = listView.TestAccessor().Dynamic._labelEdit;
+        ListViewLabelEditAccessibleObject accessibilityObject = (ListViewLabelEditAccessibleObject)labelEdit.AccessibilityObject;
+
+        Assert.Equal(listView.Items[0].Text, accessibilityObject.Name);
+    }
+
+    private ListView CreateListViewAndStartEditing()
+    {
+        SubListView listView = new()
+        {
+            Size = new Size(300, 200),
+            View = View.Details,
+            LabelEdit = true
+        };
+
+        listView.Columns.Add(new ColumnHeader() { Text = "Column 1", Width = 100 });
+
+        ListViewItem item = new("Test");
+        listView.Items.Add(item);
+
+        listView.CreateControl();
+
+        User32.SetFocus(listView.Handle);
+
+        User32.SendMessageW(listView, (User32.WM)LVM.EDITLABELW, wParam: 0);
+
+        return listView;
+    }
+
+    private class SubListView : ListView
+    {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // End the label edit because ListView cannot be correctly disposed with an active label edit when AccessibilityObject is created for the ListView
+                User32.SendMessageW(this, (User32.WM)LVM.CANCELEDITLABEL);
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4810. Implements an accessible object for label edit control in ListView. This object now is the last child of the ListView (the same behavior as in the Windows Explorer). The object now also has a non-empty name according to its value (Windows Explorer behavior). The original object wasn't producing automation events related to the text, it was done by the UIAutomationCore proxy -- this was also implemented along with the text pattern support for the new accessible object, so the Narrator announces its text correctly.


## Proposed changes

- Implemented native window wrapper and accessible object for label edit control in ListView
- Implemented text pattern provider for label edit control (and added triggering automation events about label edit text)
- Made label edit accessible object be the last child of ListView (Windows Explorer behavior)
- Made label edit name value set according to its text value (Windows Explorer behavior)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Narrator now announces the name of the label edit control

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/5282741/145061988-b1036a93-9ca3-45e9-8c04-a9e20912431e.png)


### After

![image](https://user-images.githubusercontent.com/5282741/145062071-9e26f1a3-d4e4-4c6b-a992-1519c45a6553.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual (using inspect and Narrator tools to verify hierarchy and text pattern)
- Unit-tests (not currently presented)
- CTI (planned)


 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19044.1348]
- .NET 7.0.0-alpha.1.21602.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6309)