### PR TITLE
Make ToolStripItem non-nullable in ToolStripItemRenderEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2881,12 +2881,12 @@ System.Windows.Forms.ToolStripItemClickedEventArgs.ToolStripItemClickedEventArgs
 System.Windows.Forms.ToolStripItemEventArgs.Item.get -> System.Windows.Forms.ToolStripItem?
 System.Windows.Forms.ToolStripItemEventArgs.ToolStripItemEventArgs(System.Windows.Forms.ToolStripItem? item) -> void
 System.Windows.Forms.ToolStripItemImageRenderEventArgs.Image.get -> System.Drawing.Image?
-System.Windows.Forms.ToolStripItemImageRenderEventArgs.ToolStripItemImageRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem? item, System.Drawing.Image? image, System.Drawing.Rectangle imageRectangle) -> void
-System.Windows.Forms.ToolStripItemImageRenderEventArgs.ToolStripItemImageRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem? item, System.Drawing.Rectangle imageRectangle) -> void
+System.Windows.Forms.ToolStripItemImageRenderEventArgs.ToolStripItemImageRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem! item, System.Drawing.Image? image, System.Drawing.Rectangle imageRectangle) -> void
+System.Windows.Forms.ToolStripItemImageRenderEventArgs.ToolStripItemImageRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem! item, System.Drawing.Rectangle imageRectangle) -> void
 System.Windows.Forms.ToolStripItemRenderEventArgs.Graphics.get -> System.Drawing.Graphics!
-System.Windows.Forms.ToolStripItemRenderEventArgs.Item.get -> System.Windows.Forms.ToolStripItem?
+System.Windows.Forms.ToolStripItemRenderEventArgs.Item.get -> System.Windows.Forms.ToolStripItem!
 System.Windows.Forms.ToolStripItemRenderEventArgs.ToolStrip.get -> System.Windows.Forms.ToolStrip?
-System.Windows.Forms.ToolStripItemRenderEventArgs.ToolStripItemRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem? item) -> void
+System.Windows.Forms.ToolStripItemRenderEventArgs.ToolStripItemRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripItem! item) -> void
 System.Windows.Forms.ToolStripItemTextRenderEventArgs.Text.get -> string?
 System.Windows.Forms.ToolStripItemTextRenderEventArgs.Text.set -> void
 System.Windows.Forms.ToolStripItemTextRenderEventArgs.TextFont.get -> System.Drawing.Font?
@@ -2967,7 +2967,7 @@ System.Windows.Forms.ToolStripRenderEventArgs.ToolStripRenderEventArgs(System.Dr
 ~System.Windows.Forms.ToolStripSeparator.ImageKey.set -> void
 ~System.Windows.Forms.ToolStripSeparator.ToolTipText.get -> string
 ~System.Windows.Forms.ToolStripSeparator.ToolTipText.set -> void
-System.Windows.Forms.ToolStripSeparatorRenderEventArgs.ToolStripSeparatorRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripSeparator? separator, bool vertical) -> void
+System.Windows.Forms.ToolStripSeparatorRenderEventArgs.ToolStripSeparatorRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripSeparator! separator, bool vertical) -> void
 ~System.Windows.Forms.ToolStripSplitButton.DefaultItem.get -> System.Windows.Forms.ToolStripItem
 ~System.Windows.Forms.ToolStripSplitButton.DefaultItem.set -> void
 ~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string text) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemImageRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemImageRenderEventArgs.cs
