### PR TITLE
Enable template localization on dotnet CLI

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    
+    <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>    
     <!-- Suppress some nuget warnings that are breaking our build until https://github.com/dotnet/arcade/issues/4337 is resolved -->
     <NoWarn>$(NoWarn);NU5131;NU5128</NoWarn>
 

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/Microsoft.Dotnet.Winforms.ProjectTemplates.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>$(TargetFrameworkName)$(TargetFrameworkVersion)</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>    
+    <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>
     <!-- Suppress some nuget warnings that are breaking our build until https://github.com/dotnet/arcade/issues/4337 is resolved -->
     <NoWarn>$(NoWarn);NU5131;NU5128</NoWarn>
 

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplikace Windows Forms",
   "description": "Šablona projektu pro vytvoření aplikace .NET Windows Forms (WinForms)",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.de.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms-App",
   "description": "Eine Projektvorlage zum Erstellen einer Windows Forms-App (WinForms) in .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.es.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplicación de Windows Forms",
-  "description": "Plantilla de proyecto para crear una aplicación de Windows Forms (WinForms) de .NET.",
+  "description": "Plantilla de proyecto para crear una aplicación de Windows\u00A0Forms (WinForms) de .NET.",
   "symbols/TargetFrameworkOverride/description": "Invalida la plataforma de destino",
   "symbols/TargetFrameworkOverride/displayName": "Invalidación de la plataforma de destino",
   "symbols/Framework/description": "Marco de destino del proyecto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Application Windows Forms",
   "description": "Modèle de projet pour créer une application .NET Windows Forms (WinForms).",
@@ -6,11 +6,11 @@
   "symbols/TargetFrameworkOverride/displayName": "Remplacement de l’infrastructure cible",
   "symbols/Framework/description": "Framework cible du projet.",
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Framework",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/langVersion/displayName": "Version du Langage",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.it.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "App Windows Forms",
   "description": "Modello di progetto per la creazione di un'app Windows Forms (WinForms) .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows フォーム アプリ",
   "description": ".NET Windows フォーム (WinForms) アプリを作成するためのプロジェクト テンプレート。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 앱",
   "description": ".NET WinForms(Windows Forms) 앱을 만들기 위한 프로젝트 템플릿입니다.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplikacja Windows Forms",
   "description": "Szablon projektu służący do tworzenia aplikacji .NET Windows Forms (WinForms).",
@@ -12,7 +12,7 @@
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
   "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
   "symbols/Framework/displayName": "Platforma",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/langVersion/displayName": "Wersja języka",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/skipRestore/displayName": "Pomiń przywracanie",
@@ -20,5 +20,5 @@
   "symbols/Nullable/displayName": "Włącz dopuszczającą wartość null",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/open-file/description": "Otwiera plik Form1.cs w edytorze"
+  "postActions/open-file/description": "Otwiera plik Form1.cs w\u00A0edytorze"
 }

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,8 +1,8 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplicativo do Windows Forms",
   "description": "Um modelo de projeto para criar um Aplicativo do WinForms (Windows Forms) do .NET.",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/TargetFrameworkOverride/displayName": "Substituição da estrutura de destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Приложение Windows Forms",
   "description": "Шаблон проекта для создания приложения .NET Windows Forms (WinForms).",
@@ -6,11 +6,11 @@
   "symbols/TargetFrameworkOverride/displayName": "Переопределение целевой платформы",
   "symbols/Framework/description": "Целевая платформа для проекта.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
-  "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
+  "symbols/Framework/choices/net5.0/displayName": ".NET\u00A05.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Платформа",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/langVersion/displayName": "Версия языка",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms Uygulaması",
   "description": ".NET Windows Forms (WinForms) Uygulaması oluşturmak için proje şablonu.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows 窗体应用",
   "description": "用于创建 .NET Windows 窗体(WinForms)应用的项目模板。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 應用程式",
   "description": "用於建立 .NET Windows Forms (WinForms) 應用程式的專案範本。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplikace Windows Forms",
   "description": "Šablona projektu pro vytvoření aplikace .NET Windows Forms (WinForms)",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms-App",
   "description": "Eine Projektvorlage zum Erstellen einer Windows Forms-App (WinForms) in .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,13 +1,13 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplicación de Windows Forms",
