### PR TITLE
ComboBox: fix SelectedItem/SelectedIndex when SelectedItem removed from Items

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
@@ -388,9 +388,17 @@ namespace System.Windows.Forms
                 OwnerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
                 InnerList.RemoveAt(index);
 
-                if (!_owner.IsHandleCreated && index < _owner._selectedIndex)
+                if (!_owner.IsHandleCreated)
                 {
-                    _owner._selectedIndex--;
+                    if (index < _owner._selectedIndex)
+                    {
+                        _owner._selectedIndex--;
+                    }
+                    else if (index == _owner._selectedIndex)
+                    {
+                        _owner._selectedIndex = -1;
+                        _owner.UpdateText();
+                    }
                 }
 
                 if (_owner.AutoCompleteSource == AutoCompleteSource.ListItems)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -1929,6 +1929,30 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, comboBoxChildEditUiaProvider.RaiseAutomationCallCount);
         }
 
+        [WinFormsTheory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void Combox_SelectedItem_HandlesItemRemoval(int selectedIndex)
+        {
+            using ComboBox comboBox = new();
+            for (int i = 0; i < 3; i++)
+            {
+                comboBox.Items.Add(i.ToString());
+            }
+
+            comboBox.SelectedItem = comboBox.Items[selectedIndex];
+            Assert.Equal(selectedIndex, comboBox.SelectedIndex);
+            Assert.Equal(selectedIndex.ToString(), comboBox.SelectedItem);
+            Assert.Equal(selectedIndex.ToString(), comboBox.Text);
+
+            comboBox.Items.RemoveAt(selectedIndex);
+            Assert.Equal(-1, comboBox.SelectedIndex);
+            Assert.Null(comboBox.SelectedItem);
+            Assert.Empty(comboBox.Text);
+            Assert.False(comboBox.IsHandleCreated);
+        }
+
         [WinFormsFact]
         public void ComboBox_SelectedItem_Set_DoesNotInvoke_RaiseAutomationEvent_AccessibilityObjectIsCreated()
         {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6304.


## Proposed changes

Fixes `ArgumentOutOfRangeException` when `SelectedItem` removed from `ComboBox.Items` and then `SelectedItem` property is subsequently accessed.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

No more `ArgumentOutOfRangeException`

## Regression? 

- Fixes bug in .NET Core 7 alpha

## Risk

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

Unit test added. Fails on unpatched code. Passes on patched.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6406)