### PR TITLE
Fixing NRE when the user press the left / right arrow in ListView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6931,14 +6931,13 @@ namespace System.Windows.Forms
                 case User32.WM.KEYUP:
                     int key = (int)m.WParamInternal;
 
-                    if ((key == User32.VK.LEFT || key == User32.VK.RIGHT) && SelectedItems.Count > 0)
+                    if (GroupsDisplayed && (key is User32.VK.LEFT or User32.VK.RIGHT) && SelectedItems.Count > 0)
                     {
                         ListViewGroup group = SelectedItems[0].Group;
-                        ListViewGroupCollapsedState groupCollapsedState = group.CollapsedState;
 
-                        if (group is null || groupCollapsedState == ListViewGroupCollapsedState.Default
-                            || (key == User32.VK.LEFT && groupCollapsedState == ListViewGroupCollapsedState.Collapsed)
-                            || (key == User32.VK.RIGHT && groupCollapsedState == ListViewGroupCollapsedState.Expanded))
+                        if (group is null || group.CollapsedState is ListViewGroupCollapsedState.Default
+                            || (key == User32.VK.LEFT && group.CollapsedState is ListViewGroupCollapsedState.Collapsed)
+                            || (key == User32.VK.RIGHT && group.CollapsedState is ListViewGroupCollapsedState.Expanded))
                         {
                             break;
                         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5369,6 +5369,28 @@ namespace System.Windows.Forms.Tests
             }
         }
 
+        [WinFormsTheory]
+        [InlineData(Keys.Right)]
+        [InlineData(Keys.Left)]
+        public void ListView_LeftRightArrow_DoesNotThrowException(Keys key)
+        {
+            using ListView listView = new() { ShowGroups = true };
+            listView.Items.Add(new ListViewItem("Group Item 0"));
+            listView.CreateControl();
+            listView.Items[0].Selected = true;
+            listView.Items[0].Focused = true;
+
+            // https://docs.microsoft.com/windows/win32/inputdev/wm-keyup
+            // The MSDN page tells us what bits of lParam to use for each of the parameters.
+            // All we need to do is some bit shifting to assemble lParam
+            // lParam = repeatCount | (scanCode << 16)
+            nint keyCode = (nint)key;
+            nint lParam = 0x00000001 | keyCode << 16;
+            User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
+
+            Assert.True(listView.IsHandleCreated);
+        }
+
         private class SubListViewItem : ListViewItem
         {
             public AccessibleObject CustomAccessibleObject { get; set; }


### PR DESCRIPTION
Fixes #6353

## Proposed changes
- The issue is reproduced because we are trying to access a `ListViewGroup` that the `ListViewItem` may not contain it.
- Added a condition so that the code for working with `ListViewGroups` is called only when the `ListViewGroups` are enabled (`GroupsEnabled` property).
- Fixed condition for cases when the `Group` property has `null` value. 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![Issue-6353](https://user-images.githubusercontent.com/23376742/146353359-81c3ec2f-5d81-4066-82e6-1cdc8e918861.gif)

**After fix:**
![Issue-6353_AfterFix](https://user-images.githubusercontent.com/23376742/146356548-d77d6290-fa60-4370-ac80-e88297e18a15.gif)

## Regression? 
- Yes (from #5960)

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.1348]
- .NET Core SDK: 7.0.0-alpha.1.21576.4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6354)