@@ -9,10 +9,10 @@ namespace System.Windows.Forms
 {
     public class ToolStripItemImageRenderEventArgs : ToolStripItemRenderEventArgs
     {
-        public ToolStripItemImageRenderEventArgs(Graphics g, ToolStripItem? item, Rectangle imageRectangle)
+        public ToolStripItemImageRenderEventArgs(Graphics g, ToolStripItem item, Rectangle imageRectangle)
             : base(g, item)
         {
-            Image = (item is not null && item.RightToLeftAutoMirrorImage && item.RightToLeft == RightToLeft.Yes) ? item.MirroredImage : item?.Image;
+            Image = (item.RightToLeftAutoMirrorImage && item.RightToLeft == RightToLeft.Yes) ? item.MirroredImage : item.Image;
             ImageRectangle = imageRectangle;
         }
 
@@ -21,7 +21,7 @@ namespace System.Windows.Forms
         /// </summary>
         public ToolStripItemImageRenderEventArgs(
             Graphics g,
-            ToolStripItem? item,
+            ToolStripItem item,
             Image? image,
             Rectangle imageRectangle)
             : base(g, item)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemRenderEventArgs.cs
@@ -11,10 +11,10 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents all the information to render the ToolStrip
         /// </summary>
-        public ToolStripItemRenderEventArgs(Graphics g, ToolStripItem? item)
+        public ToolStripItemRenderEventArgs(Graphics g, ToolStripItem item)
         {
             Graphics = g.OrThrowIfNull();
-            Item = item;
+            Item = item.OrThrowIfNull();
         }
 
         /// <summary>
@@ -25,11 +25,11 @@ namespace System.Windows.Forms
         /// <summary>
         ///  The item to draw
         /// </summary>
-        public ToolStripItem? Item { get; }
+        public ToolStripItem Item { get; }
 
         /// <summary>
         ///  The toolstrip the item is currently parented to
         /// </summary>
-        public ToolStrip? ToolStrip => Item?.ParentInternal;
+        public ToolStrip? ToolStrip => Item.ParentInternal;
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparatorRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparatorRenderEventArgs.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents all the information to render the ToolStrip
         /// </summary>
-        public ToolStripSeparatorRenderEventArgs(Graphics g, ToolStripSeparator? separator, bool vertical)
+        public ToolStripSeparatorRenderEventArgs(Graphics g, ToolStripSeparator separator, bool vertical)
             : base(g, separator)
         {
             Vertical = vertical;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripGripRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripGripRenderEventArgsTests.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(Ctor_Null_Graphics_ToolStrip_TestData))]
-        public void ToolStripGripRenderEventArgs_NullParameter_ThrowsArgumentNullException(Graphics g, ToolStrip toolStrip)
+        public void ToolStripGripRenderEventArgs_Null_Graphics_ToolStrip_ThrowsArgumentNullException(Graphics g, ToolStrip toolStrip)
         {
             Assert.Throws<ArgumentNullException>(() => new ToolStripGripRenderEventArgs(g, toolStrip));
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemImageRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemImageRenderEventArgsTests.cs
@@ -9,10 +9,21 @@ namespace System.Windows.Forms.Tests
 {
     public class ToolStripItemImageRenderEventArgsTests : IClassFixture<ThreadExceptionFixture>
     {
-        [WinFormsFact]
-        public void ToolStripItemImageRenderEventArgs_NullGraphics_ThrowsArgumentNullException()
+        public static IEnumerable<object[]> Ctor_Null_Graphics_ToolStripItem_TestData()
         {
-            Assert.Throws<ArgumentNullException>(() => new ToolStripItemImageRenderEventArgs(null, null, Rectangle.Empty));
+            var image = new Bitmap(10, 10);
+            Graphics graphics = Graphics.FromImage(image);
+
+            yield return new object[] { null, null };
+            yield return new object[] { null, new ToolStripButton() };
+            yield return new object[] { graphics, null };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Ctor_Null_Graphics_ToolStripItem_TestData))]
+        public void ToolStripItemImageRenderEventArgs_Null_Graphics_ToolStripItem_ThrowsArgumentNullException(Graphics g, ToolStripItem toolStripItem)
+        {
+            Assert.Throws<ArgumentNullException>(() => new ToolStripItemImageRenderEventArgs(g, toolStripItem, Rectangle.Empty));
         }
 
         public static IEnumerable<object[]> Ctor_Graphics_ToolStripItem_Rectangle_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemRenderEventArgsTests.cs
@@ -9,10 +9,21 @@ namespace System.Windows.Forms.Tests
 {
     public class ToolStripItemRenderEventArgsTests : IClassFixture<ThreadExceptionFixture>
     {
-        [WinFormsFact]
-        public void ToolStripItemRenderEventArgs_NullGraphics_ThrowsArgumentNullException()
+        public static IEnumerable<object[]> Ctor_Null_Graphics_ToolStripItem_TestData()
         {
-            Assert.Throws<ArgumentNullException>(() => new ToolStripItemRenderEventArgs(null, null));
+            var image = new Bitmap(10, 10);
+            Graphics graphics = Graphics.FromImage(image);
+
+            yield return new object[] { null, null };
+            yield return new object[] { null, new ToolStripButton() };
+            yield return new object[] { graphics, null };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Ctor_Null_Graphics_ToolStripItem_TestData))]
+        public void ToolStripItemRenderEventArgs_Null_Graphics_ToolStripItem_ThrowsArgumentNullException(Graphics g, ToolStripItem toolStripItem)
+        {
+            Assert.Throws<ArgumentNullException>(() => new ToolStripItemRenderEventArgs(g, toolStripItem));
         }
 
         public static IEnumerable<object[]> Ctor_Graphics_ToolStripItem_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRenderEventArgsTests.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(Ctor_Null_Graphics_ToolStrip_TestData))]
