### PR TITLE
Clean up code in AxHost/DataObject/ContainerControl

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.CoGetClassObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.CoGetClassObject.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
             ref Guid rclsid,
             CLSCTX dwContext,
             IntPtr pvReserved,
-            ref Guid riid,
+            in Guid riid,
             [MarshalAs(UnmanagedType.Interface)] out IClassFactory2 ppv);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.OleCreatePictureIndirect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.OleCreatePictureIndirect.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     {
         [DllImport(Libraries.Oleaut32, PreserveSig = false)]
         [return: MarshalAs(UnmanagedType.Interface)]
-        private unsafe static extern object OleCreatePictureIndirect(PICTDESC* pictdesc, ref Guid refiid, BOOL fOwn);
+        private unsafe static extern object OleCreatePictureIndirect(PICTDESC* pictdesc, in Guid refiid, BOOL fOwn);
 
         [DllImport(Libraries.Oleaut32, EntryPoint = "OleCreatePictureIndirect")]
         private unsafe static extern int OleCreatePictureIndirectRaw(PICTDESC* pictdesc, Guid* refiid, BOOL fOwn, IntPtr* lplpvObj);
@@ -19,12 +19,12 @@ internal static partial class Interop
         ///  <see cref="BOOL.TRUE"/> if the picture object is to destroy its picture when the object is destroyed.
         ///  (The picture handle in the <paramref name="pictdesc"/>.)
         /// </param>
-        public unsafe static object OleCreatePictureIndirect(ref PICTDESC pictdesc, ref Guid refiid, BOOL fOwn)
+        public unsafe static object OleCreatePictureIndirect(ref PICTDESC pictdesc, in Guid refiid, BOOL fOwn)
         {
             pictdesc.cbSizeofstruct = (uint)sizeof(PICTDESC);
             fixed (PICTDESC* p = &pictdesc)
             {
-                return OleCreatePictureIndirect(p, ref refiid, fOwn);
+                return OleCreatePictureIndirect(p, in refiid, fOwn);
             }
         }
 

--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.OleCreateFontIndirect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.OleCreateFontIndirect.cs
@@ -9,9 +9,9 @@ internal partial class Interop
     internal static partial class Oleaut32
     {
         [DllImport(Libraries.Oleaut32, ExactSpelling = true, PreserveSig = false)]
-        public static extern Ole32.IFont OleCreateFontIndirect(ref FONTDESC lpFontDesc, ref Guid riid);
+        public static extern Ole32.IFont OleCreateFontIndirect(ref FONTDESC lpFontDesc, in Guid riid);
 
         [DllImport(Libraries.Oleaut32, ExactSpelling = true, EntryPoint = "OleCreateFontIndirect", PreserveSig = false)]
-        public static extern Ole32.IFontDisp OleCreateIFontDispIndirect(ref FONTDESC lpFontDesc, ref Guid riid);
+        public static extern Ole32.IFontDisp OleCreateIFontDispIndirect(ref FONTDESC lpFontDesc, in Guid riid);
     }
 }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Mocks/MockAxHost.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/Interop/Mocks/MockAxHost.cs
