### PR TITLE
Fixing announcement of information about hidden columns and rows for DGV

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -65,6 +65,11 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetChild(int index)
             {
+                if (index < 0)
+                {
+                    return null;
+                }
+
                 if (_ownerDataGridView.Columns.Count == 0)
                 {
                     Diagnostics.Debug.Assert(GetChildCount() == 0);
@@ -248,9 +253,10 @@ namespace System.Windows.Forms
                         // Whether the _ownerDataGridView DataGridView can be sorted by some column.
                         // If so, provide not-sorted/sorted-by item status.
                         bool canSort = false;
-                        for (int i = 0; i < _ownerDataGridView.Columns.Count; i++)
+                        for (int i = 0; i < ColumnCount; i++)
                         {
-                            if (_ownerDataGridView.IsSortable(_ownerDataGridView.Columns[i]))
+                            int columnIndex = _ownerDataGridView.Columns.ActualDisplayIndexToColumnIndex(i, DataGridViewElementStates.Visible);
+                            if (_ownerDataGridView.IsSortable(_ownerDataGridView.Columns[columnIndex]))
                             {
                                 canSort = true;
                                 break;
@@ -270,7 +276,7 @@ namespace System.Windows.Forms
                             }
                         }
 
-                        break;
+                        return SR.NotSortedAccessibleStatus;
                 }
 
                 return base.GetPropertyValue(propertyID);
@@ -290,10 +296,11 @@ namespace System.Windows.Forms
                     return null;
                 }
 
-                UiaCore.IRawElementProviderSimple[] result = new UiaCore.IRawElementProviderSimple[_ownerDataGridView.Rows.Count];
-                for (int i = 0; i < _ownerDataGridView.Rows.Count; i++)
+                UiaCore.IRawElementProviderSimple[] result = new UiaCore.IRawElementProviderSimple[RowCount];
+                for (int i = 0; i < RowCount; i++)
                 {
-                    result[i] = _ownerDataGridView.Rows[i].HeaderCell.AccessibilityObject;
+                    int rowIndex = _ownerDataGridView.Rows.DisplayIndexToRowIndex(i);
+                    result[i] = _ownerDataGridView.Rows[rowIndex].HeaderCell.AccessibilityObject;
                 }
 
                 return result;
@@ -306,10 +313,11 @@ namespace System.Windows.Forms
                     return null;
                 }
 
-                UiaCore.IRawElementProviderSimple[] result = new UiaCore.IRawElementProviderSimple[_ownerDataGridView.Columns.Count];
-                for (int i = 0; i < _ownerDataGridView.Columns.Count; i++)
+                UiaCore.IRawElementProviderSimple[] result = new UiaCore.IRawElementProviderSimple[ColumnCount];
+                for (int i = 0; i < ColumnCount; i++)
                 {
-                    result[i] = _ownerDataGridView.Columns[i].HeaderCell.AccessibilityObject;
+                    int columnIndex = _ownerDataGridView.Columns.ActualDisplayIndexToColumnIndex(i, DataGridViewElementStates.Visible);
+                    result[i] = _ownerDataGridView.Columns[columnIndex].HeaderCell.AccessibilityObject;
                 }
 
                 return result;
@@ -325,9 +333,11 @@ namespace System.Windows.Forms
 
             internal override UiaCore.IRawElementProviderSimple? GetItem(int row, int column)
             {
-                if (row >= 0 && row < _ownerDataGridView.Rows.Count &&
-                    column >= 0 && column < _ownerDataGridView.Columns.Count)
+                if (row >= 0 && row < RowCount &&
+                    column >= 0 && column < ColumnCount)
                 {
+                    row = _ownerDataGridView.Rows.DisplayIndexToRowIndex(row);
+                    column = _ownerDataGridView.Columns.ActualDisplayIndexToColumnIndex(column, DataGridViewElementStates.Visible);
                     return _ownerDataGridView.Rows[row].Cells[column].AccessibilityObject;
                 }
 
@@ -338,7 +348,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    return _ownerDataGridView.RowCount;
+                    return _ownerDataGridView.Rows.GetRowCount(DataGridViewElementStates.Visible);
                 }
             }
 
