### PR TITLE
Do not use flat style in high contrast mode

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3903,7 +3903,7 @@ namespace System.Windows.Forms
                     break;
 
                 case WM.PAINT:
-                    if (GetStyle(ControlStyles.UserPaint) == false && (FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup) && !DisplayInformation.HighContrast)
+                    if (GetStyle(ControlStyles.UserPaint) == false && (FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup) && !SystemInformation.HighContrast)
                     {
                         using var dropDownRegion = new Gdi32.RegionScope(FlatComboBoxAdapter._dropDownRect);
                         using var windowRegion = new Gdi32.RegionScope(Bounds);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3903,7 +3903,7 @@ namespace System.Windows.Forms
                     break;
 
                 case WM.PAINT:
-                    if (GetStyle(ControlStyles.UserPaint) == false && (FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup))
+                    if (GetStyle(ControlStyles.UserPaint) == false && (FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup) && !DisplayInformation.HighContrast)
                     {
                         using var dropDownRegion = new Gdi32.RegionScope(FlatComboBoxAdapter._dropDownRect);
                         using var windowRegion = new Gdi32.RegionScope(Bounds);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3903,7 +3903,7 @@ namespace System.Windows.Forms
                     break;
 
                 case WM.PAINT:
-                    if (GetStyle(ControlStyles.UserPaint) == false && (FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup) && !SystemInformation.HighContrast)
+                    if (GetStyle(ControlStyles.UserPaint) == false && (FlatStyle == FlatStyle.Flat || FlatStyle == FlatStyle.Popup) && !(SystemInformation.HighContrast && BackColor == SystemColors.Window))
                     {
                         using var dropDownRegion = new Gdi32.RegionScope(FlatComboBoxAdapter._dropDownRect);
                         using var windowRegion = new Gdi32.RegionScope(Bounds);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6155.


## Proposed changes

`ComboBox.FlatStyle` has two modes that do not show up correctly when in high contrast mode:

- `FlatStyle.Flat` renders the `ComboBox` with no border
- `FlatStyle.Popup` renders the same as `FlatStyle.Flat` except when focused/moused over, in which case it attempts to simulate the natively drawn border

Since high contrast mode uses the same color for `ComboBox.BackColor` as it does for `Form.BackColor` and since the control has no border, it is not visually perceptible except for its chevron. This PR checks for high contrast mode and renders the same as `FlatStyle.Standard`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- `ComboBox` will be visible in high contrast mode

## Regression? 

- No

## Risk

Should be minimal with the exception of fringe cases such as:
 
- Possibility of a developer deriving from `ComboBox` and performing their own custom drawing logic that is somehow dependent on the current rendering behavior of the control while in high contrast mode
- Possibility that a visually imperceptible `ComboBox` is the desired outcome when in high contrast mode

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

- Left: normal
- Right: high contrast
- Styles (top to bottom): `Standard`, `Flat`, `Popup`

![image](https://user-images.githubusercontent.com/13544395/150195988-e3834c76-8a0c-4a0d-ab2d-ad860205e894.png)

### After

<!-- TODO -->

Same order as before

![image](https://user-images.githubusercontent.com/13544395/150196020-4e47ac71-6507-4306-a195-8efcf2f7f59e.png)

## Test methodology <!-- How did you ensure quality? -->

- Manual testing

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6524)