@@ -12,8 +12,8 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Mocks
 {
     internal class MockAxHost
     {
-        private static Guid ipictureDisp_Guid = typeof(IPictureDisp).GUID;
-        private static Guid ipicture_Guid = typeof(IPicture).GUID;
+        private static readonly Guid s_ipictureDisp_Guid = typeof(IPictureDisp).GUID;
+        private static readonly Guid s_ipicture_Guid = typeof(IPicture).GUID;
 
         public MockAxHost(string clsidString)
         {
@@ -22,19 +22,19 @@ namespace System.Windows.Forms.Primitives.Tests.Interop.Mocks
         public static IPictureDisp GetIPictureDispFromPicture(Image image)
         {
             PICTDESC desc = GetPICTDESCFromPicture(image);
-            return (IPictureDisp)OleCreatePictureIndirect(ref desc, ref ipictureDisp_Guid, fOwn: BOOL.TRUE);
+            return (IPictureDisp)OleCreatePictureIndirect(ref desc, in s_ipictureDisp_Guid, fOwn: BOOL.TRUE);
         }
 
         public static IPicture GetIPictureFromCursor(IntPtr cursorHandle)
         {
             PICTDESC desc = PICTDESC.FromIcon(Icon.FromHandle(cursorHandle), copy: true);
-            return (IPicture)OleCreatePictureIndirect(ref desc, ref ipicture_Guid, fOwn: BOOL.TRUE);
+            return (IPicture)OleCreatePictureIndirect(ref desc, in s_ipicture_Guid, fOwn: BOOL.TRUE);
         }
 
         public static IPicture GetIPictureFromPicture(Image image)
         {
             PICTDESC desc = GetPICTDESCFromPicture(image);
-            return (IPicture)OleCreatePictureIndirect(ref desc, ref ipicture_Guid, fOwn: BOOL.TRUE);
+            return (IPicture)OleCreatePictureIndirect(ref desc, in s_ipicture_Guid, fOwn: BOOL.TRUE);
         }
 
         public static Image? GetPictureFromIPicture(object picture)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxComponentEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxComponentEditor.cs
@@ -15,14 +15,16 @@ namespace System.Windows.Forms
     {
         public class AxComponentEditor : WindowsFormsComponentEditor
         {
+#pragma warning disable CA1725 // Parameter names should match base declaration - "obj" and "parent" is how this is documented
             public override bool EditComponent(ITypeDescriptorContext context, object obj, IWin32Window parent)
+#pragma warning restore CA1725
             {
                 if (obj is AxHost host)
                 {
                     try
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in AxComponentEditor.EditComponent");
-                        ((Ole32.IOleControlSite)host.oleSite).ShowPropertyFrame();
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in AxComponentEditor.EditComponent");
+                        ((Ole32.IOleControlSite)host._oleSite).ShowPropertyFrame();
                         return true;
                     }
                     catch (Exception t)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxContainer.cs
@@ -20,23 +20,25 @@ namespace System.Windows.Forms
     {
         internal class AxContainer : IOleContainer, IOleInPlaceFrame, IReflect
         {
-            internal ContainerControl parent;
-            private IContainer assocContainer; // associated IContainer...
-            // the assocContainer may be null, in which case all this container does is
-            // forward [de]activation messages to the requisite container...
-            private AxHost siteUIActive;
-            private AxHost siteActive;
-            private bool formAlreadyCreated;
-            private readonly Hashtable containerCache = new Hashtable();  // name -> Control
-            private int lockCount;
-            private Hashtable components;  // Control -> any
-            private Hashtable proxyCache;
-            private AxHost ctlInEditMode;
+            internal ContainerControl _parent;
+
+            // The associated container may be null, in which case all this container does is
+            // forward [de]activation messages to the requisite container.
+            private IContainer _associatedContainer;
+
+            private AxHost _siteUIActive;
+            private AxHost _siteActive;
+            private bool _formAlreadyCreated;
+            private readonly Hashtable _containerCache = new();  // name -> Control
+            private int _lockCount;
+            private Hashtable _components;  // Control -> any
+            private Hashtable _proxyCache;
+            private AxHost _controlInEditMode;
 
             internal AxContainer(ContainerControl parent)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in constructor.  Parent created : " + parent.Created.ToString());
-                this.parent = parent;
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in constructor.  Parent created : {parent.Created}");
+                _parent = parent;
                 if (parent.Created)
                 {
                     FormCreated();
@@ -95,10 +97,17 @@ namespace System.Windows.Forms
                 return Array.Empty<MemberInfo>();
             }
 
-            object IReflect.InvokeMember(string name, BindingFlags invokeAttr, Binder binder,
-                                                    object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
+            object IReflect.InvokeMember(
+                string name,
+                BindingFlags invokeAttr,
+                Binder binder,
+                object target,
+                object[] args,
+                ParameterModifier[] modifiers,
+                CultureInfo culture,
+                string[] namedParameters)
             {
-                foreach (DictionaryEntry e in containerCache)
+                foreach (DictionaryEntry e in _containerCache)
                 {
                     string ctlName = GetNameForControl((Control)e.Key);
                     if (ctlName.Equals(name))
@@ -107,7 +116,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                throw E_FAIL;
+                throw s_unknownErrorException;
             }
 
             Type IReflect.UnderlyingSystemType
@@ -121,20 +130,20 @@ namespace System.Windows.Forms
             internal Oleaut32.IExtender GetProxyForControl(Control ctl)
             {
                 Oleaut32.IExtender rval = null;
-                if (proxyCache is null)
+                if (_proxyCache is null)
                 {
-                    proxyCache = new Hashtable();
+                    _proxyCache = new Hashtable();
                 }
                 else
                 {
-                    rval = (Oleaut32.IExtender)proxyCache[ctl];
+                    rval = (Oleaut32.IExtender)_proxyCache[ctl];
                 }
 
                 if (rval is null)
                 {
-                    if (ctl != parent && !GetControlBelongs(ctl))
+                    if (ctl != _parent && !GetControlBelongs(ctl))
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "!parent || !belongs NYI");
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "!parent || !belongs NYI");
                         AxContainer c = FindContainerForControl(ctl);
                         if (c is not null)
                         {
@@ -142,7 +151,7 @@ namespace System.Windows.Forms
                         }
                         else
                         {
-                            Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "unable to find proxy, returning null");
+                            Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "unable to find proxy, returning null");
                             return null;
                         }
                     }
@@ -151,10 +160,10 @@ namespace System.Windows.Forms
                         rval = new ExtenderProxy(ctl, this);
                     }
 
-                    proxyCache.Add(ctl, rval);
+                    _proxyCache.Add(ctl, rval);
                 }
 
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "found proxy " + rval.ToString());
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"found proxy {rval}");
                 return rval;
             }
 
@@ -166,22 +175,21 @@ namespace System.Windows.Forms
 
             internal void AddControl(Control ctl)
             {
-                //
                 lock (this)
                 {
-                    if (containerCache.Contains(ctl))
+                    if (_containerCache.Contains(ctl))
                     {
                         throw new ArgumentException(string.Format(SR.AXDuplicateControl, GetNameForControl(ctl)), nameof(ctl));
                     }
 
-                    containerCache.Add(ctl, ctl);
+                    _containerCache.Add(ctl, ctl);
 
-                    if (assocContainer is null)
+                    if (_associatedContainer is null)
                     {
                         ISite site = ctl.Site;
                         if (site is not null)
                         {
-                            assocContainer = site.Container;
+                            _associatedContainer = site.Container;
                             IComponentChangeService ccs = (IComponentChangeService)site.GetService(typeof(IComponentChangeService));
                             if (ccs is not null)
                             {
@@ -193,9 +201,9 @@ namespace System.Windows.Forms
                     {
 #if DEBUG
                         ISite site = ctl.Site;
-                        if (site is not null && assocContainer != site.Container)
+                        if (site is not null && _associatedContainer != site.Container)
                         {
-                            Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "mismatch between assoc container & added control");
+                            Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "mismatch between assoc container & added control");
                         }
 #endif
                     }
@@ -204,27 +212,26 @@ namespace System.Windows.Forms
 
             internal void RemoveControl(Control ctl)
             {
-                //
                 lock (this)
                 {
-                    if (containerCache.Contains(ctl))
+                    if (_containerCache.Contains(ctl))
                     {
-                        containerCache.Remove(ctl);
+                        _containerCache.Remove(ctl);
                     }
                 }
             }
 
             private void LockComponents()
             {
-                lockCount++;
+                _lockCount++;
             }
 
             private void UnlockComponents()
             {
-                lockCount--;
-                if (lockCount == 0)
+                _lockCount--;
+                if (_lockCount == 0)
                 {
-                    components = null;
+                    _components = null;
                 }
             }
 
@@ -246,7 +253,7 @@ namespace System.Windows.Forms
                     if (onlyNext && onlyPrev)
                     {
                         Debug.Fail("onlyNext && onlyPrev are both set!");
-                        throw E_INVALIDARG;
+                        throw s_invalidArgumentException;
                     }
 
                     if (dwWhich == GC_WCH.CONTAINER || dwWhich == GC_WCH.CONTAINED)
@@ -254,7 +261,7 @@ namespace System.Windows.Forms
                         if (onlyNext || onlyPrev)
                         {
                             Debug.Fail("GC_WCH_FONLYNEXT or FONLYPREV used with CONTAINER or CONTAINED");
-                            throw E_INVALIDARG;
+                            throw s_invalidArgumentException;
                         }
                     }
 
@@ -265,7 +272,7 @@ namespace System.Windows.Forms
                     {
                         default:
                             Debug.Fail("Bad GC_WCH");
-                            throw E_INVALIDARG;
+                            throw s_invalidArgumentException;
                         case GC_WCH.CONTAINED:
                             ctls = ctl.GetChildControlsInTabOrder(false);
                             ctl = null;
@@ -299,8 +306,8 @@ namespace System.Windows.Forms
                                 AxContainer cont = FindContainerForControl(ctl);
                                 if (cont is not null)
                                 {
-                                    MaybeAdd(l, cont.parent, selected, dwOleContF, true);
-                                    ctl = cont.parent;
+                                    MaybeAdd(l, cont._parent, selected, dwOleContF, true);
+                                    ctl = cont._parent;
                                 }
                                 else
                                 {
@@ -313,7 +320,7 @@ namespace System.Windows.Forms
                             Hashtable htbl = GetComponents();
                             ctls = new Control[htbl.Keys.Count];
                             htbl.Keys.CopyTo(ctls, 0);
-                            ctl = parent;
+                            ctl = _parent;
                             break;
                     }
 
@@ -358,7 +365,7 @@ namespace System.Windows.Forms
 
             private void MaybeAdd(ArrayList l, Control ctl, bool selected, OLECONTF dwOleContF, bool ignoreBelong)
             {
-                if (!ignoreBelong && ctl != parent && !GetControlBelongs(ctl))
+                if (!ignoreBelong && ctl != _parent && !GetControlBelongs(ctl))
                 {
                     return;
                 }
@@ -393,12 +400,12 @@ namespace System.Windows.Forms
                     ComponentCollection comps = container.Components;
                     if (comps is not null)
                     {
-                        components = new Hashtable();
+                        _components = new Hashtable();
                         foreach (IComponent comp in comps)
                         {
-                            if (comp is Control && comp != parent && comp.Site is not null)
+                            if (comp is Control && comp != _parent && comp.Site is not null)
                             {
-                                components.Add(comp, comp);
+                                _components.Add(comp, comp);
                             }
                         }
 
@@ -406,30 +413,30 @@ namespace System.Windows.Forms
                     }
                 }
 
-                Debug.Assert(parent.Site is null, "Parent is sited but we could not find IContainer!!!");
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Did not find a container in FillComponentsTable!!!");
+                Debug.Assert(_parent.Site is null, "Parent is sited but we could not find IContainer!!!");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "Did not find a container in FillComponentsTable!!!");
 
                 bool checkHashTable = true;
-                Control[] ctls = new Control[containerCache.Values.Count];
-                containerCache.Values.CopyTo(ctls, 0);
+                Control[] ctls = new Control[_containerCache.Values.Count];
+                _containerCache.Values.CopyTo(ctls, 0);
                 if (ctls is not null)
                 {
-                    if (ctls.Length > 0 && components is null)
+                    if (ctls.Length > 0 && _components is null)
                     {
-                        components = new Hashtable();
+                        _components = new Hashtable();
                         checkHashTable = false;
                     }
 
                     for (int i = 0; i < ctls.Length; i++)
                     {
-                        if (checkHashTable && !components.Contains(ctls[i]))
+                        if (checkHashTable && !_components.Contains(ctls[i]))
                         {
-                            components.Add(ctls[i], ctls[i]);
+                            _components.Add(ctls[i], ctls[i]);
                         }
                     }
                 }
 
-                GetAllChildren(parent);
+                GetAllChildren(_parent);
             }
 
             private void GetAllChildren(Control ctl)
@@ -439,14 +446,14 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                if (components is null)
+                if (_components is null)
                 {
-                    components = new Hashtable();
+                    _components = new Hashtable();
                 }
 
-                if (ctl != parent && !components.Contains(ctl))
+                if (ctl != _parent && !_components.Contains(ctl))
                 {
-                    components.Add(ctl, ctl);
+                    _components.Add(ctl, ctl);
                 }
 
                 foreach (Control c in ctl.Controls)
@@ -462,12 +469,12 @@ namespace System.Windows.Forms
 
             private Hashtable GetComponents(IContainer cont)
             {
-                if (lockCount == 0)
+                if (_lockCount == 0)
                 {
                     FillComponentsTable(cont);
                 }
 
-                return components;
+                return _components;
             }
 
             private bool GetControlBelongs(Control ctl)
@@ -478,7 +485,7 @@ namespace System.Windows.Forms
 
             private IContainer GetParentIsDesigned()
             {
-                ISite site = parent.Site;
+                ISite site = _parent.Site;
                 if (site is not null && site.DesignMode)
                 {
                     return site.Container;
@@ -490,9 +497,9 @@ namespace System.Windows.Forms
             private IContainer GetParentsContainer()
             {
                 IContainer rval = GetParentIsDesigned();
-                Debug.Assert(rval is null || assocContainer is null || (rval == assocContainer),
+                Debug.Assert(rval is null || _associatedContainer is null || (rval == _associatedContainer),
                              "mismatch between getIPD & aContainer");
-                return rval ?? assocContainer;
+                return rval ?? _associatedContainer;
             }
 
             private bool RegisterControl(AxHost ctl)
@@ -503,13 +510,13 @@ namespace System.Windows.Forms
                     IContainer cont = site.Container;
                     if (cont is not null)
                     {
-                        if (assocContainer is not null)
+                        if (_associatedContainer is not null)
                         {
-                            return cont == assocContainer;
+                            return cont == _associatedContainer;
                         }
                         else
                         {
-                            assocContainer = cont;
+                            _associatedContainer = cont;
                             IComponentChangeService ccs = (IComponentChangeService)site.GetService(typeof(IComponentChangeService));
                             if (ccs is not null)
                             {
@@ -526,7 +533,7 @@ namespace System.Windows.Forms
 
             private void OnComponentRemoved(object sender, ComponentEventArgs e)
             {
-                if (sender == assocContainer && e.Component is Control c)
+                if (sender == _associatedContainer && e.Component is Control c)
                 {
                     RemoveControl(c);
                 }
@@ -536,9 +543,9 @@ namespace System.Windows.Forms
             {
                 if (ctl is AxHost axctl)
                 {
-                    if (axctl.container is not null)
+                    if (axctl._container is not null)
                     {
-                        return axctl.container;
+                        return axctl._container;
                     }
 
                     ContainerControl f = axctl.ContainingControl;
@@ -558,12 +565,12 @@ namespace System.Windows.Forms
 
             internal void OnInPlaceDeactivate(AxHost site)
             {
-                if (siteActive == site)
+                if (_siteActive == site)
                 {
-                    siteActive = null;
+                    _siteActive = null;
                     if (site.GetSiteOwnsDeactivation())
                     {
-                        parent.ActiveControl = null;
+                        _parent.ActiveControl = null;
                     }
                     else
                     {
@@ -575,12 +582,12 @@ namespace System.Windows.Forms
 
             internal void OnUIDeactivate(AxHost site)
             {
-                Debug.Assert(siteUIActive is null || siteUIActive == site, "deactivating when not active...");
+                Debug.Assert(_siteUIActive is null || _siteUIActive == site, "deactivating when not active...");
 
-                siteUIActive = null;
+                _siteUIActive = null;
                 site.RemoveSelectionHandler();
                 site.SetSelectionStyle(1);
-                site.editMode = EDITM_NONE;
+                site._editMode = EDITM_NONE;
             }
 
             internal void OnUIActivate(AxHost site)
@@ -588,30 +595,30 @@ namespace System.Windows.Forms
                 // The ShDocVw control repeatedly calls OnUIActivate() with the same
                 // site. This causes the assert below to fire.
                 //
-                if (siteUIActive == site)
+                if (_siteUIActive == site)
                 {
                     return;
                 }
 
-                if (siteUIActive is not null && siteUIActive != site)
+                if (_siteUIActive is not null && _siteUIActive != site)
                 {
-                    AxHost tempSite = siteUIActive;
-                    bool ownDisposing = tempSite.GetAxState(AxHost.ownDisposing);
+                    AxHost tempSite = _siteUIActive;
+                    bool ownDisposing = tempSite.GetAxState(s_ownDisposing);
                     try
                     {
-                        tempSite.SetAxState(AxHost.ownDisposing, true);
+                        tempSite.SetAxState(s_ownDisposing, true);
                         tempSite.GetInPlaceObject().UIDeactivate();
                     }
                     finally
                     {
-                        tempSite.SetAxState(AxHost.ownDisposing, ownDisposing);
+                        tempSite.SetAxState(s_ownDisposing, ownDisposing);
                     }
                 }
 
                 site.AddSelectionHandler();
-                Debug.Assert(siteUIActive is null, "Object did not call OnUIDeactivate");
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "active Object is now " + site.ToString());
-                siteUIActive = site;
+                Debug.Assert(_siteUIActive is null, "Object did not call OnUIDeactivate");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"active Object is now {site}");
+                _siteUIActive = site;
                 ContainerControl f = site.ContainingControl;
                 if (f is not null)
                 {
@@ -651,8 +658,8 @@ namespace System.Windows.Forms
 
             internal void ControlCreated(AxHost invoker)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in controlCreated for " + invoker.ToString() + " fAC: " + formAlreadyCreated.ToString());
-                if (formAlreadyCreated)
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in controlCreated for {invoker} fAC: {_formAlreadyCreated}");
+                if (_formAlreadyCreated)
                 {
                     if (invoker.IsUserMode() && invoker.AwaitingDefreezing())
                     {
@@ -662,18 +669,18 @@ namespace System.Windows.Forms
                 else
                 {
                     // the form will be created in the future
-                    parent.CreateAxContainer();
+                    _parent.CreateAxContainer();
                 }
             }
 
             internal void FormCreated()
             {
-                if (formAlreadyCreated)
+                if (_formAlreadyCreated)
                 {
                     return;
                 }
 
-                formAlreadyCreated = true;
+                _formAlreadyCreated = true;
                 ArrayList l = new ArrayList();
                 ListAxControls(l, false);
                 AxHost[] axControls = new AxHost[l.Count];
@@ -691,7 +698,7 @@ namespace System.Windows.Forms
             // IOleContainer methods:
             unsafe HRESULT IOleContainer.ParseDisplayName(IntPtr pbc, string pszDisplayName, uint* pchEaten, IntPtr* ppmkOut)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in ParseDisplayName");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in ParseDisplayName");
                 if (ppmkOut is not null)
                 {
                     *ppmkOut = IntPtr.Zero;
@@ -702,11 +709,10 @@ namespace System.Windows.Forms
 
             HRESULT IOleContainer.EnumObjects(OLECONTF grfFlags, out IEnumUnknown ppenum)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in EnumObjects");
-                ppenum = null;
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in EnumObjects");
                 if ((grfFlags & OLECONTF.EMBEDDINGS) != 0)
                 {
-                    Debug.Assert(parent is not null, "gotta have it...");
+                    Debug.Assert(_parent is not null, "gotta have it...");
                     ArrayList list = new ArrayList();
                     ListAxControls(list, true);
                     if (list.Count > 0)
@@ -724,7 +730,7 @@ namespace System.Windows.Forms
 
             HRESULT IOleContainer.LockContainer(BOOL fLock)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in LockContainer");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in LockContainer");
                 return HRESULT.E_NOTIMPL;
             }
 
@@ -736,68 +742,68 @@ namespace System.Windows.Forms
                     return HRESULT.E_POINTER;
                 }
 
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in GetWindow");
-                *phwnd = parent.Handle;
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in GetWindow");
+                *phwnd = _parent.Handle;
                 return HRESULT.S_OK;
             }
 
             HRESULT IOleInPlaceFrame.ContextSensitiveHelp(BOOL fEnterMode)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in ContextSensitiveHelp");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in ContextSensitiveHelp");
                 return HRESULT.S_OK;
             }
 
             unsafe HRESULT IOleInPlaceFrame.GetBorder(RECT* lprectBorder)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in GetBorder");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in GetBorder");
                 return HRESULT.E_NOTIMPL;
             }
 
             unsafe HRESULT IOleInPlaceFrame.RequestBorderSpace(RECT* pborderwidths)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in RequestBorderSpace");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in RequestBorderSpace");
                 return HRESULT.E_NOTIMPL;
             }
 
             unsafe HRESULT IOleInPlaceFrame.SetBorderSpace(RECT* pborderwidths)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in SetBorderSpace");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in SetBorderSpace");
                 return HRESULT.E_NOTIMPL;
             }
 
             internal void OnExitEditMode(AxHost ctl)
             {
-                Debug.Assert(ctlInEditMode is null || ctlInEditMode == ctl, "who is exiting edit mode?");
-                if (ctlInEditMode is null || ctlInEditMode != ctl)
+                Debug.Assert(_controlInEditMode is null || _controlInEditMode == ctl, "who is exiting edit mode?");
+                if (_controlInEditMode is null || _controlInEditMode != ctl)
                 {
                     return;
                 }
 
-                ctlInEditMode = null;
+                _controlInEditMode = null;
             }
 
             HRESULT IOleInPlaceFrame.SetActiveObject(IOleInPlaceActiveObject pActiveObject, string pszObjName)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in SetActiveObject " + (pszObjName ?? "<null>"));
-                if (siteUIActive is not null)
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in SetActiveObject {pszObjName ?? "<null>"}");
+                if (_siteUIActive is not null)
                 {
-                    if (siteUIActive.iOleInPlaceActiveObjectExternal != pActiveObject)
+                    if (_siteUIActive._iOleInPlaceActiveObjectExternal != pActiveObject)
                     {
-                        if (siteUIActive.iOleInPlaceActiveObjectExternal is not null)
+                        if (_siteUIActive._iOleInPlaceActiveObjectExternal is not null)
                         {
-                            Marshal.ReleaseComObject(siteUIActive.iOleInPlaceActiveObjectExternal);
+                            Marshal.ReleaseComObject(_siteUIActive._iOleInPlaceActiveObjectExternal);
                         }
 
-                        siteUIActive.iOleInPlaceActiveObjectExternal = pActiveObject;
+                        _siteUIActive._iOleInPlaceActiveObjectExternal = pActiveObject;
                     }
                 }
 
                 if (pActiveObject is null)
                 {
-                    if (ctlInEditMode is not null)
+                    if (_controlInEditMode is not null)
                     {
-                        ctlInEditMode.editMode = EDITM_NONE;
-                        ctlInEditMode = null;
+                        _controlInEditMode._editMode = EDITM_NONE;
+                        _controlInEditMode = null;
                     }
 
                     return HRESULT.S_OK;
@@ -808,30 +814,30 @@ namespace System.Windows.Forms
                 {
                     HRESULT hr = oleObject.GetClientSite(out IOleClientSite clientSite);
                     Debug.Assert(hr.Succeeded());
-                    if (clientSite is OleInterfaces)
+                    if (clientSite is OleInterfaces interfaces)
                     {
-                        ctl = ((OleInterfaces)(clientSite)).GetAxHost();
+                        ctl = interfaces.GetAxHost();
                     }
 
-                    if (ctlInEditMode is not null)
+                    if (_controlInEditMode is not null)
                     {
-                        Debug.Fail("control " + ctlInEditMode.ToString() + " did not reset its edit mode to null");
-                        ctlInEditMode.SetSelectionStyle(1);
-                        ctlInEditMode.editMode = EDITM_NONE;
+                        Debug.Fail($"control {_controlInEditMode} did not reset its edit mode to null");
+                        _controlInEditMode.SetSelectionStyle(1);
+                        _controlInEditMode._editMode = EDITM_NONE;
                     }
 
                     if (ctl is null)
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "control w/o a valid site called setactiveobject");
-                        ctlInEditMode = null;
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "control w/o a valid site called setactiveobject");
+                        _controlInEditMode = null;
                     }
                     else
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "resolved to " + ctl.ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"resolved to {ctl}");
                         if (!ctl.IsUserMode())
                         {
-                            ctlInEditMode = ctl;
-                            ctl.editMode = EDITM_OBJECT;
+                            _controlInEditMode = ctl;
+                            ctl._editMode = EDITM_OBJECT;
                             ctl.AddSelectionHandler();
                             ctl.SetSelectionStyle(2);
                         }
@@ -843,37 +849,37 @@ namespace System.Windows.Forms
 
             unsafe HRESULT IOleInPlaceFrame.InsertMenus(IntPtr hmenuShared, OLEMENUGROUPWIDTHS* lpMenuWidths)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in InsertMenus");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in InsertMenus");
                 return HRESULT.S_OK;
             }
 
             HRESULT IOleInPlaceFrame.SetMenu(IntPtr hmenuShared, IntPtr holemenu, IntPtr hwndActiveObject)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in SetMenu");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in SetMenu");
                 return HRESULT.E_NOTIMPL;
             }
 
             HRESULT IOleInPlaceFrame.RemoveMenus(IntPtr hmenuShared)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in RemoveMenus");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in RemoveMenus");
                 return HRESULT.E_NOTIMPL;
             }
 
             HRESULT IOleInPlaceFrame.SetStatusText(string pszStatusText)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in SetStatusText");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in SetStatusText");
                 return HRESULT.E_NOTIMPL;
             }
 
             HRESULT IOleInPlaceFrame.EnableModeless(BOOL fEnable)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in EnableModeless");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in EnableModeless");
                 return HRESULT.E_NOTIMPL;
             }
 
             unsafe HRESULT IOleInPlaceFrame.TranslateAccelerator(User32.MSG* lpmsg, ushort wID)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in IOleInPlaceFrame.TranslateAccelerator");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in IOleInPlaceFrame.TranslateAccelerator");
                 return HRESULT.S_FALSE;
             }
 
