### PR TITLE
Use generic list in FindMergeableToolStrips

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.ComponentModel.Design;
@@ -5640,7 +5639,7 @@ namespace System.Windows.Forms
             // try to merge each one of the MDI Child toolstrip with the first toolstrip
             // in the parent form that has the same type NOTE: THESE LISTS ARE ORDERED (See ToolstripManager)
             ToolStrip thisToolstrip = MainMenuStrip;
-            ArrayList childrenToolStrips = ToolStripManager.FindMergeableToolStrips(ActiveMdiChildInternal);
+            List<ToolStrip> childrenToolStrips = ToolStripManager.FindMergeableToolStrips(ActiveMdiChildInternal);
 
             // revert any previous merge
             if (thisToolstrip is not null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripCustomIComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripCustomIComparer.cs
@@ -4,13 +4,11 @@
 
 #nullable disable
 
-using System.Collections;
-
 namespace System.Windows.Forms
 {
-    internal class ToolStripCustomIComparer : IComparer
+    internal class ToolStripCustomIComparer : IComparer<ToolStrip>
     {
-        int IComparer.Compare(object x, object y)
+        public int Compare(ToolStrip x, ToolStrip y)
         {
             if (x.GetType() == y.GetType())
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Drawing;
@@ -1160,9 +1159,9 @@ namespace System.Windows.Forms
             return result;
         }
 
-        internal static ArrayList FindMergeableToolStrips(ContainerControl container)
+        internal static List<ToolStrip> FindMergeableToolStrips(ContainerControl container)
         {
-            ArrayList result = new ArrayList();
+            List<ToolStrip> result = new();
             if (container is not null)
             {
                 for (int i = 0; i < ToolStrips.Count; i++)


### PR DESCRIPTION
## Proposed changes

- Use generic list in FindMergeableToolStrips.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6397)