### PR TITLE
Move ENPROTECTED to Interop Richedit

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENPROTECTED.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENPROTECTED.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        public struct ENPROTECTED
+        {
+            public User32.NMHDR nmhdr;
+            public uint msg;
+            public UIntPtr wParam;
+            public IntPtr lParam;
+            public CHARRANGE chrg;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -141,23 +141,6 @@ namespace System.Windows.Forms
             public byte[] contents = new byte[56];
         }
 
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-        public class ENPROTECTED
-        {
-            public User32.NMHDR nmhdr;
-            public int msg;
-            public IntPtr wParam;
-            public IntPtr lParam;
-            public Richedit.CHARRANGE chrg;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public class ENPROTECTED64
-        {
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 56)]
-            public byte[] contents = new byte[56];
-        }
-
         public class ActiveX
         {
             public const int ALIGN_MIN = 0x0;

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Richedit/ENPROTECTEDTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Richedit/ENPROTECTEDTests.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop.Richedit;
+
+namespace System.Windows.Forms.Primitives.Tests.Interop.Richedit
+{
+    public class ENPROTECTEDTests
+    {
+        [Fact]
+        public unsafe void Enprotected_Size_Get_ReturnsExpected()
+        {
+            if (IntPtr.Size == 4)
+            {
+                Assert.Equal(32, sizeof(ENPROTECTED));
+            }
+            else
+            {
+                Assert.Equal(56, sizeof(ENPROTECTED));
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3443,22 +3443,11 @@ namespace System.Windows.Forms
 
                     case EN.PROTECTED:
                         {
-                            NativeMethods.ENPROTECTED enprotected;
-
-                            //On 64-bit, we do some custom marshalling to get this to work. The richedit control
-                            //unfortunately does not respect IA64 struct alignment conventions.
-                            if (IntPtr.Size == 8)
-                            {
-                                enprotected = ConvertFromENPROTECTED64((NativeMethods.ENPROTECTED64)m.GetLParam(typeof(NativeMethods.ENPROTECTED64)));
-                            }
-                            else
-                            {
-                                enprotected = (NativeMethods.ENPROTECTED)m.GetLParam(typeof(NativeMethods.ENPROTECTED));
-                            }
+                            ENPROTECTED enprotected = (ENPROTECTED)m.GetLParam(typeof(ENPROTECTED));
 
                             switch (enprotected.msg)
                             {
-                                case (int)EM.SETCHARFORMAT:
+                                case (uint)EM.SETCHARFORMAT:
                                     // Allow change of protected style
                                     CHARFORMAT2W* charFormat = (CHARFORMAT2W*)enprotected.lParam;
                                     if ((charFormat->dwMask & CFM.PROTECTED) != 0)
@@ -3471,11 +3460,11 @@ namespace System.Windows.Forms
 
                                 // Throw an exception for the following
                                 //
-                                case (int)EM.SETPARAFORMAT:
-                                case (int)User32.EM.REPLACESEL:
+                                case (uint)EM.SETPARAFORMAT:
+                                case (uint)User32.EM.REPLACESEL:
                                     break;
 
-                                case (int)EM.STREAMIN:
+                                case (uint)EM.STREAMIN:
                                     // Don't allow STREAMIN to replace protected selection
                                     if ((unchecked((SF)(long)enprotected.wParam) & SF.F_SELECTION) != 0)
                                     {
@@ -3486,9 +3475,9 @@ namespace System.Windows.Forms
                                     return;
 
                                 // Allow the following
-                                case (int)User32.WM.COPY:
-                                case (int)User32.WM.SETTEXT:
-                                case (int)EM.EXLIMITTEXT:
+                                case (uint)User32.WM.COPY:
+                                case (uint)User32.WM.SETTEXT:
+                                case (uint)EM.EXLIMITTEXT:
                                     m.ResultInternal = 0;
                                     return;
 
@@ -3512,28 +3501,6 @@ namespace System.Windows.Forms
             {
                 base.WndProc(ref m);
             }
-        }
-
-        private unsafe NativeMethods.ENPROTECTED ConvertFromENPROTECTED64(NativeMethods.ENPROTECTED64 es64)
-        {
-            NativeMethods.ENPROTECTED es = new NativeMethods.ENPROTECTED();
-
-            fixed (byte* es64p = &es64.contents[0])
-            {
-                es.nmhdr = new User32.NMHDR();
-                es.chrg = new Richedit.CHARRANGE();
-
-                es.nmhdr.hwndFrom = Marshal.ReadIntPtr((IntPtr)es64p);
-                es.nmhdr.idFrom = Marshal.ReadIntPtr((IntPtr)(es64p + 8));
-                es.nmhdr.code = Marshal.ReadInt32((IntPtr)(es64p + 16));
-                es.msg = Marshal.ReadInt32((IntPtr)(es64p + 24));
-                es.wParam = Marshal.ReadIntPtr((IntPtr)(es64p + 28));
-                es.lParam = Marshal.ReadIntPtr((IntPtr)(es64p + 36));
-                es.chrg.cpMin = Marshal.ReadInt32((IntPtr)(es64p + 44));
-                es.chrg.cpMax = Marshal.ReadInt32((IntPtr)(es64p + 48));
-            }
-
-            return es;
         }
 
         private static unsafe NativeMethods.ENLINK ConvertFromENLINK64(NativeMethods.ENLINK64 es64)


### PR DESCRIPTION
## Proposed changes

- Move ENPROTECTED to Interop Richedit.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6399)