### PR TITLE
Fixing announcing the tooltip for the TabPage

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -642,7 +642,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            tool.AccessibilityObject.RaiseAutomationNotification(
+            tool.AccessibilityObject.InternalRaiseAutomationNotification(
                 Automation.AutomationNotificationKind.ActionCompleted,
                 Automation.AutomationNotificationProcessing.All,
                 $"{ToolTipTitle} {text}");
@@ -2073,7 +2073,9 @@ namespace System.Windows.Forms
 
             if (!e.Cancel)
             {
-                AnnounceText(toolControl, GetCaptionForTool(toolControl));
+                // Use GetWindowText instead of GetCaptionForTool to retrieve the actual caption.
+                // GetCaptionForTool doesn't work correctly when the text for a tool is retrieved by TTN_NEEDTEXT notification (e.g. TabPages of TabControl).
+                AnnounceText(toolControl, User32.GetWindowText(this));
             }
 
             // We need to re-get the rectangle of the tooltip here because


### PR DESCRIPTION
Fixes #5835. There are some controls that are adding their own tools (e.g. TabControls adds a tool for each TabPage) and for these tools we don't have an associated caption. Moreover these tools are typically retrieving the caption using TTN_NEEDTEXT notification.

The simplest way to fix this issue is to retrieve the caption using the `GetWindowText` function. At `WmShow` we know that the caption was already retrieved and set by the tooltip, so it can be retrieved using this API function. This way works for both static and dynamic captions.

The more complex way is to change the logic of the current tool retrieval and also the most important to change the logic of the caption retrieval, to support the dynamic ones.

The first approach was chosen as it is very simple and works without any downsides. The second approach also means that we are actually retrieving the caption twice: once by the tooltip internal logic and then once by our announcing logic.


## Proposed changes

- Changed `GetCaptionForTool` to `GetWindowText` in the caption retrieval logic inside `WmShow` method

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The user of Narrator hears the correct caption for a tab page's tooltip

## Regression? 

- The announcing feature was introduced in #2074 and it already had issue for tab pages

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![](http://g.recordit.co/mkmTYzONP3.gif)

### After

![](http://g.recordit.co/5sNDODtoEl.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit-tests
- CTI (planned)



## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.19044.1415]
- .NET 7.0.0-alpha.1.22058.4


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6489)