### PR TITLE
Enable nullability in RestoreFocusMessageFilter

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.RestoreFocusMessageFilter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.RestoreFocusMessageFilter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static Interop;


### PR DESCRIPTION
## Proposed changes

- Enable nullability in RestoreFocusMessageFilter.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6408)