@@ -346,7 +356,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    return _ownerDataGridView.ColumnCount;
+                    return _ownerDataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
@@ -118,6 +118,11 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
 
+                if (index > GetChildCount() - 1)
+                {
+                    return null;
+                }
+
                 if (index == 0 && _ownerDataGridView.RowHeadersVisible)
                 {
                     return _ownerDataGridView.TopLeftHeaderCell.AccessibilityObject;
@@ -180,9 +185,14 @@ namespace System.Windows.Forms
                         }
 
                     case AccessibleNavigation.FirstChild:
-                        return GetChild(0);
+                        return GetChildCount() > 0
+                            ? GetChild(0)
+                            : null;
                     case AccessibleNavigation.LastChild:
-                        return GetChild(GetChildCount() - 1);
+                        int childCount = GetChildCount();
+                        return childCount > 0
+                            ? GetChild(childCount - 1)
+                            : null;
                     default:
                         return null;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -50,12 +50,16 @@ namespace System.Windows.Forms
                         throw new InvalidOperationException(SR.DataGridViewCellAccessibleObject_OwnerNotSet);
                     }
 
-                    if (_owner.OwningColumn is null)
+                    if (_owner.OwningColumn is null || _owner.OwningRow is null)
                     {
                         return string.Empty;
                     }
 
-                    string name = string.Format(SR.DataGridView_AccDataGridViewCellName, _owner.OwningColumn.HeaderText, _owner.OwningRow.Index);
+                    int rowIndex = _owner.DataGridView is null
+                        ? -1
+                        : _owner.DataGridView.Rows.GetVisibleIndex(_owner.OwningRow);
+
+                    string name = string.Format(SR.DataGridView_AccDataGridViewCellName, _owner.OwningColumn.HeaderText, rowIndex);
 
                     if (_owner.OwningColumn.SortMode != DataGridViewColumnSortMode.NotSortable)
                     {
@@ -728,9 +732,15 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            internal override int Row => _owner?.OwningRow is not null ? _owner.OwningRow.Index : -1;
+            internal override int Row
+                => _owner?.OwningRow?.Visible is true && _owner.DataGridView is not null
+                    ? _owner.DataGridView.Rows.GetVisibleIndex(_owner.OwningRow)
+                    : -1;
 
-            internal override int Column => _owner?.OwningColumn is not null ? _owner.OwningColumn.Index : -1;
+            internal override int Column
+                => _owner?.OwningColumn?.Visible is true && _owner.DataGridView is not null
+                    ? _owner.DataGridView.Columns.GetVisibleIndex(_owner.OwningColumn)
+                    : -1;
 
             internal override UiaCore.IRawElementProviderSimple? ContainingGrid => _owner?.DataGridView?.AccessibilityObject;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
@@ -193,7 +193,7 @@ namespace System.Windows.Forms
                 dataGridViewColumn = GetNextColumn(dataGridViewColumn, includeFilter, DataGridViewElementStates.None);
             }
 
-            return dataGridViewColumn.Index;
+            return dataGridViewColumn?.Index ?? -1;
         }
 
         /// <summary>
@@ -457,6 +457,24 @@ namespace System.Windows.Forms
 
             Debug.Fail("no column found in GetColumnAtDisplayIndex");
             return null;
+        }
+
+        /// <summary>
+        ///  Returns the index of a column, taking into account DisplayIndex properties
+        ///  and the invisibility of other columns
+        /// </summary>
+        internal int GetVisibleIndex(DataGridViewColumn column)
+        {
+            for (int i = 0; i < Count; i++)
+            {
+                int index = ActualDisplayIndexToColumnIndex(i, DataGridViewElementStates.Visible);
+                if (index != -1 && _items[index] == column)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
         }
 
         public int GetColumnCount(DataGridViewElementStates includeFilter)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
@@ -1289,6 +1289,23 @@ namespace System.Windows.Forms
             return rowCount;
         }
 