-  "description": "Plantilla de proyecto para crear una aplicación de Windows Forms (WinForms) de .NET.",
+  "description": "Plantilla de proyecto para crear una aplicación de Windows\u00A0Forms (WinForms) de .NET.",
   "symbols/TargetFrameworkOverride/description": "Invalida la plataforma de destino",
   "symbols/TargetFrameworkOverride/displayName": "Invalidación de la plataforma de destino",
   "symbols/UseAppFramework/description": "La aplicación debería usar el marco de trabajo de la aplicación de Visual Basic",
   "symbols/Framework/description": "Marco de destino del proyecto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Application Windows Forms",
   "description": "Modèle de projet pour créer une application .NET Windows Forms (WinForms).",
@@ -7,11 +7,11 @@
   "symbols/UseAppFramework/description": "L’application doit utiliser l’Infrastructure d’Application Visual Basic",
   "symbols/Framework/description": "Framework cible du projet.",
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Framework",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/langVersion/displayName": "Version du Langage",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "App Windows Forms",
   "description": "Modello di progetto per la creazione di un'app Windows Forms (WinForms) .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows フォーム アプリ",
   "description": ".NET Windows フォーム (WinForms) アプリを作成するためのプロジェクト テンプレート。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 앱",
   "description": ".NET WinForms(Windows Forms) 앱을 만들기 위한 프로젝트 템플릿입니다.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplikacja Windows Forms",
   "description": "Szablon projektu służący do tworzenia aplikacji .NET Windows Forms (WinForms).",
@@ -13,11 +13,11 @@
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
   "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
   "symbols/Framework/displayName": "Platforma",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/langVersion/displayName": "Wersja języka",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/skipRestore/displayName": "Pomiń przywracanie",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/open-file/description": "Otwiera plik Form1.vb w edytorze"
+  "postActions/open-file/description": "Otwiera plik Form1.vb w\u00A0edytorze"
 }

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,8 +1,8 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplicativo do Windows Forms",
   "description": "Um modelo de projeto para criar um Aplicativo do WinForms (Windows Forms) do .NET.",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/TargetFrameworkOverride/displayName": "Substituição da estrutura de destino",
   "symbols/UseAppFramework/description": "O aplicativo deve usar a Estrutura do aplicativo Visual Basic",
   "symbols/Framework/description": "A estrutura de destino do projeto.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Приложение Windows Forms",
   "description": "Шаблон проекта для создания приложения .NET Windows Forms (WinForms).",
@@ -7,11 +7,11 @@
   "symbols/UseAppFramework/description": "Приложение должно использовать платформу приложений Visual Basic",
   "symbols/Framework/description": "Целевая платформа для проекта.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
-  "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
+  "symbols/Framework/choices/net5.0/displayName": ".NET\u00A05.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Платформа",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/langVersion/displayName": "Версия языка",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms Uygulaması",
   "description": ".NET Windows Forms (WinForms) Uygulaması oluşturmak için proje şablonu.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows 窗体应用",
   "description": "用于创建 .NET Windows 窗体(WinForms)应用的项目模板。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 應用程式",
   "description": "用於建立 .NET Windows Forms (WinForms) 應用程式的專案範本。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Knihovna ovládacích prvků Windows Forms",
   "description": "Šablona projektu pro vytvoření knihovny ovládacích prvků, která cílí na .NET Windows Forms (WinForms).",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.de.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms-Steuerelementbibliothek",
   "description": "Eine Projektvorlage zum Erstellen einer Steuerelementbibliothek für Windows Forms (WinForms) in .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.es.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "author": "Microsoft",
-  "name": "Biblioteca de controles de Windows Forms",
-  "description": "Plantilla de proyecto para crear una biblioteca de controles para Windows Forms (WinForms) de .NET.",
+  "name": "Biblioteca de controles de Windows\u00A0Forms",
+  "description": "Plantilla de proyecto para crear una biblioteca de controles para Windows\u00A0Forms (WinForms) de .NET.",
   "symbols/TargetFrameworkOverride/description": "Invalida la plataforma de destino",
   "symbols/TargetFrameworkOverride/displayName": "Invalidación de la plataforma de destino",
   "symbols/Framework/description": "Marco de destino del proyecto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothèque de contrôles Windows Forms",
   "description": "Modèle de projet pour créer une bibliothèque de contrôles ciblant .NET Windows Forms (WinForms).",
