### PR TITLE
Enable nullability in ToolStripPanelRenderEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2928,8 +2928,8 @@ System.Windows.Forms.ToolStripItemTextRenderEventArgs.ToolStripItemTextRenderEve
 ~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.ToolStripPanelRowCollection(System.Windows.Forms.ToolStripPanel owner) -> void
 ~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.ToolStripPanelRowCollection(System.Windows.Forms.ToolStripPanel owner, System.Windows.Forms.ToolStripPanelRow[] value) -> void
 System.Windows.Forms.ToolStripPanelRenderEventArgs.Graphics.get -> System.Drawing.Graphics!
-System.Windows.Forms.ToolStripPanelRenderEventArgs.ToolStripPanel.get -> System.Windows.Forms.ToolStripPanel?
-System.Windows.Forms.ToolStripPanelRenderEventArgs.ToolStripPanelRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripPanel? toolStripPanel) -> void
+System.Windows.Forms.ToolStripPanelRenderEventArgs.ToolStripPanel.get -> System.Windows.Forms.ToolStripPanel!
+System.Windows.Forms.ToolStripPanelRenderEventArgs.ToolStripPanelRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripPanel! toolStripPanel) -> void
 ~System.Windows.Forms.ToolStripPanelRow.CanMove(System.Windows.Forms.ToolStrip toolStripToDrag) -> bool
 ~System.Windows.Forms.ToolStripPanelRow.Controls.get -> System.Windows.Forms.Control[]
 ~System.Windows.Forms.ToolStripPanelRow.LayoutEngine.get -> System.Windows.Forms.Layout.LayoutEngine

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2927,9 +2927,9 @@ System.Windows.Forms.ToolStripItemTextRenderEventArgs.ToolStripItemTextRenderEve
 ~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.Remove(System.Windows.Forms.ToolStripPanelRow value) -> void
 ~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.ToolStripPanelRowCollection(System.Windows.Forms.ToolStripPanel owner) -> void
 ~System.Windows.Forms.ToolStripPanel.ToolStripPanelRowCollection.ToolStripPanelRowCollection(System.Windows.Forms.ToolStripPanel owner, System.Windows.Forms.ToolStripPanelRow[] value) -> void
-~System.Windows.Forms.ToolStripPanelRenderEventArgs.Graphics.get -> System.Drawing.Graphics
-~System.Windows.Forms.ToolStripPanelRenderEventArgs.ToolStripPanel.get -> System.Windows.Forms.ToolStripPanel
-~System.Windows.Forms.ToolStripPanelRenderEventArgs.ToolStripPanelRenderEventArgs(System.Drawing.Graphics g, System.Windows.Forms.ToolStripPanel toolStripPanel) -> void
+System.Windows.Forms.ToolStripPanelRenderEventArgs.Graphics.get -> System.Drawing.Graphics!
+System.Windows.Forms.ToolStripPanelRenderEventArgs.ToolStripPanel.get -> System.Windows.Forms.ToolStripPanel?
+System.Windows.Forms.ToolStripPanelRenderEventArgs.ToolStripPanelRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripPanel? toolStripPanel) -> void
 ~System.Windows.Forms.ToolStripPanelRow.CanMove(System.Windows.Forms.ToolStrip toolStripToDrag) -> bool
 ~System.Windows.Forms.ToolStripPanelRow.Controls.get -> System.Windows.Forms.Control[]
 ~System.Windows.Forms.ToolStripPanelRow.LayoutEngine.get -> System.Windows.Forms.Layout.LayoutEngine

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRenderEventArgs.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms
@@ -13,9 +11,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents all the information to render the toolStrip
         /// </summary>
-        public ToolStripPanelRenderEventArgs(Graphics g, ToolStripPanel toolStripPanel)
+        public ToolStripPanelRenderEventArgs(Graphics g, ToolStripPanel? toolStripPanel)
         {
-            Graphics = g;
+            Graphics = g.OrThrowIfNull();
             ToolStripPanel = toolStripPanel;
         }
 
@@ -27,7 +25,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Represents which toolStrip was affected by the click
         /// </summary>
-        public ToolStripPanel ToolStripPanel { get; }
+        public ToolStripPanel? ToolStripPanel { get; }
 
         public bool Handled { get; set; }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRenderEventArgs.cs
@@ -11,10 +11,10 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents all the information to render the toolStrip
         /// </summary>
