### PR TITLE
Fixing PGV accessibility tree for property descriptors and dropdown holders

### DIFF
--- a/src/System.Windows.Forms/src/Properties/AssemblyInfo.cs
+++ b/src/System.Windows.Forms/src/Properties/AssemblyInfo.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 [assembly: System.Runtime.InteropServices.ComVisible(false)]
 
 [assembly: InternalsVisibleTo("System.Windows.Forms.Tests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("System.Windows.Forms.TestUtilities, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.Primitives.TestUtilities, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.UI.IntegrationTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiImageListTests, PublicKey=00000000000000000400000000000000")]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static System.Windows.Forms.PropertyGridInternal.PropertyDescriptorGridEntry;
 using static Interop;
 
 namespace System.Windows.Forms.PropertyGridInternal
@@ -47,18 +48,19 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// <returns>Returns the element in the specified direction.</returns>
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
-                if (direction == UiaCore.NavigateDirection.Parent &&
-                    _owningPropertyGrid?.SelectedGridEntry is not null &&
-                    _owningDropDownButton.Visible)
+                if (!_owningDropDownButton.Visible
+                    || _owningPropertyGrid?.SelectedGridEntry?.AccessibilityObject is not PropertyDescriptorGridEntryAccessibleObject parent)
                 {
-                    return _owningPropertyGrid.SelectedGridEntry?.AccessibilityObject;
-                }
-                else if (direction == UiaCore.NavigateDirection.PreviousSibling)
-                {
-                    return _owningPropertyGrid?.EditAccessibleObject;
+                    return null;
                 }
 
-                return base.FragmentNavigate(direction);
+                return direction switch
+                {
+                    UiaCore.NavigateDirection.Parent => parent,
+                    UiaCore.NavigateDirection.NextSibling => parent.GetNextChild(this),
+                    UiaCore.NavigateDirection.PreviousSibling => parent.GetPreviousChild(this),
+                    _ => base.FragmentNavigate(direction),
+                };
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObject.cs
@@ -266,7 +266,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 int index = GetChildIndex(child);
 
                 // Ensure that it is a valid child and not the first child.
-                if (index == -1 || index == 0)
+                if (index <= 0)
                 {
                     return null;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static System.Windows.Forms.PropertyGridInternal.PropertyDescriptorGridEntry;
 using static Interop;
 
 namespace System.Windows.Forms.PropertyGridInternal
@@ -20,20 +21,33 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
-                    => direction switch
+                {
+                    if (!ExistsInAccessibleTree)
                     {
-                        UiaCore.NavigateDirection.Parent => ExistsInAccessibleTree
-                            ? _owningDropDownHolder._gridView?.SelectedGridEntry?.AccessibilityObject
-                            : null,
-                        UiaCore.NavigateDirection.NextSibling => ExistsInAccessibleTree
-                            ? _owningDropDownHolder._gridView?.EditAccessibleObject
-                            : null,
-                        UiaCore.NavigateDirection.PreviousSibling => null,
+                        return null;
+                    }
+
+                    PropertyGridView? gridView = _owningDropDownHolder._gridView;
+                    GridEntry? selectedEntry = gridView?.SelectedGridEntry;
+                    if (selectedEntry?.AccessibilityObject is not PropertyDescriptorGridEntryAccessibleObject parent)
+                    {
+                        return null;
+                    }
+
+                    return direction switch
+                    {
+                        UiaCore.NavigateDirection.Parent => parent,
+                        UiaCore.NavigateDirection.NextSibling => parent.GetNextChild(this),
+                        UiaCore.NavigateDirection.PreviousSibling => parent.GetPreviousChild(this),
+                        UiaCore.NavigateDirection.FirstChild or UiaCore.NavigateDirection.LastChild
+                            when selectedEntry.Enumerable && _owningDropDownHolder.Component == gridView!.DropDownListBox
+                            => gridView.DropDownListBoxAccessibleObject,
                         _ => base.FragmentNavigate(direction),
                     };
+                }
 
                 internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot =>
-                    _owningDropDownHolder._gridView?.OwnerGrid?.AccessibilityObject;
+                    _owningDropDownHolder._gridView?.AccessibilityObject;
 
                 public override string? Name => SR.PropertyGridViewDropDownControlHolderAccessibleName;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxAccessibleObject.cs
@@ -36,17 +36,17 @@ namespace System.Windows.Forms.PropertyGridInternal
             /// <returns>Returns the element in the specified direction.</returns>
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
-                if (direction == UiaCore.NavigateDirection.Parent && _owningPropertyGridView.SelectedGridEntry is not null)
+                if (!_owningPropertyGridView.DropDownVisible || _owningPropertyGridView.SelectedGridEntry is null
+                    || _owningPropertyGridView.DropDownControlHolder.Component != Owner)
                 {
-                    return _owningPropertyGridView.SelectedGridEntry.AccessibilityObject;
+                    return null;
                 }
 
-                if (direction == UiaCore.NavigateDirection.NextSibling)
+                return direction switch
                 {
-                    return _owningPropertyGridView.EditTextBox.AccessibilityObject;
-                }
-
-                return base.FragmentNavigate(direction);
+                    UiaCore.NavigateDirection.Parent => _owningPropertyGridView.DropDownControlHolder.AccessibilityObject,
+                    _ => base.FragmentNavigate(direction)
+                };
             }
 
             public override string? Name

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static System.Windows.Forms.PropertyGridInternal.PropertyDescriptorGridEntry;
 using static Interop;
 
 namespace System.Windows.Forms.PropertyGridInternal
@@ -49,30 +50,19 @@ namespace System.Windows.Forms.PropertyGridInternal
                 /// <returns>Returns the element in the specified direction.</returns>
                 internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
                 {
-                    if (direction == UiaCore.NavigateDirection.Parent && _owningPropertyGridView.SelectedGridEntry is not null)
+                    if (!_owningPropertyGridView.IsEditTextBoxCreated
+                        || _owningPropertyGridView.SelectedGridEntry?.AccessibilityObject is not PropertyDescriptorGridEntryAccessibleObject parent)
                     {
-                        return _owningPropertyGridView.SelectedGridEntry.AccessibilityObject;
-                    }
-                    else if (direction == UiaCore.NavigateDirection.NextSibling)
-                    {
-                        if (_owningPropertyGridView.DropDownButton.Visible)
-                        {
-                            return _owningPropertyGridView.DropDownButton.AccessibilityObject;
-                        }
-                        else if (_owningPropertyGridView.DialogButton.Visible)
-                        {
-                            return _owningPropertyGridView.DialogButton.AccessibilityObject;
-                        }
-                    }
-                    else if (direction == UiaCore.NavigateDirection.PreviousSibling)
-                    {
-                        if (_owningPropertyGridView.DropDownVisible)
-                        {
-                            return _owningPropertyGridView.DropDownControlHolder.AccessibilityObject;
-                        }
+                        return null;
                     }
 
-                    return base.FragmentNavigate(direction);
+                    return direction switch
+                    {
+                        UiaCore.NavigateDirection.Parent => parent,
+                        UiaCore.NavigateDirection.NextSibling => parent.GetNextChild(this),
+                        UiaCore.NavigateDirection.PreviousSibling => parent.GetPreviousChild(this),
+                        _ => base.FragmentNavigate(direction),
+                    };
                 }
 
                 /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -242,7 +242,7 @@ namespace System.Windows.Forms.PropertyGridInternal
         ///   the selected row's <see cref="GridEntry"/>.
         ///  </para>
         /// </remarks>
-        private Button DialogButton
+        internal Button DialogButton
         {
             get
             {

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObjectTests.cs
@@ -1,0 +1,75 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms.PropertyGridInternal.TestUtilities;
+using System.Windows.Forms.UITests;
+using Xunit;
+using Xunit.Abstractions;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.PropertyGridInternal.UITests;
+
+public class DropDownButtonAccessibleObjectTests : ControlTestBase
+{
+    public DropDownButtonAccessibleObjectTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    [WinFormsFact]
+    public async Task DropDownButtonAccessibleObject_FragmentNavigate_Parent_IsSelectedEntryAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            Assert.Equal(grid.SelectedEntry.AccessibilityObject,
+                grid.GridView.DropDownButton.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task DropDownButtonAccessibleObject_FragmentNavigate_PreviousSibling_IsTextBoxAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            Assert.Equal(grid.GridView.EditAccessibleObject,
+                grid.GridView.DropDownButton.AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task DropDownButtonAccessibleObject_FragmentNavigate_NextSibling_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            Assert.Null(grid.GridView.DropDownButton.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task DropDownButtonAccessibleObject_FragmentNavigate_NextSibling_IsChildEntryAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Font)];
+
+            grid.SelectedEntry.Expanded = true;
+
+            Assert.Equal(grid.SelectedEntry.Children.First().AccessibilityObject,
+                grid.GridView.DialogButton.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PropertyGridInternal/PropertyDescriptorGridEntry.PropertyDescriptorGridEntryAccessibleObjectTests.cs
@@ -1,0 +1,277 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms.PropertyGridInternal.TestUtilities;
+using System.Windows.Forms.UITests;
+using Xunit;
+using Xunit.Abstractions;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.PropertyGridInternal.UITests;
+
+public class PropertyDescriptorGridEntryAccessibleObjectTests : ControlTestBase
+{
+    public PropertyDescriptorGridEntryAccessibleObjectTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_Parent_IsParentEntryAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            GridEntry entry = grid[nameof(Button.Font)];
+            entry.Expanded = true;
+
+            Assert.Equal(entry.AccessibilityObject,
+                entry.Children.First().AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_PreviousSibling_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            GridEntry entry = grid[nameof(Button.Font)];
+            entry.Expanded = true;
+
+            Assert.Null(entry.Children.First().AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_PreviousSibling_IsChildEntryAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            GridEntry entry = grid[nameof(Button.Font)];
+            entry.Expanded = true;
+
+            Assert.Equal(entry.Children.First().AccessibilityObject,
+                entry.Children[1].AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_PreviousSibling_IsTextBoxAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Size)];
+            grid.SelectedEntry.Expanded = true;
+
+            Assert.Equal(grid.GridView.EditAccessibleObject,
+                grid.SelectedEntry.Children.First().AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_PreviousSibling_IsDialogButtonAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Font)];
+            grid.SelectedEntry.Expanded = true;
+
+            Assert.Equal(grid.GridView.DialogButton.AccessibilityObject,
+                grid.SelectedEntry.Children.First().AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_NextSibling_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            GridEntry entry = grid[nameof(Button.Font)];
+            entry.Expanded = true;
+
+            Assert.Null(entry.Children.Last().AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_NextSibling_IsChildEntryAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            GridEntry entry = grid[nameof(Button.Font)];
+            entry.Expanded = true;
+
+            Assert.Equal(entry.Children[1].AccessibilityObject,
+                entry.Children.First().AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_FirstChild_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            Assert.Null(grid[nameof(Button.Font)].AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_FirstChild_IsChildEntryAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            GridEntry entry = grid[nameof(Button.Font)];
+            entry.Expanded = true;
+
+            Assert.Equal(entry.Children.First().AccessibilityObject,
+                entry.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_FirstChild_IsNullAfterExpandCollapsedAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            GridEntry entry = grid[nameof(Button.Font)];
+
+            entry.Expanded = true;
+            entry.Expanded = false;
+
+            Assert.Null(entry.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_FirstChild_IsTextBoxAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            Assert.Equal(grid.GridView.EditAccessibleObject,
+                grid.SelectedEntry.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_FirstChild_IsDropDownHolderAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            grid.PopupEditorAndClose(() =>
+                Assert.Equal(grid.GridView.DropDownControlHolder.AccessibilityObject,
+                    grid.SelectedEntry.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild)));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_LastChild_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            Assert.Null(grid[nameof(Button.Font)].AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_LastChild_IsChildEntryAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            GridEntry entry = grid[nameof(Button.Font)];
+            entry.Expanded = true;
+
+            Assert.Equal(entry.Children.Last().AccessibilityObject,
+                entry.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_LastChild_IsNullAfterExpandCollapsedAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            GridEntry entry = grid[nameof(Button.Font)];
+
+            entry.Expanded = true;
+            entry.Expanded = false;
+
+            Assert.Null(entry.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_LastChild_IsTextBoxAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Size)];
+
+            Assert.Equal(grid.GridView.EditAccessibleObject,
+                grid.SelectedEntry.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_LastChild_IsDropDownButtonAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            Assert.Equal(grid.GridView.DropDownButton.AccessibilityObject,
+                grid.SelectedEntry.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task PropertyDescriptorGridEntryAccessibleObject_FragmentNavigate_LastChild_IsDialogButtonAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Font)];
+
+            Assert.Equal(grid.GridView.DialogButton.AccessibilityObject,
+                grid.SelectedEntry.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObjectTests.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms.PropertyGridInternal.TestUtilities;
+using System.Windows.Forms.UITests;
+using Xunit;
+using Xunit.Abstractions;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.PropertyGridInternal.UITests;
+
+public class PropertyGridView_DropDownHolder_DropDownHolderAccessibleObjectTests : ControlTestBase
+{
+    public PropertyGridView_DropDownHolder_DropDownHolderAccessibleObjectTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    [WinFormsFact]
+    public async Task DropDownHolderAccessibleObject_FragmentNavigate_Parent_IsSelectedEntryAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            grid.PopupEditorAndClose(() =>
+                Assert.Equal(grid.SelectedEntry.AccessibilityObject,
+                    grid.GridView.DropDownControlHolder.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent)));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task DropDownHolderAccessibleObject_FragmentNavigate_PreviousSibling_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            grid.PopupEditorAndClose(() =>
+                Assert.Null(grid.GridView.DropDownControlHolder.AccessibilityObject.FragmentNavigate(NavigateDirection.PreviousSibling)));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task DropDownHolderAccessibleObject_FragmentNavigate_NextSibling_IsTextBoxAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            grid.PopupEditorAndClose(() =>
+                Assert.Equal(grid.GridView.EditAccessibleObject,
+                    grid.GridView.DropDownControlHolder.AccessibilityObject.FragmentNavigate(NavigateDirection.NextSibling)));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task DropDownHolderAccessibleObject_FragmentNavigate_FirstLastChild_IsListBoxAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            grid.PopupEditorAndClose(() =>
+            {
+                Assert.Equal(grid.GridView.DropDownListBoxAccessibleObject,
+                    grid.GridView.DropDownControlHolder.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Equal(grid.GridView.DropDownListBoxAccessibleObject,
+                    grid.GridView.DropDownControlHolder.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+            });
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task DropDownHolderAccessibleObject_FragmentNavigate_FirstLastChild_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Anchor)];
+
+            grid.PopupEditorAndClose(() =>
+            {
+                Assert.Null(grid.GridView.DropDownControlHolder.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+                Assert.Null(grid.GridView.DropDownControlHolder.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+            });
+
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PropertyGridInternal/PropertyGridView.GridViewListBox.GridViewListBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PropertyGridInternal/PropertyGridView.GridViewListBox.GridViewListBoxAccessibleObjectTests.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms.PropertyGridInternal.TestUtilities;
+using System.Windows.Forms.UITests;
+using Xunit;
+using Xunit.Abstractions;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.PropertyGridInternal.UITests;
+
+public class PropertyGridView_GridViewListBox_GridViewListBoxAccessibleObjectTests : ControlTestBase
+{
+    public PropertyGridView_GridViewListBox_GridViewListBoxAccessibleObjectTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    [WinFormsFact]
+    public async Task GridViewListBoxAccessibleObject_FragmentNavigate_Parent_IsDropDownHolderAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            grid.PopupEditorAndClose(() =>
+            {
+                Assert.Equal(grid.GridView.DropDownControlHolder.AccessibilityObject,
+                    grid.GridView.DropDownListBoxAccessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            });
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task GridViewListBoxAccessibleObject_FragmentNavigate_PreviousSibling_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            grid.PopupEditorAndClose(() =>
+            {
+                Assert.Null(grid.GridView.DropDownListBoxAccessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            });
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task GridViewListBoxAccessibleObject_FragmentNavigate_NextSibling_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.AccessibleRole)];
+
+            grid.PopupEditorAndClose(() =>
+            {
+                Assert.Null(grid.GridView.DropDownListBoxAccessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            });
+
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObjectTests.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms.PropertyGridInternal.TestUtilities;
+using System.Windows.Forms.UITests;
+using Xunit;
+using Xunit.Abstractions;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.PropertyGridInternal.UITests;
+
+public class PropertyGridView_GridViewTextBox_GridViewTextBoxAccessibleObjectTests : ControlTestBase
+{
+    public PropertyGridView_GridViewTextBox_GridViewTextBoxAccessibleObjectTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    [WinFormsFact]
+    public async Task GridViewTextBoxAccessibleObject_FragmentNavigate_Parent_IsSelectedEntryAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Size)];
+
+            Assert.Equal(grid.SelectedEntry.AccessibilityObject,
+                grid.GridView.EditAccessibleObject.FragmentNavigate(NavigateDirection.Parent));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task GridViewTextBoxAccessibleObject_FragmentNavigate_PreviousSibling_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Size)];
+
+            Assert.Null(grid.GridView.EditAccessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task GridViewTextBoxAccessibleObject_FragmentNavigate_PreviousSibling_IsDropDownHolderAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.FlatStyle)];
+
+            grid.PopupEditorAndClose(onClosingAction: () =>
+                Assert.Equal(grid.GridView.DropDownControlHolder.AccessibilityObject,
+                    grid.GridView.EditAccessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling)));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task GridViewTextBoxAccessibleObject_FragmentNavigate_NextSibling_IsNullAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Size)];
+
+            Assert.Null(grid.GridView.EditAccessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task GridViewTextBoxAccessibleObject_FragmentNavigate_NextSibling_IsChildEntryAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Size)];
+            grid.SelectedEntry.Expanded = true;
+
+            Assert.Equal(grid.SelectedEntry.Children.First().AccessibilityObject,
+                grid.GridView.EditAccessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task GridViewTextBoxAccessibleObject_FragmentNavigate_NextSibling_IsDropDownButtonAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.FlatStyle)];
+
+            Assert.Equal(grid.GridView.DropDownButton.AccessibilityObject,
+                grid.GridView.EditAccessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+
+    [WinFormsFact]
+    public async Task GridViewTextBoxAccessibleObject_FragmentNavigate_NextSibling_IsDialogButtonAsync()
+    {
+        await RunSingleControlTestAsync<SubPropertyGrid<Button>>((form, grid) =>
+        {
+            grid.SelectedEntry = grid[nameof(Button.Font)];
+
+            Assert.Equal(grid.GridView.DialogButton.AccessibilityObject,
+                grid.GridView.EditAccessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/System.Windows.Forms.UI.IntegrationTests.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/System.Windows.Forms.UI.IntegrationTests.csproj
@@ -17,8 +17,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\Common\tests\TestUtilities\System.Windows.Forms.Common.TestUtilities.csproj" />
+    <ProjectReference Include="..\..\..\..\System.Design\src\System.Design.Facade.csproj" />
+    <ProjectReference Include="..\..\..\..\System.Drawing.Design\src\System.Drawing.Design.Facade.csproj" />
     <ProjectReference Include="..\..\..\..\System.Windows.Forms.Primitives\src\System.Windows.Forms.Primitives.csproj" />
     <ProjectReference Include="..\..\..\src\System.Windows.Forms.csproj" />
+    <ProjectReference Include="..\..\TestUtilities\System.Windows.Forms.TestUtilities.csproj" />
     <ProjectReference Include="..\System.Windows.Forms.IntegrationTests.Common\System.Windows.Forms.IntegrationTests.Common.csproj" />
   </ItemGroup>
 

--- a/src/System.Windows.Forms/tests/TestUtilities/Properties/InternalsVisibleTo.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/Properties/InternalsVisibleTo.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 
 // Awkward, but necessary to expose Interop based internals to other test libraries
 [assembly: InternalsVisibleTo("System.Windows.Forms.Tests, PublicKey=00000000000000000400000000000000")]
+[assembly: InternalsVisibleTo("System.Windows.Forms.UI.IntegrationTests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("System.Windows.Forms.Design.Tests, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("WinformsControlsTest, PublicKey=00000000000000000400000000000000")]
 [assembly: InternalsVisibleTo("MauiListViewTests, PublicKey=00000000000000000400000000000000")]

--- a/src/System.Windows.Forms/tests/TestUtilities/PropertyGridInternal/SubPropertyGrid.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/PropertyGridInternal/SubPropertyGrid.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.ComponentModel;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+using Xunit;
+using static Interop;
+
+namespace System.Windows.Forms.PropertyGridInternal.TestUtilities;
+
+public class SubPropertyGrid<TSelected> : PropertyGrid where TSelected : new()
+{
+    private static readonly User32.WM WM_DELAYEDEXECUTION = User32.RegisterWindowMessageW("WinFormsSubPropertyGridDelayedExecution");
+
+    internal PropertyGridView GridView => this.TestAccessor().Dynamic._gridView;
+
+    internal GridEntry SelectedEntry
+    {
+        get => GridView.SelectedGridEntry;
+        set => SelectedGridItem = value;
+    }
+
+    internal GridEntry this[string propertyName]
+    {
+        get
+        {
+            string categoryName = SelectedObject.GetType().GetProperty(propertyName)!
+                .GetCustomAttribute<CategoryAttribute>()!.Category;
+            return GetCurrentEntries().Single(entry => entry.PropertyName == categoryName)
+                .Children.Single(entry => entry.PropertyName == propertyName);
+        }
+    }
+
+    public SubPropertyGrid() => SelectedObject = new TSelected();
+
+    public void PopupEditorAndClose(Action? onClosingAction = null)
+    {
+        Exception? exception = null;
+        bool called = false;
+
+        var callbackHandle = GCHandle.Alloc(() =>
+        {
+            try
+            {
+                onClosingAction?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            GridView.CloseDropDown();
+
+            called = true;
+        });
+
+        try
+        {
+            User32.PostMessageW(this, WM_DELAYEDEXECUTION, lParam: GCHandle.ToIntPtr(callbackHandle));
+            GridView.PopupEditor(GridView.TestAccessor().Dynamic._selectedRow);
+        }
+        finally
+        {
+            callbackHandle.Free();
+        }
+
+        Assert.True(called);
+
+        if (exception is not null)
+        {
+            ExceptionDispatchInfo.Capture(exception).Throw();
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        object selectedObject = SelectedObject;
+
+        base.Dispose(disposing);
+
+        if (disposing && selectedObject is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+
+    protected override void WndProc(ref Message m)
+    {
+        if (m.MsgInternal != WM_DELAYEDEXECUTION)
+        {
+            base.WndProc(ref m);
+            return;
+        }
+
+        ((Action)GCHandle.FromIntPtr(m.LParamInternal).Target!)();
+    }
+
+    protected override void OnGotFocus(EventArgs e)
+    {
+        base.OnGotFocus(e);
+
+        GridView.Focus();
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObjectTests.cs
@@ -58,26 +58,6 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             Assert.False(dropDownButton.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DropDownButtonAccessibleObject_FragmentNavigate_SiblingsAreExpected()
-        {
-            using PropertyGrid control = new();
-            using Button button = new();
-            control.SelectedObject = button;
-            control.SelectedGridItem = control.GetCurrentEntries()[1].GridItems[5]; // FlatStyle property
-
-            PropertyGridView gridView = control.TestAccessor().GridView;
-            DropDownButton dropDownButton = gridView.DropDownButton;
-
-            object nextSibling = dropDownButton.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling);
-            object previousSibling = dropDownButton.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling);
-
-            Assert.Null(nextSibling);
-            Assert.Equal(gridView.EditAccessibleObject, previousSibling);
-            Assert.False(control.IsHandleCreated);
-            Assert.False(dropDownButton.IsHandleCreated);
-        }
-
         [WinFormsTheory]
         [InlineData((int)UiaCore.NavigateDirection.FirstChild)]
         [InlineData((int)UiaCore.NavigateDirection.LastChild)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObjectTests.cs
@@ -39,15 +39,12 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
         [WinFormsFact]
         public void DropDownHolder_AccessibilityObject_ReturnsExpected()
         {
-            using PropertyGrid propertyGrid = new PropertyGrid();
+            using PropertyGrid propertyGrid = new();
             PropertyGridView propertyGridView = propertyGrid.TestAccessor().GridView;
-
-            using PropertyGridView.DropDownHolder ownerControl = new PropertyGridView.DropDownHolder(propertyGridView);
+            using PropertyGridView.DropDownHolder ownerControl = new(propertyGridView);
             Control.ControlAccessibleObject accessibilityObject = ownerControl.AccessibilityObject as Control.ControlAccessibleObject;
 
-            Assert.NotNull(accessibilityObject.Owner);
             Assert.Equal(ownerControl, accessibilityObject.Owner);
-
             Assert.Equal(SR.PropertyGridViewDropDownControlHolderAccessibleName,
                 accessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
 
@@ -63,12 +60,7 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             selectedGridEntryAccessibleObject = gridEntry.AccessibilityObject;
             Assert.Equal(selectedGridEntryAccessibleObject, accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
 
-            AccessibleObject editAccessibleObject = propertyGridView.EditAccessibleObject;
-            Assert.Equal(editAccessibleObject, accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-
-            Assert.Null(accessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.Equal(propertyGrid.AccessibilityObject, accessibilityObject.FragmentRoot);
+            Assert.Equal(propertyGridView.AccessibilityObject, accessibilityObject.FragmentRoot);
         }
 
         [WinFormsFact]


### PR DESCRIPTION
Resolves dotnet#2848 by fixing sibiling relationship between child property descriptors and selected entry controls. Also resolves dotnet#4876 by fixing parent-child relationship between drop-down holder and listbox.

The fixes are implemented by adding helper methods to retrieve a sibling node for a specified child node. This implementation removes the need for copy-paste throughout different child nodes of property descriptor entry, it greatly simplifies the implementation and helps to avoid mistakes in future because the implementation is now located in a single place.


## Proposed changes

- Fix sibling relationship between child property descriptors and selected entry controls
- Fix parent-child relationship between dropdown holder and listbox

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Accessibility tools may incorrectly navigate through the descriptor entry children (controls, other entries) before this PR

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manual testing
- Unit-tests


 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19044.1348]
- .NET 7.0.0-alpha.1.21602.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6341)