### PR TITLE
Moving GetPropertyValue duplicate logic to the base class

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -401,6 +401,11 @@ namespace System.Windows.Forms
                 UiaCore.UIA.IsValuePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.ValuePatternId),
                 UiaCore.UIA.HelpTextPropertyId => Help ?? string.Empty,
                 UiaCore.UIA.RuntimeIdPropertyId => RuntimeId,
+                UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
+                UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
+                UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId => !string.IsNullOrEmpty(DefaultAction) ? DefaultAction : null,
+                UiaCore.UIA.LegacyIAccessibleNamePropertyId => !string.IsNullOrEmpty(Name) ? Name : null,
+                UiaCore.UIA.ValueValuePropertyId => !string.IsNullOrEmpty(Value) ? Value : null,
                 _ => null
             };
 
@@ -421,6 +426,9 @@ namespace System.Windows.Forms
                     case AccessibleRole.ButtonDropDownGrid:
                     case AccessibleRole.Clock:
                     case AccessibleRole.SplitButton:
+                    case AccessibleRole.CheckButton:
+                    case AccessibleRole.Cell:
+                    case AccessibleRole.ListItem:
                         return true;
 
                     case AccessibleRole.Default:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedListBoxItemAccessibleObject.cs
@@ -44,8 +44,6 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.CheckBoxControlTypeId,
-                    UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
-                    UiaCore.UIA.ValueValuePropertyId => Value,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObject.cs
@@ -17,13 +17,14 @@ namespace System.Windows.Forms
                 _owningColumnHeader = columnHeader.OrThrowIfNull();
             }
 
+            public override string? Name => _owningColumnHeader.Text;
+
             internal override int[] RuntimeId => new int[] { RuntimeIDFirstItem, _owningColumnHeader.GetHashCode() };
 
             internal override object? GetPropertyValue(UIA propertyID)
                 => propertyID switch
                 {
                     UIA.ControlTypePropertyId => UIA.HeaderItemControlTypeId,
-                    UIA.NamePropertyId => _owningColumnHeader.Text,
                     _ => base.GetPropertyValue(propertyID)
                 };
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
@@ -74,6 +74,8 @@ namespace System.Windows.Forms
                 }
             }
 
+            public override string Name => base.Name ?? SR.ComboBoxEditDefaultAccessibleName;
+
             /// <summary>
             ///  Gets the accessible property value.
             /// </summary>
@@ -85,8 +87,6 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.EditControlTypeId;
-                    case UiaCore.UIA.NamePropertyId:
-                        return Name ?? SR.ComboBoxEditDefaultAccessibleName;
                     case UiaCore.UIA.AccessKeyPropertyId:
                         return string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -135,8 +135,6 @@ namespace System.Windows.Forms
                         return true;
                     case UiaCore.UIA.IsPasswordPropertyId:
                         return false;
-                    case UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId:
-                        return true;
                     case UiaCore.UIA.SelectionItemIsSelectedPropertyId:
                         return (State & AccessibleStates.Selected) != 0;
                     case UiaCore.UIA.SelectionItemSelectionContainerPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
@@ -60,6 +60,8 @@ namespace System.Windows.Forms
                 return base.FragmentNavigate(direction);
             }
 
+            public override string? Name => SR.DataGridView_AccEditingPanelAccName;
+
             internal override void SetFocus()
             {
                 if (_panel.IsHandleCreated && _panel.CanFocus)
@@ -83,8 +85,6 @@ namespace System.Windows.Forms
                         return Owner.AccessibleRole == AccessibleRole.Default
                                ? UiaCore.UIA.PaneControlTypeId
                                : base.GetPropertyValue(propertyId);
-                    case UiaCore.UIA.NamePropertyId:
-                        return SR.DataGridView_AccEditingPanelAccName;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return true;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
@@ -98,10 +98,6 @@ namespace System.Windows.Forms
                         return false;
                     case UiaCore.UIA.AccessKeyPropertyId:
                         return _panel.AccessibilityObject.KeyboardShortcut;
-                    case UiaCore.UIA.HelpTextPropertyId:
-                        return string.Empty;
-                    case UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId:
-                        return true;
                     case UiaCore.UIA.ProviderDescriptionPropertyId:
                         return SR.DataGridViewEditingPanelUiaProviderDescription;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
@@ -277,8 +277,6 @@ namespace System.Windows.Forms
             {
                 switch (propertyId)
                 {
-                    case UiaCore.UIA.NamePropertyId:
-                        return SR.DataGridView_AccTopRow;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return false;
@@ -291,10 +289,7 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.IsPasswordPropertyId:
                         return false;
                     case UiaCore.UIA.AccessKeyPropertyId:
-                    case UiaCore.UIA.HelpTextPropertyId:
                         return string.Empty;
-                    case UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId:
-                        return true;
                 }
 
                 return base.GetPropertyValue(propertyId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellAccessibleObject.cs
@@ -141,7 +141,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.IsTogglePatternAvailablePropertyId => (object)IsPatternSupported(UiaCore.UIA.TogglePatternId),
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.CheckBoxControlTypeId,
                     _ => base.GetPropertyValue(propertyID)
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.DataGridViewImageCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.DataGridViewImageCellAccessibleObject.cs
@@ -64,7 +64,6 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ImageControlTypeId,
-                    UiaCore.UIA.IsInvokePatternAvailablePropertyId => true,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
@@ -20,19 +20,6 @@ namespace System.Windows.Forms
                 _owningDomainUpDown = owner;
             }
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                switch (propertyID)
-                {
-                    case UiaCore.UIA.LegacyIAccessibleStatePropertyId:
-                        return State;
-                    case UiaCore.UIA.LegacyIAccessibleRolePropertyId:
-                        return Role;
-                    default:
-                        return base.GetPropertyValue(propertyID);
-                }
-            }
-
             private DomainItemListAccessibleObject ItemList
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObject.cs
@@ -105,8 +105,6 @@ namespace System.Windows.Forms
                             return UiaCore.UIA.ImageControlTypeId;
                         case UiaCore.UIA.BoundingRectanglePropertyId:
                             return BoundingRectangle;
-                        case UiaCore.UIA.LegacyIAccessibleStatePropertyId:
-                            return State;
                         case UiaCore.UIA.NativeWindowHandlePropertyId:
                             return _window.Handle;
                         default:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObject.cs
@@ -82,8 +82,6 @@ namespace System.Windows.Forms
                     {
                         case UiaCore.UIA.ControlTypePropertyId:
                             return UiaCore.UIA.GroupControlTypeId;
-                        case UiaCore.UIA.LegacyIAccessibleStatePropertyId:
-                            return State;
                         case UiaCore.UIA.NativeWindowHandlePropertyId:
                             return _owner.Handle;
                         default:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObject.cs
@@ -91,7 +91,6 @@ namespace System.Windows.Forms
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.HyperlinkControlTypeId,
                         UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                         UiaCore.UIA.HasKeyboardFocusPropertyId => _owningLinkLabel.FocusLink == _owningLink,
-                        UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
                         _ => base.GetPropertyValue(propertyID)
                     };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -183,8 +183,6 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.AutomationIdPropertyId => AutomationId,
-                    UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
-                    UiaCore.UIA.LegacyIAccessibleNamePropertyId => Name,
                     UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.GroupControlTypeId,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListView.Focused && Focused,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -176,7 +176,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsOffscreenPropertyId => OwningGroup?.CollapsedState == ListViewGroupCollapsedState.Collapsed
                                                         || (bool)(base.GetPropertyValue(UiaCore.UIA.IsOffscreenPropertyId) ?? false),
                     UiaCore.UIA.NativeWindowHandlePropertyId => _owningListView.IsHandleCreated ? _owningListView.Handle : IntPtr.Zero,
-                    UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -402,7 +402,6 @@ namespace System.Windows.Forms
                         ? UiaCore.UIA.CalendarControlTypeId
                         : base.GetPropertyValue(propertyID),
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => IsEnabled,
-                    UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarChildAccessibleObject.cs
@@ -26,8 +26,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.HasKeyboardFocusPropertyId => HasKeyboardFocus,
                     UiaCore.UIA.IsEnabledPropertyId => IsEnabled,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => false,
-                    UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
-                    UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.NumericUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.NumericUpDownAccessibleObject.cs
@@ -41,19 +41,6 @@ namespace System.Windows.Forms
                 return 2;
             }
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                switch (propertyID)
-                {
-                    case UiaCore.UIA.LegacyIAccessibleStatePropertyId:
-                        return State;
-                    case UiaCore.UIA.LegacyIAccessibleRolePropertyId:
-                        return Role;
-                    default:
-                        return base.GetPropertyValue(propertyID);
-                }
-            }
-
             public override AccessibleRole Role
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObject.cs
@@ -77,8 +77,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             internal override object GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
             {
                 UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
-                UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId => true,
-                UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
                 _ => base.GetPropertyValue(propertyID),
             };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -340,9 +340,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     UiaCore.UIA.IsEnabledPropertyId => true,
                     UiaCore.UIA.AutomationIdPropertyId => GetHashCode().ToString(),
                     UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.IsGridItemPatternAvailablePropertyId or UiaCore.UIA.IsTableItemPatternAvailablePropertyId => true,
