### PR TITLE
Enable nullability in DomainUpDown accessible objects

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -421,11 +421,11 @@ override System.Windows.Forms.Design.EventsTab.TabName.get -> string!
 ~override System.Windows.Forms.Design.WindowsFormsComponentEditor.EditComponent(System.ComponentModel.ITypeDescriptorContext context, object component) -> bool
 ~override System.Windows.Forms.DockingAttribute.Equals(object obj) -> bool
 ~override System.Windows.Forms.DomainUpDown.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Name.get -> string
-~override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Name.set -> void
-~override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Value.get -> string
-~override System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject
+override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Name.get -> string?
+override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Name.set -> void
+override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject!
+override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Value.get -> string?
+override System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject?
 ~override System.Windows.Forms.DomainUpDown.DomainUpDownItemCollection.Add(object item) -> int
 ~override System.Windows.Forms.DomainUpDown.DomainUpDownItemCollection.Insert(int index, object item) -> void
 ~override System.Windows.Forms.DomainUpDown.DomainUpDownItemCollection.Remove(object item) -> void
@@ -2005,8 +2005,8 @@ System.Windows.Forms.Design.EventsTab.EventsTab(System.IServiceProvider? sp) -> 
 System.Windows.Forms.Design.IWindowsFormsEditorService.DropDownControl(System.Windows.Forms.Control? control) -> void
 System.Windows.Forms.Design.IWindowsFormsEditorService.ShowDialog(System.Windows.Forms.Form! dialog) -> System.Windows.Forms.DialogResult
 ~System.Windows.Forms.Design.WindowsFormsComponentEditor.EditComponent(object component, System.Windows.Forms.IWin32Window owner) -> bool
-~System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.DomainItemAccessibleObject(string name, System.Windows.Forms.AccessibleObject parent) -> void
-~System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.DomainUpDownAccessibleObject(System.Windows.Forms.DomainUpDown owner) -> void
+System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.DomainItemAccessibleObject(string? name, System.Windows.Forms.AccessibleObject! parent) -> void
+System.Windows.Forms.DomainUpDown.DomainUpDownAccessibleObject.DomainUpDownAccessibleObject(System.Windows.Forms.DomainUpDown! owner) -> void
 ~System.Windows.Forms.DomainUpDown.Items.get -> System.Windows.Forms.DomainUpDown.DomainUpDownItemCollection
 ~System.Windows.Forms.DomainUpDown.OnSelectedItemChanged(object source, System.EventArgs e) -> void
 ~System.Windows.Forms.DomainUpDown.SelectedItem.get -> object

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainItemAccessibleObject.cs
@@ -2,32 +2,30 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class DomainUpDown
     {
         public class DomainItemAccessibleObject : AccessibleObject
         {
-            private string name;
-            private readonly DomainItemListAccessibleObject parent;
+            private string? _name;
+            private readonly DomainItemListAccessibleObject _parent;
 
-            public DomainItemAccessibleObject(string name, AccessibleObject parent) : base()
+            public DomainItemAccessibleObject(string? name, AccessibleObject parent) : base()
             {
-                this.name = name;
-                this.parent = (DomainItemListAccessibleObject)parent;
+                _name = name;
+                _parent = (DomainItemListAccessibleObject)parent.OrThrowIfNull();
             }
 
-            public override string Name
+            public override string? Name
             {
                 get
                 {
-                    return name;
+                    return _name;
                 }
                 set
                 {
-                    name = value;
+                    _name = value;
                 }
             }
 
@@ -35,7 +33,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    return parent;
+                    return _parent;
                 }
             }
 
