### PR TITLE
Fixing incorrect state set for State.Created flag on the Control

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -9900,9 +9900,6 @@ namespace System.Windows.Forms
                     // the call shouldn't fail.
                     // However, it could fail if this.CreateParams.Parent is changed outside our control.
                     CreateHandle();
-
-                    // DestroyHandle resets the state, but CreateHandle doesn't set the state back.
-                    SetState(States.Created, true);
                 }
                 catch (Exception)
                 {
@@ -9932,7 +9929,7 @@ namespace System.Windows.Forms
                     // - or -
                     // CreateHandle is successful.
                     //      We will move the child controls to the new parent.
-                    if (controlSnapshot is not null && GetState(States.Created))
+                    if (controlSnapshot is not null && IsHandleCreated)
                     {
                         for (int i = 0; i < controlSnapshot.Length; i++)
                         {


### PR DESCRIPTION
This PR is the result of regressions caused by #6114 and #2262.

`State.Created` must be set only when `Handle` and the `Control `associated with it is created. Otherwise, recreating `Control `scenarios would be out of sync.  Changes in this PR is basically bringing the source code back to 6.0 GA state with respect to setting flag on `State.Created`.

Setting `State.Created` when the `Handle `is created but the associated `Control `is not, have repercussions mentioned in #6464. We cache this state and check before creating the control. Incorrect state would skip this. ex: https://github.com/dotnet/winforms/blob/0d4484331f57113d3303275c6aa5717fcd4b6c25/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs#L5044

fixes #6464 
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6477)