### PR TITLE
Fix Form snap layout when in maximized state

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -2382,7 +2382,6 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated && Visible)
                 {
-                    IntPtr hWnd = Handle;
                     switch (value)
                     {
                         case FormWindowState.Normal:
@@ -5931,12 +5930,15 @@ namespace System.Windows.Forms
                         SuspendLayoutForMinimize();
                     }
 
-                    _restoredWindowBounds.Size = ClientSize;
-                    _formStateEx[FormStateExWindowBoundsWidthIsClientSize] = 1;
-                    _formStateEx[FormStateExWindowBoundsHeightIsClientSize] = 1;
-                    _restoredWindowBoundsSpecified = BoundsSpecified.Size;
-                    _restoredWindowBounds.Location = Location;
-                    _restoredWindowBoundsSpecified |= BoundsSpecified.Location;
+                    if (!OsVersion.IsWindows11_OrGreater)
+                    {
+                        _restoredWindowBounds.Size = ClientSize;
+                        _formStateEx[FormStateExWindowBoundsWidthIsClientSize] = 1;
+                        _formStateEx[FormStateExWindowBoundsHeightIsClientSize] = 1;
+                        _restoredWindowBoundsSpecified = BoundsSpecified.Size;
+                        _restoredWindowBounds.Location = Location;
+                        _restoredWindowBoundsSpecified |= BoundsSpecified.Location;
+                    }
 
                     // stash off restoreBounds As well...
                     _restoreBounds.Size = Size;

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/FormTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/FormTests.cs
@@ -1,0 +1,157 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using WindowsInput.Native;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Windows.Forms.UITests
+{
+    public class FormTests : ControlTestBase
+    {
+        // When using the keyboard for snap layout menu, there are various times when
+        // a delay is needed. This value may need to be adjusted if tests fail
+        // in CI/different environment
+        private const int SnapLayoutDelayMS = 500;
+
+        public FormTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+        }
+
+        [WinFormsTheory]
+        [InlineData(FormWindowState.Normal)]
+        [InlineData(FormWindowState.Maximized)]
+        public async Task Form_SnapsLeftAsync(FormWindowState windowState)
+        {
+            if (!OsVersion.IsWindows11_OrGreater)
+            {
+                return;
+            }
+
+            await RunEmptyFormTestAsync(async form =>
+            {
+                form.Location = new Point(20, 21);
+                form.Size = new Size(300, 310);
+
+                form.WindowState = windowState;
+
+                await InputSimulator.SendAsync(
+                    form,
+                    inputSimulator => inputSimulator.Keyboard.ModifiedKeyStroke(VirtualKeyCode.LWIN, VirtualKeyCode.VK_Z));
+
+                // inputSimulator.Sleep appears wildly inconsistent with snap panel timing. Task.Delay does not
+                await Task.Delay(SnapLayoutDelayMS);
+
+                // Snap left
+                await InputSimulator.SendAsync(
+                    form,
+                    inputSimulator => inputSimulator.Keyboard.KeyPress(VirtualKeyCode.RIGHT)
+                                                             .KeyPress(VirtualKeyCode.RETURN));
+
+                await Task.Delay(SnapLayoutDelayMS);
+
+                // At this point, Windows displays a panel containing all running applications so the
+                // user can select one to dock next to our form. It also takes the keyboard focus away.
+                // If left in this state, subsequently run tests will fail since keyboard focus is not
+                // given to any newly launched window until this panel is dismissed.
+                await InputSimulator.SendAsync(
+                    form,
+                    inputSimulator => inputSimulator.Keyboard.KeyPress(VirtualKeyCode.ESCAPE));
+
+                await Task.Delay(SnapLayoutDelayMS);
+
+                var screenWorkingArea = Screen.FromControl(form).WorkingArea;
+                int borderSize = (form.Width - form.ClientRectangle.Width) / 2;
+
+                Assert.True(form.Left <= screenWorkingArea.X);
+                Assert.True(form.Left >= screenWorkingArea.X - borderSize);
+
+                Assert.True(form.Top <= screenWorkingArea.Y);
+                Assert.True(form.Top >= screenWorkingArea.Y - borderSize);
+
+                Assert.True(form.Height >= screenWorkingArea.Height);
+                Assert.True(form.Height <= screenWorkingArea.Height + (borderSize * 2));
+
+                Assert.True(form.Width >= screenWorkingArea.Width / 2);
+                Assert.True(form.Width <= (screenWorkingArea.Width / 2) + (borderSize * 2));
+            });
+        }
+
+        [WinFormsTheory]
+        [InlineData(FormWindowState.Normal)]
+        [InlineData(FormWindowState.Maximized)]
+        public async Task Form_SnapsRightAsync(FormWindowState windowState)
+        {
+            if (!OsVersion.IsWindows11_OrGreater)
+            {
+                return;
+            }
+
+            await RunEmptyFormTestAsync(async form =>
+            {
+                form.Location = new Point(20, 21);
+                form.Size = new Size(300, 310);
+
+                form.WindowState = windowState;
+
+                await InputSimulator.SendAsync(
+                    form,
+                    inputSimulator => inputSimulator.Keyboard.ModifiedKeyStroke(VirtualKeyCode.LWIN, VirtualKeyCode.VK_Z));
+
+                // inputSimulator.Sleep appears wildly inconsistent with snap panel timing. Task.Delay does not
+                await Task.Delay(SnapLayoutDelayMS);
+
+                // Snap right
+                await InputSimulator.SendAsync(
+                    form,
+                    inputSimulator => inputSimulator.Keyboard.KeyPress(VirtualKeyCode.RIGHT)
+                                                             .KeyPress(VirtualKeyCode.RIGHT)
+                                                             .KeyPress(VirtualKeyCode.RETURN));
+
+                await Task.Delay(SnapLayoutDelayMS);
+
+                // At this point, Windows displays a panel containing all running applications so the
+                // user can select one to dock next to our form. It also takes the keyboard focus away.
+                // If left in this state, subsequently run tests will fail since keyboard focus is not
+                // given to any newly launched window until this panel is dismissed.
+                await InputSimulator.SendAsync(
+                    form,
+                    inputSimulator => inputSimulator.Keyboard.KeyPress(VirtualKeyCode.ESCAPE));
+
+                await Task.Delay(SnapLayoutDelayMS);
+
+                var screenWorkingArea = Screen.FromControl(form).WorkingArea;
+                int screenMiddleX = screenWorkingArea.X + (screenWorkingArea.Width / 2);
+                int borderSize = (form.Width - form.ClientRectangle.Width) / 2;
+
+                Assert.True(form.Left <= screenMiddleX);
+                Assert.True(form.Left >= screenMiddleX - borderSize);
+
+                Assert.True(form.Top <= screenWorkingArea.Y);
+                Assert.True(form.Top >= screenWorkingArea.Y - borderSize);
+
+                Assert.True(form.Height >= screenWorkingArea.Height);
+                Assert.True(form.Height <= screenWorkingArea.Height + (borderSize * 2));
+
+                Assert.True(form.Width >= screenWorkingArea.Width / 2);
+                Assert.True(form.Width <= (screenWorkingArea.Width / 2) + (borderSize * 2));
+            });
+        }
+
+        private async Task RunEmptyFormTestAsync(Func<Form, Task> testDriverAsync)
+        {
+            await RunFormWithoutControlAsync(
+                () =>
+                {
+                    var form = new Form();
+                    form.TopMost = true;
+
+                    return form;
+                },
+                testDriverAsync);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -975,6 +975,64 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void Form_Restore_RestoresPosition_User()
+        {
+            if (!OsVersion.IsWindows11_OrGreater)
+            {
+                return;
+            }
+
+            using var form = new Form();
+            form.Show();
+
+            form.Location = new Point(10, 11);
+            form.Size = new Size(200, 210);
+
+            User32.SendMessageW(form, User32.WM.SYSCOMMAND, (nint)User32.SC.MAXIMIZE, 0);
+
+            form.Location = new Point(20, 21);
+            form.Size = new Size(300, 310);
+
+            Assert.Equal(FormWindowState.Maximized, form.WindowState);
+            Assert.NotEqual(new Point(20, 21), form.Location);
+            Assert.NotEqual(new Size(300, 310), form.Size);
+
+            User32.SendMessageW(form, User32.WM.SYSCOMMAND, (nint)User32.SC.RESTORE, 0);
+
+            Assert.Equal(new Point(20, 21), form.Location);
+            Assert.Equal(new Size(300, 310), form.Size);
+        }
+
+        [WinFormsFact]
+        public void Form_Restore_RestoresPosition_WindowState()
+        {
+            if (!OsVersion.IsWindows11_OrGreater)
+            {
+                return;
+            }
+
+            using var form = new Form();
+            form.Show();
+
+            form.Location = new Point(10, 11);
+            form.Size = new Size(200, 210);
+
+            form.WindowState = FormWindowState.Maximized;
+
+            form.Location = new Point(20, 21);
+            form.Size = new Size(300, 310);
+
+            Assert.Equal(FormWindowState.Maximized, form.WindowState);
+            Assert.NotEqual(new Point(20, 21), form.Location);
+            Assert.NotEqual(new Size(300, 310), form.Size);
+
+            form.WindowState = FormWindowState.Normal;
+
+            Assert.Equal(new Point(20, 21), form.Location);
+            Assert.Equal(new Size(300, 310), form.Size);
+        }
+
         [WinFormsTheory]
         [InlineData(false, true)]
         [InlineData(true, false)]


### PR DESCRIPTION
Fixes #6153. 

## Proposed changes

`System.Windows.Forms.Form` caches size and location upon becoming maximized and restores it when exiting maximized state. This creates a problem when using Windows snap layout since the form will be brought out of a maximized state and "docked" to a specific location by Windows only have its size and location subsequently changed to the internally cached values when the form processes `WM_WINDOWPOSCHANGED`.

~~If it were possible to not use internally cached values when coming out of a maximized state due to a snap layout command, this problem should be resolved. It does not appear that Windows provides any way to detect that. Instead, this PR assumes that any position change not initiated by the user or by a programmatic change of `Form.WindowState` is instead initiated by a window manager and cached positional values are not used.~~

~~Note: for determining if the change was initiated by the user, it was observed that a window message of `WM_SYSCOMMAND` containing a `wParam` of `SC_RESTORE` was sent regardless of whether the max/min button was clicked, the title bar was double-clicked, or if the restore command was used from the window's context menu. I was not able to find any way for the user to exit maximized state without triggering the `WM_SYSCOMMAND`. If that were possible, this fix would not work.~~

This PR fixes the issue by removing the unconditional caching of size/location that occurred when a form is maximized/minimized. By only attempting to set these values when necessary (e.g. a form is minimized and `Size` or `Location` is changed programmatically) it allows Windows to otherwise handle positioning.

The original attempt to fix left unconditional caching alone and only addressed the scenario of a form coming out of maximized state due to Windows snap layout. However, there were additional scenarios identified in which Windows attempted to set the geometry only to have been overridden by unconditionally cached values.


## Customer Impact

Customers should observe that `Form` objects respond properly when using snap layout while in a maximized state.

## Regression? 

- No

## Risk

~~Risk is that manner of determining whether Form position change is due to Windows snap layout versus user/programmatic change is deficient and does not cover all scenarios.~~

- It is unclear why form geometry was unconditionally cached and restored. There is risk that the original author had an presently unidentified edge case in mind. This change should be tested thoroughly.

## Test methodology

- Unit tests
- UI integration tests
- Manually manipulated a `Form` object with the mouse and keyboard to verify behavior

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6335)