### PR TITLE
Fixing empty value of DefaultAction of DateTimePicker control

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -2,3 +2,5 @@
 ~override System.Windows.Forms.PrintPreviewControl.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.Name.get -> string
 ~override System.Windows.Forms.DateTimePicker.OnGotFocus(System.EventArgs e) -> void
+override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.DoDefaultAction() -> void
+~override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.DefaultAction.get -> string

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
@@ -116,10 +116,34 @@ namespace System.Windows.Forms
                 };
 
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
-                => (patternId == UiaCore.UIA.TogglePatternId && ((DateTimePicker)Owner).ShowCheckBox) ||
-                    patternId == UiaCore.UIA.ExpandCollapsePatternId ||
-                    patternId == UiaCore.UIA.ValuePatternId ||
-                    base.IsPatternSupported(patternId);
+                => patternId switch
+                {
+                    UiaCore.UIA.TogglePatternId when ((DateTimePicker)Owner).ShowCheckBox => true,
+                    UiaCore.UIA.ExpandCollapsePatternId => true,
+                    UiaCore.UIA.ValuePatternId => true,
+                    _ => base.IsPatternSupported(patternId)
+                };
+
+            public override string DefaultAction
+                => ExpandCollapseState switch
+                {
+                    UiaCore.ExpandCollapseState.Collapsed => SR.AccessibleActionExpand,
+                    UiaCore.ExpandCollapseState.Expanded => SR.AccessibleActionCollapse,
+                    _ => string.Empty
+                };
+
+            public override void DoDefaultAction()
+            {
+                switch (ExpandCollapseState)
+                {
+                    case UiaCore.ExpandCollapseState.Collapsed:
+                        Expand();
+                        break;
+                    case UiaCore.ExpandCollapseState.Expanded:
+                        Collapse();
+                        break;
+                }
+            }
 
             #region Toggle Pattern
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
@@ -290,5 +290,55 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(testAccessibleName, dateTimePicker.AccessibilityObject.Name);
             Assert.False(dateTimePicker.IsHandleCreated);
         }
+
+        public static IEnumerable<object[]> DateTimePickerAccessibleObject_DefaultAction_ReturnsExpected_TestData()
+        {
+            // Expanded dtp control has "Collapse" as a default action, else "Expand".
+            yield return new object[] { true, SR.AccessibleActionCollapse };
+            yield return new object[] { false, SR.AccessibleActionExpand };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(DateTimePickerAccessibleObject_DefaultAction_ReturnsExpected_TestData))]
+        public void DateTimePickerAccessibleObject_DefaultAction_ReturnsExpected(bool isExpanded, string expected)
+        {
+            using DateTimePicker dateTimePicker = new();
+            dateTimePicker.CreateControl();
+
+            AccessibleObject accessibleObject = dateTimePicker.AccessibilityObject;
+
+            if (isExpanded)
+            {
+                accessibleObject.Expand();
+            }
+
+            Assert.Equal(expected, accessibleObject.DefaultAction);
+            Assert.True(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true, (int)UiaCore.ExpandCollapseState.Collapsed)]
+        [InlineData(false, (int)UiaCore.ExpandCollapseState.Expanded)]
+        public void DateTimePickerAccessibleObject_DoDefaultAction_IfHandleIsCreated_ReturnsExpected(bool isExpanded, int expected)
+        {
+            using DateTimePicker dateTimePicker = new();
+            dateTimePicker.CreateControl();
+
+            AccessibleObject accessibleObject = dateTimePicker.AccessibilityObject;
+
+            Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
+
+            if (isExpanded)
+            {
+                accessibleObject.Expand();
+
+                Assert.Equal(UiaCore.ExpandCollapseState.Expanded, accessibleObject.ExpandCollapseState);
+            }
+
+            accessibleObject.DoDefaultAction();
+
+            Assert.Equal((UiaCore.ExpandCollapseState)expected, accessibleObject.ExpandCollapseState);
+            Assert.True(dateTimePicker.IsHandleCreated);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6317 


## Proposed changes

- Overridden `DefaultAction` property of DateTimePicker AO to return `Expand` value if the control is collapsed. Otherwise, return `Collapse` if the control is expanded.
- Overridden `DoDefaultAction` method to perform `Collapse()` or `Expand()` methods.
- Added test case for it.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Receive the correct `DefaultAction` value of a dtp control and improve accessibility.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Property returns empty value.

#### Collapsed

![DTP_col_b](https://user-images.githubusercontent.com/58004471/147646575-d5bbcbf6-0310-4d5e-a665-8a18a0db627b.png)

#### Expanded

![DTP_exp_b](https://user-images.githubusercontent.com/58004471/147646610-9c1e9bec-0589-4d80-8fa6-232c1bea19de.png)

### After

Returns `Expand` or `Collapse` value.

#### Collapsed

![DTP_col](https://user-images.githubusercontent.com/58004471/147646729-1a41ffcd-fbe0-44d4-87f7-411438f76747.png)

#### Expanded

![DTP_exp](https://user-images.githubusercontent.com/58004471/147646741-da6eaf97-1482-4ef5-8a32-561770bd9e69.png)

#### Accessibility Insights

Also has no additional errors in AI.

![AI](https://user-images.githubusercontent.com/58004471/147646911-785658bd-19fe-4bdf-8b18-4f5b28701705.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit tests
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Inspect
- AI
- Narrator
 
## Test environment(s) <!-- Remove any that don't apply -->

- .Net version:   6.0.100
- OS version: 10.0.19044

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6436)