### PR TITLE
Added UIA support for split container

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+~override System.Windows.Forms.SplitContainer.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.SplitContainerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.SplitContainerAccessibleObject.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class SplitContainer
+    {
+        internal class SplitContainerAccessibleObject : ControlAccessibleObject
+        {
+            public SplitContainerAccessibleObject(SplitContainer owner) : base(owner)
+            {
+            }
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+               => propertyID switch
+               {
+                   UiaCore.UIA.AutomationIdPropertyId
+                       => Owner.Name,
+                   UiaCore.UIA.HasKeyboardFocusPropertyId
+                       => Owner.Focused,
+                   UiaCore.UIA.IsKeyboardFocusablePropertyId
+                       => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                   _ => base.GetPropertyValue(propertyID)
+               };
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
     [Docking(DockingBehavior.AutoDock)]
     [Designer("System.Windows.Forms.Design.SplitContainerDesigner, " + AssemblyRef.SystemDesign)]
     [SRDescription(nameof(SR.DescriptionSplitContainer))]
-    public class SplitContainer : ContainerControl, ISupportInitialize
+    public partial class SplitContainer : ContainerControl, ISupportInitialize
     {
         // Constants used during split container movement
         private const int DrawStart = 1;
@@ -830,6 +830,8 @@ namespace System.Windows.Forms
             }
         }
 
+        internal override bool SupportsUiaProviders => true;
+
         /// <summary>
         ///  Indicates whether the user can give the focus to this control using the TAB
         ///  key. This property is read-only.
@@ -1474,6 +1476,9 @@ namespace System.Windows.Forms
 
             return r;
         }
+
+        protected override AccessibleObject CreateAccessibilityInstance()
+            => new SplitContainerAccessibleObject(this);
 
         /// <summary>
         ///  Draws the splitter bar at the current location. Will automatically

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitContainer.SplitContainerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitContainer.SplitContainerAccessibleObjectTests.cs
@@ -3,39 +3,39 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using static Interop;
+using static Interop.UiaCore;
 
 namespace System.Windows.Forms.Tests
 {
-    public class SplitContainer_SplitContainerAccessibilityObjectTests : IClassFixture<ThreadExceptionFixture>
+    public class SplitContainer_SplitContainerAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
-        public void SplitContainerAccessibilityObject_Ctor_Default()
+        public void SplitContainerAccessibleObject_Ctor_Default()
         {
-            using SplitContainer splitContainer = new SplitContainer();
-            splitContainer.CreateControl();
+            using SplitContainer splitContainer = new();
+            SplitContainer.SplitContainerAccessibleObject accessibleObject = new(splitContainer);
 
-            Assert.NotNull(splitContainer.AccessibilityObject);
-            Assert.True(splitContainer.IsHandleCreated);
+            Assert.Equal(splitContainer, accessibleObject.Owner);
+            Assert.False(splitContainer.IsHandleCreated);
         }
 
         [WinFormsFact]
-        public void SplitContainerAccessibilityObject_ControlType_IsPane_IfAccessibleRoleIsDefault()
+        public void SplitContainerAccessibleObject_ControlType_IsPane_IfAccessibleRoleIsDefault()
         {
-            using SplitContainer splitContainer = new SplitContainer();
+            using SplitContainer splitContainer = new();
             splitContainer.CreateControl();
             // AccessibleRole is not set = Default
 
-            object actual = splitContainer.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
+            object actual = splitContainer.AccessibilityObject.GetPropertyValue(UIA.ControlTypePropertyId);
 
-            Assert.Equal(UiaCore.UIA.PaneControlTypeId, actual);
+            Assert.Equal(UIA.PaneControlTypeId, actual);
             Assert.True(splitContainer.IsHandleCreated);
         }
 
         [WinFormsFact]
-        public void SplitContainerAccessibilityObject_Role_IsClient_ByDefault()
+        public void SplitContainerAccessibleObject_Role_IsClient_ByDefault()
         {
-            using SplitContainer splitContainer = new SplitContainer();
+            using SplitContainer splitContainer = new();
             splitContainer.CreateControl();
             // AccessibleRole is not set = Default
 
@@ -64,14 +64,58 @@ namespace System.Windows.Forms.Tests
         [MemberData(nameof(SplitContainerAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData))]
         public void SplitContainerAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole(AccessibleRole role)
         {
-            using SplitContainer splitContainer = new SplitContainer();
+            using SplitContainer splitContainer = new();
             splitContainer.AccessibleRole = role;
 
-            object actual = splitContainer.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
-            UiaCore.UIA expected = AccessibleRoleControlTypeMap.GetControlType(role);
+            object actual = splitContainer.AccessibilityObject.GetPropertyValue(UIA.ControlTypePropertyId);
+            UIA expected = AccessibleRoleControlTypeMap.GetControlType(role);
 
             Assert.Equal(expected, actual);
             Assert.False(splitContainer.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UIA.NamePropertyId, "TestName")]
+        [InlineData((int)UIA.AutomationIdPropertyId, "SplitContainer1")]
+        public void SplitContainerAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
+        {
+            using SplitContainer control = new()
+            {
+                Name = "SplitContainer1",
+                AccessibleName = "TestName"
+            };
+
+            var accessibleObject = new SplitContainer.SplitContainerAccessibleObject(control);
+            object value = accessibleObject.GetPropertyValue((UIA)propertyID);
+
+            Assert.Equal(expected, value);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void SplitContainerAccessibleObject_GetPropertyValue_HasKeyboardFocus_ReturnsTrue_IfControlHasFocus()
+        {
+            using SplitContainer control = new();
+
+            var accessibleObject = new SplitContainer.SplitContainerAccessibleObject(control);
+            Assert.False(control.IsHandleCreated);
+            control.FocusActiveControlInternal();
+            bool value = (bool)accessibleObject.GetPropertyValue(UIA.HasKeyboardFocusPropertyId);
+
+            Assert.True(value);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void SplitContainerAccessibleObject_GetPropertyValue_HasKeyboardFocus_ReturnsFalse_IfControlHasNoFocus()
+        {
+            using SplitContainer control = new();
+
+            var accessibleObject = new SplitContainer.SplitContainerAccessibleObject(control);
+            bool value = (bool)accessibleObject.GetPropertyValue(UIA.HasKeyboardFocusPropertyId);
+
+            Assert.False(value);
+            Assert.False(control.IsHandleCreated);
         }
     }
 }


### PR DESCRIPTION
Partially implements #3421

## Proposed changes

- Updated "SupportsUiaProviders" flag.
- Added and implemented splitContainer accessible object
- Added unit tests

## Customer Impact

**Before update:**

![InspectPropertiesWithoutUIA](https://user-images.githubusercontent.com/74228865/150120413-8c3a7d07-607b-4905-a6e0-4c0150483c70.png)


![AIPropertiesWithoutUIA](https://user-images.githubusercontent.com/74228865/150120445-4343adc8-12a4-483a-b3ce-1b6a89bd68ff.PNG)

**After update:**

![InspectPropertiesWithUIA](https://user-images.githubusercontent.com/74228865/150120490-64c7c459-574b-435d-ba70-309093b64d4b.png)

![AIPropertiesWithUIA](https://user-images.githubusercontent.com/74228865/150120509-5ad97fda-ddea-4a45-ba1a-dac51ea4891d.PNG)


## Regression? 

- No

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Narrator
- Inspect
- Accessibility Insights

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.22000.318]
- .NET Core SDK: 7.0.0-alpha.1.21562.1


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6519)