### PR TITLE
Implementing support UIA Provider for TreeView control

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -4,3 +4,4 @@
 ~override System.Windows.Forms.DateTimePicker.OnGotFocus(System.EventArgs e) -> void
 override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.DoDefaultAction() -> void
 ~override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.DefaultAction.get -> string
+~override System.Windows.Forms.TreeView.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
@@ -91,8 +91,10 @@ namespace System.Windows.Forms
                         => _owningTreeNode.IsExpanded
                             ? _owningTreeNode.LastNode?.AccessibilityObject
                             : null,
-                    UiaCore.NavigateDirection.NextSibling => _owningTreeNode.NextNode?.AccessibilityObject,
-                    UiaCore.NavigateDirection.PreviousSibling => _owningTreeNode.PrevNode?.AccessibilityObject,
+                    UiaCore.NavigateDirection.NextSibling
+                        => _owningTreeNode.NextNode?.AccessibilityObject,
+                    UiaCore.NavigateDirection.PreviousSibling
+                        => _owningTreeNode.PrevNode?.AccessibilityObject,
                     _ => base.FragmentNavigate(direction),
                 };
 
@@ -103,9 +105,12 @@ namespace System.Windows.Forms
                         => _owningTreeView.CheckBoxes
                             ? UiaCore.UIA.CheckBoxControlTypeId
                             : UiaCore.UIA.TreeItemControlTypeId,
-                    UiaCore.UIA.IsEnabledPropertyId => _owningTreeView.Enabled,
-                    UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
-                    UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,
+                    UiaCore.UIA.IsEnabledPropertyId
+                        => _owningTreeView.Enabled,
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId
+                        => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId
+                        => (State & AccessibleStates.Focused) == AccessibleStates.Focused,
                     _ => base.GetPropertyValue(propertyID)
                 };
 
@@ -126,11 +131,7 @@ namespace System.Windows.Forms
                     _ => base.IsPatternSupported(patternId),
                 };
 
-            public override string? Name
-            {
-                get => _owningTreeNode.Text;
-                set => _owningTreeNode.Text = value;
-            }
+            public override string? Name => _owningTreeNode.Text;
 
             public override AccessibleObject? Parent => _owningTreeNode.Parent?.AccessibilityObject;
 
@@ -170,6 +171,11 @@ namespace System.Windows.Forms
                     if (_owningTreeNode.IsSelected)
                     {
                         state |= AccessibleStates.Focused | AccessibleStates.Selected;
+                    }
+
+                    if (!_owningTreeView.Enabled)
+                    {
+                        state |= AccessibleStates.Unavailable;
                     }
 
                     return state;
