### PR TITLE
Clean up AccessibleObject

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -2477,7 +2477,7 @@ namespace System.Windows.Forms.Tests
             using Button button = new Button();
             button.CreateControl();
             var accessibleObject = button.AccessibilityObject;
-            var wrapper = accessibleObject.TestAccessor().Dynamic.systemIAccessible;
+            var wrapper = accessibleObject.TestAccessor().Dynamic._systemIAccessible;
             Assert.NotSame(wrapper, accessibleObject.GetSystemIAccessibleInternal());
         }
 
@@ -2487,7 +2487,7 @@ namespace System.Windows.Forms.Tests
             using Button button = new Button();
             button.CreateControl();
             var accessibleObject = button.AccessibilityObject;
-            var wrapper = accessibleObject.TestAccessor().Dynamic.systemIAccessible;
+            var wrapper = accessibleObject.TestAccessor().Dynamic._systemIAccessible;
             var wrapIAccessibleResult = accessibleObject.TestAccessor().Dynamic.WrapIAccessible(accessibleObject.GetSystemIAccessibleInternal());
 
             Assert.Same(accessibleObject, wrapIAccessibleResult);


### PR DESCRIPTION
- Use standard field naming
- Use interpolated strings


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6548)