-        public void ToolStripRenderEventArgs_NullParameters_ThrowsArgumentNullException(Graphics g, ToolStrip toolStrip)
+        public void ToolStripRenderEventArgs_Null_Graphics_ToolStrip_ThrowsArgumentNullException(Graphics g, ToolStrip toolStrip)
         {
             Assert.Throws<ArgumentNullException>(() => new ToolStripRenderEventArgs(g, toolStrip));
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
@@ -81,7 +81,6 @@ namespace System.Windows.Forms.Tests
 
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
-            yield return new object[] { new ToolStripItemRenderEventArgs(graphics, null) };
             yield return new object[] { new ToolStripItemRenderEventArgs(graphics, new SubToolStripItem()) };
         }
 
@@ -194,7 +193,6 @@ namespace System.Windows.Forms.Tests
         {
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
-            yield return new object[] { graphics, null, new Bitmap(10, 10), Rectangle.Empty };
             yield return new object[] { graphics, new SubToolStripItem(), new Bitmap(10, 10), new Rectangle(1, 2, 3, 4) };
             yield return new object[] { graphics, new SubToolStripItem { Enabled = false }, new Bitmap(10, 10), new Rectangle(1, 2, 3, 4) };
 
@@ -423,8 +421,6 @@ namespace System.Windows.Forms.Tests
 
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
-            yield return new object[] { new ToolStripSeparatorRenderEventArgs(graphics, null, true) };
-            yield return new object[] { new ToolStripSeparatorRenderEventArgs(graphics, null, false) };
             yield return new object[] { new ToolStripSeparatorRenderEventArgs(graphics, new ToolStripSeparator(), true) };
             yield return new object[] { new ToolStripSeparatorRenderEventArgs(graphics, new ToolStripSeparator(), false) };
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSeparatorRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSeparatorRenderEventArgsTests.cs
@@ -9,17 +9,28 @@ namespace System.Windows.Forms.Tests
 {
     public class ToolStripSeparatorRenderEventArgsTests : IClassFixture<ThreadExceptionFixture>
     {
-        [WinFormsFact]
-        public void ToolStripSeparatorRenderEventArgs_NullGraphics_ThrowsArgumentNullException()
+        public static IEnumerable<object[]> Ctor_Null_Graphics_ToolStripSeparator_TestData()
         {
-            Assert.Throws<ArgumentNullException>(() => new ToolStripSeparatorRenderEventArgs(null, null, true));
+            var image = new Bitmap(10, 10);
+            Graphics graphics = Graphics.FromImage(image);
+
+            yield return new object[] { null, null };
+            yield return new object[] { null, new ToolStripSeparator() };
+            yield return new object[] { graphics, null };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(Ctor_Null_Graphics_ToolStripSeparator_TestData))]
+        public void ToolStripSeparatorRenderEventArgs_Null_Graphics_ToolStripSeparator_ThrowsArgumentNullException(Graphics g, ToolStripSeparator toolStripSeparator)
+        {
+            Assert.Throws<ArgumentNullException>(() => new ToolStripSeparatorRenderEventArgs(g, toolStripSeparator, true));
         }
 
         public static IEnumerable<object[]> Ctor_Graphics_ToolStripItem_Bool_TestData()
         {
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
-            yield return new object[] { graphics, null, true };
+            yield return new object[] { graphics, new ToolStripSeparator(), true };
             yield return new object[] { graphics, new ToolStripSeparator(), false };
         }
 


### PR DESCRIPTION
## Proposed changes

- Make ToolStripItem non-nullable in ToolStripItemRenderEventArgs.
- Addresses feedback in https://github.com/dotnet/winforms/pull/6391.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6507)