### PR TITLE
ControlTestBase: less sensitive point coordinates assessment

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/Infra/ControlTestBase.cs
@@ -142,7 +142,9 @@ namespace System.Windows.Forms.UITests
 
             if (assertCorrectLocation)
             {
-                Assert.Equal(point, new Point(actualPoint.X, actualPoint.Y));
+                // Allow for rounding errors (observed in certain scenarios)
+                Assert.InRange(point.X, actualPoint.X - 1, actualPoint.X + 1);
+                Assert.InRange(point.Y, actualPoint.Y - 1, actualPoint.Y + 1);
             }
         }
 


### PR DESCRIPTION
Stems from #6334
Replaced direct point coordinates assessment to the small range of pixels
## Proposed changes

- Let occur small inaccuracies in the coordinates in the MoveMouseToControlAsync

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6433)