### PR TITLE
Enable nullability in ListViewItemStateImageIndexConverter

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -592,7 +592,7 @@ override System.Windows.Forms.Layout.ArrangedElementCollection.Equals(object? ob
 ~override System.Windows.Forms.ListViewItem.ToString() -> string
 ~override System.Windows.Forms.ListViewItemConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) -> bool
 ~override System.Windows.Forms.ListViewItemConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) -> object
-~override System.Windows.Forms.ListViewItemStateImageIndexConverter.GetStandardValues(System.ComponentModel.ITypeDescriptorContext context) -> System.ComponentModel.TypeConverter.StandardValuesCollection
+override System.Windows.Forms.ListViewItemStateImageIndexConverter.GetStandardValues(System.ComponentModel.ITypeDescriptorContext? context) -> System.ComponentModel.TypeConverter.StandardValuesCollection!
 ~override System.Windows.Forms.MaskedTextBox.CreateParams.get -> System.Windows.Forms.CreateParams
 ~override System.Windows.Forms.MaskedTextBox.OnBackColorChanged(System.EventArgs e) -> void
 ~override System.Windows.Forms.MaskedTextBox.OnHandleCreated(System.EventArgs e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemStateImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItemStateImageIndexConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Windows.Forms
@@ -42,30 +40,30 @@ namespace System.Windows.Forms
         ///  this collection contains a single object with a value of -1. This method returns<see langword="null" />
         ///  if the data type doesn't support a standard set of values.
         /// </returns>
-        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext? context)
         {
             if (context is not null && context.Instance is not null)
             {
                 object instance = context.Instance;
 
-                ImageList imageList = null;
+                ImageList? imageList = null;
 
                 PropertyDescriptorCollection listViewItemProps = TypeDescriptor.GetProperties(instance);
-                PropertyDescriptor listViewProp = listViewItemProps["ListView"];
+                PropertyDescriptor? listViewProp = listViewItemProps["ListView"];
 
                 if (listViewProp is not null)
                 {
                     // Grab the ListView property off of the TreeNode.
-                    object listViewInstance = listViewProp.GetValue(instance);
+                    object? listViewInstance = listViewProp.GetValue(instance);
 
                     if (listViewInstance is not null)
                     {
                         // Get the ImageList property from the ListView and set it to be the currentImageList.
                         PropertyDescriptorCollection listViewProps = TypeDescriptor.GetProperties(listViewInstance);
-                        PropertyDescriptor listViewImageListProperty = listViewProps["StateImageList"];
+                        PropertyDescriptor? listViewImageListProperty = listViewProps["StateImageList"];
                         if (listViewImageListProperty is not null)
                         {
-                            imageList = (ImageList)listViewImageListProperty.GetValue(listViewInstance);
+                            imageList = (ImageList?)listViewImageListProperty.GetValue(listViewInstance);
                         }
                     }
                 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ListViewItemStateImageIndexConverter.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6457)