+        /// <summary>
+        ///  Returns the index of the row, taking into account the invisibility of other rows
+        /// </summary>
+        internal int GetVisibleIndex(DataGridViewRow row)
+        {
+            for (int i = 0; i < Count; i++)
+            {
+                int index = DisplayIndexToRowIndex(i);
+                if (index != -1 && items[index] == row)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
         internal int GetRowCount(DataGridViewElementStates includeFilter, int fromRowIndex, int toRowIndex)
         {
             Debug.Assert(toRowIndex >= fromRowIndex);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewColumnHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewColumnHeaderCellAccessibleObjectTests.cs
@@ -114,6 +114,7 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewColumnHeaderCellAccessibleObject_IsPatternSupported_ReturnsExpected(int patternId)
         {
             var accessibleObject = new DataGridViewColumnHeaderCellAccessibleObject(null);
+
             Assert.True((bool)accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
         }
 
@@ -121,6 +122,7 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewColumnHeaderCellAccessibleObject_ControlType_ReturnsExpected()
         {
             var accessibleObject = new DataGridViewColumnHeaderCellAccessibleObject(null);
+
             Assert.Equal(UiaCore.UIA.HeaderControlTypeId, accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
         }
 
@@ -129,11 +131,816 @@ namespace System.Windows.Forms.Tests
         {
             using DataGridView control = new();
             control.Columns.Add("Column 1", "Header text 1");
-            DataGridViewColumn column = control.Columns[0];
+            var accessibleObject = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject topRowAccessibleObject = control.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
 
-            var accessibleObject = (DataGridViewColumnHeaderCellAccessibleObject)column.HeaderCell.AccessibilityObject;
+            Assert.Equal(topRowAccessibleObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
 
-            Assert.Equal(control.AccessibilityObject.GetChild(0), accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfFirstColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].Visible = false;
+
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfSecondColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[1].Visible = false;
+
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfLastColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[2].Visible = false;
+
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject0, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].Visible = false;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject0, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfSecondColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[1].Visible = false;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject0, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfLastColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[2].Visible = false;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject0, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfFirstColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].Visible = false;
+
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfSecondColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[1].Visible = false;
+
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfLastColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[2].Visible = false;
+
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject2.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject0, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject0.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].Visible = false;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject0.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject0, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject0.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfSecondColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[1].Visible = false;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject0, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject0.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfLastColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[2].Visible = false;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject2.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject0, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject0.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Child_ReturnsNull_IfRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            AccessibleObject accessibleObject = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Null(accessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Null(accessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Child_ReturnsNull()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Null(accessibleObject0.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Null(accessibleObject0.Navigate(AccessibleNavigation.LastChild));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Child_ReturnsNull_IfRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            AccessibleObject accessibleObject = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Child_ReturnsNull()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Null(accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject0, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndFirstColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[0].Visible = false;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject0, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndSecondColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[1].Visible = false;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject0, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndLastColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+            control.Columns[2].Visible = false;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject0, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject0.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndFirstColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[0].Visible = false;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndSecondColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[1].Visible = false;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndLastColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+            control.Columns[2].Visible = false;
+
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject0, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject0.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfCustomOrderAndFirstColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[0].Visible = false;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject2.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject0, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject0.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfCustomOrderAndSecondColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[1].Visible = false;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, accessibleObject0.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject0, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject0.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfCustomOrderAndLastColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+            control.Columns[2].Visible = false;
+
+            AccessibleObject accessibleObject0 = control.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject0.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject0, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject0.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfCustomOrderAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfCustomOrderAndFirstColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[0].Visible = false;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject2.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfCustomOrderAndSecondColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[1].Visible = false;
+            control.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject accessibleObject1 = control.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewColumnHeaderCellAccessibleObject_Navigate_Sibling_ReturnsExpected_IfCustomOrderAndLastColumnAndRowHeadersHidden()
+        {
+            using DataGridView control = new() { RowHeadersVisible = false };
+            control.Columns.Add("Column 1", "Column 1");
+            control.Columns.Add("Column 2", "Column 2");
+            control.Columns.Add("Column 3", "Column 3");
+            control.Columns[0].DisplayIndex = 2;
+            control.Columns[1].DisplayIndex = 1;
+            control.Columns[2].DisplayIndex = 0;
+            control.Columns[2].Visible = false;
+
+            AccessibleObject accessibleObject2 = control.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject2.Navigate(AccessibleNavigation.Previous));
             Assert.False(control.IsHandleCreated);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
@@ -15,6 +15,7 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewRowAccessibleObject_Ctor_Default()
         {
             var accessibleObject = new DataGridViewRowAccessibleObject();
+
             Assert.Null(accessibleObject.Owner);
             Assert.Equal(AccessibleRole.Row, accessibleObject.Role);
             Assert.Null(accessibleObject.DefaultAction);
@@ -32,6 +33,7 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewRowAccessibleObject_Ctor_DataGridViewRow(DataGridViewRow owner)
         {
             var accessibleObject = new DataGridViewRowAccessibleObject(owner);
+
             Assert.Equal(owner, accessibleObject.Owner);
             Assert.Equal(AccessibleRole.Row, accessibleObject.Role);
             Assert.Null(accessibleObject.DefaultAction);
@@ -63,16 +65,91 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Bounds);
         }
 
-        public static IEnumerable<object[]> Name_TestData()
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected_IfDataGridViewNotExist()
         {
-            yield return new object[] { new DataGridViewRowAccessibleObject(new DataGridViewRow()), "Row -1" };
+            AccessibleObject accessibilityObject = new DataGridViewRowAccessibleObject(new DataGridViewRow());
+
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibilityObject.Name);
         }
 
-        [Theory]
-        [MemberData(nameof(Name_TestData))]
-        public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected(AccessibleObject accessibleObject, string expected)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected()
         {
-            Assert.Equal(expected, accessibleObject.Name);
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject1.Name);
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject2.Name);
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, 2), accessibleObject3.Name);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected_IfFirstRowHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[0].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibleObject1.Name);
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject2.Name);
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject3.Name);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected_IfSecondRowHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[1].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject1.Name);
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibleObject2.Name);
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject3.Name);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Name_Get_ReturnsExpected_IfLastRowHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[2].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, 0), accessibleObject1.Name);
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, 1), accessibleObject2.Name);
+            Assert.Equal(string.Format(SR.DataGridView_AccRowName, -1), accessibleObject3.Name);
+            Assert.False(dataGridView.IsHandleCreated);
         }
 
         [Theory]