-                    UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
-                    UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId => DefaultAction,
                     _ => base.GetPropertyValue(propertyID),
                 };
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.DropDownHolder.DropDownHolderAccessibleObject.cs
@@ -35,10 +35,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot =>
                     _owningDropDownHolder._gridView?.OwnerGrid?.AccessibilityObject;
 
-                internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                    => propertyID == UiaCore.UIA.NamePropertyId
-                        ? SR.PropertyGridViewDropDownControlHolderAccessibleName
-                        : base.GetPropertyValue(propertyID);
+                public override string? Name => SR.PropertyGridViewDropDownControlHolderAccessibleName;
 
                 private bool ExistsInAccessibleTree
                     => _owningDropDownHolder.IsHandleCreated && _owningDropDownHolder.Visible;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.PropertyGridViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.PropertyGridViewAccessibleObject.cs
@@ -89,8 +89,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TableControlTypeId,
-                    UiaCore.UIA.IsTablePatternAvailablePropertyId => true,
-                    UiaCore.UIA.IsGridPatternAvailablePropertyId => true,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
@@ -121,7 +121,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsPasswordPropertyId => false,
                     UiaCore.UIA.IsEnabledPropertyId => OwningTabControl?.Enabled ?? false,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,
-                    UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:
                         // IsKeyboardFocusable = true regardless the control is enabled/disabled.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
@@ -85,7 +85,6 @@ namespace System.Windows.Forms
                 {
                     UiaCore.UIA.AutomationIdPropertyId => _owningTabPage.Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTabPage.Focused,
-                    UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:
                         // IsKeyboardFocusable = true regardless the control is enabled/disabled.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -111,8 +111,6 @@ namespace System.Windows.Forms
                     // See: docs/accessibility/accessible-role-controltype.md
                     case UiaCore.UIA.ControlTypePropertyId:
                         return AccessibleRoleControlTypeMap.GetControlType(Role);
-                    case UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId:
-                        return (object)IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId);
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _ownerItem.Enabled;
                     case UiaCore.UIA.IsOffscreenPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.ToolStripLabelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.ToolStripLabelAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using static Interop;
-
 namespace System.Windows.Forms
 {
     public partial class ToolStripLabel
@@ -38,16 +36,6 @@ namespace System.Windows.Forms
                 {
                     base.DoDefaultAction();
                 }
-            }
-
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                if (propertyID == UiaCore.UIA.LegacyIAccessibleStatePropertyId)
-                {
-                    return State;
-                }
-
-                return base.GetPropertyValue(propertyID);
             }
 
             public override AccessibleRole Role

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObject.cs
@@ -76,9 +76,6 @@ namespace System.Windows.Forms
                     internal override object? GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
                     {
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
-                        UiaCore.UIA.LegacyIAccessibleStatePropertyId => State,
-                        UiaCore.UIA.LegacyIAccessibleRolePropertyId => Role,
-                        UiaCore.UIA.IsInvokePatternAvailablePropertyId => IsPatternSupported(UiaCore.UIA.InvokePatternId),
                         _ => base.GetPropertyValue(propertyID),
                     };
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DataGridViewTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DataGridViewTest.Designer.cs
@@ -40,6 +40,7 @@ namespace WinformsControlsTest
             this.column3 = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.column4 = new System.Windows.Forms.DataGridViewComboBoxColumn();
             this.column5 = new System.Windows.Forms.DataGridViewComboBoxColumn();
+            this.column6 = new System.Windows.Forms.DataGridViewImageColumn();
             this.currentDPILabel1 = new WinformsControlsTest.CurrentDPILabel();
             this.changeFontButton = new System.Windows.Forms.Button();
             this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
@@ -65,7 +66,8 @@ namespace WinformsControlsTest
             this.column2,
             this.column5,
             this.column3,
-            this.column4});
+            this.column4,
+            this.column6});
             dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Info;
             dataGridViewCellStyle3.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
@@ -106,6 +108,11 @@ namespace WinformsControlsTest
             this.column5.HeaderText = "Hidden Column";
             this.column5.Name = "column5";
             this.column5.Visible = false;
+            // 
+            // column6
+            // 
+            this.column6.HeaderText = "Column6";
+            this.column6.Name = "column6";
             // 
             // currentDPILabel1
             // 
@@ -206,6 +213,7 @@ namespace WinformsControlsTest
         private System.Windows.Forms.DataGridViewCheckBoxColumn column3;
         private System.Windows.Forms.DataGridViewComboBoxColumn column4;
         private System.Windows.Forms.DataGridViewComboBoxColumn column5;
