### PR TITLE
Fixing issue with getting ListViewItem.AccessibilityObject when ListView does not exist

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
@@ -427,6 +427,8 @@ namespace System.Windows.Forms
 
                 owner.ApplyUpdateCachedItems();
                 int itemID = DisplayIndexToID(index);
+
+                this[index].Focused = false;
                 this[index].UnHost(true);
 
                 if (owner.IsHandleCreated)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -78,17 +78,7 @@ namespace System.Windows.Forms
         }
 
         internal AccessibleObject AccessibilityObject
-        {
-            get
-            {
-                if (_accessibilityObject is null)
-                {
-                    _accessibilityObject = new ListViewGroupAccessibleObject(this, ListView?.Groups.Contains(this) == false);
-                }
-
-                return _accessibilityObject;
-            }
-        }
+            => _accessibilityObject ??= new ListViewGroupAccessibleObject(this, ListView?.Groups.Contains(this) == false);
 
         /// <summary>
         ///  The text displayed in the group header.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -227,7 +227,13 @@ namespace System.Windows.Forms
         {
             get
             {
-                ListView owningListView = listView ?? Group.ListView ?? throw new InvalidOperationException(nameof(listView));
+                ListView owningListView = listView ?? Group?.ListView;
+                if (owningListView is null)
+                {
+                    _accessibilityObject = null;
+                    return _accessibilityObject;
+                }
+
                 if (_accessibilityObject is null || owningListView.View != _accessibilityObjectView)
                 {
                     _accessibilityObjectView = owningListView.View;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemTests.cs
@@ -852,15 +852,16 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { Color.Red, Color.Red };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(BackColor_Set_TestData))]
         public void ListViewItem_BackColor_GetWithOwner_ReturnsExpected(Color value, Color expected)
         {
-            var listView = new ListView
+            using ListView listView = new()
             {
                 BackColor = value
             };
-            var item = new ListViewItem();
+
+            ListViewItem item = new();
             listView.Items.Add(item);
             Assert.Equal(expected, item.BackColor);
 
@@ -884,12 +885,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, item.BackColor);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(BackColor_Set_TestData))]
         public void ListViewItem_BackColor_SetWithOwner_GetReturnsExpected(Color value, Color expected)
         {
-            var listView = new ListView();
-            var item = new ListViewItem();
+            using ListView listView = new();
+            ListViewItem item = new();
             listView.Items.Add(item);
 
             item.BackColor = value;
@@ -908,15 +909,16 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { Color.Red, Color.Red };
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(ForeColor_Set_TestData))]
         public void ListViewItem_ForeColor_GetWithOwner_ReturnsExpected(Color value, Color expected)
         {
-            var listView = new ListView
+            using ListView listView = new()
             {
                 ForeColor = value
             };
-            var item = new ListViewItem();
+
+            ListViewItem item = new();
             listView.Items.Add(item);
             Assert.Equal(expected, item.ForeColor);
 
@@ -929,10 +931,11 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(ForeColor_Set_TestData))]
         public void ListViewItem_ForeColor_Set_GetReturnsExpected(Color value, Color expected)
         {
-            var item = new ListViewItem
+            ListViewItem item = new()
             {
                 ForeColor = value
             };
+
             Assert.Equal(expected, item.ForeColor);
 
             // Set same.
@@ -940,12 +943,12 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, item.ForeColor);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [MemberData(nameof(ForeColor_Set_TestData))]
         public void ListViewItem_ForeColor_SetWithOwner_GetReturnsExpected(Color value, Color expected)
         {
-            var listView = new ListView();
-            var item = new ListViewItem();
+            using ListView listView = new();
+            ListViewItem item = new();
             listView.Items.Add(item);
 
             item.ForeColor = value;
@@ -956,15 +959,16 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, item.ForeColor);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(typeof(CommonTestHelperEx), nameof(CommonTestHelperEx.GetFontTheoryData))]
         public void ListViewItem_Font_GetWithOwner_ReturnsExpected(Font value)
         {
-            var listView = new ListView
+            using ListView listView = new()
             {
                 Font = value
             };
-            var item = new ListViewItem();
+
+            ListViewItem item = new();
             listView.Items.Add(item);
             Assert.Equal(value ?? Control.DefaultFont, item.Font);
 
@@ -981,6 +985,7 @@ namespace System.Windows.Forms.Tests
             {
                 Font = value
             };
+
             Assert.Equal(value ?? Control.DefaultFont, item.Font);
 
             // Set same.
@@ -988,15 +993,16 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value ?? Control.DefaultFont, item.Font);
         }
 
