### PR TITLE
Update ListViewGroup.CollapsedState from native when changed by keyboard

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6941,7 +6941,7 @@ namespace System.Windows.Forms
                             break;
                         }
 
-                        var nativeState = group.GetNativeCollapsedState();
+                        ListViewGroupCollapsedState nativeState = group.GetNativeCollapsedState();
                         if (nativeState != group.CollapsedState)
                         {
                             group.SetCollapsedStateInternal(nativeState);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6931,22 +6931,22 @@ namespace System.Windows.Forms
                 case User32.WM.KEYUP:
                     int key = (int)m.WParamInternal;
 
+                    // User can collapse/expand a group using the keyboard by focusing the group header and using left/right
                     if (GroupsDisplayed && (key is User32.VK.LEFT or User32.VK.RIGHT) && SelectedItems.Count > 0)
                     {
                         ListViewGroup group = SelectedItems[0].Group;
 
-                        if (group is null || group.CollapsedState is ListViewGroupCollapsedState.Default
-                            || (key == User32.VK.LEFT && group.CollapsedState is ListViewGroupCollapsedState.Collapsed)
-                            || (key == User32.VK.RIGHT && group.CollapsedState is ListViewGroupCollapsedState.Expanded))
+                        if (group is null || group.CollapsedState is ListViewGroupCollapsedState.Default)
                         {
                             break;
                         }
 
-                        group.SetCollapsedStateInternal(group.CollapsedState == ListViewGroupCollapsedState.Expanded
-                                                ? ListViewGroupCollapsedState.Collapsed
-                                                : ListViewGroupCollapsedState.Expanded);
-
-                        OnGroupCollapsedStateChanged(new ListViewGroupEventArgs(Groups.IndexOf(group)));
+                        var nativeState = group.GetNativeCollapsedState();
+                        if (nativeState != group.CollapsedState)
+                        {
+                            group.SetCollapsedStateInternal(nativeState);
+                            OnGroupCollapsedStateChanged(new ListViewGroupEventArgs(Groups.IndexOf(group)));
+                        }
                     }
 
                     break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -413,6 +413,11 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(nameof(ListView));
             }
 
+            if (!ListView.GroupsEnabled)
+            {
+                return ListViewGroupCollapsedState.Default;
+            }
+
             LVGS state = (LVGS)User32.SendMessageW(ListView, (User32.WM)LVM.GETGROUPSTATE, ID, (nint)(LVGS.COLLAPSIBLE | LVGS.COLLAPSED));
             if (!state.HasFlag(LVGS.COLLAPSIBLE))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -408,13 +408,13 @@ namespace System.Windows.Forms
 
         internal ListViewGroupCollapsedState GetNativeCollapsedState()
         {
-            if(ListView is null)
+            if (ListView is null)
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(nameof(ListView));
             }
 
             LVGS state = (LVGS)User32.SendMessageW(ListView, (User32.WM)LVM.GETGROUPSTATE, ID, (nint)(LVGS.COLLAPSIBLE | LVGS.COLLAPSED));
-            if(!state.HasFlag(LVGS.COLLAPSIBLE))
+            if (!state.HasFlag(LVGS.COLLAPSIBLE))
             {
                 return ListViewGroupCollapsedState.Default;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -6,6 +6,8 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.Serialization;
+using static Interop;
+using static Interop.ComCtl32;
 
 namespace System.Windows.Forms
 {
@@ -402,6 +404,22 @@ namespace System.Windows.Forms
 
                 Items.AddRange(items);
             }
+        }
+
+        internal ListViewGroupCollapsedState GetNativeCollapsedState()
+        {
+            if(ListView is null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            LVGS state = (LVGS)User32.SendMessageW(ListView, (User32.WM)LVM.GETGROUPSTATE, ID, (nint)(LVGS.COLLAPSIBLE | LVGS.COLLAPSED));
+            if(!state.HasFlag(LVGS.COLLAPSIBLE))
+            {
+                return ListViewGroupCollapsedState.Default;
+            }
+
+            return state.HasFlag(LVGS.COLLAPSED) ? ListViewGroupCollapsedState.Collapsed : ListViewGroupCollapsedState.Expanded;
         }
 
         // Should be used for the cases when sending the message `LVM.SETGROUPINFO` isn't required

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -685,7 +685,8 @@ namespace System.Windows.Forms.Tests
             };
 
             listView.Groups.Add(listViewGroup);