+        private System.Windows.Forms.DataGridViewImageColumn column6;
         private WinformsControlsTest.CurrentDPILabel currentDPILabel1;
         private System.Windows.Forms.Button changeFontButton;
         private System.Windows.Forms.NumericUpDown numericUpDown1;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DataGridViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DataGridViewTest.cs
@@ -28,6 +28,7 @@ namespace WinformsControlsTest
             dataGridView1.Rows.Add("DefaultCellStyle", dataGridView1.DefaultCellStyle.Font.ToString());
             dataGridView1.Rows.Add("ColumnHeadersDefaultCellStyle", dataGridView1.ColumnHeadersDefaultCellStyle.Font.ToString());
             dataGridView1.Rows.Add("RowHeadersDefaultCellStyle", dataGridView1.RowHeadersDefaultCellStyle.Font.ToString());
+            column6.Image = Image.FromFile("Images\\SmallA.bmp");
 
             int i = 1;
             foreach (DataGridViewRow row in dataGridView1.Rows)

--- a/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/CheckedListBoxItemAccessibleObjectTests.cs
@@ -5,6 +5,7 @@
 using Xunit;
 using static System.Windows.Forms.CheckedListBox;
 using static Interop;
+using System.Windows.Forms.TestUtilities;
 
 namespace System.Windows.Forms.Tests.AccessibleObjects
 {
@@ -193,6 +194,19 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
         }
 
         [WinFormsTheory]