@@ -901,16 +907,16 @@ namespace System.Windows.Forms
 
                 HRESULT IVBGetControl.EnumControls(OLECONTF dwOleContF, GC_WCH dwWhich, out IEnumUnknown ppenum)
                 {
-                    Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in EnumControls for proxy");
+                    Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in EnumControls for proxy");
                     ppenum = GetC().EnumControls(GetP(), dwOleContF, dwWhich);
                     return HRESULT.S_OK;
                 }
 
                 unsafe HRESULT IGetOleObject.GetOleObject(Guid* riid, out object ppvObj)
                 {
-                    Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in GetOleObject for proxy");
+                    Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in GetOleObject for proxy");
                     ppvObj = null;
-                    if (riid is null || !riid->Equals(ioleobject_Guid))
+                    if (riid is null || !riid->Equals(s_ioleobject_Guid))
                     {
                         return HRESULT.E_INVALIDARG;
                     }
@@ -926,13 +932,13 @@ namespace System.Windows.Forms
 
                 unsafe HRESULT IGetVBAObject.GetObject(Guid* riid, IVBFormat[] rval, uint dwReserved)
                 {
-                    Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in GetObject for proxy");
+                    Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in GetObject for proxy");
                     if (rval is null || riid is null)
                     {
                         return HRESULT.E_INVALIDARG;
                     }
 
-                    if (!riid->Equals(ivbformat_Guid))
+                    if (!riid->Equals(s_ivbformat_Guid))
                     {
                         rval[0] = null;
                         return HRESULT.E_NOINTERFACE;
@@ -946,8 +952,8 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getAlign for proxy for " + GetP().ToString());
-                        int rval = (int)((Control)GetP()).Dock;
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getAlign for proxy for {GetP()}");
+                        int rval = (int)(GetP()).Dock;
                         if (rval < NativeMethods.ActiveX.ALIGN_MIN || rval > NativeMethods.ActiveX.ALIGN_MAX)
                         {
                             rval = NativeMethods.ActiveX.ALIGN_NO_CHANGE;
@@ -957,8 +963,7 @@ namespace System.Windows.Forms
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setAlign for proxy for " + GetP().ToString() + " " +
-                                          value.ToString(CultureInfo.InvariantCulture));
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setAlign for proxy for {GetP()} {value}");
                         GetP().Dock = (DockStyle)value;
                     }
                 }
@@ -967,14 +972,13 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getBackColor for proxy for " + GetP().ToString());
-                        return AxHost.GetOleColorFromColor(((Control)GetP()).BackColor);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getBackColor for proxy for {GetP()}");
+                        return GetOleColorFromColor(GetP().BackColor);
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setBackColor for proxy for " + GetP().ToString() + " " +
-                                          value.ToString(CultureInfo.InvariantCulture));
-                        GetP().BackColor = AxHost.GetColorFromOleColor(value);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setBackColor for proxy for {GetP()} {value}");
+                        GetP().BackColor = GetColorFromOleColor(value);
                     }
                 }
 
@@ -982,12 +986,12 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getEnabled for proxy for " + GetP().ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getEnabled for proxy for {GetP()}");
                         return GetP().Enabled.ToBOOL();
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setEnabled for proxy for " + GetP().ToString() + " " + value.ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setEnabled for proxy for {GetP()} {value}");
                         GetP().Enabled = value.IsTrue();
                     }
                 }
@@ -996,14 +1000,13 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getForeColor for proxy for " + GetP().ToString());
-                        return AxHost.GetOleColorFromColor(((Control)GetP()).ForeColor);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getForeColor for proxy for {GetP()}");
+                        return GetOleColorFromColor(GetP().ForeColor);
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setForeColor for proxy for " + GetP().ToString() + " " +
-                                          value.ToString(CultureInfo.InvariantCulture));
-                        GetP().ForeColor = AxHost.GetColorFromOleColor(value);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setForeColor for proxy for {GetP()} {value}");
+                        GetP().ForeColor = GetColorFromOleColor(value);
                     }
                 }
 
@@ -1011,14 +1014,13 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getHeight for proxy for " + GetP().ToString());
-                        return Pixel2Twip(GetP().Height, false);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getHeight for proxy for {GetP()}");
+                        return Pixel2Twip(GetP().Height, xDirection: false);
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setHeight for proxy for " + GetP().ToString() + " " +
-                                          Twip2Pixel(value, false).ToString(CultureInfo.InvariantCulture));
-                        GetP().Height = Twip2Pixel(value, false);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setHeight for proxy for {GetP()} {Twip2Pixel(value, false)}");
+                        GetP().Height = Twip2Pixel(value, xDirection: false);
                     }
                 }
 
@@ -1026,14 +1028,13 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getLeft for proxy for " + GetP().ToString());
-                        return Pixel2Twip(GetP().Left, true);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getLeft for proxy for {GetP()}");
+                        return Pixel2Twip(GetP().Left, xDirection: true);
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setLeft for proxy for " + GetP().ToString() + " " +
-                                          Twip2Pixel(value, true).ToString(CultureInfo.InvariantCulture));
-                        GetP().Left = Twip2Pixel(value, true);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setLeft for proxy for {GetP()} {Twip2Pixel(value, true)}");
+                        GetP().Left = Twip2Pixel(value, xDirection: true);
                     }
                 }
 
@@ -1041,8 +1042,8 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getParent for proxy for " + GetP().ToString());
-                        return GetC().GetProxyForControl(GetC().parent);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getParent for proxy for {GetP()}");
+                        return GetC().GetProxyForControl(GetC()._parent);
                     }
                 }
 
@@ -1050,14 +1051,13 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getTabIndex for proxy for " + GetP().ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getTabIndex for proxy for {GetP()}");
                         return (short)GetP().TabIndex;
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setTabIndex for proxy for " + GetP().ToString() + " " +
-                                          value.ToString(CultureInfo.InvariantCulture));
-                        GetP().TabIndex = (int)value;
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setTabIndex for proxy for {GetP()} {value}");
+                        GetP().TabIndex = value;
                     }
                 }
 
@@ -1065,12 +1065,12 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getTabStop for proxy for " + GetP().ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getTabStop for proxy for {GetP()}");
                         return GetP().TabStop.ToBOOL();
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setTabStop for proxy for " + GetP().ToString() + " " + value.ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setTabStop for proxy for {GetP()} {value}");
                         GetP().TabStop = value.IsTrue();
                     }
                 }
@@ -1079,14 +1079,13 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getTop for proxy for " + GetP().ToString());
-                        return Pixel2Twip(GetP().Top, false);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getTop for proxy for {GetP()}");
+                        return Pixel2Twip(GetP().Top, xDirection: false);
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setTop for proxy for " + GetP().ToString() + " " +
-                                          Twip2Pixel(value, false).ToString(CultureInfo.InvariantCulture));
-                        GetP().Top = Twip2Pixel(value, false);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setTop for proxy for {GetP()} {Twip2Pixel(value, false)}");
+                        GetP().Top = Twip2Pixel(value, xDirection: false);
                     }
                 }
 
@@ -1094,12 +1093,12 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getVisible for proxy for " + GetP().ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getVisible for proxy for {GetP()}");
                         return GetP().Visible.ToBOOL();
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setVisible for proxy for " + GetP().ToString() + " " + value.ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setVisible for proxy for {GetP()} {value}");
                         GetP().Visible = value.IsTrue();
                     }
                 }
@@ -1108,14 +1107,13 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getWidth for proxy for " + GetP().ToString());
-                        return Pixel2Twip(GetP().Width, true);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getWidth for proxy for {GetP()}");
+                        return Pixel2Twip(GetP().Width, xDirection: true);
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setWidth for proxy for " + GetP().ToString() + " " +
-                                          Twip2Pixel(value, true).ToString(CultureInfo.InvariantCulture));
-                        GetP().Width = Twip2Pixel(value, true);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setWidth for proxy for {GetP()} {Twip2Pixel(value, true)}");
+                        GetP().Width = Twip2Pixel(value, xDirection: true);
                     }
                 }
 
@@ -1123,7 +1121,7 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getName for proxy for " + GetP().ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getName for proxy for {GetP()}");
                         return GetC().GetNameForControl(GetP());
                     }
                 }
@@ -1132,7 +1130,7 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getHwnd for proxy for " + GetP().ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getHwnd for proxy for {GetP()}");
                         return GetP().Handle;
                     }
                 }
@@ -1143,12 +1141,12 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getText for proxy for " + GetP().ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in getText for proxy for {GetP()}");
                         return GetP().Text;
                     }
                     set
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in setText for proxy for " + GetP().ToString());
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in setText for proxy for {GetP()}");
                         GetP().Text = value;
                     }
                 }
@@ -1195,7 +1193,13 @@ namespace System.Windows.Forms
                     return prop;
                 }
 
-                PropertyInfo IReflect.GetProperty(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
+                PropertyInfo IReflect.GetProperty(
+                    string name,
+                    BindingFlags bindingAttr,
+                    Binder binder,
+                    Type returnType,
+                    Type[] types,
+                    ParameterModifier[] modifiers)
                 {
                     PropertyInfo prop = GetP().GetType().GetProperty(name, bindingAttr, binder, returnType, types, modifiers);
                     if (prop is null)
@@ -1273,8 +1277,15 @@ namespace System.Windows.Forms
                     }
                 }
 
