### PR TITLE
Fixing multiple adding of `ControlBox` buttons to MDI child form

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1354,7 +1354,7 @@ namespace System.Windows.Forms
                 Properties.SetObject(PropMainMenuStrip, value);
                 if (IsHandleCreated)
                 {
-                    UpdateMenuHandles();
+                    UpdateMenuHandles(recreateMenu: true);
                 }
             }
         }
@@ -5540,7 +5540,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private void UpdateMenuHandles()
+        private void UpdateMenuHandles(bool recreateMenu = false)
         {
             if (!IsHandleCreated)
             {
@@ -5567,7 +5567,7 @@ namespace System.Windows.Forms
                     // an ole menu is being removed.
                     // Make MDI forget the mdi item position.
                     IntPtr? dummyMenu = Properties.GetObject(PropDummyMdiMenu) as IntPtr?;
-                    if (!dummyMenu.HasValue || dummyMenu.Value == IntPtr.Zero)
+                    if (!dummyMenu.HasValue || dummyMenu.Value == IntPtr.Zero || recreateMenu)
                     {
                         dummyMenu = User32.CreateMenu();
                         Properties.SetObject(PropDummyMdiMenu, dummyMenu);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
@@ -282,6 +282,34 @@ namespace System.Windows.Forms.Tests
             Assert.True(menuStrip.IsHandleCreated);
         }
 
+        [WinFormsTheory]
+        [InlineData(RightToLeft.No)]
+        [InlineData(RightToLeft.Yes)]
+        public void MdiControlStrip_MaximizedChildWindow_ControlbBoxButtons_AreNotCloned(RightToLeft rightToLeft)
+        {
+            using ToolStripMenuItem toolStripMenuItem1 = new() { Text = "&Test1" };
+            using ToolStripMenuItem toolStripMenuItem2 = new() { Text = "&Test2" };
+            using MenuStrip menuStrip = new() { RightToLeft = rightToLeft };
+            menuStrip.Items.AddRange(new ToolStripItem[] { toolStripMenuItem1, toolStripMenuItem2 });
+            using Form mdiParent = new() { IsMdiContainer = true };
+            using Form mdiChild = new()
+            {
+                MdiParent = mdiParent,
+                WindowState = FormWindowState.Maximized
+            };
+
+            mdiParent.Show();
+            mdiChild.Show();
+            mdiParent.MainMenuStrip = menuStrip;
+            mdiParent.MainMenuStrip = null;
+            mdiParent.MainMenuStrip = menuStrip;
+            mdiParent.MainMenuStrip = null;
+            IntPtr menuHandle = User32.GetMenu(mdiParent.Handle);
+            int menuItemCount = User32.GetMenuItemCount(menuHandle);
+            // Four buttons: System, Minimize, Maximize, Close
+            Assert.True(menuItemCount == 4);
+        }
+
         private class SubMdiControlStrip : MdiControlStrip
         {
             public new const int ScrollStateAutoScrolling = MenuStrip.ScrollStateAutoScrolling;


### PR DESCRIPTION
Fixes #6339

## Proposed changes

- The fix is based on PR #4465. Looks like something was changed in WinAPI: now not the latest build of 5.0 nor this specifically checked out commit doesn't fix the issue.
- Now we need to recreate the dummy menu every time we're setting the `MainMenuStrip` property of the `Form`.

## Customer Impact
**Before the fix** 
![cloneBeforeTheFix](https://user-images.githubusercontent.com/87859299/146737047-e16a1ece-1281-4964-9bfa-df8ed478dc28.gif)

**After the fix** 
![cloneAfterTheFix](https://user-images.githubusercontent.com/87859299/146737065-bb89a644-8008-4547-9d6d-4562800ffef6.gif)

## Regression? 
- Yes

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manual testing (see the screenshots above)
- Unit tests
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
Windows 10 10.0.19043.1415
.NET SDK 7.0.0-alpha.1.21606.7

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6368)