### PR TITLE
Fixing incorrect rendering of button rounded borders for Windows 11

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
@@ -21,6 +21,9 @@ namespace System.Windows.Forms.ButtonInternal
         // Coefficient for darkening the border color of the "Popup" and "Standard" buttons
         protected const float ButtonBorderDarkerOffset = 0.8f;
 
+        // This coefficient was added to simulate the original gradient as in Windows 11.
+        protected const float ButtonBottomBorderDarkerOffset = 0.7f;
+
         internal ButtonBaseAdapter(ButtonBase control) =>
             Control = control.OrThrowIfNull();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonRenderer.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms
         /// </summary>
         public static bool RenderMatchingApplicationState { get; set; } = true;
 
-        private static bool RenderWithVisualStyles
+        internal static bool RenderWithVisualStyles
         {
             get
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -150,6 +150,40 @@ namespace System.Windows.Forms
         public static Color ContrastControlDark
             => SystemInformation.HighContrast ? SystemColors.WindowFrame : SystemColors.ControlDark;
 
+        internal static void DrawRoundedBorder(this Graphics graphics, Pen pen, Rectangle bounds, int cornerRadius)
+        {
+            using GraphicsPath path = new GraphicsPath();
+
+            if (cornerRadius == 0)
+            {
+                path.AddRectangle(bounds);
+                graphics.DrawPath(pen, path);
+                return;
+            }
+
+            int diameter = cornerRadius * 2;
+            Size size = new(diameter, diameter);
+            Rectangle cornerBounds = new(bounds.Location, size);
+
+            // top left arc
+            path.AddArc(cornerBounds, startAngle: 180, sweepAngle: 90);
+
+            // top right arc
+            cornerBounds.X = bounds.Right - diameter;
+            path.AddArc(cornerBounds, startAngle: 270, sweepAngle: 90);
+
+            // bottom right arc
+            cornerBounds.Y = bounds.Bottom - diameter;
+            path.AddArc(cornerBounds, startAngle: 0, sweepAngle: 90);
+
+            // bottom left arc
+            cornerBounds.X = bounds.Left;
+            path.AddArc(cornerBounds, startAngle: 90, sweepAngle: 90);
+
+            path.CloseFigure();
+            graphics.DrawPath(pen, path);
+        }
+
         /// <summary>
         ///  Creates a 16-bit color bitmap.
         ///  Sadly, this must be public for the designer to get at it.


### PR DESCRIPTION
Fixes #6187


## Proposed changes
- The issue is reproduced because we have always drawn rectangular borders, although Windows 11 uses rounded borders.
- Added logic for drawing a rounded border.
- Added logic to draw a line at the bottom to simulate a gradient effect

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/149326045-cf625099-03e1-45f3-b17d-40df5bd8635c.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/149326114-c0e4dcf7-6ab9-47ae-96b0-c1c7741b718f.png)
![image](https://user-images.githubusercontent.com/23376742/149326175-7c0c01e8-9880-4fa4-b0ac-c2e643781ab5.png)
![image](https://user-images.githubusercontent.com/23376742/149328158-d9d9e618-49ac-4918-a5ae-4f7e0d6d3ff4.png)

## Regression impact
**Before fix:**
Rendering 500 standard buttons on local machine takes an average of **2208** seconds.
Rendering 500 standard buttons on a virtual machine takes an average of **1.999** seconds.

**After fix:**
Rendering 500 standard buttons on local machine takes an average of **2229** seconds.
Rendering 500 standard buttons on a virtual machine takes an average of **1.879** seconds.

## Regression? 
- Yes (from #6059)

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.22000.434]
- .NET Core SDK: 7.0.0-alpha.1.22061.11

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6497)