-                object IReflect.InvokeMember(string name, BindingFlags invokeAttr, Binder binder,
-                                             object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
+                object IReflect.InvokeMember(
+                    string name,
+                    BindingFlags invokeAttr,
+                    Binder binder,
+                    object target,
+                    object[] args,
+                    ParameterModifier[] modifiers,
+                    CultureInfo culture,
+                    string[] namedParameters)
                 {
                     try
                     {
@@ -1290,7 +1301,7 @@ namespace System.Windows.Forms
                 {
                     get
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "In UnderlyingSystemType");
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "In UnderlyingSystemType");
                         return null;
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPerPropertyBrowsingEnum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPerPropertyBrowsingEnum.cs
@@ -92,7 +92,7 @@ namespace System.Windows.Forms
                         for (int i = 0; i < _names.Length; i++)
                         {
                             cookie = _cookies[i];
-                            if (_names[i] is null || !(_names[i] is string))
+                            if (_names[i] is null)
                             {
                                 Debug.Fail($"Bad IPerPropertyBrowsing item [{i}], name={_names?[i] ?? "(unknown)"}");
                                 continue;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyTypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyTypeEditor.cs
@@ -14,13 +14,13 @@ namespace System.Windows.Forms
     {
         private class AxPropertyTypeEditor : UITypeEditor
         {
-            private readonly AxPropertyDescriptor propDesc;
-            private Guid guid;
+            private readonly AxPropertyDescriptor _propertyDescriptor;
+            private readonly Guid _guid;
 
             public AxPropertyTypeEditor(AxPropertyDescriptor pd, Guid guid)
             {
-                propDesc = pd;
-                this.guid = guid;
+                _propertyDescriptor = pd;
+                _guid = guid;
             }
 
             /// <summary>
@@ -35,7 +35,7 @@ namespace System.Windows.Forms
                 try
                 {
                     object instance = context.Instance;
-                    propDesc._owner.ShowPropertyPageForDispid(propDesc.Dispid, guid);
+                    _propertyDescriptor._owner.ShowPropertyPageForDispid(_propertyDescriptor.Dispid, _guid);
                 }
                 catch (Exception ex1)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.ClsidAttribute.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.ClsidAttribute.cs
@@ -11,20 +11,12 @@ namespace System.Windows.Forms
         [AttributeUsage(AttributeTargets.Class, Inherited = false)]
         public sealed class ClsidAttribute : Attribute
         {
-            private readonly string val;
-
             public ClsidAttribute(string clsid)
             {
-                val = clsid;
+                Value = clsid;
             }
 
-            public string Value
-            {
-                get
-                {
-                    return val;
-                }
-            }
+            public string Value { get; }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.EnumUnknown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.EnumUnknown.cs
@@ -13,21 +13,20 @@ namespace System.Windows.Forms
     {
         internal class EnumUnknown : Ole32.IEnumUnknown
         {
-            private readonly object[] arr;
-            private int loc;
-            private readonly int size;
+            private readonly object[] _array;
+            private int _location;
+            private readonly int _size;
 
-            internal EnumUnknown(object[] arr)
+            internal EnumUnknown(object[] array)
             {
-                //if (AxHTraceSwitch.TraceVerbose) Debug.WriteObject(arr);
-                this.arr = arr;
-                loc = 0;
-                size = (arr is null) ? 0 : arr.Length;
+                _array = array;
+                _location = 0;
+                _size = (array is null) ? 0 : array.Length;
             }
 
-            private EnumUnknown(object[] arr, int loc) : this(arr)
+            private EnumUnknown(object[] array, int location) : this(array)
             {
-                this.loc = loc;
+                _location = location;
             }
 
             unsafe HRESULT Ole32.IEnumUnknown.Next(uint celt, IntPtr rgelt, uint* pceltFetched)
@@ -43,18 +42,18 @@ namespace System.Windows.Forms
                 }
 
                 uint fetched = 0;
-                if (loc >= size)
+                if (_location >= _size)
                 {
                     fetched = 0;
                 }
                 else
                 {
-                    for (; loc < size && fetched < celt; ++loc)
+                    for (; _location < _size && fetched < celt; ++_location)
                     {
-                        if (arr[loc] is not null)
+                        if (_array[_location] is not null)
                         {
-                            Marshal.WriteIntPtr(rgelt, Marshal.GetIUnknownForObject(arr[loc]));
-                            rgelt = (IntPtr)((long)rgelt + (long)sizeof(IntPtr));
+                            Marshal.WriteIntPtr(rgelt, Marshal.GetIUnknownForObject(_array[_location]));
+                            rgelt = (IntPtr)((long)rgelt + sizeof(IntPtr));
                             ++fetched;
                         }
                     }
@@ -75,8 +74,8 @@ namespace System.Windows.Forms
 
             HRESULT Ole32.IEnumUnknown.Skip(uint celt)
             {
-                loc += (int)celt;
-                if (loc >= size)
+                _location += (int)celt;
+                if (_location >= _size)
                 {
                     return HRESULT.S_FALSE;
                 }
@@ -86,13 +85,13 @@ namespace System.Windows.Forms
 
             HRESULT Ole32.IEnumUnknown.Reset()
             {
-                loc = 0;
+                _location = 0;
                 return HRESULT.S_OK;
             }
 
             HRESULT Ole32.IEnumUnknown.Clone(out Ole32.IEnumUnknown ppenum)
             {
-                ppenum = new EnumUnknown(arr, loc);
+                ppenum = new EnumUnknown(_array, _location);
                 return HRESULT.S_OK;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.InvalidActiveXStateException.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.InvalidActiveXStateException.cs
@@ -21,20 +21,13 @@ namespace System.Windows.Forms
             {
             }
 
-            public override string ToString()
+            public override string ToString() => _kind switch
             {
-                switch (_kind)
-                {
-                    case ActiveXInvokeKind.MethodInvoke:
-                        return string.Format(SR.AXInvalidMethodInvoke, _name);
-                    case ActiveXInvokeKind.PropertyGet:
-                        return string.Format(SR.AXInvalidPropertyGet, _name);
-                    case ActiveXInvokeKind.PropertySet:
-                        return string.Format(SR.AXInvalidPropertySet, _name);
-                    default:
-                        return base.ToString();
-                }
-            }
+                ActiveXInvokeKind.MethodInvoke => string.Format(SR.AXInvalidMethodInvoke, _name),
+                ActiveXInvokeKind.PropertyGet => string.Format(SR.AXInvalidPropertyGet, _name),
+                ActiveXInvokeKind.PropertySet => string.Format(SR.AXInvalidPropertySet, _name),
+                _ => base.ToString(),
+            };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.OleInterfaces.cs
@@ -33,12 +33,12 @@ namespace System.Windows.Forms
             IReflect,
             IDisposable
         {
-            private readonly AxHost host;
-            private ConnectionPointCookie connectionPoint;
+            private readonly AxHost _host;
+            private ConnectionPointCookie _connectionPoint;
 
             internal OleInterfaces(AxHost host)
             {
-                this.host = host.OrThrowIfNull();
+                _host = host.OrThrowIfNull();
             }
 
             private void Dispose(bool disposing)
@@ -68,7 +68,7 @@ namespace System.Windows.Forms
 
             internal AxHost GetAxHost()
             {
-                return host;
+                return _host;
             }
 
             internal void OnOcxCreate()
@@ -78,16 +78,16 @@ namespace System.Windows.Forms
 
             internal void StartEvents()
             {
-                if (connectionPoint is not null)
+                if (_connectionPoint is not null)
                 {
                     return;
                 }
 
-                object nativeObject = host.GetOcx();
+                object nativeObject = _host.GetOcx();
 
                 try
                 {
-                    connectionPoint = new ConnectionPointCookie(nativeObject, this, typeof(IPropertyNotifySink));
+                    _connectionPoint = new ConnectionPointCookie(nativeObject, this, typeof(IPropertyNotifySink));
                 }
                 catch
                 {
@@ -96,12 +96,12 @@ namespace System.Windows.Forms
 
             void AttemptStopEvents(object trash)
             {
-                if (connectionPoint is null)
+                if (_connectionPoint is null)
                 {
                     return;
                 }
 
-                if (connectionPoint.threadId == Thread.CurrentThread.ManagedThreadId)
+                if (_connectionPoint._threadId == Environment.CurrentManagedThreadId)
                 {
                     StopEvents();
                 }
@@ -113,24 +113,24 @@ namespace System.Windows.Forms
 
             internal void StopEvents()
             {
-                if (connectionPoint is not null)
+                if (_connectionPoint is not null)
                 {
-                    connectionPoint.Disconnect();
-                    connectionPoint = null;
+                    _connectionPoint.Disconnect();
+                    _connectionPoint = null;
                 }
             }
 
             // IGetVBAObject methods:
             unsafe HRESULT IGetVBAObject.GetObject(Guid* riid, IVBFormat[] rval, uint dwReserved)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in GetObject");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in GetObject");
 
                 if (rval is null || riid is null)
                 {
                     return HRESULT.E_INVALIDARG;
                 }
 
-                if (!riid->Equals(ivbformat_Guid))
+                if (!riid->Equals(s_ivbformat_Guid))
                 {
                     rval[0] = null;
                     return HRESULT.E_NOINTERFACE;
@@ -144,8 +144,8 @@ namespace System.Windows.Forms
 
             unsafe HRESULT IVBGetControl.EnumControls(OLECONTF dwOleContF, GC_WCH dwWhich, out IEnumUnknown ppenum)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in EnumControls");
-                ppenum = host.GetParentContainer().EnumControls(host, dwOleContF, dwWhich);
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in EnumControls");
+                ppenum = _host.GetParentContainer().EnumControls(_host, dwOleContF, dwWhich);
                 return HRESULT.S_OK;
             }
 
@@ -192,7 +192,13 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            PropertyInfo IReflect.GetProperty(string name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
+            PropertyInfo IReflect.GetProperty(
+                string name,
+                BindingFlags bindingAttr,
+                Binder binder,
+                Type returnType,
+                Type[] types,
+                ParameterModifier[] modifiers)
             {
                 return null;
             }
@@ -212,20 +218,28 @@ namespace System.Windows.Forms
                 return Array.Empty<MemberInfo>();
             }
 
-            object IReflect.InvokeMember(string name, BindingFlags invokeAttr, Binder binder, object target, object[] args, ParameterModifier[] modifiers, CultureInfo culture, string[] namedParameters)
+            object IReflect.InvokeMember(
+                string name,
+                BindingFlags invokeAttr,
+                Binder binder,
+                object target,
+                object[] args,
+                ParameterModifier[] modifiers,
+                CultureInfo culture,
+                string[] namedParameters)
             {
                 if (name.StartsWith("[DISPID="))
                 {
                     int endIndex = name.IndexOf(']');
                     DispatchID dispid = (DispatchID)int.Parse(name.Substring(8, endIndex - 8), CultureInfo.InvariantCulture);
-                    object ambient = host.GetAmbientProperty(dispid);
+                    object ambient = _host.GetAmbientProperty(dispid);
                     if (ambient is not null)
                     {
                         return ambient;
                     }
                 }
 
-                throw E_FAIL;
+                throw s_unknownErrorException;
             }
 
             Type IReflect.UnderlyingSystemType
@@ -239,25 +253,25 @@ namespace System.Windows.Forms
             // IOleControlSite methods:
             HRESULT IOleControlSite.OnControlInfoChanged()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in OnControlInfoChanged");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in OnControlInfoChanged");
                 return HRESULT.S_OK;
             }
 
             HRESULT IOleControlSite.LockInPlaceActive(BOOL fLock)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in LockInPlaceActive");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in LockInPlaceActive");
                 return HRESULT.E_NOTIMPL;
             }
 
             unsafe HRESULT IOleControlSite.GetExtendedControl(IntPtr* ppDisp)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in GetExtendedControl " + host.ToString());
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in GetExtendedControl {_host}");
                 if (ppDisp is null)
                 {
                     return HRESULT.E_POINTER;
                 }
 
-                object proxy = host.GetParentContainer().GetProxyForControl(host);
+                object proxy = _host.GetParentContainer().GetProxyForControl(_host);
                 if (proxy is null)
                 {
                     return HRESULT.E_NOTIMPL;
@@ -284,17 +298,17 @@ namespace System.Windows.Forms
                 {
                     if ((dwFlags & XFORMCOORDS.SIZE) != 0)
                     {
-                        pPtfContainer->X = (float)host.HM2Pix(pPtlHimetric->X, logPixelsX);
-                        pPtfContainer->Y = (float)host.HM2Pix(pPtlHimetric->Y, logPixelsY);
+                        pPtfContainer->X = _host.HM2Pix(pPtlHimetric->X, s_logPixelsX);
+                        pPtfContainer->Y = _host.HM2Pix(pPtlHimetric->Y, s_logPixelsY);
                     }
                     else if ((dwFlags & XFORMCOORDS.POSITION) != 0)
                     {
-                        pPtfContainer->X = (float)host.HM2Pix(pPtlHimetric->X, logPixelsX);
-                        pPtfContainer->Y = (float)host.HM2Pix(pPtlHimetric->Y, logPixelsY);
+                        pPtfContainer->X = _host.HM2Pix(pPtlHimetric->X, s_logPixelsX);
+                        pPtfContainer->Y = _host.HM2Pix(pPtlHimetric->Y, s_logPixelsY);
                     }
                     else
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "\t dwFlags not supported: " + dwFlags);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"\t dwFlags not supported: {dwFlags}");
                         return HRESULT.E_INVALIDARG;
                     }
                 }
@@ -302,23 +316,23 @@ namespace System.Windows.Forms
                 {
                     if ((dwFlags & XFORMCOORDS.SIZE) != 0)
                     {
-                        pPtlHimetric->X = host.Pix2HM((int)pPtfContainer->X, logPixelsX);
-                        pPtlHimetric->Y = host.Pix2HM((int)pPtfContainer->Y, logPixelsY);
+                        pPtlHimetric->X = _host.Pix2HM((int)pPtfContainer->X, s_logPixelsX);
+                        pPtlHimetric->Y = _host.Pix2HM((int)pPtfContainer->Y, s_logPixelsY);
                     }
                     else if ((dwFlags & XFORMCOORDS.POSITION) != 0)
                     {
-                        pPtlHimetric->X = host.Pix2HM((int)pPtfContainer->X, logPixelsX);
-                        pPtlHimetric->Y = host.Pix2HM((int)pPtfContainer->Y, logPixelsY);
+                        pPtlHimetric->X = _host.Pix2HM((int)pPtfContainer->X, s_logPixelsX);
+                        pPtlHimetric->Y = _host.Pix2HM((int)pPtfContainer->Y, s_logPixelsY);
                     }
                     else
                     {
-                        Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "\t dwFlags not supported: " + dwFlags);
+                        Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"\t dwFlags not supported: {dwFlags}");
                         return HRESULT.E_INVALIDARG;
                     }
                 }
                 else
                 {
-                    Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "\t dwFlags not supported: " + dwFlags);
+                    Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"\t dwFlags not supported: {dwFlags}");
                     return HRESULT.E_INVALIDARG;
                 }
 
@@ -332,18 +346,18 @@ namespace System.Windows.Forms
                     return HRESULT.E_POINTER;
                 }
 
-                Debug.Assert(!host.GetAxState(AxHost.siteProcessedInputKey), "Re-entering IOleControlSite.TranslateAccelerator!!!");
-                host.SetAxState(AxHost.siteProcessedInputKey, true);
+                Debug.Assert(!_host.GetAxState(s_siteProcessedInputKey), "Re-entering IOleControlSite.TranslateAccelerator!!!");
+                _host.SetAxState(s_siteProcessedInputKey, true);
 
                 Message msg = *pMsg;
                 try
                 {
-                    bool f = ((Control)host).PreProcessMessage(ref msg);
+                    bool f = _host.PreProcessMessage(ref msg);
                     return f ? HRESULT.S_OK : HRESULT.S_FALSE;
                 }
                 finally
                 {
-                    host.SetAxState(AxHost.siteProcessedInputKey, false);
+                    _host.SetAxState(s_siteProcessedInputKey, false);
                 }
             }
 
@@ -351,9 +365,9 @@ namespace System.Windows.Forms
 
             HRESULT IOleControlSite.ShowPropertyFrame()
             {
-                if (host.CanShowPropertyPages())
+                if (_host.CanShowPropertyPages())
                 {
-                    host.ShowPropertyPages();
+                    _host.ShowPropertyPages();
                     return HRESULT.S_OK;
                 }
 
@@ -363,7 +377,7 @@ namespace System.Windows.Forms
             // IOleClientSite methods:
             HRESULT IOleClientSite.SaveObject()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in SaveObject");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in SaveObject");
                 return HRESULT.E_NOTIMPL;
             }
 
@@ -381,53 +395,53 @@ namespace System.Windows.Forms
 
             IOleContainer IOleClientSite.GetContainer()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in getContainer");
-                return host.GetParentContainer();
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in getContainer");
+                return _host.GetParentContainer();
             }
 
             unsafe HRESULT IOleClientSite.ShowObject()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in ShowObject");
-                if (host.GetAxState(AxHost.fOwnWindow))
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in ShowObject");
+                if (_host.GetAxState(s_fOwnWindow))
                 {
                     Debug.Fail("we can't be in showobject if we own our window...");
                     return HRESULT.S_OK;
                 }
 
