### PR TITLE
Make toolStrip non-nullable in ToolStripGripRenderEventArgs and ToolStripRenderEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2836,7 +2836,7 @@ System.Windows.Forms.ToolStripContentPanelRenderEventArgs.ToolStripContentPanelR
 ~System.Windows.Forms.ToolStripDropDownItem.ToolStripDropDownItem(string text, System.Drawing.Image image, System.EventHandler onClick) -> void
 ~System.Windows.Forms.ToolStripDropDownItem.ToolStripDropDownItem(string text, System.Drawing.Image image, System.EventHandler onClick, string name) -> void
 ~System.Windows.Forms.ToolStripDropDownItemAccessibleObject.ToolStripDropDownItemAccessibleObject(System.Windows.Forms.ToolStripDropDownItem item) -> void
-System.Windows.Forms.ToolStripGripRenderEventArgs.ToolStripGripRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStrip? toolStrip) -> void
+System.Windows.Forms.ToolStripGripRenderEventArgs.ToolStripGripRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStrip! toolStrip) -> void
 ~System.Windows.Forms.ToolStripItem.AccessibilityObject.get -> System.Windows.Forms.AccessibleObject
 ~System.Windows.Forms.ToolStripItem.AccessibleDefaultActionDescription.get -> string
 ~System.Windows.Forms.ToolStripItem.AccessibleDefaultActionDescription.set -> void
@@ -2960,9 +2960,9 @@ System.Windows.Forms.ToolStripRenderer.DrawToolStripContentPanelBackground(Syste
 System.Windows.Forms.ToolStripRenderer.DrawToolStripPanelBackground(System.Windows.Forms.ToolStripPanelRenderEventArgs! e) -> void
 System.Windows.Forms.ToolStripRenderer.DrawToolStripStatusLabelBackground(System.Windows.Forms.ToolStripItemRenderEventArgs! e) -> void
 System.Windows.Forms.ToolStripRenderEventArgs.Graphics.get -> System.Drawing.Graphics!
-System.Windows.Forms.ToolStripRenderEventArgs.ToolStrip.get -> System.Windows.Forms.ToolStrip?
-System.Windows.Forms.ToolStripRenderEventArgs.ToolStripRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStrip? toolStrip) -> void
-System.Windows.Forms.ToolStripRenderEventArgs.ToolStripRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStrip? toolStrip, System.Drawing.Rectangle affectedBounds, System.Drawing.Color backColor) -> void
+System.Windows.Forms.ToolStripRenderEventArgs.ToolStrip.get -> System.Windows.Forms.ToolStrip!
+System.Windows.Forms.ToolStripRenderEventArgs.ToolStripRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStrip! toolStrip) -> void
+System.Windows.Forms.ToolStripRenderEventArgs.ToolStripRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStrip! toolStrip, System.Drawing.Rectangle affectedBounds, System.Drawing.Color backColor) -> void
 ~System.Windows.Forms.ToolStripSeparator.ImageKey.get -> string
 ~System.Windows.Forms.ToolStripSeparator.ImageKey.set -> void
 ~System.Windows.Forms.ToolStripSeparator.ToolTipText.get -> string

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripGripRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripGripRenderEventArgs.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents all the information to render the toolStrip
         /// </summary>
-        public ToolStripGripRenderEventArgs(Graphics g, ToolStrip? toolStrip)
+        public ToolStripGripRenderEventArgs(Graphics g, ToolStrip toolStrip)
             : base(g, toolStrip)
         {
         }
@@ -19,16 +19,16 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The graphics object to draw with
         /// </summary>
-        public Rectangle GripBounds => ToolStrip?.GripRectangle ?? default;
+        public Rectangle GripBounds => ToolStrip.GripRectangle;
 
         /// <summary>
         ///  Vertical or horizontal
         /// </summary>
-        public ToolStripGripDisplayStyle GripDisplayStyle => ToolStrip?.GripDisplayStyle ?? default;
+        public ToolStripGripDisplayStyle GripDisplayStyle => ToolStrip.GripDisplayStyle;
 
         /// <summary>
         ///  Visible or hidden
         /// </summary>
-        public ToolStripGripStyle GripStyle => ToolStrip?.GripStyle ?? default;
+        public ToolStripGripStyle GripStyle => ToolStrip.GripStyle;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderEventArgs.cs
@@ -13,8 +13,8 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents all the information to render the toolStrip
         /// </summary>
-        public ToolStripRenderEventArgs(Graphics g, ToolStrip? toolStrip)
-            : this(g, toolStrip, new Rectangle(Point.Empty, toolStrip?.Size ?? Size.Empty), Color.Empty)
+        public ToolStripRenderEventArgs(Graphics g, ToolStrip toolStrip)
+            : this(g, toolStrip, new Rectangle(Point.Empty, toolStrip?.Size ?? throw new ArgumentNullException(nameof(toolStrip))), Color.Empty)
         {
         }
 