@@ -179,6 +256,7 @@ namespace System.Windows.Forms.Tests
         {
             using var owner = new DataGridViewRow();
             var accessibleObject = new DataGridViewRowAccessibleObject(owner);
+
             Assert.Null(accessibleObject.GetChild(index));
         }
 
@@ -203,6 +281,7 @@ namespace System.Windows.Forms.Tests
         {
             using var owner = new DataGridViewRow();
             var accessibleObject = new DataGridViewRowAccessibleObject(owner);
+
             Assert.Equal(0, accessibleObject.GetChildCount());
         }
 
@@ -229,6 +308,7 @@ namespace System.Windows.Forms.Tests
             Assert.Same(accessibleObject.GetSelected(), accessibleObject.GetSelected());
 
             AccessibleObject selectedAccessibleObject = accessibleObject.GetSelected();
+
             Assert.Equal("Selected Row Cells", selectedAccessibleObject.Name);
             Assert.Equal(owner.AccessibilityObject, selectedAccessibleObject.Parent);
             Assert.Equal(AccessibleRole.Grouping, selectedAccessibleObject.Role);
@@ -276,6 +356,7 @@ namespace System.Windows.Forms.Tests
         {
             using var owner = new DataGridViewRow();
             var accessibleObject = new DataGridViewRowAccessibleObject(owner);
+
             Assert.Null(accessibleObject.Navigate(navigationDirection));
         }
 
