### PR TITLE
Fixing incorrect mouse tooltip for TabPage of TabControl

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -842,6 +842,17 @@ namespace System.Windows.Forms
 
         private void SetToolInfo(Control control, string caption)
         {
+            // Don't add a tool for the TabControl itself. It's not needed because:
+            // 1. TabControl already relays all mouse events to its tooltip:
+            // https://docs.microsoft.com/windows/win32/controls/tab-controls#default-tab-control-message-processing
+            // 2. Hit-testing against TabControl detects only TabPages which are separate tools added by TabControl.
+            // This prevents a bug when a TabPage tool is placed before the TabControl tool after reordering caused by a tool deletion.
+            // Also prevents double handling of mouse messages which is caused by subclassing altogether with the message relaying from the TabControl internals.
+            if (control is TabControl)
+            {
+                return;
+            }
+
             IntPtr result = GetTOOLINFO(control, caption).SendMessage(this, (User32.WM)TTM.ADDTOOLW);
 
             if ((control is TreeView tv && tv.ShowNodeToolTips)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
@@ -866,6 +866,29 @@ namespace System.Windows.Forms.Tests
                 Times.Once);
         }
 
+        [WinFormsFact]
+        public void ToolTip_SetToolTip_TabControl_DoesNotAddToolForTabControlItself()
+        {
+            // We need a Form because tooltips don't work on controls without a valid parent.
+            using Form form = new();
+            using ToolTip toolTip = new();
+            using TabControl tabControl = new() { ShowToolTips = true };
+            using TabPage tabPage1 = new();
+            using TabPage tabPage2 = new();
+
+            toolTip.SetToolTip(tabControl, "Test");
+            tabControl.Controls.Add(tabPage1);
+            tabControl.Controls.Add(tabPage2);
+            form.Controls.Add(tabControl);
+            form.Show();
+
+            Assert.NotEqual(IntPtr.Zero, tabControl.InternalHandle);
+            Assert.True(toolTip.GetHandleCreated());
+
+            // Only tools for TabPages were added.
+            Assert.Equal(tabControl.TabCount, User32.SendMessageW(toolTip, (User32.WM)ComCtl32.TTM.GETTOOLCOUNT));
+        }
+
         private class SubToolTip : ToolTip
         {
             public SubToolTip() : base()


### PR DESCRIPTION
Fixes #4750. The DELTOOL message of tooltip causes moving of the last tool to the slot of the deleted tool in the tool array (e.g. deleting `Button` from the `[Button, TabControl, TabPage1, TabPage2]` results in `[TabPage1, TabControl, TabPage2]`). This breaks the hit-test logic of the tooltip that checks the tools in the reverse order. Thus the TabControl may be checked earlier than any of TabPages and tooltip will be shown for the TabControl and not for the TabPage.

A possible fix is to reorder the tools in the tools array, but there is no way to access it directly. It is possible to change the array through GETTOOLINFO and SETTOOLINFO messages but this may have undesirable side-effects of breaking caches and other things.

The other way is to remove deletion from the keyboard tooltips logic. But it won't actually help because deletion may be called directly.

The only appropriate solution is to not add a tool for the TabControl itself. It doesn't break anything because the TabControl relays mouse messages to the tooltip by itself (no subclassing is needed) and there is no area where the tool for the TabControl will be shown (hit-testing detects only TabPages, the other things are transparent).


## Proposed changes

- Removed adding a tool for the `TabControl` in the tooltip logic

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The user sees the correct tooltip in the correct rectangle for a tab page of tab control

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![](http://g.recordit.co/ixoSv2dpaR.gif)

### After

![](http://g.recordit.co/pdly4JDumj.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit-tests
- CTI (planned)


 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19044.1415]
- .NET 7.0.0-alpha.1.22058.4


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6488)