-                if (host.GetAxState(AxHost.fFakingWindow))
+                if (_host.GetAxState(s_fFakingWindow))
                 {
                     // we really should not be here...
                     // this means that the ctl inplace deactivated and didn't call on inplace activate before calling showobject
                     // so we need to destroy our fake window first...
-                    host.DestroyFakeWindow();
+                    _host.DestroyFakeWindow();
 
                     // The fact that we have a fake window means that the OCX inplace deactivated when we hid it. It means
                     // that we have to bring it back from RUNNING to INPLACE so that it can re-create its handle properly.
                     //
-                    host.TransitionDownTo(OC_LOADED);
-                    host.TransitionUpTo(OC_INPLACE);
+                    _host.TransitionDownTo(OC_LOADED);
+                    _host.TransitionUpTo(OC_INPLACE);
                 }
 
-                if (host.GetOcState() < OC_INPLACE)
+                if (_host.GetOcState() < OC_INPLACE)
                 {
                     return HRESULT.S_OK;
                 }
 
                 IntPtr hwnd = IntPtr.Zero;
-                if (host.GetInPlaceObject().GetWindow(&hwnd).Succeeded())
+                if (_host.GetInPlaceObject().GetWindow(&hwnd).Succeeded())
                 {
-                    if (host.GetHandleNoCreate() != hwnd)
+                    if (_host.GetHandleNoCreate() != hwnd)
                     {
-                        host.DetachWindow();
+                        _host.DetachWindow();
                         if (hwnd != IntPtr.Zero)
                         {
-                            host.AttachWindow(hwnd);
+                            _host.AttachWindow(hwnd);
                         }
                     }
                 }
-                else if (host.GetInPlaceObject() is IOleInPlaceObjectWindowless)
+                else if (_host.GetInPlaceObject() is IOleInPlaceObjectWindowless)
                 {
-                    Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Windowless control.");
+                    Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "Windowless control.");
                     throw new InvalidOperationException(SR.AXWindowlessControl);
                 }
 
@@ -436,13 +450,13 @@ namespace System.Windows.Forms
 
             HRESULT IOleClientSite.OnShowWindow(BOOL fShow)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in OnShowWindow");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in OnShowWindow");
                 return HRESULT.S_OK;
             }
 
             HRESULT IOleClientSite.RequestNewObjectLayout()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in RequestNewObjectLayout");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in RequestNewObjectLayout");
                 return HRESULT.E_NOTIMPL;
             }
 
@@ -455,38 +469,38 @@ namespace System.Windows.Forms
                     return HRESULT.E_POINTER;
                 }
 
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in GetWindow");
-                Control parent = host.ParentInternal;
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in GetWindow");
+                Control parent = _host.ParentInternal;
                 *phwnd = parent is not null ? parent.Handle : IntPtr.Zero;
                 return HRESULT.S_OK;
             }
 
             HRESULT IOleInPlaceSite.ContextSensitiveHelp(BOOL fEnterMode)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in ContextSensitiveHelp");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in ContextSensitiveHelp");
                 return HRESULT.E_NOTIMPL;
             }
 
             HRESULT IOleInPlaceSite.CanInPlaceActivate()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in CanInPlaceActivate");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in CanInPlaceActivate");
                 return HRESULT.S_OK;
             }
 
             HRESULT IOleInPlaceSite.OnInPlaceActivate()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in OnInPlaceActivate");
-                host.SetAxState(AxHost.ownDisposing, false);
-                host.SetAxState(AxHost.rejectSelection, false);
-                host.SetOcState(OC_INPLACE);
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in OnInPlaceActivate");
+                _host.SetAxState(s_ownDisposing, false);
+                _host.SetAxState(s_rejectSelection, false);
+                _host.SetOcState(OC_INPLACE);
                 return HRESULT.S_OK;
             }
 
             HRESULT IOleInPlaceSite.OnUIActivate()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in OnUIActivate for " + host.ToString());
-                host.SetOcState(OC_UIACTIVE);
-                host.GetParentContainer().OnUIActivate(host);
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in OnUIActivate for {_host}");
+                _host.SetOcState(OC_UIACTIVE);
+                _host.GetParentContainer().OnUIActivate(_host);
                 return HRESULT.S_OK;
             }
 
@@ -498,14 +512,14 @@ namespace System.Windows.Forms
                 OLEINPLACEFRAMEINFO* lpFrameInfo)
             {
                 ppDoc = null;
-                ppFrame = host.GetParentContainer();
+                ppFrame = _host.GetParentContainer();
 
                 if (lprcPosRect is null || lprcClipRect is null)
                 {
                     return HRESULT.E_POINTER;
                 }
 
-                *lprcPosRect = host.Bounds;
+                *lprcPosRect = _host.Bounds;
                 *lprcClipRect = WebBrowserHelper.GetClipRect();
                 if (lpFrameInfo is not null)
                 {
@@ -513,7 +527,7 @@ namespace System.Windows.Forms
                     lpFrameInfo->fMDIApp = BOOL.FALSE;
                     lpFrameInfo->hAccel = IntPtr.Zero;
                     lpFrameInfo->cAccelEntries = 0;
-                    lpFrameInfo->hwndFrame = host.ParentInternal.Handle;
+                    lpFrameInfo->hwndFrame = _host.ParentInternal.Handle;
                 }
 
                 return HRESULT.S_OK;
@@ -523,11 +537,11 @@ namespace System.Windows.Forms
 
             HRESULT IOleInPlaceSite.OnUIDeactivate(BOOL fUndoable)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in OnUIDeactivate for " + host.ToString());
-                host.GetParentContainer().OnUIDeactivate(host);
-                if (host.GetOcState() > OC_INPLACE)
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in OnUIDeactivate for {_host}");
+                _host.GetParentContainer().OnUIDeactivate(_host);
+                if (_host.GetOcState() > OC_INPLACE)
                 {
-                    host.SetOcState(OC_INPLACE);
+                    _host.SetOcState(OC_INPLACE);
                 }
 
                 return HRESULT.S_OK;
@@ -535,28 +549,28 @@ namespace System.Windows.Forms
 
             HRESULT IOleInPlaceSite.OnInPlaceDeactivate()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in OnInPlaceDeactivate");
-                if (host.GetOcState() == OC_UIACTIVE)
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in OnInPlaceDeactivate");
+                if (_host.GetOcState() == OC_UIACTIVE)
                 {
                     ((IOleInPlaceSite)this).OnUIDeactivate(0);
                 }
 
-                host.GetParentContainer().OnInPlaceDeactivate(host);
-                host.DetachWindow();
-                host.SetOcState(OC_RUNNING);
+                _host.GetParentContainer().OnInPlaceDeactivate(_host);
+                _host.DetachWindow();
+                _host.SetOcState(OC_RUNNING);
                 return HRESULT.S_OK;
             }
 
             HRESULT IOleInPlaceSite.DiscardUndoState()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in DiscardUndoState");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in DiscardUndoState");
                 return HRESULT.S_OK;
             }
 
             HRESULT IOleInPlaceSite.DeactivateAndUndo()
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in DeactivateAndUndo for " + host.ToString());
-                return host.GetInPlaceObject().UIDeactivate();
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in DeactivateAndUndo for {_host}");
+                return _host.GetInPlaceObject().UIDeactivate();
             }
 
             unsafe HRESULT IOleInPlaceSite.OnPosRectChange(RECT* lprcPosRect)
@@ -572,21 +586,21 @@ namespace System.Windows.Forms
                 // visual basic6 does the same.
                 //
                 bool useRect = true;
-                if (AxHost.windowsMediaPlayer_Clsid.Equals(host.clsid))
+                if (s_windowsMediaPlayer_Clsid.Equals(_host._clsid))
                 {
-                    useRect = host.GetAxState(AxHost.handlePosRectChanged);
+                    useRect = _host.GetAxState(s_handlePosRectChanged);
                 }
 
                 if (useRect)
                 {
-                    Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in OnPosRectChange" + lprcPosRect->ToString());
+                    Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in OnPosRectChange{lprcPosRect->ToString()}");
                     RECT clipRect = WebBrowserHelper.GetClipRect();
-                    host.GetInPlaceObject().SetObjectRects(lprcPosRect, &clipRect);
-                    host.MakeDirty();
+                    _host.GetInPlaceObject().SetObjectRects(lprcPosRect, &clipRect);
+                    _host.MakeDirty();
                 }
                 else
                 {
-                    Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "Control directly called OnPosRectChange... ignoring the new size");
+                    Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "Control directly called OnPosRectChange... ignoring the new size");
                 }
 
                 return HRESULT.S_OK;