@@ -291,6 +372,7 @@ namespace System.Windows.Forms.Tests
         {
             using var owner = new DataGridViewRow();
             var accessibleObject = new DataGridViewRowAccessibleObject(owner);
+
             accessibleObject.Select(flags);
         }
 
@@ -305,6 +387,7 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewRowAccessibleObject_FragmentRoot_ReturnsNull_WithoutDataGridView()
         {
             using DataGridViewRow dataGridViewRow = new();
+
             Assert.Null(dataGridViewRow.AccessibilityObject.FragmentRoot);
         }
 
@@ -313,7 +396,1974 @@ namespace System.Windows.Forms.Tests
         {
             using DataGridViewRow dataGridViewRow = new();
             bool actualValue = (bool)dataGridViewRow.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsEnabledPropertyId);
+
             Assert.False(actualValue);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfFirstRowHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(topRowAccessibleObject, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfSecondRowHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfLastRowHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfSpecialRowHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false, AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfFirstRowAndSpecialRowHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false, AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[0].Visible = false;
+
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfSecondRowAndSpecialRowHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false, AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[1].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfLastRowAndSpecialRowHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false, AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[2].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfColumnHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfFirstRowAndColumnHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            dataGridView.Rows[0].Visible = false;
+
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfSecondRowAndColumnHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            dataGridView.Rows[1].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfLastRowAndColumnHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            dataGridView.Rows[2].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject4, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfUserRowHidden()
+        {
+            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfFirstRowAndUserRowHidden()
+        {
+            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(topRowAccessibleObject, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfSecondRowAndUserRowHidden()
+        {
+            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject3, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Sibling_ReturnExpected_IfLastRowAndUserRowHidden()
+        {
+            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(accessibleObject2, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject4, accessibleObject3.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject4.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(topRowAccessibleObject.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfFirstRowHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject4, accessibleObject3.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject4.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(topRowAccessibleObject, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(topRowAccessibleObject.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfSecondRowHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject4, accessibleObject3.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject4.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(topRowAccessibleObject.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfLastRowHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject4, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject4.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject4.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(topRowAccessibleObject.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfSpecialRowHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false, AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfFirstRowAndSpecialRowHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false, AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[0].Visible = false;
+
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfSecondRowAndSpecialRowHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false, AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[1].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfLastRowAndSpecialRowHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false, AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[2].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject2.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfColumnHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject4, accessibleObject3.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject4.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfFirstRowAndColumnHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            dataGridView.Rows[0].Visible = false;
+
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject4, accessibleObject3.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject4.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfSecondRowAndColumnHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            dataGridView.Rows[1].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject3, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject4, accessibleObject3.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject4.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject3, accessibleObject4.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfLastRowAndColumnHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { ColumnHeadersVisible = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            dataGridView.Rows[2].Visible = false;
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject4 = dataGridView.Rows[3].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject4, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject4.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject4.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfUserRowHidden()
+        {
+            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(topRowAccessibleObject.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfFirstRowAndUserRowHidden()
+        {
+            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject2.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject2, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(topRowAccessibleObject, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(topRowAccessibleObject.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfSecondRowAndUserRowHidden()
+        {
+            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject3, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject3.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject3.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(topRowAccessibleObject.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Sibling_ReturnExpected_IfLastRowAndUserRowHidden()
+        {
+            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add("1");
+            dataGridView.Rows.Add("2");
+            dataGridView.Rows.Add("3");
+            dataGridView.Rows[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[1].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.Next));
+            Assert.Equal(accessibleObject2, accessibleObject1.Navigate(AccessibleNavigation.Next));
+            Assert.Null(accessibleObject2.Navigate(AccessibleNavigation.Next));
+
+            Assert.Equal(accessibleObject1, accessibleObject2.Navigate(AccessibleNavigation.Previous));
+            Assert.Equal(topRowAccessibleObject, accessibleObject1.Navigate(AccessibleNavigation.Previous));
+            Assert.Null(topRowAccessibleObject.Navigate(AccessibleNavigation.Previous));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_ReturnsExpected_IfColumnsHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsNull_IfRowHeadersAndColumnsHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Null(rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfRowHeadersAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfRowHeadersAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfRowHeadersAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfRowHeadersAndAllColumnsHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Null(rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfAllColumnsHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndFirstColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndSecondColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndLastColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsNull_IfRowHeadersAndColumnsHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Null(rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Null(rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfRowHeadersAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfRowHeadersAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfRowHeadersAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfRowHeadersAndAllColumnsHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Null(rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Null(rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfAllColumnsHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfCustomOrderAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfCustomOrderAndFirstColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfCustomOrderAndSecondColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfCustomOrderAndLastColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfCustomOrderAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfCustomOrderAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Navigate_Child_ReturnsExpected_IfCustomOrderAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, rowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfRowHeadersAndColumnsHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Null(rowAccessibleObject.GetChild(0));
+            Assert.Null(rowAccessibleObject.GetChild(1));
+            Assert.Null(rowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(2));
+            Assert.Null(rowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfRowHeadersAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(1));
+            Assert.Null(rowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfRowHeadersAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(1));
+            Assert.Null(rowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfRowHeadersAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(1));
+            Assert.Null(rowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(2));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(3));
+            Assert.Null(rowAccessibleObject.GetChild(4));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfAllColumnsHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.GetChild(0));
+            Assert.Null(rowAccessibleObject.GetChild(1));
+            Assert.Null(rowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(2));
+            Assert.Null(rowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(2));
+            Assert.Null(rowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfThirdColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(2));
+            Assert.Null(rowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(2));
+            Assert.Null(rowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndRowHeadersAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(1));
+            Assert.Null(rowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndRowHeadersAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(1));
+            Assert.Null(rowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndRowHeadersAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(1));
+            Assert.Null(rowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(2));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(3));
+            Assert.Null(rowAccessibleObject.GetChild(4));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(2));
+            Assert.Null(rowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, rowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(2));
+            Assert.Null(rowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, rowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, rowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, rowAccessibleObject.GetChild(2));
+            Assert.Null(rowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChildCount_ReturnsFour()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Equal(4, rowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChildCount_ReturnsThree_IfOneColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Equal(3, rowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChildCount_ReturnsTwo_IfTwoColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Equal(2, rowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChildCount_ReturnsOne_IfAllColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Equal(1, rowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChildCount_ReturnsThreeIfRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Equal(3, rowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChildCount_ReturnsTwo_IfRowHeadersAndOneColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Equal(2, rowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChildCount_ReturnsOne_IfRowHeadersAndTwoColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Equal(1, rowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_GetChildCount_ReturnsZero_IfRowHeadersAndAllColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Equal(0, rowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
         }
 
         private class SubDataGridViewCell : DataGridViewCell

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopRowAccessibleObjectTests.cs
@@ -26,6 +26,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expectedNextSibling, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
             Assert.Equal(expectedFirstChild, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
             Assert.Equal(expectedLastChild, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -45,6 +46,7 @@ namespace System.Windows.Forms.Tests
             Assert.Null(topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
             Assert.Equal(expectedFirstChild, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
             Assert.Equal(expectedLastChild, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -60,6 +62,1174 @@ namespace System.Windows.Forms.Tests
             Assert.Null(topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
             Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
             Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfRowHeadersAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfRowHeadersAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfRowHeadersAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfRowHeadersAndAllColumnsHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfAllColumnsHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndFirstColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndSecondColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndLastColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfCustomOrderAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfRowHeadersAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfRowHeadersAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfRowHeadersAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfRowHeadersAndAllColumnsHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Null(topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Null(topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfAllColumnsHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfCustomOrderAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfCustomOrderAndFirstColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfCustomOrderAndSecondColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfCustomOrderAndLastColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfCustomOrderAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfCustomOrderAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_Navigate_ReturnsExpected_IfCustomOrderAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.Navigate(AccessibleNavigation.FirstChild));
+            Assert.Equal(accessibleObject, topRowAccessibleObject.Navigate(AccessibleNavigation.LastChild));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfRowHeadersAndColumnsHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Null(topRowAccessibleObject.GetChild(0));
+            Assert.Null(topRowAccessibleObject.GetChild(1));
+            Assert.Null(topRowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(2));
+            Assert.Null(topRowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfRowHeadersAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(1));
+            Assert.Null(topRowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfRowHeadersAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(1));
+            Assert.Null(topRowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfRowHeadersAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(1));
+            Assert.Null(topRowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(2));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(3));
+            Assert.Null(topRowAccessibleObject.GetChild(4));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfAllColumnsHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.GetChild(0));
+            Assert.Null(topRowAccessibleObject.GetChild(1));
+            Assert.Null(topRowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(2));
+            Assert.Null(topRowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(2));
+            Assert.Null(topRowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfThirdColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(2));
+            Assert.Null(topRowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(2));
+            Assert.Null(topRowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndRowHeadersAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(1));
+            Assert.Null(topRowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndRowHeadersAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(1));
+            Assert.Null(topRowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndRowHeadersAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(1));
+            Assert.Null(topRowAccessibleObject.GetChild(2));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(2));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(3));
+            Assert.Null(topRowAccessibleObject.GetChild(4));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(2));
+            Assert.Null(topRowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject1 = dataGridView.Columns[2].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject1, topRowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(2));
+            Assert.Null(topRowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChild_ReturnsExpected_IfCustomOrderAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+            AccessibleObject topLeftAccessibilityObject = dataGridView.TopLeftHeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Columns[1].HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject3 = dataGridView.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(topLeftAccessibilityObject, topRowAccessibleObject.GetChild(0));
+            Assert.Equal(accessibleObject2, topRowAccessibleObject.GetChild(1));
+            Assert.Equal(accessibleObject3, topRowAccessibleObject.GetChild(2));
+            Assert.Null(topRowAccessibleObject.GetChild(3));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChildCount_ReturnsFour()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Equal(4, topRowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChildCount_ReturnsThree_IfOneColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Equal(3, topRowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChildCount_ReturnsTwo_IfTwoColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Equal(2, topRowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChildCount_ReturnsOne_IfAllColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Equal(1, topRowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChildCount_ReturnsThreeIfRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Equal(3, topRowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChildCount_ReturnsTwo_IfRowHeadersAndOneColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Equal(2, topRowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChildCount_ReturnsOne_IfRowHeadersAndTwoColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Equal(1, topRowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopRowAccessibleObject_GetChildCount_ReturnsZero_IfRowHeadersAndAllColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Column 1");
+            dataGridView.Columns.Add("Column 2", "Column 2");
+            dataGridView.Columns.Add("Column 3", "Column 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.Columns[2].Visible = false;
+
+            AccessibleObject topRowAccessibleObject = dataGridView.AccessibilityObject.TestAccessor().Dynamic.TopRowAccessibilityObject;
+
+            Assert.Equal(0, topRowAccessibleObject.GetChildCount());
+            Assert.False(dataGridView.IsHandleCreated);
         }
     }
 }


### PR DESCRIPTION
Fixes #6471

## Proposed changes
- The issue is reproduced because when getting information about a `DataGridViewCell`/`DataGridViewRow`, we do not take into account that `DataGridViewColumn` and `DataGridViewRow` may be hidden.
- Added refactoring for some methods. Added additional checks to avoid exceptions.
- Fixed the logic for getting the following properties:
  - `DataGridViewRowAccessibleObject`
    * `ColumnCount`
    * `GetColumnHeaders`
    * `GetItem`
    * `GetRowHeaders`
    * `RowCount`
  - `DataGridViewCellAccessibleObject`
    * `Column`
    * `Name`
    * `Row`
  - `DataGridViewRowAccessibleObject.Name`
- Added unit tests

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/149331974-8263eda4-ee7f-49ac-83e8-cf39f44fd309.png)
 
**After fix:** 
![image](https://user-images.githubusercontent.com/23376742/149333251-949b9f9f-04c9-4a70-bdaa-83be8a97d76b.png)

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect
- Narrator
- Accessibility Insights
 
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19041.1348]
- .NET Core SDK: 7.0.0-alpha.1.22061.11

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6498)