### PR TITLE
Do not attempt to cache CheckedItems if in virtual mode

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -468,7 +468,7 @@ namespace System.Windows.Forms
                             throw new NotSupportedException(SR.ListViewCheckBoxesNotSupportedInTileView);
                         }
 
-                        if (CheckBoxes)
+                        if (CheckBoxes && !VirtualMode)
                         {
                             // Save away the checked items just in case we re-activate checkboxes
                             //
@@ -515,7 +515,7 @@ namespace System.Windows.Forms
                             throw new NotSupportedException(SR.ListViewCheckBoxesNotSupportedInTileView);
                         }
 
-                        if (CheckBoxes)
+                        if (CheckBoxes && !VirtualMode)
                         {
                             // Save away the checked items just in case we re-activate checkboxes
                             //

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -4421,24 +4421,28 @@ namespace System.Windows.Forms.Tests
 
                 foreach (bool showGroups in new[] { true, false })
                 {
-                    yield return new object[] { view, showGroups };
+                    foreach(bool useCompatibleStateImageBehavior in new[] { true, false })
+                    {
+                        yield return new object[] { view, showGroups, useCompatibleStateImageBehavior };
+                    }
                 }
             }
         }
 
         [WinFormsTheory]
         [MemberData(nameof(ListView_Checkboxes_VirtualMode_Disabling_TestData))]
-        public void ListView_Checkboxes_VirtualMode_Disabling_ThrowException(View view, bool showGroups)
+        public void ListView_Checkboxes_VirtualMode_Disabling_Succeeds(View view, bool showGroups, bool useCompatibleStateImageBehavior)
         {
             using var listView = new SubListView
             {
                 View = view,
                 VirtualMode = true,
-                ShowGroups = showGroups
+                ShowGroups = showGroups,
+                UseCompatibleStateImageBehavior = useCompatibleStateImageBehavior
             };
 
             listView.CheckBoxes = true;
-            Assert.Throws<InvalidOperationException>(() => listView.CheckBoxes = false);
+            listView.CheckBoxes = false; // This would throw an InvalidOperationException prior to fix of #4042
         }
 
         [WinFormsFact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4042 


## Proposed changes

`ListView` attempts to cache `CheckedItems` when setting `CheckBoxes` to `false`. This results in an `InvalidOperationException` in `CheckedItems.Count` when the `ListView` is in virtual mode. Since `CheckedItems` cannot be used in virtual mode anyway, the fix is to skip this caching logic when `VirtualMode == true`.

Note: there was a unit test that ensured this behavior. It's not clear why since it seems undesirable. The error is trivial to repro. All you have to do is drop a new `ListView` into the forms designer, set `VirtualMode` to `true`,  and then try toggling `CheckBoxes` to `true` and then back to `false`, all within the properties tool window. The existing unit test was modified to ensure the error does not happen.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Customer should be able to toggle `CheckBoxes` from `true` to `false` when in virtual mode.

## Regression? 

- No

## Risk

Can't identify any

<!-- end TELL-MODE -->
## Test methodology <!-- How did you ensure quality? -->

- Unit test ensures functionality 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6356)