@@ -598,24 +612,24 @@ namespace System.Windows.Forms
             {
                 // Some controls fire OnChanged() notifications when getting values of some properties.
                 // To prevent this kind of recursion, we check to see if we are already inside a OnChanged() call.
-                if (host.NoComponentChangeEvents != 0)
+                if (_host.NoComponentChangeEvents != 0)
                 {
                     return HRESULT.S_OK;
                 }
 
-                host.NoComponentChangeEvents++;
+                _host.NoComponentChangeEvents++;
                 try
                 {
                     AxPropertyDescriptor prop = null;
 
-                    Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in OnChanged");
+                    Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in OnChanged");
 
                     if (dispid != DispatchID.UNKNOWN)
                     {
-                        prop = host.GetPropertyDescriptorFromDispid(dispid);
+                        prop = _host.GetPropertyDescriptorFromDispid(dispid);
                         if (prop is not null)
                         {
-                            prop.OnValueChanged(host);
+                            prop.OnValueChanged(_host);
                             if (!prop.SettingValue)
                             {
                                 prop.UpdateTypeConverterAndTypeEditor(true);
@@ -625,7 +639,7 @@ namespace System.Windows.Forms
                     else
                     {
                         // update them all for DISPID_UNKNOWN.
-                        PropertyDescriptorCollection props = ((ICustomTypeDescriptor)host).GetProperties();
+                        PropertyDescriptorCollection props = ((ICustomTypeDescriptor)_host).GetProperties();
                         foreach (PropertyDescriptor p in props)
                         {
                             prop = p as AxPropertyDescriptor;
@@ -636,11 +650,11 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    if (host.Site.TryGetService(out IComponentChangeService changeService))
+                    if (_host.Site.TryGetService(out IComponentChangeService changeService))
                     {
                         try
                         {
-                            changeService.OnComponentChanging(host, prop);
+                            changeService.OnComponentChanging(_host, prop);
                         }
                         catch (CheckoutException e) when (e == CheckoutException.Canceled)
                         {
@@ -648,7 +662,7 @@ namespace System.Windows.Forms
                         }
 
                         // Now notify the change service that the change was successful.
-                        changeService.OnComponentChanged(host, prop, oldValue: null, prop?.GetValue(host));
+                        changeService.OnComponentChanged(_host, prop, oldValue: null, prop?.GetValue(_host));
                     }
                 }
                 catch (Exception t)
@@ -658,7 +672,7 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-                    host.NoComponentChangeEvents--;
+                    _host.NoComponentChangeEvents--;
                 }
 
                 return HRESULT.S_OK;
@@ -666,7 +680,7 @@ namespace System.Windows.Forms
 
             HRESULT IPropertyNotifySink.OnRequestEdit(DispatchID dispid)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in OnRequestEdit for " + host.ToString());
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, $"in OnRequestEdit for {_host}");
                 return HRESULT.S_OK;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.VBFormat.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.VBFormat.cs
@@ -22,7 +22,7 @@ namespace System.Windows.Forms
                 Ole32.VarFormatFirstWeekOfYear sFirstWeekOfYear,
                 ushort* rcb)
             {
-                Debug.WriteLineIf(AxHTraceSwitch.TraceVerbose, "in Format");
+                Debug.WriteLineIf(s_axHTraceSwitch.TraceVerbose, "in Format");
                 if (rcb is null)
                 {
                     return HRESULT.E_INVALIDARG;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PictureConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PictureConverter.cs
@@ -129,7 +129,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 }
 
                 Guid iid = typeof(IPicture).GUID;
-                IPicture pict = (IPicture)OleCreatePictureIndirect(ref pictdesc, ref iid, own);
+                IPicture pict = (IPicture)OleCreatePictureIndirect(ref pictdesc, in iid, own);
                 _lastManaged = managedValue;
                 _lastNativeHandle = (IntPtr)pict.Handle;
                 _pictureRef = new WeakReference(pict);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -21,14 +21,14 @@ namespace System.Windows.Forms
     {
         private Control _activeControl;
 
-        /// <remarks>
-        ///  The current focused control. Do not directly edit this value.
-        /// </remarks>
+        /// <summary>
+        ///   The current focused control. Do not directly edit this value.
+        /// </summary>
         private Control _focusedControl;
 
-        /// <remarks>
+        /// <summary>
         ///  The last control that requires validation. Do not directly edit this value.
-        /// </remarks>
+        /// </summary>
         private Control _unvalidatedControl;
 
         /// <summary>
@@ -273,7 +273,9 @@ namespace System.Windows.Forms
                 // Note: If overriding this property make sure to copy the Debug code and call this method.
 
                 Debug.Indent();
-                Debug.WriteLineIf(CompModSwitches.ImeMode.Level >= TraceLevel.Info, "Inside get_CanEnableIme(), value = false" + ", this = " + this);
+                Debug.WriteLineIf(
+                    CompModSwitches.ImeMode.Level >= TraceLevel.Info,
+                    $"Inside get_CanEnableIme(), value = false, this = {this}");
                 Debug.Unindent();
 
                 return false;
@@ -391,7 +393,9 @@ namespace System.Windows.Forms
 
         internal bool ActivateControl(Control control, bool originator)
         {
-            Debug.WriteLineIf(s_focusTracing.TraceVerbose, "ContainerControl::ActivateControl(" + (control is null ? "null" : control.Name) + "," + originator.ToString() + ") - " + Name);
+            Debug.WriteLineIf(
+                s_focusTracing.TraceVerbose,
+                $"ContainerControl::ActivateControl({control?.Name ?? "null"},{originator}) - {Name}");
 
             // Recursive function that makes sure that the chain of active controls is coherent.
             bool ret = true;
@@ -465,7 +469,7 @@ namespace System.Windows.Forms
         {
             ContainerControl cc;
             Debug.Assert(control is not null);
-            Debug.WriteLineIf(s_focusTracing.TraceVerbose, "ContainerControl::AfterControlRemoved(" + control.Name + ") - " + Name);
+            Debug.WriteLineIf(s_focusTracing.TraceVerbose, $"ContainerControl::AfterControlRemoved({control.Name}) - {Name}");
             if (control == _activeControl || control.Contains(_activeControl))
             {
                 bool selected = SelectNextControl(control, true, true, true, true);
@@ -539,7 +543,9 @@ namespace System.Windows.Forms
             }
 #endif
 
-            Debug.WriteLineIf(s_focusTracing.TraceVerbose, "ContainerControl::AssignActiveControlInternal(" + (value is null ? "null" : value.Name) + ") - " + Name);
+            Debug.WriteLineIf(
+                s_focusTracing.TraceVerbose,
+                $"ContainerControl::AssignActiveControlInternal({value?.Name ?? "null"}) - {Name}");
             if (_activeControl != value)
             {
                 try
@@ -648,7 +654,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal void FocusActiveControlInternal()
         {
-            Debug.WriteLineIf(s_focusTracing.TraceVerbose, "ContainerControl::FocusActiveControlInternal() - " + Name);
+            Debug.WriteLineIf(s_focusTracing.TraceVerbose, $"ContainerControl::FocusActiveControlInternal() - {Name}");
 #if DEBUG
             // Things really get ugly if you try to pop up an assert dialog here
             if (_activeControl is not null && !Contains(_activeControl))
@@ -661,7 +667,7 @@ namespace System.Windows.Forms
             {
                 // Avoid focus loops, especially with ComboBoxes.
                 IntPtr focusHandle = User32.GetFocus();
-                if (focusHandle == IntPtr.Zero || Control.FromChildHandle(focusHandle) != _activeControl)
+                if (focusHandle == IntPtr.Zero || FromChildHandle(focusHandle) != _activeControl)
                 {
                     User32.SetFocus(new HandleRef(_activeControl, _activeControl.Handle));
                 }
@@ -1190,10 +1196,10 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected override bool ProcessDialogChar(char charCode)
         {
-            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "ContainerControl.ProcessDialogChar [" + charCode.ToString() + "]");
+            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"ContainerControl.ProcessDialogChar [{charCode}]");
 
             // If we're the top-level form or control, we need to do the mnemonic handling
-            if (GetContainerControl() is ContainerControl parent && charCode != ' ' && ProcessMnemonic(charCode))
+            if (GetContainerControl() is ContainerControl && charCode != ' ' && ProcessMnemonic(charCode))
             {
                 return true;
             }
@@ -1209,7 +1215,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected override bool ProcessDialogKey(Keys keyData)
         {
-            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "ContainerControl.ProcessDialogKey [" + keyData.ToString() + "]");
+            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"ContainerControl.ProcessDialogKey [{keyData}]");
 
             LastKeyData = keyData;
             if ((keyData & (Keys.Alt | Keys.Control)) == Keys.None)
@@ -1243,7 +1249,7 @@ namespace System.Windows.Forms
 
         protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
         {
-            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "ContainerControl.ProcessCmdKey " + msg.ToString());
+            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"ContainerControl.ProcessCmdKey {msg}");
 
             if (base.ProcessCmdKey(ref msg, keyData))
             {
@@ -1266,9 +1272,9 @@ namespace System.Windows.Forms
 
         protected internal override bool ProcessMnemonic(char charCode)
         {
-            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "ContainerControl.ProcessMnemonic [" + charCode.ToString() + "]");
+            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"ContainerControl.ProcessMnemonic [{charCode}]");
             Debug.Indent();
-            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "this == " + ToString());
+            Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"this == {this}");
 
             if (!CanProcessMnemonic())
             {
@@ -1282,7 +1288,6 @@ namespace System.Windows.Forms
             }
 
             // Start with the active control.
-            //
             Control start = ActiveControl;
 
 #if DEBUG
@@ -1301,7 +1306,7 @@ namespace System.Windows.Forms
                 bool wrapped = false;
 
                 Control ctl = start;
-                Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "Check starting at '" + ((start is not null) ? start.ToString() : "<null>") + "'");
+                Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"Check starting at '{start?.ToString() ?? "<null>"}'");
 
                 do
                 {
@@ -1318,16 +1323,18 @@ namespace System.Windows.Forms
                     if (ctl is not null)
                     {
 #if DEBUG
-                        Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "  ...checking for mnemonics on " + ctl.ToString());
+                        Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, $"  ...checking for mnemonics on {ctl}");
                         // Control.TraceMnemonicProcessing.Enabled disables CanProcessMnemonic consistency check.
-                        bool canProcess = s_traceMnemonicProcessing.Enabled ? true : ctl.CanProcessMnemonic(); // Processing the mnemonic can change the value of CanProcessMnemonic.
+                        bool canProcess = s_traceMnemonicProcessing.Enabled || ctl.CanProcessMnemonic(); // Processing the mnemonic can change the value of CanProcessMnemonic.
 #endif
                         // Processing the mnemonic can change the value of CanProcessMnemonic.
                         if (ctl.ProcessMnemonic(charCode))
                         {
 #if DEBUG
                             Debug.WriteLineIf(s_controlKeyboardRouting.TraceVerbose, "  ...mnemonics found");
-                            Debug.Assert((s_traceMnemonicProcessing.Enabled || canProcess), "ProcessMnemonic returned true, even though CanProcessMnemonic() is false. Someone probably overrode ProcessMnemonic and forgot to test CanSelect or CanProcessMnemonic().");
+                            Debug.Assert(
+                                s_traceMnemonicProcessing.Enabled || canProcess,
+                                "ProcessMnemonic returned true, even though CanProcessMnemonic() is false. Someone probably overrode ProcessMnemonic and forgot to test CanSelect or CanProcessMnemonic().");
                             Debug.Unindent();
 #endif
                             processed = true;
@@ -1367,7 +1374,7 @@ namespace System.Windows.Forms
         private ScrollableControl FindScrollableParent(Control ctl)
         {
             Control current = ctl.ParentInternal;
-            while (current is not null && !(current is ScrollableControl))
+            while (current is not null && current is not ScrollableControl)
             {
                 current = current.ParentInternal;
             }
@@ -1385,7 +1392,6 @@ namespace System.Windows.Forms
                 while (scrollParent is not null)
                 {
                     scrollParent.ScrollControlIntoView(_activeControl);
-                    last = scrollParent;
                     scrollParent = FindScrollableParent(scrollParent);
                 }
             }
@@ -1496,7 +1502,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal void SetActiveControl(Control value)
         {
-            Debug.WriteLineIf(s_focusTracing.TraceVerbose, $"ContainerControl::SetActiveControl({(value is null ? "null" : value.Name)}) - {Name}");
+            Debug.WriteLineIf(s_focusTracing.TraceVerbose, $"ContainerControl::SetActiveControl({value?.Name ?? "null"}) - {Name}");
 
             if (_activeControl == value && (value is null || value.Focused))
             {
@@ -1709,7 +1715,8 @@ namespace System.Windows.Forms
             }
 
 #if DEBUG
-            if (_activeControl is null || (_activeControl is not null && _activeControl.ParentInternal is not null && !_activeControl.ParentInternal.IsContainerControl))
+            if (_activeControl is null
+                || (_activeControl?.ParentInternal is not null && !_activeControl.ParentInternal.IsContainerControl))
             {
                 Debug.Assert(_activeControl is null || _activeControl.ParentInternal.GetContainerControl() == this);
             }
@@ -1822,9 +1829,11 @@ namespace System.Windows.Forms
         ///  This version always performs validation, regardless of the AutoValidate setting of the control's parent.
         /// </summary>
         /// <remarks>
-        ///  This version is intended for user code that wants to force validation, even
-        ///  while auto-validation is turned off. When adding any explicit Validate() calls to our code, consider using
-        ///  Validate(true) rather than Validate(), so that you will be sensitive to the current auto-validation setting.
+        ///  <para>
+        ///   This version is intended for user code that wants to force validation, even while auto-validation is
+        ///   turned off. When adding any explicit Validate() calls to our code, consider using Validate(true) rather
+        ///   than Validate(), so that you will be sensitive to the current auto-validation setting.
+        ///  </para>
         /// </remarks>
         public bool Validate() => Validate(checkAutoValidate: false);
 
@@ -1835,7 +1844,7 @@ namespace System.Windows.Forms
         /// </summary>
         public bool Validate(bool checkAutoValidate)
         {
-            return ValidateInternal(checkAutoValidate, out bool validatedControlAllowsFocusChange);
+            return ValidateInternal(checkAutoValidate, out _);
         }
 
         internal bool ValidateInternal(bool checkAutoValidate, out bool validatedControlAllowsFocusChange)
@@ -1847,9 +1856,9 @@ namespace System.Windows.Forms
             {
                 if (_unvalidatedControl is null)
                 {
-                    if (_focusedControl is ContainerControl && _focusedControl.CausesValidation)
+                    if (_focusedControl is ContainerControl control && _focusedControl.CausesValidation)
                     {
-                        ContainerControl c = (ContainerControl)_focusedControl;
+                        ContainerControl c = control;
                         if (!c.ValidateInternal(checkAutoValidate, out validatedControlAllowsFocusChange))
                         {
                             return false;
@@ -2052,7 +2061,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmSetFocus(ref Message m)
         {
-            Debug.WriteLineIf(s_focusTracing.TraceVerbose, "ContainerControl::WmSetFocus() - " + Name);
+            Debug.WriteLineIf(s_focusTracing.TraceVerbose, $"ContainerControl::WmSetFocus() - {Name}");
             if (!HostedInWin32DialogManager)
             {
                 if (ActiveControl is not null)
@@ -2073,7 +2082,7 @@ namespace System.Windows.Forms
                         IContainerControl c = ParentInternal.GetContainerControl();
                         if (c is not null)
                         {
-                            bool succeeded = false;
+                            bool succeeded;
 
                             if (c is ContainerControl knowncontainer)
                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXFontMarshaler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXFontMarshaler.cs
@@ -46,7 +46,7 @@ namespace System.Windows.Forms
                     fStrikethrough = font.Strikeout.ToBOOL(),
                 };
                 Guid iid = typeof(Ole32.IFont).GUID;
-                Ole32.IFont oleFont = Oleaut32.OleCreateFontIndirect(ref fontDesc, ref iid);
+                Ole32.IFont oleFont = Oleaut32.OleCreateFontIndirect(ref fontDesc, in iid);
                 IntPtr pFont = Marshal.GetIUnknownForObject(oleFont);
 
                 int hr = Marshal.QueryInterface(pFont, ref iid, out IntPtr pIFont);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -326,12 +326,12 @@ namespace System.Windows.Forms
                     // bytes for the guid serializedObjectID at the front
                     // of the stream.  Check for that here.
                     //
-                    if (size > serializedObjectID.Length)
+                    if (size > s_serializedObjectID.Length)
                     {
                         isSerializedObject = true;
-                        for (int i = 0; i < serializedObjectID.Length; i++)
+                        for (int i = 0; i < s_serializedObjectID.Length; i++)
                         {
-                            if (serializedObjectID[i] != bytes[i])
+                            if (s_serializedObjectID[i] != bytes[i])
                             {
                                 isSerializedObject = false;
                                 break;
@@ -342,7 +342,7 @@ namespace System.Windows.Forms
                         //
                         if (isSerializedObject)
                         {
-                            index = serializedObjectID.Length;
+                            index = s_serializedObjectID.Length;
                         }
                     }
                     else
@@ -559,9 +559,9 @@ namespace System.Windows.Forms
                     lindex = -1
                 };
 
-                for (int i = 0; i < ALLOWED_TYMEDS.Length; i++)
+                for (int i = 0; i < s_allowedTymeds.Length; i++)
                 {
-                    formatetc.tymed |= ALLOWED_TYMEDS[i];
+                    formatetc.tymed |= s_allowedTymeds[i];
                 }
 
                 int hr = QueryGetDataUnsafe(ref formatetc);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -8,9 +8,6 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
-#if DEBUG
-using System.Globalization;
-#endif
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
@@ -32,22 +29,22 @@ namespace System.Windows.Forms
 
         private const int DATA_S_SAMEFORMATETC = 0x00040130;
 
-        private static readonly TYMED[] ALLOWED_TYMEDS =
-        new TYMED[]
-        {
-            TYMED.TYMED_HGLOBAL,
-            TYMED.TYMED_ISTREAM,
-            TYMED.TYMED_GDI
-        };
+        private static readonly TYMED[] s_allowedTymeds =
+            new TYMED[]
+            {
+                TYMED.TYMED_HGLOBAL,
+                TYMED.TYMED_ISTREAM,
+                TYMED.TYMED_GDI
+            };
 
-        private readonly IDataObject innerData;
+        private readonly IDataObject _innerData;
 
         // We use this to identify that a stream is actually a serialized object.  On read,
         // we don't know if the contents of a stream were saved "raw" or if the stream is really
         // pointing to a serialized object.  If we saved an object, we prefix it with this
         // guid.
-        //
-        private static readonly byte[] serializedObjectID = new Guid("FD9EA796-3B13-4370-A679-56106BB288FB").ToByteArray();
+
+        private static readonly byte[] s_serializedObjectID = new Guid("FD9EA796-3B13-4370-A679-56106BB288FB").ToByteArray();
 
         /// <summary>
         ///  Initializes a new instance of the <see cref="DataObject"/> class, with the specified <see cref="IDataObject"/>.
@@ -55,8 +52,8 @@ namespace System.Windows.Forms
         internal DataObject(IDataObject data)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Constructed DataObject based on IDataObject");
-            innerData = data;
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
+            _innerData = data;
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
         }
 
         /// <summary>
@@ -66,26 +63,25 @@ namespace System.Windows.Forms
         {
             if (data is DataObject)
             {
-                innerData = data as IDataObject;
+                _innerData = data as IDataObject;
             }
             else
             {
                 Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Constructed DataObject based on IComDataObject");
-                innerData = new OleConverter(data);
+                _innerData = new OleConverter(data);
             }
 
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
         }
 
         /// <summary>
-        ///  Initializes a new instance of the <see cref="DataObject"/>
-        ///  class, which can store arbitrary data.
+        ///  Initializes a new instance of the <see cref="DataObject"/> class, which can store arbitrary data.
         /// </summary>
         public DataObject()
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Constructed DataObject standalone");
-            innerData = new DataStore();
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
+            _innerData = new DataStore();
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
         }
 
         /// <summary>
@@ -93,22 +89,22 @@ namespace System.Windows.Forms
         /// </summary>
         public DataObject(object data)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Constructed DataObject base on Object: " + data.ToString());
-            if (data is IDataObject && !Marshal.IsComObject(data))
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"Constructed DataObject base on Object: {data}");
+            if (data is IDataObject dataObject && !Marshal.IsComObject(data))
             {
-                innerData = (IDataObject)data;
+                _innerData = dataObject;
             }
-            else if (data is IComDataObject)
+            else if (data is IComDataObject comDataObject)
             {
-                innerData = new OleConverter((IComDataObject)data);
+                _innerData = new OleConverter(comDataObject);
             }
             else
             {
-                innerData = new DataStore();
+                _innerData = new DataStore();
                 SetData(data);
             }
 
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
         }
 
         /// <summary>
@@ -118,7 +114,7 @@ namespace System.Windows.Forms
         public DataObject(string format, object data) : this()
         {
             SetData(format, data);
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
         }
 
         private Gdi32.HBITMAP GetCompatibleBitmap(Bitmap bm)
@@ -155,99 +151,86 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Retrieves the data associated with the specified data
-        ///  format, using an automated conversion parameter to determine whether to convert
-        ///  the data to the format.
+        ///  Retrieves the data associated with the specified data format, using an automated conversion parameter to
+        ///  determine whether to convert the data to the format.
         /// </summary>
         public virtual object GetData(string format, bool autoConvert)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Request data: " + format + ", " + autoConvert.ToString());
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
-            return innerData.GetData(format, autoConvert);
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"Request data: {format}, {autoConvert}");
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
+            return _innerData.GetData(format, autoConvert);
         }
 
         /// <summary>
-        ///  Retrieves the data associated with the specified data
-        ///  format.
+        ///  Retrieves the data associated with the specified data format.
         /// </summary>
         public virtual object GetData(string format)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Request data: " + format);
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"Request data: {format}");
             return GetData(format, true);
         }
 
         /// <summary>
-        ///  Retrieves the data associated with the specified class
-        ///  type format.
+        ///  Retrieves the data associated with the specified class type format.
         /// </summary>
         public virtual object GetData(Type format)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Request data: " + format?.FullName ?? "(null)");
-            if (format is null)
-            {
-                return null;
-            }
-
-            return GetData(format.FullName);
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"Request data: {format?.FullName ?? "(null)"}");
+            return format is null ? null : GetData(format.FullName);
         }
 
         /// <summary>
-        ///  Determines whether data stored in this instance is
-        ///  associated with, or can be converted to, the specified
-        ///  format.
+        ///  Determines whether data stored in this instance is associated with, or can be converted to,
+        ///  the specified format.
         /// </summary>
         public virtual bool GetDataPresent(Type format)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Check data: " + format?.FullName ?? "(null)");
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"Check data: {format?.FullName ?? "(null)"}");
             if (format is null)
             {
                 return false;
             }
 
-            bool b = GetDataPresent(format.FullName);
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "  ret: " + b.ToString());
-            return b;
+            bool present = GetDataPresent(format.FullName);
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"  ret: {present}");
+            return present;
         }
 
         /// <summary>