@@ -6,11 +6,11 @@
   "symbols/TargetFrameworkOverride/displayName": "Remplacement de l’infrastructure cible",
   "symbols/Framework/description": "Framework cible du projet.",
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Framework",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/langVersion/displayName": "Version du Langage",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.it.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Libreria di controlli Windows Form",
   "description": "Modello di progetto per la creazione di una libreria di controlli destinata a Windows Forms (WinForms) .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows フォーム コントロール ライブラリ",
   "description": ".NET Windows フォーム (WinForms) を対象とするコントロール ライブラリを作成するためのプロジェクト テンプレート。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 컨트롤 라이브러리",
   "description": ".NET WinForms(Windows Forms)를 대상으로 하는 컨트롤 라이브러리를 만들기 위한 프로젝트 템플릿입니다.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteka kontrolek Windows Forms",
   "description": "Szablon projektu służący do tworzenia biblioteki kontrolek przeznaczonej dla środowiska .NET Windows Forms (WinForms).",
@@ -12,7 +12,7 @@
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
   "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
   "symbols/Framework/displayName": "Platforma",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/langVersion/displayName": "Wersja języka",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/skipRestore/displayName": "Pomiń przywracanie",
@@ -20,5 +20,5 @@
   "symbols/Nullable/displayName": "Włącz dopuszczającą wartość null",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/open-file/description": "Otwiera plik UserControl1.cs w edytorze"
+  "postActions/open-file/description": "Otwiera plik UserControl1.cs w\u00A0edytorze"
 }

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,8 +1,8 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de Controles do Windows Forms",
   "description": "Um modelo de projeto para criar uma biblioteca de controles direcionada ao WinForms (Windows Forms) do .NET.",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/TargetFrameworkOverride/displayName": "Substituição da estrutura de destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Библиотека элементов управления Windows Forms",
   "description": "Шаблон проекта для создания библиотеки элементов управления, предназначенной для платформы .NET Windows Forms (WinForms).",
@@ -6,11 +6,11 @@
   "symbols/TargetFrameworkOverride/displayName": "Переопределение целевой платформы",
   "symbols/Framework/description": "Целевая платформа для проекта.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
-  "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
+  "symbols/Framework/choices/net5.0/displayName": ".NET\u00A05.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Платформа",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/langVersion/displayName": "Версия языка",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms Denetim Kitaplığı",
   "description": ".NET Windows Forms'u (WinForms) hedefleyen bir denetim kitaplığı oluşturmaya yönelik proje şablonu.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows 窗体控件库",
   "description": "用于创建面向 .NET Windows 窗体(WinForms)的控件库的项目模板。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 控制項程式庫",
   "description": "用於建立以 .NET Windows Forms (WinForms) 為目標之控制項程式庫的專案範本。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Knihovna ovládacích prvků Windows Forms",
   "description": "Šablona projektu pro vytvoření knihovny ovládacích prvků, která cílí na .NET Windows Forms (WinForms).",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms-Steuerelementbibliothek",
   "description": "Eine Projektvorlage zum Erstellen einer Steuerelementbibliothek für Windows Forms (WinForms) in .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "author": "Microsoft",
-  "name": "Biblioteca de controles de Windows Forms",
-  "description": "Plantilla de proyecto para crear una biblioteca de controles para Windows Forms (WinForms) de .NET.",
+  "name": "Biblioteca de controles de Windows\u00A0Forms",
+  "description": "Plantilla de proyecto para crear una biblioteca de controles para Windows\u00A0Forms (WinForms) de .NET.",
   "symbols/TargetFrameworkOverride/description": "Invalida la plataforma de destino",
   "symbols/TargetFrameworkOverride/displayName": "Invalidación de la plataforma de destino",
   "symbols/Framework/description": "Marco de destino del proyecto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothèque de contrôles Windows Forms",
   "description": "Modèle de projet pour créer une bibliothèque de contrôles ciblant .NET Windows Forms (WinForms).",
