### PR TITLE
Reverting fix with drawing a border for a standard button

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms.ButtonInternal
         // SystemInformation.Border3DSize + 2 pixels for focus rect
         protected const int ButtonBorderSize = 4;
 
-        // Coefficient for darkening the border color of the "Popup" and "Standard" buttons
+        // Coefficient for darkening the border color of the "Popup" button
         protected const float ButtonBorderDarkerOffset = 0.8f;
 
         internal ButtonBaseAdapter(ButtonBase control) =>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonStandardAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonStandardAdapter.cs
@@ -72,14 +72,6 @@ namespace System.Windows.Forms.ButtonInternal
                 pbState,
                 DpiHelper.IsScalingRequirementMet ? Control.HandleInternal : IntPtr.Zero);
 
-            if (!SystemInformation.HighContrast && pbState == PushButtonState.Normal)
-            {
-                ControlPaint.DrawBorderSimple(
-                    e.GraphicsInternal,
-                    Rectangle.Inflate(bounds, -1, -1),
-                    ControlPaint.Darker(SystemColors.ButtonShadow, ButtonBorderDarkerOffset));
-            }
-
             // Now overlay the background image or backcolor (the former overrides the latter), leaving a margin.
             // We hardcode this margin for now since GetThemeMargins returns 0 all the time.
             //


### PR DESCRIPTION
## Proposed changes

- Reverting fix with drawing a border for a standard button

## Regression? 

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
-  Manual testing

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19044.1469]
- .NET Core SDK: 7.0.0-alpha.1.22067.10

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6522)