@@ -224,6 +230,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
+                // We don't need to scroll if the item is visible.
                 if (_owningTreeNode.IsVisible)
                 {
                     return;
@@ -254,11 +261,7 @@ namespace System.Windows.Forms
 
             #region Value Pattern
 
-            public override string? Value
-            {
-                get => _owningTreeNode.Text;
-                set => _owningTreeNode.Text = value;
-            }
+            public override string? Value => _owningTreeNode.Text;
 
             #endregion
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
@@ -1,0 +1,266 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class TreeNode
+    {
+        internal class TreeNodeAccessibleObject : AccessibleObject
+        {
+            private readonly TreeNode _owningTreeNode;
+            private readonly TreeView _owningTreeView;
+
+            public TreeNodeAccessibleObject(TreeNode owningTreeNode, TreeView owningTreeView)
+            {
+                _owningTreeNode = owningTreeNode.OrThrowIfNull();
+                _owningTreeView = owningTreeView.OrThrowIfNull();
+            }
+
+            public override Rectangle Bounds
+            {
+                get
+                {
+                    if (!_owningTreeView.IsHandleCreated || !_owningTreeNode.IsVisible)
+                    {
+                        return Rectangle.Empty;
+                    }
+
+                    return _owningTreeNode.RectangleToScreen(_owningTreeNode.Bounds);
+                }
+            }
+
+            public override string DefaultAction
+            {
+                get
+                {
+                    if (_owningTreeView.CheckBoxes)
+                    {
+                        return _owningTreeNode.Checked
+                            ? SR.AccessibleActionUncheck
+                            : SR.AccessibleActionCheck;
+                    }
+
+                    UiaCore.ExpandCollapseState expandCollapseState = ExpandCollapseState;
+                    if (expandCollapseState == UiaCore.ExpandCollapseState.LeafNode)
+                    {
+                        return string.Empty;
+                    }
+
+                    return expandCollapseState == UiaCore.ExpandCollapseState.Expanded
+                        ? SR.AccessibleActionCollapse
+                        : SR.AccessibleActionExpand;
+                }
+            }
+
+            public override void DoDefaultAction()
+            {
+                if (_owningTreeView.CheckBoxes)
+                {
+                    Toggle();
+                }
+
+                if (_owningTreeNode.IsExpanded)
+                {
+                    Collapse();
+                }
+                else
+                {
+                    Expand();
+                }
+
+                return;
+            }
+
+            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
+                => _owningTreeView.AccessibilityObject;
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+                => direction switch
+                {
+                    UiaCore.NavigateDirection.Parent
+                        => Parent ?? _owningTreeView.AccessibilityObject,
+                    UiaCore.NavigateDirection.FirstChild
+                        => _owningTreeNode.IsExpanded
+                            ? _owningTreeNode.FirstNode?.AccessibilityObject
+                            : null,
+                    UiaCore.NavigateDirection.LastChild
+                        => _owningTreeNode.IsExpanded
+                            ? _owningTreeNode.LastNode?.AccessibilityObject
+                            : null,
+                    UiaCore.NavigateDirection.NextSibling => _owningTreeNode.NextNode?.AccessibilityObject,
+                    UiaCore.NavigateDirection.PreviousSibling => _owningTreeNode.PrevNode?.AccessibilityObject,
+                    _ => base.FragmentNavigate(direction),
+                };
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
+                {
+                    UiaCore.UIA.ControlTypePropertyId
+                        => _owningTreeView.CheckBoxes
+                            ? UiaCore.UIA.CheckBoxControlTypeId
+                            : UiaCore.UIA.TreeItemControlTypeId,
+                    UiaCore.UIA.IsEnabledPropertyId => _owningTreeView.Enabled,
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,
+                    _ => base.GetPropertyValue(propertyID)
+                };
+
+            public override AccessibleObject? HitTest(int x, int y)
+                => _owningTreeView.AccessibilityObject.HitTest(x, y);
+
+            internal int Index => _owningTreeView.Nodes.IndexOf(_owningTreeNode);
+
+            internal override bool IsPatternSupported(UiaCore.UIA patternId)
+                => patternId switch
+                {
+                    UiaCore.UIA.ExpandCollapsePatternId => true,
+                    UiaCore.UIA.LegacyIAccessiblePatternId => true,
+                    UiaCore.UIA.ScrollItemPatternId => true,
+                    UiaCore.UIA.SelectionItemPatternId => true,
+                    UiaCore.UIA.TogglePatternId when _owningTreeView.CheckBoxes => true,
+                    UiaCore.UIA.ValuePatternId when _owningTreeView.LabelEdit => true,
+                    _ => base.IsPatternSupported(patternId),
+                };
+
+            public override string? Name
+            {
+                get => _owningTreeNode.Text;
+                set => _owningTreeNode.Text = value;
+            }
+
+            public override AccessibleObject? Parent => _owningTreeNode.Parent?.AccessibilityObject;
+
+            public override AccessibleRole Role
+                => _owningTreeView.CheckBoxes
+                    ? AccessibleRole.CheckButton
+                    : AccessibleRole.OutlineItem;
+
+            internal override int[] RuntimeId
+                => new int[]
+                {
+                    RuntimeIDFirstItem,
+                    PARAM.ToInt(_owningTreeView.InternalHandle),
+                    _owningTreeNode.GetHashCode()
+                };
+
+            public override AccessibleStates State
+            {
+                get
+                {
+                    AccessibleStates state = AccessibleStates.Selectable | AccessibleStates.Focusable;
+
+                    if (!_owningTreeNode.IsVisible)
+                    {
+                        state |= AccessibleStates.Invisible | AccessibleStates.Offscreen;
+                    }
+
+                    if (ExpandCollapseState == UiaCore.ExpandCollapseState.Expanded)
+                    {
+                        state |= AccessibleStates.Expanded;
+                    }
+                    else if (ExpandCollapseState == UiaCore.ExpandCollapseState.Collapsed)
+                    {
+                        state |= AccessibleStates.Collapsed;
+                    }
+
+                    if (_owningTreeNode.IsSelected)
+                    {
+                        state |= AccessibleStates.Focused | AccessibleStates.Selected;
+                    }
+
+                    return state;
+                }
+            }
+
+            #region Expand-Collapse Pattern
+
+            internal override void Expand()
+            {
+                if (_owningTreeNode.Nodes.Count == 0)
+                {
+                    return;
+                }
+
+                _owningTreeNode.Expand();
+            }
+
+            internal override void Collapse()
+            {
+                if (_owningTreeNode.Nodes.Count == 0)
+                {
+                    return;
+                }
+
+                _owningTreeNode.Collapse();
+            }
+
+            internal override UiaCore.ExpandCollapseState ExpandCollapseState
+            {
+                get
+                {
+                    if (_owningTreeNode.Nodes.Count == 0)
+                    {
+                        return UiaCore.ExpandCollapseState.LeafNode;
+                    }
+
+                    return _owningTreeNode.IsExpanded
+                        ? UiaCore.ExpandCollapseState.Expanded
+                        : UiaCore.ExpandCollapseState.Collapsed;
+                }
+            }
+
+            #endregion
+
+            #region Scroll Item Pattern
+
+            internal override void ScrollIntoView()
+            {
+                if (!_owningTreeView.IsHandleCreated || !_owningTreeView.Enabled)
+                {
+                    return;
+                }
+
+                if (_owningTreeNode.IsVisible)
+                {
+                    return;
+                }
+
+                _owningTreeView.TopNode = _owningTreeNode;
+            }
+
+            #endregion
+
+            #region Selection Item Pattern
+
+            internal override bool IsItemSelected => _owningTreeNode.IsSelected;
+
+            internal override UiaCore.IRawElementProviderSimple? ItemSelectionContainer
+                => _owningTreeView.AccessibilityObject;
+
+            #endregion
+
+            #region Toggle Pattern
+
+            internal override void Toggle() => _owningTreeNode.Checked = !_owningTreeNode.Checked;
+
+            internal override UiaCore.ToggleState ToggleState
+                => _owningTreeNode.Checked ? UiaCore.ToggleState.On : UiaCore.ToggleState.Off;
+
+            #endregion
+
+            #region Value Pattern
+
+            public override string? Value
+            {
+                get => _owningTreeNode.Text;
+                set => _owningTreeNode.Text = value;
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -58,6 +58,8 @@ namespace System.Windows.Forms
         private ContextMenuStrip _contextMenuStrip;
         internal bool nodesCleared;
 
+        private TreeNodeAccessibleObject _accessibleObject;
+
         internal TreeNodeImageIndexer ImageIndexer
         {
             get
@@ -1181,6 +1183,9 @@ namespace System.Windows.Forms
                 return treeView;
             }
         }
+
+        internal TreeNodeAccessibleObject AccessibilityObject
+            => _accessibleObject ??= new TreeNodeAccessibleObject(this, TreeView);
 
         /// <summary>
         ///  Adds a new child node at the appropriate sorted position

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.TreeViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.TreeViewAccessibleObject.cs
@@ -1,0 +1,127 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using static Interop;
+using static Interop.UiaCore;
+using static System.Windows.Forms.TreeNode;
+
+namespace System.Windows.Forms
+{
+    public partial class TreeView
+    {
+        internal class TreeViewAccessibleObject : ControlAccessibleObject
+        {
+            private readonly TreeView _owningTreeView;
+
+            public TreeViewAccessibleObject(TreeView owningTreeView) : base(owningTreeView)
+            {
+                _owningTreeView = owningTreeView;
+            }
+
+            internal override IRawElementProviderFragment? ElementProviderFromPoint(double x, double y)
+                => HitTest((int)x, (int)y) ?? base.ElementProviderFromPoint(x, y);
+
+            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot => this;
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+                => direction switch
+                {
+                    UiaCore.NavigateDirection.FirstChild => GetChild(0),
+                    UiaCore.NavigateDirection.LastChild => GetChild(GetChildCount() - 1),
+                    _ => base.FragmentNavigate(direction),
+                };
+
+            public override AccessibleObject? GetChild(int index)
+                => index >= 0 && index < GetChildCount()
+                    ? _owningTreeView.Nodes[index].AccessibilityObject
+                    : null;
+
+            public override int GetChildCount() => _owningTreeView.Nodes.Count;
+
+            internal override int GetChildIndex(AccessibleObject? child)
+                => child is TreeNodeAccessibleObject node ? node.Index : -1;
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
+                {
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TreeControlTypeId,
+                    UiaCore.UIA.IsEnabledPropertyId => _owningTreeView.Enabled,
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTreeView.Nodes.Count == 0,
+                    _ => base.GetPropertyValue(propertyID)
+                };
+
+            public override AccessibleObject? HitTest(int x, int y)
+            {
+                if (!_owningTreeView.IsHandleCreated)
+                {
+                    return null;
+                }
+
+                Point p = _owningTreeView.PointToClient(new Point(x, y));
+                TreeNode node = _owningTreeView.GetNodeAt(p);
+
+                if (node is not null)
+                {
+                    return node.AccessibilityObject;
+                }
+
+                if (Bounds.Contains(x, y))
+                {
+                    return this;
+                }
+
+                return null;
+            }
+
+            internal override int[] RuntimeId
+                => new int[]
+                {
+                    RuntimeIDFirstItem,
+                    PARAM.ToInt(_owningTreeView.InternalHandle),
+                    _owningTreeView.GetHashCode()
+                };
+
+            public override AccessibleStates State
+            {
+                get
+                {
+                    AccessibleStates state = AccessibleStates.Focusable;
+
+                    if (_owningTreeView.Focused)
+                    {
+                        state |= AccessibleStates.Focused;
+                    }
+
+                    return state;
+                }
+            }
+
+            internal override bool IsPatternSupported(UiaCore.UIA patternId)
+                => patternId switch
+                {
+                    UiaCore.UIA.LegacyIAccessiblePatternId => true,
+                    UiaCore.UIA.SelectionPatternId => true,
+                    _ => base.IsPatternSupported(patternId),
+                };
+
+            #region Selection Pattern
+
+            internal override bool IsSelectionRequired => true;
+
+            internal override UiaCore.IRawElementProviderSimple[]? GetSelection()
+            {
+                if (_owningTreeView.IsHandleCreated && GetSelected() is UiaCore.IRawElementProviderSimple selected)
+                {
+                    return new[] {  selected };
+                }
+
+                return Array.Empty<UiaCore.IRawElementProviderSimple>();
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.TreeViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.TreeViewAccessibleObject.cs
@@ -49,7 +49,7 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TreeControlTypeId,
                     UiaCore.UIA.IsEnabledPropertyId => _owningTreeView.Enabled,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
-                    UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTreeView.Nodes.Count == 0,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTreeView.Enabled && _owningTreeView.Nodes.Count == 0,
                     _ => base.GetPropertyValue(propertyID)
                 };
 
@@ -95,6 +95,11 @@ namespace System.Windows.Forms
                         state |= AccessibleStates.Focused;
                     }
 
+                    if (!_owningTreeView.Enabled)
+                    {
+                        state |= AccessibleStates.Unavailable;
+                    }
+
                     return state;
                 }
             }
@@ -109,13 +114,13 @@ namespace System.Windows.Forms
 
             #region Selection Pattern
 
-            internal override bool IsSelectionRequired => true;
+            internal override bool IsSelectionRequired => _owningTreeView.Nodes.Count != 0;
 
             internal override UiaCore.IRawElementProviderSimple[]? GetSelection()
             {
                 if (_owningTreeView.IsHandleCreated && GetSelected() is UiaCore.IRawElementProviderSimple selected)
                 {
-                    return new[] {  selected };
+                    return new[] { selected };
                 }
 
                 return Array.Empty<UiaCore.IRawElementProviderSimple>();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
@@ -225,7 +225,7 @@ namespace System.Windows.Forms.Tests
             using TreeView control = new() { CheckBoxes = true };
             TreeNode node = new(control);
 
-            var expected = UiaCore.UIA.CheckBoxControlTypeId;
+            UiaCore.UIA expected = UiaCore.UIA.CheckBoxControlTypeId;
 
             Assert.Equal(expected, node.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
             Assert.False(control.IsHandleCreated);
@@ -237,7 +237,7 @@ namespace System.Windows.Forms.Tests
             using TreeView control = new() { CheckBoxes = false };
             TreeNode node = new(control);
 
-            var expected = UiaCore.UIA.TreeItemControlTypeId;
+            UiaCore.UIA expected = UiaCore.UIA.TreeItemControlTypeId;
 
             Assert.Equal(expected, node.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
             Assert.False(control.IsHandleCreated);
@@ -469,7 +469,7 @@ namespace System.Windows.Forms.Tests
             using TreeView control = new() { CheckBoxes = true };
             TreeNode node = new(control) { Checked = isChecked };
 
-            var expected = isChecked ? UiaCore.ToggleState.On : UiaCore.ToggleState.Off;
+            UiaCore.ToggleState expected = isChecked ? UiaCore.ToggleState.On : UiaCore.ToggleState.Off;
 
             Assert.Equal(expected, node.AccessibilityObject.ToggleState);
             Assert.False(control.IsHandleCreated);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
@@ -1,0 +1,489 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms.TestUtilities;
+using Xunit;
+using static System.Windows.Forms.TreeNode;
+using static Interop;
+
+namespace System.Windows.Forms.Tests
+{
+    public class TreeNodeAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Ctor_Default()
+        {
+            using TreeView control = new();
+            TreeNode node = new(control);
+
+            Assert.NotNull(node.AccessibilityObject);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Ctor_ThrowsException_IfOwningNodeIsNull()
+        {
+            using TreeView control = new();
+
+            Assert.Throws<ArgumentNullException>(() => new TreeNodeAccessibleObject(null, control));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Ctor_ThrowsException_IfOwningTreeIsNull()
+        {
+            TreeNode node = new();
+
+            Assert.Throws<ArgumentNullException>(() => new TreeNodeAccessibleObject(node, null));
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_DefaultAction_IsEmptyString_IfNodeIsLeaf()
+        {
+            using TreeView control = new() { CheckBoxes = false };
+            TreeNode node = new(control);
+
+            Assert.Empty(node.AccessibilityObject.DefaultAction);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void TreeNodeAccessibleObject_DefaultAction_ReturnsExpected_IfNodeIsParent(bool isExpanded)
+        {
+            using TreeView control = new() { CheckBoxes = false };
+            TreeNode node = new TreeNode("Root node", new TreeNode[] { new() });
+            control.Nodes.Add(node);
+            if (isExpanded)
+            {
+                node.Expand();
+            }
+
+            string expected = isExpanded ? SR.AccessibleActionCollapse : SR.AccessibleActionExpand;
+
+            Assert.Equal(expected, node.AccessibilityObject.DefaultAction);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void TreeNodeAccessibleObject_DefaultAction_ReturnsExpected_IfNodesAreCheckBoxes(bool isChecked)
+        {
+            using TreeView control = new() { CheckBoxes = true };
+            TreeNode node = new(control) { Checked = isChecked };
+
+            string expected = isChecked ? SR.AccessibleActionUncheck : SR.AccessibleActionCheck;
+
+            Assert.Equal(expected, node.AccessibilityObject.DefaultAction);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void TreeNodeAccessibleObject_DoDefaultAction_ToggleNodeCheckBox_IfNodesAreCheckBoxes(bool isChecked)
+        {
+            using TreeView control = new() { CheckBoxes = true };
+            TreeNode node = new(control) { Checked = isChecked };
+
+            Assert.Equal(isChecked, node.Checked);
+
+            node.AccessibilityObject.DoDefaultAction();
+
+            Assert.Equal(!isChecked, node.Checked);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void TreeNodeAccessibleObject_DoDefaultAction_ExpandOrCollapse_IfNodeIsNotLeaf(bool isExpanded)
+        {
+            using TreeView control = new();
+            TreeNode node = new TreeNode("Root node", new TreeNode[] { new() });
+            control.Nodes.Add(node);
+            if (isExpanded)
+            {
+                node.Expand();
+            }
+
+            Assert.Equal(isExpanded, node.IsExpanded);
+
+            node.AccessibilityObject.DoDefaultAction();
+
+            Assert.Equal(!isExpanded, node.IsExpanded);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_FragmentRoot_ReturnsTree()
+        {
+            using TreeView control = new();
+            TreeNode node = new(control);
+
+            Assert.Equal(control.AccessibilityObject, node.AccessibilityObject.FragmentRoot);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_FragmentNavigate_Parent_ReturnsTree()
+        {
+            using TreeView control = new();
+            TreeNode node = new(control);
+
+            var actual = (AccessibleObject)node.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent);
+
+            Assert.Equal(control.AccessibilityObject, actual);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_FragmentNavigate_Parent_ReturnsParent()
+        {
+            using TreeView control = new();
+            TreeNode node = new();
+            control.Nodes.Add(new TreeNode("Root node", new[] { node }));
+
+            var actual = (AccessibleObject)node.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent);
+
+            Assert.Equal(node.Parent.AccessibilityObject, actual);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void TreeNodeAccessibleObject_FragmentNavigate_FirstChild_ReturnsExpected(bool isExpanded)
+        {
+            using TreeView control = new();
+            TreeNode node = new TreeNode("Root node", new TreeNode[] { new(), new(), new() });
+            control.Nodes.Add(node);
+            if (isExpanded)
+            {
+                node.Expand();
+            }
+
+            // If node is collapsed, child is not visible, so returns null instead of child ao.
+            AccessibleObject expected = isExpanded ? node.FirstNode?.AccessibilityObject : null;
+
+            Assert.Equal(expected, node.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void TreeNodeAccessibleObject_FragmentNavigate_LastChild_ReturnsExpected(bool isExpanded)
+        {
+            using TreeView control = new();
+            TreeNode node = new TreeNode("Root node", new TreeNode[] { new(), new(), new() });
+            control.Nodes.Add(node);
+            if (isExpanded)
+            {
+                node.Expand();
+            }
+
+            // If node is collapsed, child is not visible, so returns null instead of child ao.
+            AccessibleObject expected = isExpanded ? node.LastNode?.AccessibilityObject : null;
+
+            Assert.Equal(expected, node.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected()
+        {
+            using TreeView control = new();
+            control.Nodes.AddRange(new TreeNode[] { new(), new(), new() });
+
+            AccessibleObject accessibleObject1 = control.Nodes[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Nodes[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Nodes[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        {
+            using TreeView control = new();
+            control.Nodes.AddRange(new TreeNode[] { new(), new(), new() });
+
+            AccessibleObject accessibleObject1 = control.Nodes[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Nodes[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Nodes[2].AccessibilityObject;
+
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_GetPropertyValue_ControlType_IsCheckBox_IfNodesAreCheckBoxes()
+        {
+            using TreeView control = new() { CheckBoxes = true };
+            TreeNode node = new(control);
+
+            var expected = UiaCore.UIA.CheckBoxControlTypeId;
+
+            Assert.Equal(expected, node.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_GetPropertyValue_ControlType_IsTreeItem_IfNodesAreNotCheckBoxes()
+        {
+            using TreeView control = new() { CheckBoxes = false };
+            TreeNode node = new(control);
+
+            var expected = UiaCore.UIA.TreeItemControlTypeId;
+
+            Assert.Equal(expected, node.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        [InlineData((int)UiaCore.UIA.ScrollItemPatternId)]
+        [InlineData((int)UiaCore.UIA.SelectionItemPatternId)]
+        public void TreeNodeAccessibleObject_IsPatternSupported_IfCommonNodes(int patternId)
+        {
+            using TreeView control = new();
+            TreeNode node = new(control);
+
+            Assert.True(node.AccessibilityObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        [InlineData((int)UiaCore.UIA.ScrollItemPatternId)]
+        [InlineData((int)UiaCore.UIA.SelectionItemPatternId)]
+        [InlineData((int)UiaCore.UIA.TogglePatternId)]
+        public void TreeNodeAccessibleObject_IsPatternSupported_IfNodesAreCheckBoxes(int patternId)
+        {
+            using TreeView control = new() { CheckBoxes = true };
+            TreeNode node = new(control);
+
+            Assert.True(node.AccessibilityObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        [InlineData((int)UiaCore.UIA.ScrollItemPatternId)]
+        [InlineData((int)UiaCore.UIA.SelectionItemPatternId)]
+        [InlineData((int)UiaCore.UIA.ValuePatternId)]
+        public void TreeNodeAccessibleObject_IsPatternSupported_IfNodesAreEditable(int patternId)
+        {
+            using TreeView control = new() { LabelEdit = true };
+            TreeNode node = new(control);
+
+            Assert.True(node.AccessibilityObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Index_ReturnsExpected()
+        {
+            using TreeView control = new();
+            control.Nodes.AddRange(new TreeNode[] { new(), new(), new() });
+
+            TreeNodeAccessibleObject accessibleObject1 = control.Nodes[0].AccessibilityObject;
+            TreeNodeAccessibleObject accessibleObject2 = control.Nodes[1].AccessibilityObject;
+            TreeNodeAccessibleObject accessibleObject3 = control.Nodes[2].AccessibilityObject;
+
+            Assert.Equal(0, accessibleObject1.Index);
+            Assert.Equal(1, accessibleObject2.Index);
+            Assert.Equal(2, accessibleObject3.Index);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Name_EqualsText()
+        {
+            using TreeView control = new();
+            string testText = "This is test string for Text property of TreeNode.";
+            TreeNode node = new(control) { Text = testText };
+
+            Assert.Equal(testText, node.AccessibilityObject.Name);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Parent_ReturnsNull_IfNodeHasNoParent()
+        {
+            using TreeView control = new();
+            TreeNode node = new(control);
+
+            Assert.Null(node.AccessibilityObject.Parent);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Parent_ReturnsParent()
+        {
+            using TreeView control = new();
+            TreeNode node = new();
+
+            control.Nodes.Add(new TreeNode("Root node", new[] { node }));
+
+            Assert.Equal(node.Parent.AccessibilityObject, node.AccessibilityObject.Parent);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Role_IsOutlineItem()
+        {
+            using TreeView control = new();
+            TreeNode node = new(control);
+
+            Assert.Equal(AccessibleRole.OutlineItem, node.AccessibilityObject.Role);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Role_IsCheckButton_IfNodesAreCheckBoxes()
+        {
+            using TreeView control = new() { CheckBoxes = true };
+            TreeNode node = new(control);
+
+            Assert.Equal(AccessibleRole.CheckButton, node.AccessibilityObject.Role);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Expand_WorksExpected_IfNodeIsCollapsed()
+        {
+            using TreeView control = new();
+            TreeNode node = new("Root node", new TreeNode[] { new() });
+
+            control.Nodes.Add(node);
+
+            Assert.False(node.IsExpanded);
+
+            node.AccessibilityObject.Expand();
+
+            Assert.True(node.IsExpanded);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Expand_DoesNothing_IfNodeHasNoChild()
+        {
+            using TreeView control = new();
+            TreeNode node = new();
+
+            control.Nodes.Add(node);
+
+            Assert.False(node.IsExpanded);
+
+            node.AccessibilityObject.Expand();
+
+            Assert.False(node.IsExpanded);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Collapse_WorksExpected_IfNodeIsExpanded()
+        {
+            using TreeView control = new();
+            TreeNode node = new("Root node", new TreeNode[] { new() });
+
+            control.Nodes.Add(node);
+
+            node.Expand();
+            Assert.True(node.IsExpanded);
+
+            node.AccessibilityObject.Collapse();
+
+            Assert.False(node.IsExpanded);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_ExpandCollapseState_ReturnsLeafNode_IfNodeHasNoChild()
+        {
+            using TreeView control = new();
+            TreeNode node = new(control);
+
+            Assert.Equal(UiaCore.ExpandCollapseState.LeafNode, node.AccessibilityObject.ExpandCollapseState);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void TreeNodeAccessibleObject_ExpandCollapseState_ReturnsExpected(bool isExpanded)
+        {
+            using TreeView control = new();
+            TreeNode node = new("Root node", new TreeNode[] { new() });
+
+            control.Nodes.Add(node);
+
+            if (isExpanded)
+            {
+                node.Expand();
+            }
+
+            UiaCore.ExpandCollapseState expected = isExpanded
+                    ? UiaCore.ExpandCollapseState.Expanded
+                    : UiaCore.ExpandCollapseState.Collapsed;
+
+            Assert.Equal(expected, node.AccessibilityObject.ExpandCollapseState);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_ItemSelectionContainer_ReturnsExpected()
+        {
+            using TreeView control = new();
+            TreeNode node = new(control);
+
+            Assert.Equal(control.AccessibilityObject, node.AccessibilityObject.ItemSelectionContainer);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void TreeNodeAccessibleObject_Toggle_WorksExpected(bool isChecked)
+        {
+            using TreeView control = new() { CheckBoxes = true };
+            TreeNode node = new(control) { Checked = isChecked };
+
+            Assert.Equal(isChecked, node.Checked);
+
+            node.AccessibilityObject.Toggle();
+
+            Assert.Equal(!isChecked, node.Checked);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void TreeNodeAccessibleObject_ToggleState_WorksExpected(bool isChecked)
+        {
+            using TreeView control = new() { CheckBoxes = true };
+            TreeNode node = new(control) { Checked = isChecked };
+
+            var expected = isChecked ? UiaCore.ToggleState.On : UiaCore.ToggleState.Off;
+
+            Assert.Equal(expected, node.AccessibilityObject.ToggleState);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_Value_EqualsText()
+        {
+            using TreeView control = new() { LabelEdit = true };
+            string testText = "This is test string for Text property of TreeNode.";
+            TreeNode node = new(control) { Text = testText };
+
+            Assert.Equal(testText, node.AccessibilityObject.Value);
+            Assert.False(control.IsHandleCreated);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeView.TreeViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeView.TreeViewAccessibleObjectTests.cs
@@ -2,47 +2,249 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
+using System.Windows.Forms.TestUtilities;
 using Xunit;
+using static System.Windows.Forms.TreeView;
 using static Interop;
 
 namespace System.Windows.Forms.Tests
 {
-    public class TreeViewAccessibilityObjectTests : IClassFixture<ThreadExceptionFixture>
+    public class TreeViewAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
-        public void TreeViewAccessibilityObject_Ctor_Default()
+        public void TreeViewAccessibleObject_Ctor_Default()
         {
-            using TreeView treeView = new TreeView();
-            treeView.CreateControl();
+            using TreeView control = new();
+            control.CreateControl();
 
-            Assert.NotNull(treeView.AccessibilityObject);
-            Assert.True(treeView.IsHandleCreated);
+            Assert.NotNull(control.AccessibilityObject);
+            Assert.True(control.IsHandleCreated);
         }
 
         [WinFormsFact]
-        public void TreeViewAccessibilityObject_ControlType_IsTree_IfAccessibleRoleIsDefault()
+        public void TreeViewAccessibleObject_Ctor_ThrowsException_IfOwnerIsNull()
         {
-            using TreeView treeView = new TreeView();
-            treeView.CreateControl();
-            // AccessibleRole is not set = Default
+            Assert.Throws<ArgumentNullException>(() => new TreeViewAccessibleObject(null));
+        }
 
-            object actual = treeView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_ControlType_IsTree_IfAccessibleRoleIsDefault()
+        {
+            using TreeView control = new();
+
+            // AccessibleRole is not set = Default
+            object actual = control.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
 
             Assert.Equal(UiaCore.UIA.TreeControlTypeId, actual);
-            Assert.True(treeView.IsHandleCreated);
+            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsFact]
-        public void TreeViewAccessibilityObject_Role_IsOutline_ByDefault()
+        public void TreeViewAccessibleObject_Role_IsOutline_ByDefault()
         {
-            using TreeView treeView = new TreeView();
-            treeView.CreateControl();
-            // AccessibleRole is not set = Default
+            using TreeView control = new();
+            control.CreateControl();
 
-            AccessibleRole actual = treeView.AccessibilityObject.Role;
+            // AccessibleRole is not set = Default
+            AccessibleRole actual = control.AccessibilityObject.Role;
 
             Assert.Equal(AccessibleRole.Outline, actual);
-            Assert.True(treeView.IsHandleCreated);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_FragmentRoot_ReturnsExpected()
+        {
+            using TreeView control = new();
+
+            AccessibleObject accessibleObject = control.AccessibilityObject;
+
+            Assert.Equal(accessibleObject, accessibleObject.FragmentRoot);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_FragmentNavigate_FirstChild_ReturnsExpected()
+        {
+            using TreeView control = new();
+            control.Nodes.AddRange(new TreeNode[] { new("Node 1"), new("Node 2"), new("Node 3") });
+
+            AccessibleObject accessibleObject = control.AccessibilityObject;
+            AccessibleObject expected = control.Nodes[0].AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_FragmentNavigate_LastChild_ReturnsExpected()
+        {
+            using TreeView control = new();
+            control.Nodes.AddRange(new TreeNode[] { new("Node 1"), new("Node 2"), new("Node 3") });
+
+            AccessibleObject accessibleObject = control.AccessibilityObject;
+            AccessibleObject expected = control.Nodes[^1].AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(10)]
+        public void TreeViewAccessibleObject_FragmentNavigate_GetChild_ReturnsExpected(int index)
+        {
+            using TreeView control = new();
+            control.Nodes.AddRange(new TreeNode[] { new("Node 1"), new("Node 2"), new("Node 3") });
+
+            AccessibleObject expected = index >= 0 && index < control.Nodes.Count
+                ? control.Nodes[index].AccessibilityObject
+                : null;
+
+            Assert.Equal(expected, control.AccessibilityObject.GetChild(index));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_FragmentNavigate_GetChildCount_ReturnsExpected()
+        {
+            using TreeView control = new();
+            control.Nodes.AddRange(new TreeNode[] { new("Node 1"), new("Node 2"), new("Node 3") });
+
+            int expected = 3;
+
+            Assert.Equal(expected, control.AccessibilityObject.GetChildCount());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void TreeViewAccessibleObject_GetPropertyValue_IsEnabled_ReturnsExpected(bool isEnabled)
+        {
+            using TreeView control = new() { Enabled = isEnabled };
+
+            Assert.Equal(isEnabled, control.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsEnabledPropertyId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_ReturnsTrue_IfNoItems()
+        {
+            using TreeView control = new();
+
+            Assert.True((bool)control.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_ReturnsFalse_IfContainsItems()
+        {
+            using TreeView control = new();
+            control.Nodes.Add("Node 1");
+
+            Assert.False((bool)control.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        [InlineData((int)UiaCore.UIA.SelectionPatternId)]
+        public void TreeViewAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
+        {
+            using TreeView control = new();
+
+            Assert.True(control.AccessibilityObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_IsSelectionRequired_ReturnsExpected()
+        {
+            using TreeView control = new();
+
+            Assert.True(control.AccessibilityObject.IsSelectionRequired);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_GetSelection_ReturnsEmptyArray_IfControlIsNotCreated()
+        {
+            using TreeView control = new();
+
+            Assert.Empty(control.AccessibilityObject.GetSelection());
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_GetSelection_ReturnsEmptyArray_IfNoSelectedNodes()
+        {
+            using TreeView control = new();
+            control.CreateControl();
+
+            Assert.Empty(control.AccessibilityObject.GetSelection());
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_GetSelection_ReturnsExpected()
+        {
+            using TreeView control = new();
+            control.CreateControl();
+            control.Nodes.AddRange(new TreeNode[] { new("Node 1"), new("Node 2"), new("Node 3") });
+            control.SelectedNode = control.Nodes[1];
+
+            UiaCore.IRawElementProviderSimple[] expected = new[] { control.Nodes[1].AccessibilityObject };
+
+            Assert.Equal(expected, control.AccessibilityObject.GetSelection());
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_HitTest_ReturnsNull_IfControlDoesNotCreated()
+        {
+            using TreeView control = new() { Size = new Size(300, 100) };
+            TreeNode node = new("First node.");
+            control.Nodes.Add(node);
+
+            AccessibleObject accessibleObject = control.AccessibilityObject;
+            Point point = accessibleObject.Bounds.Location;
+
+            Assert.Null(accessibleObject.HitTest(point.X, point.Y));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_HitTest_ReturnsTree()
+        {
+            using TreeView control = new() { Size = new Size(300, 100) };
+            TreeNode node = new("First node.");
+            control.Nodes.Add(node);
+            control.CreateControl();
+
+            AccessibleObject accessibleObject = control.AccessibilityObject;
+            Point point = new Point(accessibleObject.Bounds.X, accessibleObject.Bounds.Bottom - 1);
+
+            Assert.Equal(accessibleObject, accessibleObject.HitTest(point.X, point.Y));
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_HitTest_ReturnsNode()
+        {
+            using TreeView control = new() { Size = new Size(300, 100) };
+            TreeNode node = new("First node.");
+            control.Nodes.Add(node);
+            control.CreateControl();
+
+            Point point = node.AccessibilityObject.Bounds.Location;
+
+            Assert.Equal(node.AccessibilityObject, control.AccessibilityObject.HitTest(point.X, point.Y));
+            Assert.True(control.IsHandleCreated);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeView.TreeViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeView.TreeViewAccessibleObjectTests.cs
@@ -137,7 +137,18 @@ namespace System.Windows.Forms.Tests
         {
             using TreeView control = new();
 
+            Assert.True(control.Enabled);
             Assert.True((bool)control.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_ReturnsFalse_IfIsDisabled()
+        {
+            using TreeView control = new() { Enabled = false };
+
+            Assert.False(control.Enabled);
+            Assert.False((bool)control.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
             Assert.False(control.IsHandleCreated);
         }
 
@@ -147,6 +158,7 @@ namespace System.Windows.Forms.Tests
             using TreeView control = new();
             control.Nodes.Add("Node 1");
 
+            Assert.True(control.Enabled);
             Assert.False((bool)control.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
             Assert.False(control.IsHandleCreated);
         }
@@ -163,11 +175,21 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void TreeViewAccessibleObject_IsSelectionRequired_ReturnsExpected()
+        public void TreeViewAccessibleObject_IsSelectionRequired_ReturnsTrue_IfControlHasItem()
+        {
+            using TreeView control = new();
+            control.Nodes.Add("Item1");
+
+            Assert.True(control.AccessibilityObject.IsSelectionRequired);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeViewAccessibleObject_IsSelectionRequired_ReturnsFalse_IfControlHasNoItem()
         {
             using TreeView control = new();
 
-            Assert.True(control.AccessibilityObject.IsSelectionRequired);
+            Assert.False(control.AccessibilityObject.IsSelectionRequired);
             Assert.False(control.IsHandleCreated);
         }
 


### PR DESCRIPTION
Implemented accessible objects for TreeView and TreeNode. Added needed automation events and unit tests.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Implements part of #3421


## Proposed changes

- Switched on `SupportsUiaProviders` property of `TreeView` class.
- Implemented accessible objects for `TreeView` and `TreeNode` classes.
- Added needed automation events and unit tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improving development experience for `TreeView` control accessibility.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Inspect

#### `TreeView` before and after

![treeInspect](https://user-images.githubusercontent.com/58004471/147510526-ea1fd609-cb83-48c0-9a62-343d669e8d0b.png)

#### Default `TreeNode` before and after

![nodeInspect](https://user-images.githubusercontent.com/58004471/147510598-3d6c6aa4-d689-4096-8b42-76aaeadf2d60.png)

#### Expanded `TreeNode` before and after

![nodeExpandedInspect](https://user-images.githubusercontent.com/58004471/147510641-ed1a6b4e-2f89-49c4-a1b0-d4328163d19a.png)

#### Leaf `TreeNode` before and after

![nodeLeafInspect](https://user-images.githubusercontent.com/58004471/147510740-5338f9df-acaf-4a61-92c8-639661f2b5ba.png)

#### CheckBox `TreeNode` before and after

![NodeIsCheckBox](https://user-images.githubusercontent.com/58004471/147510784-e73d3152-cadc-404c-a436-1ab137356a67.png)

#### Invisible `TreeNode` before and after

![invisibleNode](https://user-images.githubusercontent.com/58004471/147510820-2732e09f-fec2-402e-8e5d-5c8f99c6a2ee.png)

#### Editable `TreeNode` before and after

![nodeEditable](https://user-images.githubusercontent.com/58004471/147510856-16c4a0eb-291d-4bfb-a2ae-c3b8650543a3.png)

### Accessibility Insights

There is no specific errors. You can see errors on next image, but they are not about accessibility changes were created in this PR.

![AI](https://user-images.githubusercontent.com/58004471/147511075-7519afab-29c3-4714-9b03-3533fe8da74c.png)

### Narrator

#### Expand and collapse default node before and after

![NBExpandCollapse](https://user-images.githubusercontent.com/58004471/147511138-ec17d1dd-9f19-42a3-b44e-900dd1a8e038.png)

#### Check and uncheck node before and after

![NBCheckedBox](https://user-images.githubusercontent.com/58004471/147511169-b1ca4ecd-545f-443c-8dff-129982fea28f.png)

#### Edit default node before and after

![NBEdit](https://user-images.githubusercontent.com/58004471/147511183-ac62934d-29cb-4ab5-b32c-6f91e78e3f05.png)

### `ScrollIntoView` method comparison

#### `ScrollIntoView` method before

![ScrollIntoViewBefore](https://user-images.githubusercontent.com/58004471/147511275-2caad097-acb4-46f0-8aa2-4b115a934890.gif)

#### `ScrollIntoView` method after

![ScrollIntoViewAfter](https://user-images.githubusercontent.com/58004471/147511279-557713bb-3539-4801-b81a-dc80e1215ed3.gif)

This realization sets calling node as `TopNode`  of `TreeView` if the node is invisible. Looks like it works the same. 

### Focus on `TreeView` issue

By default, when we focus on a `TreeView` control, Inspect and Narrator highlight the `SelectedNode` of
 this control. As I know it takes raise an events for a selected node accessible object to notify it was focused. But calling AccessibilityObject forces creation the object. It takes accessible object of the tree, so forces creating the object if it doesn't exist yet.
 To avoid force creation if this is not needed should use check `IsAccessibilityObjectCreated`. But I found next problem when I try to add this check. Highlight after focus doesn't work for the first time if the control has first `TabIndex` on form.  You can see this issue behavior below.
 
 #### Focus on the control with check `IsAccessibilityObjectCreated`
 
It works incorrect.
 

![BrokenFocusOnTreeView](https://user-images.githubusercontent.com/58004471/147512386-b429de63-9bda-4498-bc64-5bd25076beaa.gif)

 #### Focus on the control without check `IsAccessibilityObjectCreated`

It works great, but not safety due to forcing the object creating.

![FocusOnTreeView](https://user-images.githubusercontent.com/58004471/147512415-1f71ba67-4201-43e7-b7db-1c6381e94b05.gif)

It was not so easy for me to resolve it in the fix. So I skipped this problem and took implementation without the check. I guess this problem needs to be investigated and resolved in out of scope issue. 
 
 ### Additional note

I take it if node is check box it has `DefaultAction` equals `Check` or `Uncheck` but before the fix `DoDefaultAction` does nothing in this case. I configured this method, so it performs `Toggle` method of `TreeNodeAccessibleObject` in this case.

## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit testing
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Inspect
- Accessibility Insights
- Narrator
 

## Test environment(s) <!-- Remove any that don't apply -->

- .Net version: 6.0.100
- OS version: 10.0.19044

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6432)