-        ///  Determines whether data stored in this instance is
-        ///  associated with the specified format, using an automatic conversion
-        ///  parameter to determine whether to convert the data to the format.
+        ///  Determines whether data stored in this instance is associated with the specified format, using an
+        ///  automatic conversion parameter to determine whether to convert the data to the format.
         /// </summary>
         public virtual bool GetDataPresent(string format, bool autoConvert)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Check data: " + format + ", " + autoConvert.ToString());
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
-            bool b = innerData.GetDataPresent(format, autoConvert);
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "  ret: " + b.ToString());
-            return b;
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"Check data: {format}, {autoConvert}");
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
+            bool present = _innerData.GetDataPresent(format, autoConvert);
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"  ret: {present}");
+            return present;
         }
 
         /// <summary>
-        ///  Determines whether data stored in this instance is
-        ///  associated with, or can be converted to, the specified
-        ///  format.
+        ///  Determines whether data stored in this instance is associated with, or can be converted to,
+        ///  the specified format.
         /// </summary>
         public virtual bool GetDataPresent(string format)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Check data: " + format);
-            bool b = GetDataPresent(format, true);
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "  ret: " + b.ToString());
-            return b;
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"Check data: {format}");
+            bool present = GetDataPresent(format, autoConvert: true);
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"  ret: {present}");
+            return present;
         }
 
         /// <summary>
-        ///  Gets a list of all formats that data stored in this
-        ///  instance is associated with or can be converted to, using an automatic
-        ///  conversion parameter <paramref name="autoConvert"/> to
-        ///  determine whether to retrieve all formats that the data can be converted to or
-        ///  only native data formats.
+        ///  Gets a list of all formats that data stored in this instance is associated with or can be converted to,
+        ///  using an automatic conversion parameter <paramref name="autoConvert"/> to determine whether to retrieve
+        ///  all formats that the data can be converted to or only native data formats.
         /// </summary>
         public virtual string[] GetFormats(bool autoConvert)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Check formats: " + autoConvert.ToString());
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
-            return innerData.GetFormats(autoConvert);
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"Check formats: {autoConvert}");
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
+            return _innerData.GetFormats(autoConvert);
         }
 
         /// <summary>
@@ -257,24 +240,24 @@ namespace System.Windows.Forms
         public virtual string[] GetFormats()
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Check formats:");
-            return GetFormats(true);
+            return GetFormats(autoConvert: true);
         }
 
         // <-- WHIDBEY ADDITIONS
 
         public virtual bool ContainsAudio()
         {
-            return GetDataPresent(DataFormats.WaveAudio, false);
+            return GetDataPresent(DataFormats.WaveAudio, autoConvert: false);
         }
 
         public virtual bool ContainsFileDropList()
         {
-            return GetDataPresent(DataFormats.FileDrop, true);
+            return GetDataPresent(DataFormats.FileDrop, autoConvert: true);
         }
 
         public virtual bool ContainsImage()
         {
-            return GetDataPresent(DataFormats.Bitmap, true);
+            return GetDataPresent(DataFormats.Bitmap, autoConvert: true);
         }
 
         public virtual bool ContainsText()
@@ -287,7 +270,7 @@ namespace System.Windows.Forms
             //valid values are 0x0 to 0x4
             SourceGenerated.EnumValidator.Validate(format, nameof(format));
 
-            return GetDataPresent(ConvertToDataFormats(format), false);
+            return GetDataPresent(ConvertToDataFormats(format), autoConvert: false);
         }
 
         public virtual Stream GetAudioStream()
@@ -297,13 +280,13 @@ namespace System.Windows.Forms
 
         public virtual StringCollection GetFileDropList()
         {
-            StringCollection retVal = new StringCollection();
+            StringCollection dropList = new StringCollection();
             if (GetData(DataFormats.FileDrop, true) is string[] strings)
             {
-                retVal.AddRange(strings);
+                dropList.AddRange(strings);
             }
 
-            return retVal;
+            return dropList;
         }
 
         public virtual Image GetImage()
@@ -318,7 +301,7 @@ namespace System.Windows.Forms
 
         public virtual string GetText(TextDataFormat format)
         {
-            //valid values are 0x0 to 0x4
+            // Valid values are 0x0 to 0x4
             SourceGenerated.EnumValidator.Validate(format, nameof(format));
 
             if (GetData(ConvertToDataFormats(format), false) is string text)
@@ -368,31 +351,20 @@ namespace System.Windows.Forms
         {
             textData.ThrowIfNullOrEmpty();
 
-            //valid values are 0x0 to 0x4
+            // Valid values are 0x0 to 0x4
             SourceGenerated.EnumValidator.Validate(format, nameof(format));
 
             SetData(ConvertToDataFormats(format), false, textData);
         }
 
-        private static string ConvertToDataFormats(TextDataFormat format)
+        private static string ConvertToDataFormats(TextDataFormat format) => format switch
         {
-            switch (format)
-            {
-                case TextDataFormat.UnicodeText:
-                    return DataFormats.UnicodeText;
-
-                case TextDataFormat.Rtf:
-                    return DataFormats.Rtf;
-
-                case TextDataFormat.Html:
-                    return DataFormats.Html;
-
-                case TextDataFormat.CommaSeparatedValue:
-                    return DataFormats.CommaSeparatedValue;
-            }
-
-            return DataFormats.UnicodeText;
-        }
+            TextDataFormat.UnicodeText => DataFormats.UnicodeText,
+            TextDataFormat.Rtf => DataFormats.Rtf,
+            TextDataFormat.Html => DataFormats.Html,
+            TextDataFormat.CommaSeparatedValue => DataFormats.CommaSeparatedValue,
+            _ => DataFormats.UnicodeText,
+        };
 
         // END - WHIDBEY ADDITIONS -->
 
@@ -448,9 +420,9 @@ namespace System.Windows.Forms
         /// </summary>
         private bool GetTymedUseable(TYMED tymed)
         {
-            for (int i = 0; i < ALLOWED_TYMEDS.Length; i++)
+            for (int i = 0; i < s_allowedTymeds.Length; i++)
             {
-                if ((tymed & ALLOWED_TYMEDS[i]) != 0)
+                if ((tymed & s_allowedTymeds[i]) != 0)
                 {
                     return true;
                 }
@@ -463,42 +435,37 @@ namespace System.Windows.Forms
         ///  Populates Ole datastructes from a WinForms dataObject. This is the core
         ///  of WinForms to OLE conversion.
         /// </summary>
-        private void GetDataIntoOleStructs(ref FORMATETC formatetc,
-                                           ref STGMEDIUM medium)
+        private void GetDataIntoOleStructs(ref FORMATETC formatetc, ref STGMEDIUM medium)
         {
-            if (GetTymedUseable(formatetc.tymed) && GetTymedUseable(medium.tymed))
+            if (!GetTymedUseable(formatetc.tymed) || !GetTymedUseable(medium.tymed))
             {
-                string format = DataFormats.GetFormat(formatetc.cfFormat).Name;
+                Marshal.ThrowExceptionForHR((int)HRESULT.DV_E_TYMED);
+            }
 
-                if (GetDataPresent(format))
+            string format = DataFormats.GetFormat(formatetc.cfFormat).Name;
+
+            if (!GetDataPresent(format))
+            {
+                Marshal.ThrowExceptionForHR((int)HRESULT.DV_E_FORMATETC);
+            }
+
+            object data = GetData(format);
+
+            if ((formatetc.tymed & TYMED.TYMED_HGLOBAL) != 0)
+            {
+                HRESULT hr = SaveDataToHandle(data, format, ref medium);
+                if (hr.Failed())
                 {
-                    object data = GetData(format);
-
-                    if ((formatetc.tymed & TYMED.TYMED_HGLOBAL) != 0)
-                    {
-                        HRESULT hr = SaveDataToHandle(data, format, ref medium);
-                        if (hr.Failed())
-                        {
-                            Marshal.ThrowExceptionForHR((int)hr);
-                        }
-                    }
-                    else if ((formatetc.tymed & TYMED.TYMED_GDI) != 0)
-                    {
-                        if (format.Equals(DataFormats.Bitmap) && data is Bitmap bm
-                            && bm is not null)
-                        {
-                            // save bitmap
-                            medium.unionmember = (IntPtr)GetCompatibleBitmap(bm);
-                        }
-                    }
-                    else
-                    {
-                        Marshal.ThrowExceptionForHR((int)HRESULT.DV_E_TYMED);
-                    }
+                    Marshal.ThrowExceptionForHR((int)hr);
                 }
-                else
+            }
+            else if ((formatetc.tymed & TYMED.TYMED_GDI) != 0)
+            {
+                if (format.Equals(DataFormats.Bitmap) && data is Bitmap bm
+                    && bm is not null)
                 {
-                    Marshal.ThrowExceptionForHR((int)HRESULT.DV_E_FORMATETC);
+                    // Save bitmap
+                    medium.unionmember = (IntPtr)GetCompatibleBitmap(bm);
                 }
             }
             else
@@ -508,14 +475,14 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///     Part of IComDataObject, used to interop with OLE.
+        ///  Part of IComDataObject, used to interop with OLE.
         /// </summary>
         int IComDataObject.DAdvise(ref FORMATETC pFormatetc, ADVF advf, IAdviseSink pAdvSink, out int pdwConnection)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "DAdvise");
-            if (innerData is OleConverter)
+            if (_innerData is OleConverter converter)
             {
-                return ((OleConverter)innerData).OleDataObject.DAdvise(ref pFormatetc, advf, pAdvSink, out pdwConnection);
+                return converter.OleDataObject.DAdvise(ref pFormatetc, advf, pAdvSink, out pdwConnection);
             }
 
             pdwConnection = 0;
@@ -523,14 +490,14 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///     Part of IComDataObject, used to interop with OLE.
+        ///  Part of IComDataObject, used to interop with OLE.
         /// </summary>
         void IComDataObject.DUnadvise(int dwConnection)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "DUnadvise");
-            if (innerData is OleConverter)
+            if (_innerData is OleConverter converter)
             {
-                ((OleConverter)innerData).OleDataObject.DUnadvise(dwConnection);
+                converter.OleDataObject.DUnadvise(dwConnection);
                 return;
             }
 
@@ -538,14 +505,14 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///     Part of IComDataObject, used to interop with OLE.
+        ///  Part of IComDataObject, used to interop with OLE.
         /// </summary>
         int IComDataObject.EnumDAdvise(out IEnumSTATDATA enumAdvise)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "EnumDAdvise");
-            if (innerData is OleConverter)
+            if (_innerData is OleConverter converter)
             {
-                return ((OleConverter)innerData).OleDataObject.EnumDAdvise(out enumAdvise);
+                return converter.OleDataObject.EnumDAdvise(out enumAdvise);
             }
 
             enumAdvise = null;
