### PR TITLE
Fix FlatStyle drawing of ComboBox

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.FlatComboAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.FlatComboAdapter.cs
@@ -4,8 +4,6 @@
 
 using System.Drawing;
 using System.Windows.Forms.Layout;
-using static Interop;
-using static Interop.User32;
 
 namespace System.Windows.Forms
 {
@@ -185,48 +183,6 @@ namespace System.Windows.Forms
 
             protected virtual Color GetInnerBorderColor(ComboBox comboBox)
                 => comboBox.Enabled ? comboBox.BackColor : SystemColors.Control;
-
-            /// <summary>
-            ///  This eliminates flicker by removing the pieces we're going to paint ourselves from the update region.
-            ///  Note the UpdateRegionBox is the bounding box of the actual update region. This is here so we can
-            ///  quickly eliminate rectangles that aren't in the update region.
-            /// </summary>
-            public unsafe void ValidateOwnerDrawRegions(ComboBox comboBox, Rectangle updateRegionBox)
-            {
-                if (comboBox is null)
-                {
-                    return;
-                }
-
-                Rectangle topOwnerDrawArea = new Rectangle(0, 0, comboBox.Width, _innerBorder.Top);
-                Rectangle bottomOwnerDrawArea = new Rectangle(0, _innerBorder.Bottom, comboBox.Width, comboBox.Height - _innerBorder.Bottom);
-                Rectangle leftOwnerDrawArea = new Rectangle(0, 0, _innerBorder.Left, comboBox.Height);
-                Rectangle rightOwnerDrawArea = new Rectangle(_innerBorder.Right, 0, comboBox.Width - _innerBorder.Right, comboBox.Height);
-
-                if (topOwnerDrawArea.IntersectsWith(updateRegionBox))
-                {
-                    RECT validRect = new RECT(topOwnerDrawArea);
-                    ValidateRect(comboBox, &validRect);
-                }
-
-                if (bottomOwnerDrawArea.IntersectsWith(updateRegionBox))
-                {
-                    RECT validRect = new RECT(bottomOwnerDrawArea);
-                    ValidateRect(comboBox, &validRect);
-                }
-
-                if (leftOwnerDrawArea.IntersectsWith(updateRegionBox))
-                {
-                    RECT validRect = new RECT(leftOwnerDrawArea);
-                    ValidateRect(comboBox, &validRect);
-                }
-
-                if (rightOwnerDrawArea.IntersectsWith(updateRegionBox))
-                {
-                    RECT validRect = new RECT(rightOwnerDrawArea);
-                    ValidateRect(comboBox, &validRect);
-                }
-            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3915,8 +3915,6 @@ namespace System.Windows.Forms
                         RECT updateRegionBoundingRect = default;
                         Gdi32.GetRgnBox(windowRegion, ref updateRegionBoundingRect);
 
-                        FlatComboBoxAdapter.ValidateOwnerDrawRegions(this, updateRegionBoundingRect);
-
                         // Call the base class to do its painting (with a clipped DC).
                         bool useBeginPaint = m.WParamInternal == 0;
                         using var paintScope = useBeginPaint ? new BeginPaintScope(Handle) : default;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6494


## Proposed changes

`ComboBox.FlatComboAdapter.ValidateOwnerDrawRegions` contained a bug in its initial null check that prevented the method from executing. This bug existed under Framework 4.8 (and possibly quite earlier):

https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/ComboBox.cs,6102

The bug was fixed in #6300, which resulted in a regression when drawing a `ComboBox` with `FlatStyle.Flat` or `FlatStyle.Popup`. 

While the stated purpose of `ValidateOwnerDrawRegions` was to reduce screen flicker, the fact remains that the method never actually executed and allowing it to execute now is causing problems. This PR fixes the issue by just removing the method altogether.


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

`ComboBox` will draw itself correctly again.

## Regression? 

- Yes

## Risk

- Should be minimal. This simply returns behavior to what it was prior to #6300

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

Reference #6494 to see example of issue prior to fix

### After

<!-- TODO -->

Screenshot taken after removal of `ValidateOwnerDrawRegions`

![image](https://user-images.githubusercontent.com/13544395/149530211-1181f150-9add-4dd5-810c-3196b7bd7779.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6505)