@@ -23,13 +23,13 @@ namespace System.Windows.Forms
         /// </summary>
         public ToolStripRenderEventArgs(
             Graphics g,
-            ToolStrip? toolStrip,
+            ToolStrip toolStrip,
             Rectangle affectedBounds,
             Color backColor)
         {
             Graphics = g.OrThrowIfNull();
+            ToolStrip = toolStrip.OrThrowIfNull();
             AffectedBounds = affectedBounds;
-            ToolStrip = toolStrip;
             _backColor = backColor;
         }
 
@@ -46,7 +46,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Represents which toolStrip was affected by the click
         /// </summary>
-        public ToolStrip? ToolStrip { get; }
+        public ToolStrip ToolStrip { get; }
 
         /// <summary>
         ///  The back color to draw with.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripRenderEventArgs.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms
         ///  This class represents all the information to render the toolStrip
         /// </summary>
         public ToolStripRenderEventArgs(Graphics g, ToolStrip toolStrip)
-            : this(g, toolStrip, new Rectangle(Point.Empty, toolStrip?.Size ?? throw new ArgumentNullException(nameof(toolStrip))), Color.Empty)
+            : this(g, toolStrip, new Rectangle(Point.Empty, toolStrip.OrThrowIfNull().Size), Color.Empty)
         {
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripGripRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripGripRenderEventArgsTests.cs
@@ -9,10 +9,21 @@ namespace System.Windows.Forms.Tests
 {
     public class ToolStripGripRenderEventArgsTests : IClassFixture<ThreadExceptionFixture>
     {
-        [WinFormsFact]
-        public void ToolStripGripRenderEventArgs_NullGraphics_ThrowsArgumentNullException()
+        public static IEnumerable<object[]> Ctor_Null_Graphics_ToolStrip_TestData()
         {
-            Assert.Throws<ArgumentNullException>(() => new ToolStripGripRenderEventArgs(null, null));
+            var image = new Bitmap(10, 10);
+            Graphics graphics = Graphics.FromImage(image);
+
+            yield return new object[] { null, null };
+            yield return new object[] { null, new ToolStrip() };
+            yield return new object[] { graphics, null };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Ctor_Null_Graphics_ToolStrip_TestData))]
+        public void ToolStripGripRenderEventArgs_NullParameter_ThrowsArgumentNullException(Graphics g, ToolStrip toolStrip)
+        {
+            Assert.Throws<ArgumentNullException>(() => new ToolStripGripRenderEventArgs(g, toolStrip));
         }
 
         public static IEnumerable<object[]> Ctor_Graphics_ToolStrip_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRenderEventArgsTests.cs
@@ -9,10 +9,21 @@ namespace System.Windows.Forms.Tests
 {
     public class ToolStripRenderEventArgsTests : IClassFixture<ThreadExceptionFixture>
     {
-        [WinFormsFact]
-        public void ToolStripRenderEventArgs_NullGraphics_ThrowsArgumentNullException()
+        public static IEnumerable<object[]> Ctor_Null_Graphics_ToolStrip_TestData()
         {
-            Assert.Throws<ArgumentNullException>(() => new ToolStripRenderEventArgs(null, null));
+            var image = new Bitmap(10, 10);
+            Graphics graphics = Graphics.FromImage(image);
+
+            yield return new object[] { null, null };
+            yield return new object[] { null, new ToolStrip() };
+            yield return new object[] { graphics, null };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Ctor_Null_Graphics_ToolStrip_TestData))]
+        public void ToolStripRenderEventArgs_NullParameters_ThrowsArgumentNullException(Graphics g, ToolStrip toolStrip)
+        {
+            Assert.Throws<ArgumentNullException>(() => new ToolStripRenderEventArgs(g, toolStrip));
         }
 
         public static IEnumerable<object[]> Ctor_Graphics_ToolStrip_TestData()
@@ -64,7 +75,6 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> ConnectedArea_Empty_TestData()
         {
-            yield return new object[] { null };
             yield return new object[] { new ToolStrip() };
             yield return new object[] { new ToolStripDropDown() };
             yield return new object[] { new ToolStripOverflow(new ToolStripButton()) };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
@@ -526,7 +526,6 @@ namespace System.Windows.Forms.Tests
 
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
-            yield return new object[] { new ToolStripRenderEventArgs(graphics, null) };
             yield return new object[] { new ToolStripRenderEventArgs(graphics, new ToolStrip()) };
             yield return new object[] { new ToolStripRenderEventArgs(graphics, new StatusStrip()) };
         }


### PR DESCRIPTION
## Proposed changes

- Make toolStrip non-nullable in ToolStripGripRenderEventArgs and ToolStripRenderEventArgs.
- Addresses feedback in https://github.com/dotnet/winforms/pull/6391.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6484)