-            listView.Items.Add(new ListViewItem("Group Item", listViewGroup));
+            listView.Items.Add(new ListViewItem("Group Item 1", listViewGroup));
+            listView.Items.Add(new ListViewItem("Group Item 2", listViewGroup));
             listView.CreateControl();
             listViewGroup.Items[0].Selected = true;
             listViewGroup.Items[0].Focused = true;
@@ -702,30 +703,43 @@ namespace System.Windows.Forms.Tests
             // The MSDN page tells us what bits of lParam to use for each of the parameters.
             // All we need to do is some bit shifting to assemble lParam
             // lParam = repeatCount | (scanCode << 16)
-            nint keyCode = (nint)Keys.Left;
+            nint keyCode = (nint)Keys.Up;
             nint lParam = 0x00000001 | keyCode << 16;
+            User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
             User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
 
+            keyCode = (nint)Keys.Left;
+            lParam = 0x00000001 | keyCode << 16;
+            User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
+            User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
+
+            Assert.Equal(ListViewGroupCollapsedState.Collapsed, listViewGroup.GetNativeCollapsedState());
             Assert.Equal(ExpandCollapseState.Collapsed, listViewGroup.AccessibilityObject.ExpandCollapseState);
 
             keyCode = (nint)Keys.Left;
             lParam = 0x00000001 | keyCode << 16;
+            User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
             User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
 
             // The second left key pressing should not change Collapsed state
+            Assert.Equal(ListViewGroupCollapsedState.Collapsed, listViewGroup.GetNativeCollapsedState());
             Assert.Equal(ExpandCollapseState.Collapsed, listViewGroup.AccessibilityObject.ExpandCollapseState);
 
             keyCode = (nint)Keys.Right;
             lParam = 0x00000001 | keyCode << 16;
+            User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
             User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
 
+            Assert.Equal(ListViewGroupCollapsedState.Expanded, listViewGroup.GetNativeCollapsedState());
             Assert.Equal(ExpandCollapseState.Expanded, listViewGroup.AccessibilityObject.ExpandCollapseState);
 
             keyCode = (nint)Keys.Right;
             lParam = 0x00000001 | keyCode << 16;
+            User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
             User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
 
             // The second right key pressing should not change Expanded state
+            Assert.Equal(ListViewGroupCollapsedState.Expanded, listViewGroup.GetNativeCollapsedState());
             Assert.Equal(ExpandCollapseState.Expanded, listViewGroup.AccessibilityObject.ExpandCollapseState);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroupTests.cs
@@ -116,6 +116,26 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(ListViewGroupCollapsedState.Default)]
+        [InlineData(ListViewGroupCollapsedState.Collapsed)]
+        [InlineData(ListViewGroupCollapsedState.Expanded)]
+        public void ListViewGroup_GetNativeCollapsedState_Succeeds(ListViewGroupCollapsedState collapsedState)
+        {
+            using var listView = new ListView();
+            var group = new ListViewGroup() { CollapsedState = collapsedState };
+            listView.Groups.Add(group);
+
+            Assert.Equal(collapsedState, group.GetNativeCollapsedState());
+        }
+
+        [WinFormsFact]
+        public void ListViewGroup_GetNativeCollapsedState_NoListView_Throws()
+        {
+            var group = new ListViewGroup();
+            Assert.Throws<InvalidOperationException>(() => group.GetNativeCollapsedState());
+        }
+
+        [WinFormsTheory]
         [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetNonNegativeIntTheoryData))]
         [InlineData(-1)]
         public void ListViewGroup_TitleImageIndex_SetWithoutListView_GetReturnsExpected(int value)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6468


## Proposed changes

Previously, `ListView` would toggle `CollapsedState` of current `ListViewGroup` between `Expanded` and `Collapsed` if a `ListViewItem` was selected and:

- The left arrow key was pressed and the group state was `Expanded`
- The right arrow key was pressed and the group state was `Collapsed`

It did this regardless of whether the key press triggered an actual change in native state resulting in repeated `GroupCollapsedStateChanged` events and the group's `CollapsedState` property becoming out of sync with native state.

This change reads native state on arrow key press and updates `CollapsedState`/raises `GroupCollapsedStateChanged` only when the state is different.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

`ListViewGroup.CollapsedState` should no longer be out of sync with native state and phantom `GroupCollapsedStateChanged` events should no longer fire.

## Regression? 

- No. Appears that issue existed in initial commit of work.

## Risk

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- UI integration test
- Manual testing

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6493)