@@ -6,11 +6,11 @@
   "symbols/TargetFrameworkOverride/displayName": "Remplacement de l’infrastructure cible",
   "symbols/Framework/description": "Framework cible du projet.",
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Framework",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/langVersion/displayName": "Version du Langage",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Libreria di controlli Windows Form",
   "description": "Modello di progetto per la creazione di una libreria di controlli destinata a Windows Forms (WinForms) .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows フォーム コントロール ライブラリ",
   "description": ".NET Windows フォーム (WinForms) を対象とするコントロール ライブラリを作成するためのプロジェクト テンプレート。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 컨트롤 라이브러리",
   "description": ".NET WinForms(Windows Forms)를 대상으로 하는 컨트롤 라이브러리를 만들기 위한 프로젝트 템플릿입니다.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteka kontrolek Windows Forms",
   "description": "Szablon projektu służący do tworzenia biblioteki kontrolek przeznaczonej dla środowiska .NET Windows Forms (WinForms).",
@@ -12,11 +12,11 @@
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
   "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
   "symbols/Framework/displayName": "Platforma",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/langVersion/displayName": "Wersja języka",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/skipRestore/displayName": "Pomiń przywracanie",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/open-file/description": "Otwiera plik UserControl1.vb w edytorze"
+  "postActions/open-file/description": "Otwiera plik UserControl1.vb w\u00A0edytorze"
 }

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,8 +1,8 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de Controles do Windows Forms",
   "description": "Um modelo de projeto para criar uma biblioteca de controles direcionada ao WinForms (Windows Forms) do .NET.",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/TargetFrameworkOverride/displayName": "Substituição da estrutura de destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Библиотека элементов управления Windows Forms",
   "description": "Шаблон проекта для создания библиотеки элементов управления, предназначенной для платформы .NET Windows Forms (WinForms).",
@@ -6,11 +6,11 @@
   "symbols/TargetFrameworkOverride/displayName": "Переопределение целевой платформы",
   "symbols/Framework/description": "Целевая платформа для проекта.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
-  "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
+  "symbols/Framework/choices/net5.0/displayName": ".NET\u00A05.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Платформа",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/langVersion/displayName": "Версия языка",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms Denetim Kitaplığı",
   "description": ".NET Windows Forms'u (WinForms) hedefleyen bir denetim kitaplığı oluşturmaya yönelik proje şablonu.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows 窗体控件库",
   "description": "用于创建面向 .NET Windows 窗体(WinForms)的控件库的项目模板。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 控制項程式庫",
   "description": "用於建立以 .NET Windows Forms (WinForms) 為目標之控制項程式庫的專案範本。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Knihovna tříd pro Windows Forms",
   "description": "Šablona projektu pro vytvoření knihovny tříd, která cílí na .NET Windows Forms (WinForms)",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.de.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms-Klassenbibliothek",
   "description": "Eine Projektvorlage zum Erstellen einer Klassenbibliothek für Windows Forms (WinForms) in .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.es.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.es.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "author": "Microsoft",
-  "name": "Biblioteca de clases de Windows Forms",
-  "description": "Plantilla de proyecto para crear una biblioteca de clases para Windows Forms (WinForms) de .NET.",
+  "name": "Biblioteca de clases de Windows\u00A0Forms",
+  "description": "Plantilla de proyecto para crear una biblioteca de clases para Windows\u00A0Forms (WinForms) de .NET.",
   "symbols/TargetFrameworkOverride/description": "Invalida la plataforma de destino",
   "symbols/TargetFrameworkOverride/displayName": "Invalidación de la plataforma de destino",
   "symbols/Framework/description": "Marco de destino del proyecto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothèque de classes Windows Forms",
   "description": "Modèle de projet pour créer une bibliothèque de classes ciblant .NET Windows Forms (WinForms).",
@@ -6,11 +6,11 @@
   "symbols/TargetFrameworkOverride/displayName": "Remplacement de l’infrastructure cible",
   "symbols/Framework/description": "Framework cible du projet.",
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Framework",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/langVersion/displayName": "Version du Langage",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.it.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Libreria di classi Windows Form",
   "description": "Modello di progetto per la creazione di una libreria di classi destinata a Windows Forms (WinForms) .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows フォーム クラス ライブラリ",
   "description": ".NET Windows フォーム (WinForms) を対象とするクラス ライブラリを作成するためのプロジェクト テンプレート。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 클래스 라이브러리",
   "description": ".NET WinForms(Windows Forms)를 대상으로 하는 클래스 라이브러리를 만들기 위한 프로젝트 템플릿입니다.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteka klas Windows Forms",
   "description": "Szablon projektu służący do tworzenia biblioteki klas przeznaczonej dla środowiska .NET Windows Forms (WinForms).",
