### PR TITLE
Enable nullability in classes that inherit from ToolStripDropDownItemAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownButton.ToolStripDropDownButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownButton.ToolStripDropDownButtonAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.ToolStripOverflowButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.ToolStripOverflowButtonAccessibleObject.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.Windows.Forms
 {
     public partial class ToolStripOverflowButton
@@ -12,7 +14,8 @@ namespace System.Windows.Forms
             {
             }
 
-            public override string? Name
+            [AllowNull]
+            public override string Name
             {
                 get => Owner.AccessibleName ?? SR.ToolStripOptions;
                 set => base.Name = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.ToolStripOverflowButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.ToolStripOverflowButtonAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class ToolStripOverflowButton
@@ -14,7 +12,7 @@ namespace System.Windows.Forms
             {
             }
 
-            public override string Name
+            public override string? Name
             {
                 get => Owner.AccessibleName ?? SR.ToolStripOptions;
                 set => base.Name = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton .ToolStripSplitButtonUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton .ToolStripSplitButtonUiaProvider.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms


### PR DESCRIPTION
## Proposed changes

- Enable nullability in classes that inherit from ToolStripDropDownItemAccessibleObject.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6476)