### PR TITLE
Enable nullability in classes that inherit from ToolStripItemAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2976,7 +2976,7 @@ System.Windows.Forms.ToolStripSeparatorRenderEventArgs.ToolStripSeparatorRenderE
 ~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string text, System.Drawing.Image image, System.EventHandler onClick) -> void
 ~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string text, System.Drawing.Image image, System.EventHandler onClick, string name) -> void
 ~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(System.Drawing.Image image) -> void
-~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButtonAccessibleObject.ToolStripSplitButtonAccessibleObject(System.Windows.Forms.ToolStripSplitButton item) -> void
+System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButtonAccessibleObject.ToolStripSplitButtonAccessibleObject(System.Windows.Forms.ToolStripSplitButton! item) -> void
 ~System.Windows.Forms.ToolStripStatusLabel.ToolStripStatusLabel(string text) -> void
 ~System.Windows.Forms.ToolStripStatusLabel.ToolStripStatusLabel(string text, System.Drawing.Image image) -> void
 ~System.Windows.Forms.ToolStripStatusLabel.ToolStripStatusLabel(string text, System.Drawing.Image image, System.EventHandler onClick) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.ToolStripButtonAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms
@@ -22,7 +20,7 @@ namespace System.Windows.Forms
                 _ownerItem = ownerItem;
             }
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
             {
                 // If we don't set a default role for the accessible object
                 // it will be retrieved from Windows.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.ToolStripControlHostAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.ToolStripControlHostAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms
@@ -70,7 +68,7 @@ namespace System.Windows.Forms
             /// </summary>
             /// <param name="direction">Indicates the direction in which to navigate.</param>
             /// <returns>Returns the element in the specified direction.</returns>
-            internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
                 if (direction == UiaCore.NavigateDirection.FirstChild ||
                     direction == UiaCore.NavigateDirection.LastChild)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.ToolStripLabelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.ToolStripLabelAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms
@@ -42,7 +40,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
             {
                 if (propertyID == UiaCore.UIA.LegacyIAccessibleStatePropertyId)
                 {
@@ -62,7 +60,7 @@ namespace System.Windows.Forms
                         return role;
                     }
 
-                    return (_owningToolStripLabel.IsLink) ? AccessibleRole.Link : AccessibleRole.StaticText;
+                    return _owningToolStripLabel.IsLink ? AccessibleRole.Link : AccessibleRole.StaticText;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparator.ToolStripSeparatorAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparator.ToolStripSeparatorAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class ToolStripSeparator

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton.ToolStripSplitButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton.ToolStripSplitButtonAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class ToolStripSplitButton


### PR DESCRIPTION
## Proposed changes

- Enable nullability in classes that inherit from ToolStripItemAccessibleObject.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6463)