@@ -12,7 +12,7 @@
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
   "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
   "symbols/Framework/displayName": "Platforma",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/langVersion/displayName": "Wersja języka",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/skipRestore/displayName": "Pomiń przywracanie",
@@ -20,5 +20,5 @@
   "symbols/Nullable/displayName": "Włącz dopuszczającą wartość null",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/open-file/description": "Otwiera plik Class1.cs w edytorze"
+  "postActions/open-file/description": "Otwiera plik Class1.cs w\u00A0edytorze"
 }

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,8 +1,8 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de Classes do Windows Forms",
   "description": "Um modelo de projeto para criar uma biblioteca de classes direcionada ao WinForms (Windows Forms) do .NET.",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/TargetFrameworkOverride/displayName": "Substituição da estrutura de destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Библиотека классов Windows Forms",
   "description": "Шаблон проекта для создания библиотеки классов, предназначенной для платформы .NET Windows Forms (WinForms).",
@@ -6,11 +6,11 @@
   "symbols/TargetFrameworkOverride/displayName": "Переопределение целевой платформы",
   "symbols/Framework/description": "Целевая платформа для проекта.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
-  "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
+  "symbols/Framework/choices/net5.0/displayName": ".NET\u00A05.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Платформа",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/langVersion/displayName": "Версия языка",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms Sınıf Kitaplığı",
   "description": ".NET Windows Forms'u (WinForms) hedefleyen bir sınıf kitaplığı oluşturmaya yönelik proje.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows 窗体类库",
   "description": "用于创建面向 .NET Windows 窗体(WinForms)的类库的项目模板。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 類別庫",
   "description": "用於建立以 .NET Windows Forms (WinForms) 為目標之類別庫的專案範本。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.cs.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Knihovna tříd pro Windows Forms",
   "description": "Šablona projektu pro vytvoření knihovny tříd, která cílí na .NET Windows Forms (WinForms)",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.de.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms-Klassenbibliothek",
   "description": "Eine Projektvorlage zum Erstellen einer Klassenbibliothek für Windows Forms (WinForms) in .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.es.json
@@ -1,12 +1,12 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de clases de Windows Forms",
-  "description": "Plantilla de proyecto para crear una biblioteca de clases para Windows Forms (WinForms) de .NET.",
+  "description": "Plantilla de proyecto para crear una biblioteca de clases para Windows\u00A0Forms (WinForms) de .NET.",
   "symbols/TargetFrameworkOverride/description": "Invalida la plataforma de destino",
   "symbols/TargetFrameworkOverride/displayName": "Invalidación de la plataforma de destino",
   "symbols/Framework/description": "Marco de destino del proyecto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Objetivo netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Objetivo net5.0",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "Objetivo net6.0",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Bibliothèque de Classes Windows Forms",
   "description": "Modèle de projet pour créer une bibliothèque de classes ciblant .NET Windows Forms (WinForms).",
@@ -6,11 +6,11 @@
   "symbols/TargetFrameworkOverride/displayName": "Remplacement de l’infrastructure cible",
   "symbols/Framework/description": "Framework cible du projet.",
   "symbols/Framework/choices/netcoreapp3.1/description": "netcoreapp3.1 cible",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "net5.0 cible",
   "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
   "symbols/Framework/choices/net6.0/description": "net6.0 cible",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Framework",
   "symbols/langVersion/description": "Définit langVersion dans le fichier projet créé",
   "symbols/langVersion/displayName": "Version du Langage",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.it.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Libreria di classi di Windows Form",
   "description": "Modello di progetto per la creazione di una libreria di classi destinata a Windows Forms (WinForms) .NET.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.ja.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows フォーム クラス ライブラリ",
   "description": ".NET Windows フォーム (WinForms) を対象とするクラス ライブラリを作成するためのプロジェクト テンプレート。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.ko.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 클래스 라이브러리",
   "description": ".NET WinForms(Windows Forms)를 대상으로 하는 클래스 라이브러리를 만들기 위한 프로젝트 템플릿입니다.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.pl.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteka klas Windows Forms",
   "description": "Szablon projektu służący do tworzenia biblioteki klas przeznaczonej dla środowiska .NET Windows Forms (WinForms).",
