### PR TITLE
Move FabricBot rules to Configuration-As-Code

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,0 +1,1261 @@
+[
+  {
+    "taskType": "trigger",
+    "capabilityId": "CodeFlowLink",
+    "subCapability": "CodeFlowLink",
+    "version": "1.0",
+    "config": {
+      "taskName": "Add a CodeFlow link to new pull requests"
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestReviewResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Add needs author feedback label to pull requests when changes are requested",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "submitted"
+            }
+          },
+          {
+            "name": "isReviewState",
+            "parameters": {
+              "state": "changes_requested"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": ":mailbox_with_no_mail: waiting-author-feedback"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove needs author feedback label when the author responds to a pull request",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":mailbox_with_no_mail: waiting-author-feedback"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": ":mailbox_with_no_mail: waiting-author-feedback"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove needs author feedback label when the author comments on a pull request",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":mailbox_with_no_mail: waiting-author-feedback"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": ":mailbox_with_no_mail: waiting-author-feedback"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "issue_comment"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestReviewResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove needs author feedback label when the author responds to a pull request review comment",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":mailbox_with_no_mail: waiting-author-feedback"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": ":mailbox_with_no_mail: waiting-author-feedback"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove no recent activity label from pull requests",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": ":zzz: no-recent-activity"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestCommentResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove no recent activity label when a pull request is commented on",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": ":zzz: no-recent-activity"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "issue_comment"
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestReviewResponder",
+    "version": "1.0",
+    "config": {
+      "taskName": "Remove no recent activity label when a pull request is reviewed",
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          }
+        ]
+      },
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": ":zzz: no-recent-activity"
+          }
+        }
+      ],
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request_review"
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Close stale issues and pull requests",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": -8
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isPr",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": ":mailbox_with_no_mail: waiting-author-feedback"
+          }
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": ":zzz: no-recent-activity"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 7
+          }
+        },
+        {
+          "name": "isIssue",
+          "parameters": {}
+        }
+      ],
+      "actions": [
+        {
+          "name": "closeIssue",
+          "parameters": {}
+        },
+        {
+          "name": "removeMilestone",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "taskName": "Add no recent activity label to issues and pull requests",
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 10
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 10
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 10
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 10
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 10
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 10
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            2,
+            5,
+            8,
+            11,
+            14,
+            17,
+            20,
+            23
+          ],
+          "timezoneOffset": 10
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isPr",
+          "parameters": {}
+        },
+        {
+          "name": "isOpen",
+          "parameters": {}
+        },
+        {
+          "name": "hasLabel",
+          "parameters": {
+            "label": ":mailbox_with_no_mail: waiting-author-feedback"
+          }
+        },
+        {
+          "name": "noActivitySince",
+          "parameters": {
+            "days": 14
+          }
+        },
+        {
+          "name": "noLabel",
+          "parameters": {
+            "label": ":zzz: no-recent-activity"
+          }
+        },
+        {
+          "name": "isIssue",
+          "parameters": {}
+        }
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": ":zzz: no-recent-activity"
+          }
+        },
+        {
+          "name": "addReply",
+          "parameters": {
+            "comment": "This submission has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **14 days**. \n\nIt will be closed if no further activity occurs **within 7 days of this comment**."
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "AutoMerge",
+    "subCapability": "AutoMerge",
+    "version": "1.0",
+    "config": {
+      "taskName": "Automatically merge pull requests",
+      "label": ":octocat:  automerge",
+      "silentMode": false,
+      "minMinutesOpen": "60",
+      "mergeType": "squash",
+      "deleteBranches": true,
+      "requireAllStatuses": false,
+      "removeLabelOnPush": true,
+      "allowAutoMergeInstructionsWithoutLabel": true,
+      "conditionalMergeTypes": [
+        {
+          "mergeType": "squash",
+          "condition": {
+            "placeholder": ""
+          }
+        }
+      ],
+      "usePrDescriptionAsCommitMessage": true
+    },
+    "disabled": false
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "ReleaseAnnouncement",
+    "subCapability": "ReleaseAnnouncement",
+    "version": "1.0",
+    "config": {
+      "taskName": "Release announcement",
+      "prReply": "The fix is included in ${pkgName} ${version}.",
+      "issueReply": "Fixed in ${pkgName} ${version}."
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "InPrLabel",
+    "subCapability": "InPrLabel",
+    "version": "1.0",
+    "config": {
+      "taskName": "In-PR label",
+      "label_inPr": ":construction: work in progress",
+      "fixedLabelEnabled": false,
+      "label_fixed": "tell-mode"
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "prTargetsBranch",
+            "parameters": {
+              "branchName": "main"
+            }
+          },
+          {
+            "operator": "and",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "merged"
+                }
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "titleContains",
+                    "parameters": {
+                      "titlePattern": "[main] Update dependencies"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "actions": [
+        {
+          "name": "addMilestone",
+          "parameters": {
+            "milestoneName": "7.0 Preview2"
+          }
+        }
+      ],
+      "taskName": "Apply milestone '7.0' to PRs on the main branch",
+      "dangerZone": {
+        "respondToBotActions": true,
+        "acceptRespondToBotActions": true
+      }
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "dotnet-maestro[bot]"
+            }
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Auto-approve maestro PRs",
+      "actions": [
+        {
+          "name": "approvePullRequest",
+          "parameters": {
+            "comment": "Go, you big red fire engine!"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "labelAdded",
+            "parameters": {
+              "label": ":octocat:  automerge"
+            }
+          },
+          {
+            "operator": "or",
+            "operands": [
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "admin"
+                }
+              },
+              {
+                "name": "activitySenderHasPermissions",
+                "parameters": {
+                  "permissions": "write"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Auto-approve auto-merge PRs",
+      "actions": [
+        {
+          "name": "approvePullRequest",
+          "parameters": {
+            "comment": "Happy to oblige"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "EmailCleanser",
+    "subCapability": "EmailCleanser",
+    "version": "1.0",
+    "config": {
+      "taskName": "Cleanse emails"
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": []
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "actions": [
+        {
+          "name": "assignToUser",
+          "parameters": {
+            "user": {
+              "type": "prAuthor"
+            }
+          }
+        }
+      ],
+      "taskName": "Assign PRs to authors"
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": {
+                "type": "author"
+              }
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":mailbox_with_no_mail: waiting-author-feedback"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "Remove needs author feedback label when the author comments on an issue",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": ":mailbox_with_no_mail: waiting-author-feedback"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssueCommentResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issue_comment"
+      ],
+      "taskName": "Remove no recent activity label when an issue is commented on",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": ":zzz: no-recent-activity"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "operator": "not",
+            "operands": [
+              {
+                "name": "isAction",
+                "parameters": {
+                  "action": "closed"
+                }
+              }
+            ]
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Remove no recent activity label from issue",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": ":zzz: no-recent-activity"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "closed"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Remove closed issues from milestones",
+      "actions": [
+        {
+          "name": "removeMilestone",
+          "parameters": {}
+        }
+      ]
+    }
+  },
+  {
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "PullRequestResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isAssignedToUser",
+            "parameters": {
+              "user": "dotnet-bot"
+            }
+          },
+          {
+            "name": "titleContains",
+            "parameters": {
+              "titlePattern": "OneLocBuild"
+            }
+          },
+          {
+            "name": "isAction",
+            "parameters": {
+              "action": "opened"
+            }
+          }
+        ]
+      },
+      "eventType": "pull_request",
+      "eventNames": [
+        "pull_request",
+        "issues",
+        "project_card"
+      ],
+      "taskName": "Auto-approve OneLocBuild PRs",
+      "actions": [
+        {
+          "name": "approvePullRequest",
+          "parameters": {
+            "comment": "Go, you big red fire engine!"
+          }
+        },
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": ":octocat:  automerge"
+          }
+        }
+      ],
+      "dangerZone": {
+        "respondToBotActions": true,
+        "acceptRespondToBotActions": true
+      }
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isDraftPr",
+          "parameters": {
+            "value": "true"
+          }
+        }
+      ],
+      "actions": [
+        {
+          "name": "addLabel",
+          "parameters": {
+            "label": "draft"
+          }
+        }
+      ],
+      "taskName": "Add draft label"
+    }
+  },
+  {
+    "taskType": "scheduled",
+    "capabilityId": "ScheduledSearch",
+    "subCapability": "ScheduledSearch",
+    "version": "1.1",
+    "config": {
+      "frequency": [
+        {
+          "weekDay": 0,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 1,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 2,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 3,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 4,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 5,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        },
+        {
+          "weekDay": 6,
+          "hours": [
+            1,
+            5,
+            9,
+            13,
+            17,
+            21
+          ],
+          "timezoneOffset": -7
+        }
+      ],
+      "searchTerms": [
+        {
+          "name": "isDraftPr",
+          "parameters": {
+            "value": "false"
+          }
+        }
+      ],
+      "taskName": "Remove draft label",
+      "actions": [
+        {
+          "name": "removeLabel",
+          "parameters": {
+            "label": "draft"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/docs/infra/automation.md
+++ b/docs/infra/automation.md
@@ -1,0 +1,7 @@
+## Automation
+
+### Fabric Bot
+
+This repository uses Fabric Bot to automate issue and pull request management. All automation rules are defined in the [`.github/fabricbot.json`](.github/fabricbot.json) file.
+
+At this moment Fabric Bot has not published a JSON schema for the configuration format. In order to make changes to the configuration file, you should use the [`Fabric Bot portal`](https://portal.fabricbot.ms/bot/) to load the configuration file via the "Import Configuration" option and make changes using the editor. You need to be signed out from the portal in order for this option to appear.


### PR DESCRIPTION
Migrates FabricBot automation for the dotnet-api-docs to [Config-as-Code](https://microsoft.sharepoint.com/teams/FabricBot/SitePages/Config-as-code.aspx). The file is a dump of the automation rules that are currently active and doesn't contain any additional changes.


Similar to https://github.com/dotnet/runtime/pull/62297 and https://github.com/dotnet/dotnet-api-docs/pull/7442.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6538)