### PR TITLE
Make s_events non-nullable in SendKeys

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.SendKeysHookProc.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.SendKeysHookProc.cs
@@ -35,12 +35,12 @@ namespace System.Windows.Forms
                     case User32.HC.SKIP:
                         if (_gotNextEvent)
                         {
-                            if (s_events is not null && s_events.Count > 0)
+                            if (s_events.Count > 0)
                             {
                                 s_events.Dequeue();
                             }
 
-                            s_stopHook = s_events is null || s_events.Count == 0;
+                            s_stopHook = s_events.Count == 0;
                             break;
                         }
 
@@ -49,7 +49,7 @@ namespace System.Windows.Forms
                         _gotNextEvent = true;
 
                         Debug.Assert(
-                            s_events is not null && s_events.Count > 0 && !s_stopHook,
+                            s_events.Count > 0 && !s_stopHook,
                             "HC_GETNEXT when queue is empty!");
 
                         SKEvent @event = s_events.Peek();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -84,7 +84,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Vector of events that we have yet to post to the journaling hook.
         /// </summary>
-        private static Queue<SKEvent>? s_events;
+        private static readonly Queue<SKEvent> s_events = new Queue<SKEvent>();
 
         private static object s_lock = new object();
         private static bool s_startNewChar;
@@ -120,7 +120,6 @@ namespace System.Windows.Forms
         /// </summary>
         private static void AddEvent(SKEvent skevent)
         {
-            s_events ??= new Queue<SKEvent>();
             s_events.Enqueue(skevent);
         }
 
@@ -302,10 +301,7 @@ namespace System.Windows.Forms
             if (s_hhook != IntPtr.Zero)
             {
                 s_stopHook = false;
-                if (s_events is not null)
-                {
-                    s_events.Clear();
-                }
+                s_events.Clear();
 
                 s_hhook = IntPtr.Zero;
             }
@@ -672,11 +668,6 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    if (s_events is null)
-                    {
-                        return;
-                    }
-
                     eventsTotal = s_events.Count;
                     ClearGlobalKeys();
 
@@ -924,7 +915,7 @@ namespace System.Windows.Forms
 
             // For SendInput only, see AddCancelModifiersForPreviousEvents for details.
             SKEvent[]? previousEvents = null;
-            if ((s_events is not null) && (s_events.Count != 0))
+            if (s_events.Count != 0)
             {
                 previousEvents = s_events.ToArray();
             }
@@ -933,7 +924,7 @@ namespace System.Windows.Forms
             ParseKeys(keys, (control is not null) ? control.Handle : IntPtr.Zero);
 
             // If there weren't any events posted as a result, we're done!
-            if (s_events is null)
+            if (s_events.Count == 0)
             {
                 return;
             }
@@ -997,7 +988,7 @@ namespace System.Windows.Forms
         public static void Flush()
         {
             Application.DoEvents();
-            while (s_events is not null && s_events.Count > 0)
+            while (s_events.Count > 0)
             {
                 Application.DoEvents();
             }
@@ -1011,7 +1002,7 @@ namespace System.Windows.Forms
             if (s_hhook != IntPtr.Zero)
             {
                 s_stopHook = false;
-                s_events?.Clear();
+                s_events.Clear();
 
                 User32.UnhookWindowsHookEx(s_hhook);
                 s_hhook = IntPtr.Zero;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SendKeys.cs
@@ -672,7 +672,12 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    eventsTotal = s_events!.Count;
+                    if (s_events is null)
+                    {
+                        return;
+                    }
+
+                    eventsTotal = s_events.Count;
                     ClearGlobalKeys();
 
                     for (int i = 0; i < eventsTotal; i++)


### PR DESCRIPTION
## Proposed changes

- Addresses post-merge feedback in https://github.com/dotnet/winforms/pull/6428.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6470)