-        [Theory]
+        [WinFormsTheory]
         [CommonMemberData(typeof(CommonTestHelperEx), nameof(CommonTestHelperEx.GetFontTheoryData))]
         public void ListViewItem_Font_SetWithOwner_GetReturnsExpected(Font value)
         {
-            var listView = new ListView
+            using ListView listView = new()
             {
                 Font = SystemFonts.CaptionFont
             };
-            var item = new ListViewItem();
+
+            ListViewItem item = new();
             listView.Items.Add(item);
 
             item.Font = value;
@@ -1007,11 +1013,11 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(value ?? SystemFonts.CaptionFont, item.Font);
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ListViewItem_EnsureVisible_HasListViewWithoutHandle_Nop()
         {
-            var listView = new ListView();
-            var item = new ListViewItem();
+            using ListView listView = new();
+            ListViewItem item = new();
             listView.Items.Add(item);
             item.EnsureVisible();
         }
@@ -1023,11 +1029,11 @@ namespace System.Windows.Forms.Tests
             item.EnsureVisible();
         }
 
-        [Fact]
+        [WinFormsFact]
         public void ListViewItem_Remove_HasListView_Success()
         {
-            var listView = new ListView();
-            var item = new ListViewItem();
+            using ListView listView = new();
+            ListViewItem item = new();
             listView.Items.Add(item);
             item.Remove();
             Assert.Empty(listView.Items);
@@ -1062,6 +1068,24 @@ namespace System.Windows.Forms.Tests
                 Assert.Equal(expected[i].Text, actual[i].Text);
                 Assert.Equal(expected[i].Tag, actual[i].Tag);
             }
+        }
+
+        [Fact]
+        public void ListViewItem_AccessibilityObject_ReturnsNull_IfListViewNotExists()
+        {
+            ListViewItem item = new();
+
+            Assert.Null(item.AccessibilityObject);
+        }
+
+        [WinFormsFact]
+        public void ListViewItem_AccessibilityObject_ReturnsExpected_IfListViewExists()
+        {
+            using ListView listView = new();
+            ListViewItem item = new();
+            listView.Items.Add(item);
+
+            Assert.NotNull(item.AccessibilityObject);
         }
     }
 }


### PR DESCRIPTION
Fixes #6230 

## Proposed changes
- The issue is reproduced because we have cached the `ListViewItem.AccessibilityObject`. After the changes in #4910, we added logic that, with each call to the `AccessibilityObject` property, checked that the `ListView` exists and, if absent, threw an exception. Now we return null as a `ListViewItem.AccessibilityObject` instead of returning an exception.

- Also, after the focused `ListViewItem` is removed, it remains cached in the `FocusedItem` property. It also forces the Accessibility tool to try to retrieve the data of the `ListViewItem` that is not displayed. As a fix, a logic was added to reset the Focused flag from the `ListViewItem`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![Issue-6230](https://user-images.githubusercontent.com/23376742/144040481-714f76ab-e33b-46dc-bdcc-d98e00346f1d.gif)

**After fix:**
![Issue-6230-SecondFix](https://user-images.githubusercontent.com/23376742/146338936-c1449c40-5a78-4c2b-8d4a-2f00036f44be.gif)

## Regression? 
- Yes (from #4910)

## Risk
- Minimal

## Test methodology
- Manual testing
- CTI team
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect 
- Narrator
- Accessibility Insights

## Test environment(s)
- Microsoft Windows [Version 10.0.19041.1348]
- .NET Core SDK: 7.0.0-alpha.1.21576.4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6352)