### PR TITLE
Make contentPanel non-nullable in ToolStripContentPanelRenderEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2807,8 +2807,8 @@ System.Windows.Forms.ToolStripArrowRenderEventArgs.ToolStripArrowRenderEventArgs
 ~System.Windows.Forms.ToolStripContentPanel.Renderer.get -> System.Windows.Forms.ToolStripRenderer
 ~System.Windows.Forms.ToolStripContentPanel.Renderer.set -> void
 System.Windows.Forms.ToolStripContentPanelRenderEventArgs.Graphics.get -> System.Drawing.Graphics!
-System.Windows.Forms.ToolStripContentPanelRenderEventArgs.ToolStripContentPanel.get -> System.Windows.Forms.ToolStripContentPanel?
-System.Windows.Forms.ToolStripContentPanelRenderEventArgs.ToolStripContentPanelRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripContentPanel? contentPanel) -> void
+System.Windows.Forms.ToolStripContentPanelRenderEventArgs.ToolStripContentPanel.get -> System.Windows.Forms.ToolStripContentPanel!
+System.Windows.Forms.ToolStripContentPanelRenderEventArgs.ToolStripContentPanelRenderEventArgs(System.Drawing.Graphics! g, System.Windows.Forms.ToolStripContentPanel! contentPanel) -> void
 ~System.Windows.Forms.ToolStripControlHost.Control.get -> System.Windows.Forms.Control
 ~System.Windows.Forms.ToolStripControlHost.ToolStripControlHost(System.Windows.Forms.Control c) -> void
 ~System.Windows.Forms.ToolStripControlHost.ToolStripControlHost(System.Windows.Forms.Control c, string name) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripContentPanelRenderEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripContentPanelRenderEventArgs.cs
@@ -11,10 +11,10 @@ namespace System.Windows.Forms
         /// <summary>
         ///  This class represents all the information to render the toolStrip
         /// </summary>
-        public ToolStripContentPanelRenderEventArgs(Graphics g, ToolStripContentPanel? contentPanel)
+        public ToolStripContentPanelRenderEventArgs(Graphics g, ToolStripContentPanel contentPanel)
         {
             Graphics = g.OrThrowIfNull();
-            ToolStripContentPanel = contentPanel;
+            ToolStripContentPanel = contentPanel.OrThrowIfNull();
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Represents which toolStrip was affected by the click
         /// </summary>
-        public ToolStripContentPanel? ToolStripContentPanel { get; }
+        public ToolStripContentPanel ToolStripContentPanel { get; }
 
         public bool Handled { get; set; }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelRenderEventArgsTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelRenderEventArgsTests.cs
@@ -9,28 +9,32 @@ namespace System.Windows.Forms.Tests
 {
     public class ToolStripContentPanelRenderEventArgsTests : IClassFixture<ThreadExceptionFixture>
     {
-        [WinFormsFact]
-        public void ToolStripContentPanelRenderEventArgs_NullGraphics_ThrowsArgumentNullException()
-        {
-            Assert.Throws<ArgumentNullException>(() => new ToolStripContentPanelRenderEventArgs(null, null));
-        }
-
-        public static IEnumerable<object[]> Ctor_Graphics_ToolStripContentPanel_TestData()
+        public static IEnumerable<object[]> Ctor_Null_Graphics_ToolStripContentPanel_TestData()
         {
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
 
+            yield return new object[] { null, null };
             yield return new object[] { graphics, null };
-            yield return new object[] { graphics, new ToolStripContentPanel() };
+            yield return new object[] { null, new ToolStripContentPanel() };
         }
 
         [WinFormsTheory]
-        [MemberData(nameof(Ctor_Graphics_ToolStripContentPanel_TestData))]
-        public void Ctor_Graphics_ToolStripContentPanel(Graphics g, ToolStripContentPanel contentPanel)
+        [MemberData(nameof(Ctor_Null_Graphics_ToolStripContentPanel_TestData))]
+        public void ToolStripContentPanelRenderEventArgs_Null_Graphics_ToolStripContentPanel_ThrowsArgumentNullException(Graphics g, ToolStripContentPanel toolStripContentPanel)
         {
-            var e = new ToolStripContentPanelRenderEventArgs(g, contentPanel);
-            Assert.Equal(g, e.Graphics);
-            Assert.Equal(contentPanel, e.ToolStripContentPanel);
+            Assert.Throws<ArgumentNullException>(() => new ToolStripContentPanelRenderEventArgs(g, toolStripContentPanel));
+        }
+
+        [WinFormsFact]
+        public void Ctor_Graphics_ToolStripContentPanel()
+        {
+            using var image = new Bitmap(10, 10);
+            using Graphics graphics = Graphics.FromImage(image);
+            using var toolStripContentPanel = new ToolStripContentPanel();
+            var e = new ToolStripContentPanelRenderEventArgs(graphics, toolStripContentPanel);
+            Assert.Equal(graphics, e.Graphics);
+            Assert.Equal(toolStripContentPanel, e.ToolStripContentPanel);
             Assert.False(e.Handled);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
@@ -667,7 +667,6 @@ namespace System.Windows.Forms.Tests
 
             var image = new Bitmap(10, 10);
             Graphics graphics = Graphics.FromImage(image);
-            yield return new object[] { new ToolStripContentPanelRenderEventArgs(graphics, null) };
             yield return new object[] { new ToolStripContentPanelRenderEventArgs(graphics, new ToolStripContentPanel()) };
         }
 


### PR DESCRIPTION
## Proposed changes

- Make contentPanel non-nullable in ToolStripContentPanelRenderEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6510)