@@ -55,11 +53,11 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override string Value
+            public override string? Value
             {
                 get
                 {
-                    return name;
+                    return _name;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainItemListAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainItemListAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class DomainUpDown
@@ -11,18 +9,18 @@ namespace System.Windows.Forms
         internal class DomainItemListAccessibleObject : AccessibleObject
         {
             const string DefaultName = "Items";
-            private readonly DomainUpDownAccessibleObject parent;
+            private readonly DomainUpDownAccessibleObject _parent;
 
             public DomainItemListAccessibleObject(DomainUpDownAccessibleObject parent) : base()
             {
-                this.parent = parent;
+                _parent = parent;
             }
 
-            public override string Name
+            public override string? Name
             {
                 get
                 {
-                    string baseName = base.Name;
+                    string? baseName = base.Name;
                     if (baseName is null || baseName.Length == 0)
                     {
                         return DefaultName;
@@ -37,7 +35,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    return parent;
+                    return _parent;
                 }
             }
 
@@ -59,11 +57,11 @@ namespace System.Windows.Forms
 
             internal override int[] RuntimeId => new int[] { RuntimeIDFirstItem, GetHashCode() };
 
-            public override AccessibleObject GetChild(int index)
+            public override AccessibleObject? GetChild(int index)
             {
                 if (index >= 0 && index < GetChildCount())
                 {
-                    return new DomainItemAccessibleObject(((DomainUpDown)parent.Owner).Items[index].ToString(), this);
+                    return new DomainItemAccessibleObject(((DomainUpDown)_parent.Owner).Items[index].ToString(), this);
                 }
 
                 return null;
@@ -71,7 +69,7 @@ namespace System.Windows.Forms
 
             public override int GetChildCount()
             {
-                return ((DomainUpDown)parent.Owner).Items.Count;
+                return ((DomainUpDown)_parent.Owner).Items.Count;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms
@@ -12,7 +10,7 @@ namespace System.Windows.Forms
     {
         public class DomainUpDownAccessibleObject : ControlAccessibleObject
         {
-            private DomainItemListAccessibleObject _domainItemList;
+            private DomainItemListAccessibleObject? _domainItemList;
             private readonly UpDownBase _owningDomainUpDown;
 
             /// <summary>
@@ -22,7 +20,7 @@ namespace System.Windows.Forms
                 _owningDomainUpDown = owner;
             }
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
             {
                 switch (propertyID)
                 {
@@ -65,7 +63,7 @@ namespace System.Windows.Forms
 
             /// <summary>
             /// </summary>
-            public override AccessibleObject GetChild(int index)
+            public override AccessibleObject? GetChild(int index)
             {
                 switch (index)
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDown.DomainItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDown.DomainItemAccessibleObjectTests.cs
@@ -10,11 +10,19 @@ namespace System.Windows.Forms.Tests
     public class DomainUpDown_DomainItemAccessibleObjectTests
     {
         [WinFormsFact]
+        public void DomainItemAccessibleObject_Ctor_NullParent_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DomainItemAccessibleObject(string.Empty, null));
+        }
+
+        [WinFormsFact]
         public void DomainItemAccessibleObject_Ctor_Default()
         {
             string testName = "Some test name";
-            var accessibleObject = new DomainItemAccessibleObject(testName, null);
-            Assert.Null(accessibleObject.Parent);
+            using var domainUpDown = new DomainUpDown();
+            var parent = new DomainItemListAccessibleObject(new DomainUpDownAccessibleObject(domainUpDown));
+            var accessibleObject = new DomainItemAccessibleObject(testName, parent);
+            Assert.Equal(parent, accessibleObject.Parent);
             Assert.Equal(testName, accessibleObject.Name);
             Assert.Equal(AccessibleRole.ListItem, accessibleObject.Role);
         }
@@ -25,7 +33,8 @@ namespace System.Windows.Forms.Tests
         [InlineData(null)]
         public void DomainItemAccessibleObject_Name_Set_ReturnsExpected(string testValue)
         {
-            var accessibleObject = new DomainItemAccessibleObject(null, null);
+            using var domainUpDown = new DomainUpDown();
+            var accessibleObject = new DomainItemAccessibleObject(null, new DomainItemListAccessibleObject(new DomainUpDownAccessibleObject(domainUpDown)));
             accessibleObject.Name = testValue;
             Assert.Equal(testValue, accessibleObject.Name);
         }
@@ -33,7 +42,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DomainItemAccessibleObject_State_Default_ReturnsExpected()
         {
-            var accessibleObject = new DomainItemAccessibleObject(null, null);
+            using var domainUpDown = new DomainUpDown();
+            var accessibleObject = new DomainItemAccessibleObject(null, new DomainItemListAccessibleObject(new DomainUpDownAccessibleObject(domainUpDown)));
             Assert.Equal(AccessibleStates.Selectable, accessibleObject.State);
         }
 
@@ -41,7 +51,8 @@ namespace System.Windows.Forms.Tests
         public void DomainItemAccessibleObject_Value_Default_ReturnsExpected()
         {
             string testName = "Some test name";
-            var accessibleObject = new DomainItemAccessibleObject(testName, null);
+            using var domainUpDown = new DomainUpDown();
+            var accessibleObject = new DomainItemAccessibleObject(testName, new DomainItemListAccessibleObject(new DomainUpDownAccessibleObject(domainUpDown)));
             Assert.Equal(testName, accessibleObject.Value);
         }
     }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DomainUpDown accessible objects.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6357)