@@ -12,11 +12,11 @@
   "symbols/Framework/choices/net6.0/description": "Docelowy net6.0",
   "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
   "symbols/Framework/displayName": "Platforma",
-  "symbols/langVersion/description": "Ustawia langVersion w utworzonym pliku projektu",
+  "symbols/langVersion/description": "Ustawia langVersion w\u00A0utworzonym pliku projektu",
   "symbols/langVersion/displayName": "Wersja języka",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/skipRestore/displayName": "Pomiń przywracanie",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
-  "postActions/open-file/description": "Otwiera plik Class1.vb w edytorze"
+  "postActions/open-file/description": "Otwiera plik Class1.vb w\u00A0edytorze"
 }

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.pt-BR.json
@@ -1,8 +1,8 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Biblioteca de Classes do Windows Forms",
   "description": "Um modelo de projeto para criar uma biblioteca de classes direcionada ao WinForms (Windows Forms) do .NET.",
-  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de destino",
+  "symbols/TargetFrameworkOverride/description": "Substitui a estrutura de\u00A0destino",
   "symbols/TargetFrameworkOverride/displayName": "Substituição da estrutura de destino",
   "symbols/Framework/description": "A estrutura de destino do projeto.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Netcoreapp3.1 de destino",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Майкрософт",
   "name": "Библиотека классов Windows Forms",
   "description": "Шаблон проекта для создания библиотеки классов, предназначенной для платформы .NET Windows Forms (WinForms).",
@@ -6,11 +6,11 @@
   "symbols/TargetFrameworkOverride/displayName": "Переопределение целевой платформы",
   "symbols/Framework/description": "Целевая платформа для проекта.",
   "symbols/Framework/choices/netcoreapp3.1/description": "Целевая платформа: netcoreapp3.1",
-  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core 3.1",
+  "symbols/Framework/choices/netcoreapp3.1/displayName": ".NET Core\u00A03.1",
   "symbols/Framework/choices/net5.0/description": "Целевая платформа: net5.0",
-  "symbols/Framework/choices/net5.0/displayName": ".NET 5.0",
+  "symbols/Framework/choices/net5.0/displayName": ".NET\u00A05.0",
   "symbols/Framework/choices/net6.0/description": "Целевая платформа: net6.0",
-  "symbols/Framework/choices/net6.0/displayName": ".NET 6.0",
+  "symbols/Framework/choices/net6.0/displayName": ".NET\u00A06.0",
   "symbols/Framework/displayName": "Платформа",
   "symbols/langVersion/description": "Задает свойство langVersion в созданном файле проекта",
   "symbols/langVersion/displayName": "Версия языка",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.tr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms Sınıf kitaplığı",
   "description": ".NET Windows Forms'u (WinForms) hedefleyen bir sınıf kitaplığı oluşturmaya yönelik proje.",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows 窗体类库",
   "description": "用于创建面向 .NET Windows 窗体(WinForms)的类库的项目模板。",

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-VisualBasic/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Windows Forms 類別庫",
   "description": "用於建立以 .NET Windows Forms (WinForms) 為目標之類別庫的專案範本。",


### PR DESCRIPTION
## Background:
 Template engine (`dotnet new`) added support for template localizations in .NET 6.0. This new system replaces the old way of localizing templates that only worked on Visual Studio and works on both .NET CLI as well as VS.

This PR introduces changes to switch to the new template localization system.

## Summary of the changes
- Adds `<UsingToolTemplateLocalizer>true</>` to projects containing templates.
- Adds necessary `id` fields into `template.json` files to allow localizing certain fields (specifically, post actions).
- Generates localization files to be translated by loc team


## What to expect after merging
Every time there is a change to one of the templates:
- The dev making the change should build (at the very least) the modified template project. This will update the loc files on the local working copy,
- Push the loc files together with the template modifications. Review & merge.
- OneLocBuild integration will automatically pick up the changes and will send them for translation.
- You will receive a PR containing the translated template loc files when they are ready. Review & merge.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6319)