@@ -553,14 +520,14 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///     Part of IComDataObject, used to interop with OLE.
+        ///  Part of IComDataObject, used to interop with OLE.
         /// </summary>
         IEnumFORMATETC IComDataObject.EnumFormatEtc(DATADIR dwDirection)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "EnumFormatEtc: " + dwDirection.ToString());
-            if (innerData is OleConverter innerDataOleConverter)
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"EnumFormatEtc: {dwDirection}");
+            if (_innerData is OleConverter converter)
             {
-                return innerDataOleConverter.OleDataObject.EnumFormatEtc(dwDirection);
+                return converter.OleDataObject.EnumFormatEtc(dwDirection);
             }
 
             if (dwDirection == DATADIR.DATADIR_GET)
@@ -572,14 +539,14 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///     Part of IComDataObject, used to interop with OLE.
+        /// Part of IComDataObject, used to interop with OLE.
         /// </summary>
         int IComDataObject.GetCanonicalFormatEtc(ref FORMATETC pformatetcIn, out FORMATETC pformatetcOut)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "GetCanonicalFormatEtc");
-            if (innerData is OleConverter innerDataOleConverter)
+            if (_innerData is OleConverter converter)
             {
-                return innerDataOleConverter.OleDataObject.GetCanonicalFormatEtc(ref pformatetcIn, out pformatetcOut);
+                return converter.OleDataObject.GetCanonicalFormatEtc(ref pformatetcIn, out pformatetcOut);
             }
 
             pformatetcOut = new FORMATETC();
@@ -587,64 +554,62 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///     Part of IComDataObject, used to interop with OLE.
+        ///  Part of IComDataObject, used to interop with OLE.
         /// </summary>
         void IComDataObject.GetData(ref FORMATETC formatetc, out STGMEDIUM medium)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "GetData");
-            if (innerData is OleConverter)
+            if (_innerData is OleConverter converter)
             {
-                ((OleConverter)innerData).OleDataObject.GetData(ref formatetc, out medium);
+                converter.OleDataObject.GetData(ref formatetc, out medium);
                 return;
             }
 
             medium = new STGMEDIUM();
 
-            if (GetTymedUseable(formatetc.tymed))
+            if (!GetTymedUseable(formatetc.tymed))
             {
-                if ((formatetc.tymed & TYMED.TYMED_HGLOBAL) != 0)
-                {
-                    medium.tymed = TYMED.TYMED_HGLOBAL;
-                    medium.unionmember = Kernel32.GlobalAlloc(
-                        Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT,
-                        1);
-                    if (medium.unionmember == IntPtr.Zero)
-                    {
-                        throw new OutOfMemoryException();
-                    }
+                Marshal.ThrowExceptionForHR((int)HRESULT.DV_E_TYMED);
+            }
 
-                    try
-                    {
-                        ((IComDataObject)this).GetDataHere(ref formatetc, ref medium);
-                    }
-                    catch
-                    {
-                        Kernel32.GlobalFree(medium.unionmember);
-                        medium.unionmember = IntPtr.Zero;
-                        throw;
-                    }
-                }
-                else
+            if ((formatetc.tymed & TYMED.TYMED_HGLOBAL) != 0)
+            {
+                medium.tymed = TYMED.TYMED_HGLOBAL;
+                medium.unionmember = Kernel32.GlobalAlloc(
+                    Kernel32.GMEM.MOVEABLE | Kernel32.GMEM.DDESHARE | Kernel32.GMEM.ZEROINIT,
+                    1);
+                if (medium.unionmember == IntPtr.Zero)
                 {
-                    medium.tymed = formatetc.tymed;
+                    throw new OutOfMemoryException();
+                }
+
+                try
+                {
                     ((IComDataObject)this).GetDataHere(ref formatetc, ref medium);
+                }
+                catch
+                {
+                    Kernel32.GlobalFree(medium.unionmember);
+                    medium.unionmember = IntPtr.Zero;
+                    throw;
                 }
             }
             else
             {
-                Marshal.ThrowExceptionForHR((int)HRESULT.DV_E_TYMED);
+                medium.tymed = formatetc.tymed;
+                ((IComDataObject)this).GetDataHere(ref formatetc, ref medium);
             }
         }
 
         /// <summary>
-        ///     Part of IComDataObject, used to interop with OLE.
+        ///  Part of IComDataObject, used to interop with OLE.
         /// </summary>
         void IComDataObject.GetDataHere(ref FORMATETC formatetc, ref STGMEDIUM medium)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "GetDataHere");
-            if (innerData is OleConverter)
+            if (_innerData is OleConverter converter)
             {
-                ((OleConverter)innerData).OleDataObject.GetDataHere(ref formatetc, ref medium);
+                converter.OleDataObject.GetDataHere(ref formatetc, ref medium);
             }
             else
             {
@@ -653,14 +618,14 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///     Part of IComDataObject, used to interop with OLE.
+        ///  Part of IComDataObject, used to interop with OLE.
         /// </summary>
         int IComDataObject.QueryGetData(ref FORMATETC formatetc)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "QueryGetData");
-            if (innerData is OleConverter)
+            if (_innerData is OleConverter converter)
             {
-                return ((OleConverter)innerData).OleDataObject.QueryGetData(ref formatetc);
+                return converter.OleDataObject.QueryGetData(ref formatetc);
             }
 
             if (formatetc.dwAspect == DVASPECT.DVASPECT_CONTENT)
@@ -669,7 +634,9 @@ namespace System.Windows.Forms
                 {
                     if (formatetc.cfFormat == 0)
                     {
-                        Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "QueryGetData::returning S_FALSE because cfFormat == 0");
+                        Debug.WriteLineIf(
+                            CompModSwitches.DataObject.TraceVerbose,
+                            "QueryGetData::returning S_FALSE because cfFormat == 0");
                         return (int)HRESULT.S_FALSE;
                     }
                     else if (!GetDataPresent(DataFormats.GetFormat(formatetc.cfFormat).Name))
@@ -686,22 +653,23 @@ namespace System.Windows.Forms
             {
                 return (int)HRESULT.DV_E_DVASPECT;
             }
-#if DEBUG
-            int format = unchecked((ushort)formatetc.cfFormat);
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "QueryGetData::cfFormat " + format.ToString(CultureInfo.InvariantCulture) + " found");
-#endif
+
+            Debug.WriteLineIf(
+                CompModSwitches.DataObject.TraceVerbose,
+                $"QueryGetData::cfFormat {(ushort)formatetc.cfFormat} found");
+
             return (int)HRESULT.S_OK;
         }
 
         /// <summary>
-        ///     Part of IComDataObject, used to interop with OLE.
+        ///  Part of IComDataObject, used to interop with OLE.
         /// </summary>
         void IComDataObject.SetData(ref FORMATETC pFormatetcIn, ref STGMEDIUM pmedium, bool fRelease)
         {
             Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "SetData");
-            if (innerData is OleConverter)
+            if (_innerData is OleConverter converter)
             {
-                ((OleConverter)innerData).OleDataObject.SetData(ref pFormatetcIn, ref pmedium, fRelease);
+                converter.OleDataObject.SetData(ref pFormatetcIn, ref pmedium, fRelease);
                 return;
             }
 
@@ -715,21 +683,21 @@ namespace System.Windows.Forms
         /// <returns>true - serialize only safe types, strings or bitmaps.</returns>
         private static bool RestrictDeserializationToSafeTypes(string format)
         {
-            return (format.Equals(DataFormats.StringFormat) ||
-                    format.Equals(typeof(Bitmap).FullName) ||
-                    format.Equals(DataFormats.CommaSeparatedValue) ||
-                    format.Equals(DataFormats.Dib) ||
-                    format.Equals(DataFormats.Dif) ||
-                    format.Equals(DataFormats.Locale) ||
-                    format.Equals(DataFormats.PenData) ||
-                    format.Equals(DataFormats.Riff) ||
-                    format.Equals(DataFormats.SymbolicLink) ||
-                    format.Equals(DataFormats.Tiff) ||
-                    format.Equals(DataFormats.WaveAudio) ||
-                    format.Equals(DataFormats.Bitmap) ||
-                    format.Equals(DataFormats.EnhancedMetafile) ||
-                    format.Equals(DataFormats.Palette) ||
-                    format.Equals(DataFormats.MetafilePict));
+            return format.Equals(DataFormats.StringFormat)
+                || format.Equals(typeof(Bitmap).FullName)
+                || format.Equals(DataFormats.CommaSeparatedValue)
+                || format.Equals(DataFormats.Dib)
+                || format.Equals(DataFormats.Dif)
+                || format.Equals(DataFormats.Locale)
+                || format.Equals(DataFormats.PenData)
+                || format.Equals(DataFormats.Riff)
+                || format.Equals(DataFormats.SymbolicLink)
+                || format.Equals(DataFormats.Tiff)
+                || format.Equals(DataFormats.WaveAudio)
+                || format.Equals(DataFormats.Bitmap)
+                || format.Equals(DataFormats.EnhancedMetafile)
+                || format.Equals(DataFormats.Palette)
+                || format.Equals(DataFormats.MetafilePict);
         }
 
         private HRESULT SaveDataToHandle(object data, string format, ref STGMEDIUM medium)
@@ -740,8 +708,8 @@ namespace System.Windows.Forms
                 hr = SaveStreamToHandle(ref medium.unionmember, dataStream);
             }
             else if (format.Equals(DataFormats.Text)
-                     || format.Equals(DataFormats.Rtf)
-                     || format.Equals(DataFormats.OemText))
+                || format.Equals(DataFormats.Rtf)
+                || format.Equals(DataFormats.OemText))
             {
                 hr = SaveStringToHandle(medium.unionmember, data.ToString(), false);
             }
@@ -774,10 +742,10 @@ namespace System.Windows.Forms
                 hr = HRESULT.DV_E_TYMED;
             }
             else if (format.Equals(DataFormats.Serializable)
-                     || data is ISerializable
-                     || (data is not null && data.GetType().IsSerializable))
+                || data is ISerializable
+                || (data is not null && data.GetType().IsSerializable))
             {
-                hr = SaveObjectToHandle(ref medium.unionmember, data, DataObject.RestrictDeserializationToSafeTypes(format));
+                hr = SaveObjectToHandle(ref medium.unionmember, data, RestrictDeserializationToSafeTypes(format));
             }
 
             return hr;
@@ -787,7 +755,7 @@ namespace System.Windows.Forms
         {
             Stream stream = new MemoryStream();
             BinaryWriter bw = new BinaryWriter(stream);
-            bw.Write(serializedObjectID);
+            bw.Write(s_serializedObjectID);
             SaveObjectToHandleSerializer(stream, data, restrictSerialization);
             return SaveStreamToHandle(ref handle, stream);
         }
@@ -919,8 +887,8 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Save string to handle. If unicode is set to true
-        ///  then the string is saved as Unicode, else it is saves as DBCS.
+        ///  Save string to handle. If unicode is set to true then the string is saved as Unicode,
+        ///  else it is saves as DBCS.
         /// </summary>
         private unsafe HRESULT SaveStringToHandle(IntPtr handle, string str, bool unicode)
         {
@@ -1019,50 +987,48 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Stores the specified data and its associated format in
-        ///  this instance, using the automatic conversion parameter
-        ///  to specify whether the
-        ///  data can be converted to another format.
+        ///  Stores the specified data and its associated format in this instance, using the automatic conversion
+        ///  parameter to specify whether the data can be converted to another format.
         /// </summary>
         public virtual void SetData(string format, bool autoConvert, object data)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Set data: " + format + ", " + autoConvert.ToString() + ", " + data?.ToString() ?? "(null)");
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
-            innerData.SetData(format, autoConvert, data);
+            Debug.WriteLineIf(
+                CompModSwitches.DataObject.TraceVerbose,
+                $"Set data: {format}, {autoConvert}, {data ?? "(null)"}");
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
+            _innerData.SetData(format, autoConvert, data);
         }
 
         /// <summary>
-        ///  Stores the specified data and its associated format in this
-        ///  instance.
+        ///  Stores the specified data and its associated format in this instance.
         /// </summary>
         public virtual void SetData(string format, object data)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Set data: " + format + ", " + data?.ToString() ?? "(null)");
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
-            innerData.SetData(format, data);
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"Set data: {format}, {data ?? "(null)"}");
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
+            _innerData.SetData(format, data);
         }
 
         /// <summary>
-        ///  Stores the specified data and
-        ///  its
-        ///  associated class type in this instance.
+        ///  Stores the specified data and its associated class type in this instance.
         /// </summary>
         public virtual void SetData(Type format, object data)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Set data: " + format?.FullName ?? "(null)" + ", " + data?.ToString() ?? "(null)");
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
-            innerData.SetData(format, data);
+            Debug.WriteLineIf(
+                CompModSwitches.DataObject.TraceVerbose,
+                $"Set data: {format?.FullName ?? "(null)"}, {data ?? "(null)"}");
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
+            _innerData.SetData(format, data);
         }
 
         /// <summary>
-        ///  Stores the specified data in
-        ///  this instance, using the class of the data for the format.
+        ///  Stores the specified data in this instance, using the class of the data for the format.
         /// </summary>
         public virtual void SetData(object data)
         {
-            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, "Set data: " + data?.ToString() ?? "(null)");
-            Debug.Assert(innerData is not null, "You must have an innerData on all DataObjects");
-            innerData.SetData(data);
+            Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $"Set data: {data ?? "(null)"}");
+            Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
+            _innerData.SetData(data);
         }
     }
 }


### PR DESCRIPTION
Specifically targeting a few things:

- Use interpolated strings
- Clean up field naming style
- General reduction of blue info messages

I tweaked some interop definitions to allow using readonly Guids when requesting interfaces.

Note that AxHost.State custom serializes- I went through it carefully to make sure updating the fields wouldn't impact serialization.

Most of the strings are in Debug tracing. Moving to interpolated strings will avoid a lot of needless string formatting when debugging. I'm skeptical of the value of maintaining these at all actually, but for now I'm not going to push leaving them in. (They make reading the code significantly more difficult.)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6544)