+        [MemberData(nameof(CheckedListBoxItemAccessibleObject_DefaultAction_ControlType_IfHandleIsCreated_ReturnsExpected_TestData))]
+        public void CheckedListBoxItemAccessibleObject_GetPropertyValue_LegacyIAccessibleDefaultActionPropertyId_ReturnsExpected(bool isChecked, string expected)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+            checkedListBox.SetItemChecked(0, isChecked);
+            checkedListBox.CreateControl();
+
+            Assert.Equal(expected, checkedListBox.AccessibilityObject.GetChild(0).GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.True(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
         [InlineData(true)]
         [InlineData(false)]
         public void CheckedListBoxItemAccessibleObject_Value_ReturnsExpected(bool isChecked)
@@ -286,6 +300,29 @@ namespace System.Windows.Forms.Tests.AccessibleObjects
 
             Assert.Equal(!isChecked, checkedListBox.GetItemChecked(0));
             Assert.True(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CheckedListBoxItemAccessibleObject_GetPropertyValue_IsInvokePatternAvailablePropertyId_ReturnsExpected()
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+
+            Assert.True((bool)checkedListBox.AccessibilityObject.GetChild(0).GetPropertyValue(UiaCore.UIA.IsInvokePatternAvailablePropertyId));
+            Assert.False(checkedListBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void CheckedListBoxItemAccessibleObject_GetPropertyValue_ValueValuePropertyId_ReturnsExpected(bool isChecked)
+        {
+            using CheckedListBox checkedListBox = new();
+            checkedListBox.Items.Add("A");
+            checkedListBox.SetItemChecked(0, isChecked);
+
+            AccessibleObject accessibleObject = checkedListBox.AccessibilityObject.GetChild(0);
+            Assert.Equal(isChecked, bool.Parse(accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId).ToString()));
+            Assert.False(checkedListBox.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Button.ButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Button.ButtonAccessibleObjectTests.cs
@@ -65,6 +65,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [InlineData((int)UIA.NamePropertyId, "TestName")]
+        [InlineData((int)UIA.LegacyIAccessibleNamePropertyId, "TestName")]
         [InlineData((int)UIA.ControlTypePropertyId, UIA.ButtonControlTypeId)] // If AccessibleRole is Default
         [InlineData((int)UIA.IsKeyboardFocusablePropertyId, true)]
         [InlineData((int)UIA.AutomationIdPropertyId, "Button1")]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CategoryGridEntryAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CategoryGridEntryAccessibleObjectTests.cs
@@ -157,5 +157,33 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(expected, accessibilityObject.GetPropertyValue(UiaCore.UIA.LocalizedControlTypePropertyId));
         }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessibleRolePropertyId, AccessibleRole.ButtonDropDownGrid)]
+        [InlineData((int)UiaCore.UIA.IsGridItemPatternAvailablePropertyId, true)]
+        [InlineData((int)UiaCore.UIA.IsTableItemPatternAvailablePropertyId, true)]
+        public void CategoryGridEntryAccessibleObject_GetPropertyValue_ReturnsExpected(int property, object expected)
+        {
+            using NoAssertContext context = new();
+            CategoryGridEntryAccessibleObject accessibleObject = new(null);
+            object actual = accessibleObject.GetPropertyValue((UiaCore.UIA)property);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [WinFormsFact]
+        public void CategoryGridEntryAccessibleObjectWithControl_GetPropertyValue_ReturnsExpected()
+        {
+            using PropertyGrid control = new();
+            using Button button = new();
+            control.SelectedObject = button;
+            PropertyGridView gridView = control.TestAccessor().Dynamic._gridView;
+            var category = (CategoryGridEntry)gridView.TopLevelGridEntries[0];
+            var gridViewAccessibilityObject = (PropertyGridViewAccessibleObject)gridView.AccessibilityObject;
+            AccessibleObject accessibilityObject = category.AccessibilityObject;
+
+            Assert.Equal("Collapse", accessibilityObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.Null(accessibilityObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBox.CheckBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBox.CheckBoxAccessibleObjectTests.cs
@@ -145,6 +145,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [InlineData((int)UIA.NamePropertyId, "TestName")]
+        [InlineData((int)UIA.LegacyIAccessibleNamePropertyId, "TestName")]
         [InlineData((int)UIA.ControlTypePropertyId, UIA.CheckBoxControlTypeId)] // If AccessibleRole is Default
         [InlineData((int)UIA.IsKeyboardFocusablePropertyId, true)]
         [InlineData((int)UIA.AutomationIdPropertyId, "CheckBox1")]
@@ -216,11 +217,10 @@ namespace System.Windows.Forms.Tests
         {
             using CheckBox checkBox = new CheckBox();
             checkBox.AccessibleRole = role;
-
-            object actual = checkBox.AccessibilityObject.GetPropertyValue(UIA.ControlTypePropertyId);
             UIA expected = AccessibleRoleControlTypeMap.GetControlType(role);
 
-            Assert.Equal(expected, actual);
+            Assert.Equal(expected, checkBox.AccessibilityObject.GetPropertyValue(UIA.ControlTypePropertyId));
+            Assert.Equal(checkBox.AccessibilityObject.DefaultAction, checkBox.AccessibilityObject.GetPropertyValue(UIA.LegacyIAccessibleDefaultActionPropertyId));
             Assert.False(checkBox.IsHandleCreated);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObjectTests.cs
@@ -35,6 +35,8 @@ namespace System.Windows.Forms.Tests
             ListViewColumnHeaderAccessibleObject accessibleObject = new(columnHeader);
 
             Assert.Equal(testText, accessibleObject.GetPropertyValue(UIA.NamePropertyId));
+            Assert.Equal(testText, accessibleObject.GetPropertyValue(UIA.LegacyIAccessibleNamePropertyId));
+            Assert.Null(accessibleObject.GetPropertyValue(UIA.LegacyIAccessibleDefaultActionPropertyId));
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxAccessibleObjectTests.cs
@@ -110,11 +110,15 @@ namespace System.Windows.Forms.Tests
         {
             const string name = "Test text";
             using ComboBox comboBox = new();
+
+            Assert.Null(comboBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
+            Assert.Null(comboBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleNamePropertyId));
+
             comboBox.AccessibleName = name;
             comboBox.CreateControl(false);
-            object actual = comboBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
 
-            Assert.Equal(name, actual);
+            Assert.Equal(name, comboBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
+            Assert.Equal(name, comboBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleNamePropertyId));
             Assert.True(comboBox.IsHandleCreated);
         }
 
@@ -345,6 +349,18 @@ namespace System.Windows.Forms.Tests
 
             Assert.True(comboBox.IsHandleCreated);
             Assert.Equal(expectedAction, comboBox.AccessibilityObject.DefaultAction);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ComboBoxAccessibleObject_DefaultAction_IfHandleIsCreated_ReturnsExpected_TestData))]
+        public void ComboBoxAccessibleObject_GetPropertyValue_IfHandleIsCreated_ReturnsExpected(ComboBoxStyle style, bool droppedDown, string expectedAction)
+        {
+            using ComboBox comboBox = new() { DropDownStyle = style };
+            comboBox.CreateControl();
+            comboBox.DroppedDown = droppedDown;
+
+            Assert.Equal(expectedAction, comboBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.True(comboBox.IsHandleCreated);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProviderTests.cs
@@ -153,5 +153,23 @@ namespace System.Windows.Forms.Tests
 
             Assert.True((bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsValuePatternAvailablePropertyId));
         }
+
+        [WinFormsFact]
+        public void ComboBoxChildEditUiaProvider_GetPropertyValue_ReturnsExpected()
+        {
+            using ComboBox comboBox = new ComboBox();
+            comboBox.CreateControl();
+            AccessibleObject accessibleObject = comboBox.ChildEditAccessibleObject;
+
+            Assert.Equal(SR.ComboBoxEditDefaultAccessibleName, accessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId).ToString());
+            Assert.Equal(SR.ComboBoxEditDefaultAccessibleName, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleNamePropertyId).ToString());
+            Assert.Null(accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+
+            comboBox.AccessibleName = "Combo AO name";
+
+            Assert.Equal(comboBox.AccessibleName, accessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId).ToString());
+            Assert.Equal(comboBox.AccessibleName, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleNamePropertyId).ToString());
+            Assert.Null(accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObjectTests.cs
@@ -210,7 +210,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void ComboBoxItemAccessibleObject_GetPropertyValue_ScrollItemPattern_IsAvailable()
+        public void ComboBoxItemAccessibleObject_GetPropertyValue_Pattern_IsAvailable()
         {
             using ComboBox comboBox = new ComboBox();
             comboBox.Items.AddRange(new[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" });
@@ -219,12 +219,14 @@ namespace System.Windows.Forms.Tests
             ComboBoxAccessibleObject comboBoxAccessibleObject = (ComboBoxAccessibleObject)comboBox.AccessibilityObject;
             ComboBoxItemAccessibleObjectCollection itemsCollection = comboBoxAccessibleObject.ItemAccessibleObjects;
 
-            // Check that all items support ScrollItemPattern
+            // Check that all items support Pattern
             foreach (Entry itemEntry in comboBox.Items.InnerList)
             {
                 ComboBoxItemAccessibleObject itemAccessibleObject = itemsCollection.GetComboBoxItemAccessibleObject(itemEntry);
 
                 Assert.True((bool)itemAccessibleObject.GetPropertyValue(UiaCore.UIA.IsScrollItemPatternAvailablePropertyId));
+                Assert.True((bool)itemAccessibleObject.GetPropertyValue(UiaCore.UIA.IsSelectionItemPatternAvailablePropertyId));
+                Assert.Null(itemAccessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -188,6 +188,19 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetStringWithNullTheoryData))]
+        public void ControlAccessibleObject_GetPropertyValue_LegacyIAccessibleDefaultActionPropertyId_ReturnsExpected(string accessibleDefaultActionDescription)
+        {
+            using var ownerControl = new Control
+            {
+                AccessibleDefaultActionDescription = accessibleDefaultActionDescription
+            };
+            var accessibleObject = new Control.ControlAccessibleObject(ownerControl);
+            Assert.Equal(!string.IsNullOrEmpty(accessibleDefaultActionDescription) ? accessibleDefaultActionDescription :
+                null, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetStringWithNullTheoryData))]
         public void ControlAccessibleObject_Description_GetWithAccessibleDescription_ReturnsExpected(string accessibleDescription)
         {
             using var ownerControl = new Control
@@ -1289,9 +1302,8 @@ namespace System.Windows.Forms.Tests
             control.Name = "Name1";
             control.AccessibleName = "Test Name";
 
-            var accessibleName = controlAccessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
-
-            Assert.Equal("Test Name", accessibleName);
+            Assert.Equal("Test Name", controlAccessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleNamePropertyId));
+            Assert.Equal("Test Name", controlAccessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
         }
 
         public static IEnumerable<object[]> ControlAccessibleObject_DefaultName_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObjectTests.cs
@@ -106,5 +106,19 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(editingPanel.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void DataGridViewEditingPanelAccessibleObject_GetPropertyValue_ReturnsExpected()
+        {
+            using DataGridView dataGridView = new();
+            Panel editingPanel = dataGridView.EditingPanel;
+
+            Assert.True((bool)editingPanel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+            Assert.Equal(string.Empty, editingPanel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HelpTextPropertyId));
+            Assert.Equal(SR.DataGridView_AccEditingPanelAccName, editingPanel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
+            Assert.Equal(SR.DataGridView_AccEditingPanelAccName, editingPanel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleNamePropertyId));
+            Assert.Null(editingPanel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.False(editingPanel.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewButtonCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewButtonCellAccessibleObjectTests.cs
@@ -25,6 +25,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void DataGridViewButtonCellAccessibleObject_GetPropertyValue_LegacyIAccessibleDefaultActionPropertyId_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewButtonCellAccessibleObject(null);
+            Assert.Equal(SR.DataGridView_AccButtonCellDefaultAction, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+        }
+
+        [WinFormsFact]
         public void DataGridViewButtonCellAccessibleObject_GetChildCount_ReturnsExpected()
         {
             var accessibleObject = new DataGridViewButtonCellAccessibleObject(null);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
@@ -149,6 +149,13 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [MemberData(nameof(DefaultAction_TestData))]
+        public void DataGridViewCellAccessibleObject_GetPropertyValue_LegacyIAccessibleDefaultActionPropertyId_ReturnsExpected(AccessibleObject accessibleObject, string expected)
+        {
+            Assert.Equal(expected, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId) ?? string.Empty);
+        }
+
+        [WinFormsTheory]
         [MemberData(nameof(NoOwner_TestData))]
         public void DataGridViewCellAccessibleObject_DefaultAction_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
@@ -642,10 +649,9 @@ namespace System.Windows.Forms.Tests
 
             DataGridViewCellAccessibleObject accessibleObject = new(dataGridView.Rows[0].Cells[0]);
 
-            object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
-
             //DataGridViewCellAccessibleObject name couldn't be set, it's gathered dynamically in the Name property accessor
-            Assert.Equal(accessibleObject.Name, actual);
+            Assert.Equal(accessibleObject.Name, accessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
+            Assert.Equal(accessibleObject.Name, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleNamePropertyId));
             Assert.False(dataGridView.IsHandleCreated);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCheckBoxCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCheckBoxCellAccessibleObjectTests.cs
@@ -61,6 +61,31 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(UiaCore.UIA.CheckBoxControlTypeId, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
         }
 
+        [WinFormsFact]
+        public void DataGridViewCheckBoxCellAccessibleObject_IsTogglePatternAvailablePropertyId_ReturnsExpected()
+        {
+            var accessibleObject = new DataGridViewCheckBoxCellAccessibleObject(null);
+
+            Assert.True((bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsTogglePatternAvailablePropertyId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCheckBoxCellAccessibleObject_GetPropertyValue_ValueValuePropertyId_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add(new DataGridViewCheckBoxColumn());
+            var cell = control.Rows[0].Cells[0];
+            control.CreateControl();
+            var accessibleObject = (DataGridViewCheckBoxCellAccessibleObject)cell.AccessibilityObject;
+
+            Assert.False(bool.Parse(accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId).ToString()));
+
+            accessibleObject.DoDefaultAction();
+
+            Assert.True(bool.Parse(accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId).ToString()));
+            Assert.True(control.IsHandleCreated);
+        }
+
         [WinFormsTheory]
         [InlineData((int)UiaCore.UIA.TogglePatternId)]
         public void DataGridViewCheckBoxCellAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
@@ -122,6 +147,30 @@ namespace System.Windows.Forms.Tests
             }
 
             Assert.Equal(expected, accessibleObject.DefaultAction);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DataGridViewCheckBoxCellAccessibleObject_DefaultAction_TestData))]
+        public void DataGridViewCheckBoxCellAccessibleObject_GetPropertyValue_LegacyIAccessibleDefaultActionPropertyId_ReturnsExpected(bool isChecked, string expected)
+        {
+            using DataGridView control = new();
+            control.Columns.Add(new DataGridViewCheckBoxColumn());
+            control.Rows.Add(new DataGridViewRow());
+            var cell = control.Rows[0].Cells[0];
+            // Create control to check cell if it is needed.
+            control.CreateControl();
+
+            var accessibleObject = (DataGridViewCheckBoxCellAccessibleObject)cell.AccessibilityObject;
+            if (isChecked)
+            {
+                // Make sure that default action is check as a default case.
+                Assert.Equal(SR.DataGridView_AccCheckBoxCellDefaultActionCheck, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+                // Check it.
+                accessibleObject.DoDefaultAction();
+            }
+
+            Assert.Equal(expected, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
             Assert.True(control.IsHandleCreated);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewColumnHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewColumnHeaderCellAccessibleObjectTests.cs
@@ -108,6 +108,19 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_GetPropertyValue_LegacyIAccessibleDefaultActionPropertyId_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewColumn column = control.Columns[0];
+            column.SortMode = DataGridViewColumnSortMode.Automatic;
+            var accessibleObject = (DataGridViewColumnHeaderCellAccessibleObject)column.HeaderCell.AccessibilityObject;
+
+            Assert.Equal(SR.DataGridView_AccColumnHeaderCellDefaultAction, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.False(control.IsHandleCreated);
+        }
+
         [WinFormsTheory]
         [InlineData((int)UiaCore.UIA.InvokePatternId)]
         [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
@@ -124,6 +137,18 @@ namespace System.Windows.Forms.Tests
             var accessibleObject = new DataGridViewColumnHeaderCellAccessibleObject(null);
 
             Assert.Equal(UiaCore.UIA.HeaderControlTypeId, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_ValueValuepropertyId_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewColumn column = control.Columns[0];
+            column.SortMode = DataGridViewColumnSortMode.Automatic;
+
+            var accessibleObject = (DataGridViewColumnHeaderCellAccessibleObject)column.HeaderCell.AccessibilityObject;
+            Assert.Equal("Header text 1", accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
@@ -2366,6 +2366,21 @@ namespace System.Windows.Forms.Tests
             Assert.False(dataGridView.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetPropertyValue_ValueValuePropertyId_ReturnsExpected()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.AutoGenerateColumns = false;
+            DataGridViewTextBoxColumn column = new DataGridViewTextBoxColumn();
+            column.DataPropertyName = "col1";
+            dataGridView.Columns.Add(column);
+            dataGridView.Rows.Add(new DataGridViewRow());
+            dataGridView.Rows[0].Cells[0].Value = "test1";
+
+            Assert.Equal("test1", dataGridView.Rows[0].AccessibilityObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
         private class SubDataGridViewCell : DataGridViewCell
         {
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedCellsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedCellsAccessibleObjectTests.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -187,6 +188,23 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, accessibleObject.GetChildCount());
             Assert.Equal(selecetedCell1.AccessibilityObject, accessibleObject.Navigate(AccessibleNavigation.FirstChild));
             Assert.Equal(selecetedCell1.AccessibilityObject, accessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedCellsAccessibleObject_GetPropertyValue_ValueValuePropertyId_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Rows.Add("Row1");
+            DataGridViewCell selecetedCell1 = control.Rows[0].Cells[0];
+            selecetedCell1.Selected = true;
+            Type type = typeof(DataGridView)
+                .GetNestedType("DataGridViewSelectedCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { control });
+
+            Assert.Equal("Selected Cells", accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
             Assert.False(control.IsHandleCreated);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCellsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCellsAccessibleObjectTests.cs
@@ -4,6 +4,7 @@
 
 using System.Reflection;
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -195,6 +196,24 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, accessibleObject.GetChildCount());
             Assert.Equal(selecetedCell1.AccessibilityObject, accessibleObject.Navigate(AccessibleNavigation.FirstChild));
             Assert.Equal(selecetedCell1.AccessibilityObject, accessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewSelectedRowCellsAccessibleObject_GetPropertyValue_ValueValuePropertyId_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Rows.Add("Row1");
+            DataGridViewRow row = control.Rows[0];
+            DataGridViewCell selecetedCell1 = row.Cells[0];
+            selecetedCell1.Selected = true;
+            Type type = typeof(DataGridViewRow)
+                .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { row }, null);
+
+            Assert.Equal("Selected Row Cells", accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
             Assert.False(control.IsHandleCreated);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopRowAccessibleObjectTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
@@ -1229,6 +1230,20 @@ namespace System.Windows.Forms.Tests
             AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
 
             Assert.Equal(0, topRowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetPropertyValue_ReturnsExpected()
+        {
+            using DataGridView dataGridView = new DataGridView();
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.True((bool)topRowAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+            Assert.Equal(string.Empty, topRowAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.HelpTextPropertyId));
+            Assert.Equal(SR.DataGridView_AccTopRow, topRowAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.NamePropertyId));
+            Assert.Equal(SR.DataGridView_AccTopRow, topRowAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.LegacyIAccessibleNamePropertyId));
+            Assert.Equal("Top Row", topRowAccessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
             Assert.False(dataGridView.IsHandleCreated);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
@@ -101,13 +101,15 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void DateTimePickerAccessibleObject_IsExpandCollapsePatternSupported_Supported()
+        public void DateTimePickerAccessibleObject_GetPropertyValue_ReturnsExpected()
         {
             using DateTimePicker dateTimePicker = new();
+            DateTime dt = new DateTime(2000, 1, 1);
+            dateTimePicker.TestAccessor().Dynamic._text = dt.ToLongDateString();
+            AccessibleObject accessibleObject = dateTimePicker.AccessibilityObject;
 
-            var actual = (bool)dateTimePicker.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId);
-
-            Assert.True(actual);
+            Assert.Equal(dt.ToLongDateString(), accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.True((bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId));
             Assert.False(dateTimePicker.IsHandleCreated);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DomainUpDownAccessibleObjectTests.cs
@@ -92,5 +92,19 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(domainUpDown.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessibleRolePropertyId, AccessibleRole.SpinButton)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessibleStatePropertyId, AccessibleStates.None)]
+        [InlineData((int)UiaCore.UIA.ValueValuePropertyId, null)]
+        public void DomainUpDownAccessibleObject_GetPropertyValue_ReturnsExpected(int property, object expected)
+        {
+            using DomainUpDown domainUpDown = new DomainUpDown();
+            AccessibleObject accessibleObject = domainUpDown.AccessibilityObject;
+            object actual = accessibleObject.GetPropertyValue((UiaCore.UIA)property);
+
+            Assert.Equal(expected, actual);
+            Assert.False(domainUpDown.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObjectTests.cs
@@ -166,6 +166,18 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void ControlItemAccessibleObjectTests_GetPropertyValue_ReturnsExpected()
+        {
+            Type type = typeof(ControlItem)
+               .GetNestedType("ControlItemAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null, null, null, null });
+
+            Assert.Null(accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.Null(accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.Equal(AccessibleStates.ReadOnly | AccessibleStates.HasPopup, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleStatePropertyId));
+        }
+
+        [WinFormsFact]
         public void ControlItemAccessibleObjectTests_GetChildId_ReturnsExpected()
         {
             using Control control = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObjectTests.cs
@@ -64,6 +64,18 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void ErrorWindowAccessibleObject_GetPropertyValue_ReturnsExpected()
+        {
+            Type type = typeof(ErrorWindow)
+                .GetNestedType("ErrorWindowAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, new object[] { null });
+
+            Assert.Null(accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.Null(accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.Equal(AccessibleStates.ReadOnly, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleStatePropertyId));
+        }
+
+        [WinFormsFact]
         public void ErrorWindowAccessibleObject_FragmentRoot_ReturnsExpected()
         {
             Type type = typeof(ErrorWindow)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxAccessibleObjectTests.cs
@@ -14,15 +14,18 @@ namespace System.Windows.Forms.Tests
         {
             string testAccName = "Test group name";
             using var groupBox = new GroupBox();
+            AccessibleObject groupBoxAccessibleObject = groupBox.AccessibilityObject;
+
+            Assert.Null(groupBoxAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.NamePropertyId));
+            Assert.Null(groupBoxAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.LegacyIAccessibleNamePropertyId));
+
             groupBox.Text = "Some test groupBox text";
             groupBox.Name = "Group1";
             groupBox.AccessibleName = testAccName;
-            AccessibleObject groupBoxAccessibleObject = groupBox.AccessibilityObject;
 
+            Assert.Equal(testAccName, groupBoxAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.NamePropertyId));
+            Assert.Equal(testAccName, groupBoxAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.LegacyIAccessibleNamePropertyId));
             Assert.False(groupBox.IsHandleCreated);
-
-            var accessibleName = groupBoxAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.NamePropertyId);
-            Assert.Equal(testAccName, accessibleName);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListBoxAccessibleObjectTests.cs
@@ -92,5 +92,15 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(listBox.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void ListBoxItemAccessibleObject_GetPropertyValue_ValueValuePropertyId_ReturnsExpected()
+        {
+            using ListBox listBox = new ListBox();
+            AccessibleObject accessibleObject = listBox.AccessibilityObject;
+
+            Assert.Null(accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.False(listBox.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -70,6 +70,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, controlType);
 
             Assert.True((bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
+            Assert.Equal(AccessibleRole.Grouping, accessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleRolePropertyId));
             Assert.False(list.IsHandleCreated);
         }
 
@@ -92,6 +93,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(list.DefaultGroup.Header, defaultGroupAccessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
             Assert.Equal("Group1", groupAccessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
+            Assert.Equal("Group1", groupAccessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleNamePropertyId));
 
             Assert.Equal("ListViewGroup-0", defaultGroupAccessibleObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
             Assert.Equal("ListViewGroup-1", groupAccessibleObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
@@ -101,7 +103,9 @@ namespace System.Windows.Forms.Tests
 
             Assert.True((bool)defaultGroupAccessibleObject.GetPropertyValue(UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
             Assert.True((bool)groupAccessibleObject.GetPropertyValue(UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId));
-
+            Assert.Equal(AccessibleRole.Grouping, defaultGroupAccessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleRolePropertyId));
+            Assert.Equal(AccessibleRole.Grouping, groupAccessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleRolePropertyId));
+            Assert.Null(groupAccessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
             Assert.False(list.IsHandleCreated);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
@@ -265,6 +265,19 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_GetPropertyValue_ReturnsExpected()
+        {
+            using ListView control = new();
+            ListViewItem item = new();
+            control.Items.Add(item);
+
+            Assert.Equal(SR.AccessibleActionDoubleClick, item.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.Null(item.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.True((bool)item.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsInvokePatternAvailablePropertyId));
+            Assert.False(control.IsHandleCreated);
+        }
+
         [WinFormsTheory]
         [InlineData((int)UiaCore.UIA.ScrollItemPatternId)]
         [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarButtonAccessibleObjectTests.cs
@@ -34,6 +34,17 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void CalendarButtonAccessibleObject_GetPropertyValue_LegacyIAccessibleDefaultActionPropertyId_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarButtonAccessibleObject buttonAccessibleObject = new SubCalendarButtonAccessibleObject(controlAccessibleObject);
+
+            Assert.Equal(SR.AccessibleActionClick, buttonAccessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
         public void CalendarButtonAccessibleObject_ControlType_IsButton()
         {
             using MonthCalendar control = new();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObjectTests.cs
@@ -76,6 +76,18 @@ namespace System.Windows.Forms.Tests
             Assert.False(monthCalendar.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void MonthCalendarAccessibleObject_GetPropertyValue_ReturnsExpected()
+        {
+            using MonthCalendar monthCalendar = new MonthCalendar();
+            DateTime dt = new DateTime(2000, 1, 1);
+            monthCalendar.SetDate(dt);
+
+            Assert.Equal(dt.ToLongDateString(), monthCalendar.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.Equal(AccessibleStates.None, monthCalendar.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleStatePropertyId));
+            Assert.False(monthCalendar.IsHandleCreated);
+        }
+
         [WinFormsTheory]
         [InlineData(true)]
         [InlineData(false)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NumericUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/NumericUpDownAccessibleObjectTests.cs
@@ -91,5 +91,18 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(numericUpDown.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessibleRolePropertyId, AccessibleRole.SpinButton)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessibleStatePropertyId, AccessibleStates.None)]
+        public void NumericUpDownAccessibleObject_GetPropertyValue_ReturnsExpected(int property, object expected)
+        {
+            using NumericUpDown numericUpDown = new NumericUpDown();
+            AccessibleObject accessibleObject = numericUpDown.AccessibilityObject;
+            object actual = accessibleObject.GetPropertyValue((UiaCore.UIA)property);
+
+            Assert.Equal(expected, actual);
+            Assert.False(numericUpDown.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Panel.PanelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Panel.PanelAccessibleObjectTests.cs
@@ -63,6 +63,7 @@ namespace System.Windows.Forms.Tests
         [InlineData((int)UIA.AutomationIdPropertyId, "Panel1")]
         [InlineData((int)UIA.ControlTypePropertyId, UIA.PaneControlTypeId)] // If AccessibleRole is Default
         [InlineData((int)UIA.IsKeyboardFocusablePropertyId, false)]
+        [InlineData((int)UIA.LegacyIAccessibleDefaultActionPropertyId, null)]
         public void PanelAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
         {
             using Panel panel = new()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/DropDownButton.DropDownButtonAccessibleObjectTests.cs
@@ -32,6 +32,20 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             Assert.False(dropDownButton.IsHandleCreated);
         }
 
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.IsLegacyIAccessiblePatternAvailablePropertyId, true)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessibleRolePropertyId, AccessibleRole.PushButton)]
+        [InlineData((int)UiaCore.UIA.ValueValuePropertyId, null)]
+        public void DomainUpDownAccessibleObject_GetPropertyValue_ReturnsExpected(int property, object expected)
+        {
+            using DropDownButton dropDownButton = new DropDownButton();
+            AccessibleObject accessibleObject = dropDownButton.AccessibilityObject;
+            object actual = accessibleObject.GetPropertyValue((UiaCore.UIA)property);
+
+            Assert.Equal(expected, actual);
+            Assert.False(dropDownButton.IsHandleCreated);
+        }
+
         [WinFormsFact]
         public void DropDownButtonAccessibleObject_Role_IsPushButton_ByDefault()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButton.RadioButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButton.RadioButtonAccessibleObjectTests.cs
@@ -43,6 +43,20 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void RadioButtonAccessibleObject_GetProperyValue_LegacyIAccessibleDefaultActionPropertyId_ReturnsExpected()
+        {
+            using var radioButton = new RadioButton
+            {
+                AccessibleDefaultActionDescription = "TestActionDescription"
+            };
+
+            var radioButtonAccessibleObject = new RadioButton.RadioButtonAccessibleObject(radioButton);
+
+            Assert.Equal("TestActionDescription", radioButtonAccessibleObject.GetPropertyValue(UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.False(radioButton.IsHandleCreated);
+        }
+
+        [WinFormsFact]
         public void RadioButtonAccessibleObject_Description_ReturnsExpected()
         {
             using var radioButton = new RadioButton

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
@@ -593,6 +593,21 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData("Test")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TabControlAccessibleObject_GetProperyValue_LegacyIAccessibleDefaultActionPropertyId_ReturnsExpected(string accessibleDefaultActionDescription)
+        {
+            using TabControl tabControl = new();
+            tabControl.AccessibleDefaultActionDescription = accessibleDefaultActionDescription;
+            TabControlAccessibleObject accessibleObject = Assert.IsType<TabControlAccessibleObject>(tabControl.AccessibilityObject);
+
+            Assert.Equal(!string.IsNullOrEmpty(accessibleDefaultActionDescription) ? accessibleDefaultActionDescription : null,
+                accessibleObject.GetPropertyValue(UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.False(tabControl.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
         [InlineData(true)]
         [InlineData(false)]
         public void TabControlAccessibleObject_RuntimeId_ReturnsExpected(bool createControl)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemAccessibleObjectTests.cs
@@ -166,6 +166,15 @@ namespace System.Windows.Forms.Tests
             Assert.True(actual >= UIA.ButtonControlTypeId && actual <= UIA.AppBarControlTypeId);
         }
 
+        [WinFormsFact]
+        public void ToolStripItemAccessibleObject_GetPropertyValue_ReturnsExpected()
+        {
+            using ToolStripItem toolStripItem = new SubToolStripItem();
+
+            Assert.False((bool)toolStripItem.AccessibilityObject.GetPropertyValue(UIA.IsExpandCollapsePatternAvailablePropertyId));
+            Assert.Null(toolStripItem.AccessibilityObject.GetPropertyValue(UIA.ValueValuePropertyId));
+        }
+
         private class SubToolStripItem : ToolStripItem
         {
             public SubToolStripItem() : base()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripLabel.ToolStripLabelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripLabel.ToolStripLabelAccessibleObjectTests.cs
@@ -69,10 +69,19 @@ namespace System.Windows.Forms.Tests
             using ToolStripLabel toolStripLabel = new ToolStripLabel();
             toolStripLabel.AccessibleRole = role;
 
-            object actual = toolStripLabel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
-            UiaCore.UIA expected = AccessibleRoleControlTypeMap.GetControlType(role);
+            Assert.Equal(AccessibleRoleControlTypeMap.GetControlType(role), toolStripLabel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+            Assert.Null(toolStripLabel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+        }
 
-            Assert.Equal(expected, actual);
+        [WinFormsTheory]
+        [InlineData(true, AccessibleStates.ReadOnly | AccessibleStates.Focusable)]
+        [InlineData(false, AccessibleStates.ReadOnly)]
+        public void ToolStripLabelAccessibleObject_GetPropertyValue_LegacyIAccessibleStatePropertyId_ReturnsExpected(bool isLink, AccessibleStates expectedState)
+        {
+            using ToolStripLabel toolStripLabel = new ToolStripLabel() { IsLink = isLink };
+            object actual = toolStripLabel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleStatePropertyId);
+
+            Assert.Equal(expectedState, actual);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripNumericUpDown.ToolStripNumericUpDownAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripNumericUpDown.ToolStripNumericUpDownAccessibleObjectTests.cs
@@ -27,9 +27,8 @@ namespace System.Windows.Forms.Tests
             using ToolStripNumericUpDown toolStripNumericUpDown = new ToolStripNumericUpDown();
             // AccessibleRole is not set = Default
 
-            object actual = toolStripNumericUpDown.Control.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
-
-            Assert.Equal(UiaCore.UIA.SpinnerControlTypeId, actual);
+            Assert.Equal(UiaCore.UIA.SpinnerControlTypeId, toolStripNumericUpDown.Control.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+            Assert.Null(toolStripNumericUpDown.Control.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TrackBar.TrackBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TrackBar.TrackBarAccessibleObjectTests.cs
@@ -320,6 +320,18 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData("Test Description")]
+        [InlineData(null)]
+        public void TrackBarAccessibilityObject_GetProperyValue_LegacyIAccessibleDefaultActionPropertyId_ReturnExpected(string defaultAction)
+        {
+            using TrackBar trackBar = new();
+            trackBar.AccessibleDefaultActionDescription = defaultAction;
+
+            Assert.Equal(defaultAction, trackBar.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId));
+            Assert.False(trackBar.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(typeof(TrackBarTestHelper), nameof(TrackBarTestHelper.TrackBarAccessibleObject_ButtonsAreDisplayed_TestData))]
         public void TrackBarAccessibilityObject_FragmentNavigate_Child_ReturnsExpected_ButtonsAreDisplayed(Orientation orientation, RightToLeft rightToLeft, bool rightToLeftLayout, int minimum, int maximum, int value)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObjectTests.cs
@@ -28,6 +28,23 @@ namespace System.Windows.Forms.Tests
             Assert.False(upDownBase.IsHandleCreated);
         }
 
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessibleRolePropertyId, AccessibleRole.PushButton)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessibleStatePropertyId, AccessibleStates.None)]
+        [InlineData((int)UiaCore.UIA.ValueValuePropertyId, null)]
+        public void NumericUpDownAccessibleObject_DirectionButtonAccessibleObject_GetPropertyValue_ReturnsExpected(int property, object expected)
+        {
+            using SubUpDownBase upDownBase = new();
+            using UpDownButtons upDownButtons = upDownBase.UpDownButtonsInternal;
+            UpDownButtonsAccessibleObject accessibleObject = new(upDownButtons);
+            // UpButton has 0 index
+            AccessibleObject upButton = accessibleObject.GetChild(index: 0);
+            object actual = upButton.GetPropertyValue((UiaCore.UIA)property);
+
+            Assert.Equal(expected, actual);
+            Assert.False(upDownBase.IsHandleCreated);
+        }
+
         private class SubUpDownBase : UpDownBase
         {
             protected override void UpdateEditText() => throw new NotImplementedException();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObjectTests.cs
@@ -143,6 +143,22 @@ namespace System.Windows.Forms.Tests
             Assert.False(upDownBase.IsHandleCreated);
         }
 
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessibleRolePropertyId, AccessibleRole.SpinButton)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessibleStatePropertyId, AccessibleStates.None)]
+        [InlineData((int)UiaCore.UIA.ValueValuePropertyId, null)]
+        public void UpDownButtonsAccessibleObject_GetPropertyValue_ReturnsExpected(int property, object expected)
+        {
+            using TrackBar trackBar = new();
+            using SubUpDownBase upDownBase = new();
+            UpDownButtons upDownButtons = upDownBase.UpDownButtonsInternal;
+            UpDownButtonsAccessibleObject accessibleObject = (UpDownButtonsAccessibleObject)upDownButtons.AccessibilityObject;
+            object actual = accessibleObject.GetPropertyValue((UiaCore.UIA)property);
+
+            Assert.Equal(expected, actual);
+            Assert.False(upDownBase.IsHandleCreated);
+        }
+
         private class SubUpDownBase : UpDownBase
         {
             protected override void UpdateEditText() => throw new NotImplementedException();


### PR DESCRIPTION
Fixes #6324
Continues PR #5745

## Proposed changes
- Moved the duplicate logic at the `GetPropertyValue` method to the base `AccessibleObject` class from its descendants
- Added unit tests for all cases of refactoring
- The base `AccessibleObject` class doesn't call the virtual `IsPatternSupported` method for the `IsInvokePatternAvailablePropertyId` case, but uses the large switch at the `IsInvokePatternAvailable` property instead, so we need to expand the cases of that switch for the new roles.

Also, I found out some questionable properties that I'd like to discuss:
1. The `false` value is always returned for all the `IsPasswordPropertyId` cases. Maybe we should move this property to the base class too?
2. There are 4 entries of the `FrameworkIdPropertyId` property, the value of `NativeMethods.WinFormFrameworkId` is returned in all the cases. Could it be moved to the base class too?
3. The `TopRowAccessibleObject` and `DataGridViewEditingPanelAccessibleObject` classes have the `HelpTextPropertyId` property case which returns `string.Empty`. Maybe we could delete it there, so the base class will return `Help ?? string.Empty`? By default `Help` is an empty string for both of these children classes.
4. The `AccessKeyPropertyId` property returns the `string.Empty` value for many cases at the `AccessibleObject` descendants. There was a PR #5705 where returning of the `KeyboardShortcut` was added to the `ControlAccessibleObject` class. What if we add the returning of the `KeyboardShortcut ?? string.Empty` to the base `AccessibleObject`? If its descendant has the KeyboardShortcut set, then it will be returned, that seems logical.
5. This one maybe is a bit tricky. For the `AutomationIdPropertyId` property 7 descendants of the `ControlAccessibleObject` class return the `Owner.Name` value, and 4 descendants of the `AccessibleObject` class return `AutomationId`. Maybe we should refactor them like that: base class will return `AutomationId` and `ControlAccessibleObject` will return `Owner.Name` at the overridden `GetPropertyValue` method?

## Customer Impact
- No

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manual (tested selected properties of some controls with the Inspect tool)
- Unit tests for all cases of refactoring
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
.NET SDK 7.0.0-alpha.1.21606.7
Microsoft Windows [Version 10.0.19043.1415]

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6429)