-        public ToolStripPanelRenderEventArgs(Graphics g, ToolStripPanel? toolStripPanel)
+        public ToolStripPanelRenderEventArgs(Graphics g, ToolStripPanel toolStripPanel)
         {
             Graphics = g.OrThrowIfNull();
-            ToolStripPanel = toolStripPanel;
+            ToolStripPanel = toolStripPanel.OrThrowIfNull();
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Represents which toolStrip was affected by the click
         /// </summary>
-        public ToolStripPanel? ToolStripPanel { get; }
+        public ToolStripPanel ToolStripPanel { get; }
 
         public bool Handled { get; set; }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelRenderEventArgsTests.cs
@@ -12,8 +12,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ToolStripContentPanelRenderEventArgs_NullGraphics_ThrowsArgumentNullException()
         {
-            using var toolStripContentPanel = new ToolStripContentPanel();
-            Assert.Throws<ArgumentNullException>(() => new ToolStripContentPanelRenderEventArgs(null, toolStripContentPanel));
+            Assert.Throws<ArgumentNullException>(() => new ToolStripContentPanelRenderEventArgs(null, null));
         }
 
         public static IEnumerable<object[]> Ctor_Graphics_ToolStripContentPanel_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelRenderEventArgsTests.cs
@@ -12,7 +12,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ToolStripContentPanelRenderEventArgs_NullGraphics_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ToolStripContentPanelRenderEventArgs(null, null));
+            using var toolStripContentPanel = new ToolStripContentPanel();
+            Assert.Throws<ArgumentNullException>(() => new ToolStripContentPanelRenderEventArgs(null, toolStripContentPanel));
         }
 
         public static IEnumerable<object[]> Ctor_Graphics_ToolStripContentPanel_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanelRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanelRenderEventArgsTests.cs
@@ -9,29 +9,32 @@ namespace System.Windows.Forms.Tests
 {
     public class ToolStripPanelRenderEventArgsTests : IClassFixture<ThreadExceptionFixture>
     {
-        [WinFormsFact]
-        public void ToolStripPanelRenderEventArgs_NullGraphics_ThrowsArgumentNullException()
-        {
-            using var toolStripPanel = new ToolStripPanel();
-            Assert.Throws<ArgumentNullException>(() => new ToolStripPanelRenderEventArgs(null, toolStripPanel));
-        }
-
-        public static IEnumerable<object[]> Ctor_Graphics_ToolStripPanel_TestData()
+        public static IEnumerable<object[]> Ctor_Null_Graphics_ToolStripPanel_TestData()
         {
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
 
+            yield return new object[] { null, null };
             yield return new object[] { graphics, null };
-            yield return new object[] { graphics, new ToolStripPanel() };
+            yield return new object[] { null, new ToolStripPanel() };
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(Ctor_Graphics_ToolStripPanel_TestData))]
-        public void Ctor_Graphics_ToolStripPanel(Graphics g, ToolStripPanel panel)
+        [MemberData(nameof(Ctor_Null_Graphics_ToolStripPanel_TestData))]
+        public void ToolStripPanelRenderEventArgs_Null_Graphics_ToolStripPanel_ThrowsArgumentNullException(Graphics g, ToolStripPanel toolStripPanel)
         {
-            var e = new ToolStripPanelRenderEventArgs(g, panel);
-            Assert.Equal(g, e.Graphics);
-            Assert.Equal(panel, e.ToolStripPanel);
+            Assert.Throws<ArgumentNullException>(() => new ToolStripPanelRenderEventArgs(g, toolStripPanel));
+        }
+
+        [WinFormsFact]
+        public void Ctor_Graphics_ToolStripPanel()
+        {
+            using var image = new Bitmap(10, 10);
+            using Graphics graphics = Graphics.FromImage(image);
+            using var toolStripPanel = new ToolStripPanel();
+            var e = new ToolStripPanelRenderEventArgs(graphics, toolStripPanel);
+            Assert.Equal(graphics, e.Graphics);
+            Assert.Equal(toolStripPanel, e.ToolStripPanel);
             Assert.False(e.Handled);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanelRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanelRenderEventArgsTests.cs
@@ -9,12 +9,19 @@ namespace System.Windows.Forms.Tests
 {
     public class ToolStripPanelRenderEventArgsTests : IClassFixture<ThreadExceptionFixture>
     {
+        [WinFormsFact]
+        public void ToolStripPanelRenderEventArgs_NullGraphics_ThrowsArgumentNullException()
+        {
+            using var toolStripPanel = new ToolStripPanel();
+            Assert.Throws<ArgumentNullException>(() => new ToolStripPanelRenderEventArgs(null, toolStripPanel));
+        }
+
         public static IEnumerable<object[]> Ctor_Graphics_ToolStripPanel_TestData()
         {
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
 
-            yield return new object[] { null, null };
+            yield return new object[] { graphics, null };
             yield return new object[] { graphics, new ToolStripPanel() };
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
@@ -605,7 +605,6 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> ToolStripPanelRenderEventArgs_TestData()
         {
             yield return new object[] { null };
-            yield return new object[] { new ToolStripPanelRenderEventArgs(null, null) };
 
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
@@ -608,7 +608,6 @@ namespace System.Windows.Forms.Tests
 
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
-            yield return new object[] { new ToolStripPanelRenderEventArgs(graphics, null) };
             yield return new object[] { new ToolStripPanelRenderEventArgs(graphics, new ToolStripPanel()) };
         }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripPanelRenderEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6422)