### PR TITLE
Fixing Popup button border color 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
@@ -18,13 +18,20 @@ namespace System.Windows.Forms.ButtonInternal
         // SystemInformation.Border3DSize + 2 pixels for focus rect
         protected const int ButtonBorderSize = 4;
 
-        // Coefficient for darkening the border color of the "Popup" button
-        protected const float ButtonBorderDarkerOffset = 0.8f;
-
         internal ButtonBaseAdapter(ButtonBase control) =>
             Control = control.OrThrowIfNull();
 
         protected ButtonBase Control { get; }
+
+        /// <summary>
+        ///  Returns the darkened color according to the required color contrast ratio
+        /// </summary>
+        private protected static Color GetContrastingBorderColor(Color buttonBorderShadowColor)
+            => Color.FromArgb(
+                buttonBorderShadowColor.A,
+                (int)(buttonBorderShadowColor.R * 0.8f),
+                (int)(buttonBorderShadowColor.G * 0.8f),
+                (int)(buttonBorderShadowColor.B * 0.8f));
 
         internal void Paint(PaintEventArgs pevent)
         {
@@ -293,16 +300,16 @@ namespace System.Windows.Forms.ButtonInternal
             Point p2 = new Point(r.Left, r.Top);                // Upper left
             Point p3 = new Point(r.Left, r.Bottom - 1);         // Bottom inner left
             Point p4 = new Point(r.Right - 1, r.Bottom - 1);    // Inner bottom right
-            Color darkColor = ControlPaint.Darker(colors.ButtonShadow, ButtonBorderDarkerOffset);
+            Color color = GetContrastingBorderColor(colors.ButtonShadow);
 
             // Top, left
-            using var topLeftPen = new Gdi32.CreatePenScope(up ? colors.Highlight : darkColor);
+            using var topLeftPen = new Gdi32.CreatePenScope(up ? colors.Highlight : color);
 
             hdc.DrawLine(topLeftPen, p1, p2);                   // top  (right-left)
             hdc.DrawLine(topLeftPen, p2, p3);                   // left (top-down)
 
             // Bottom, right
-            using var bottomRightPen = new Gdi32.CreatePenScope(up ? darkColor : colors.Highlight);
+            using var bottomRightPen = new Gdi32.CreatePenScope(up ? color : colors.Highlight);
 
             p1.Offset(0, -1);                                   // Need to paint last pixel too.
             hdc.DrawLine(bottomRightPen, p3, p4);               // Bottom (left-right)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonPopupAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonPopupAdapter.cs
@@ -42,14 +42,14 @@ namespace System.Windows.Forms.ButtonInternal
                 state != CheckState.Indeterminate && IsHighContrastHighlighted() ? SystemColors.HighlightText : colors.WindowText,
                 drawFocus: true);
 
-            DrawDefaultBorder(e, r, colors.Options.HighContrast ? colors.WindowText : colors.ButtonShadow, Control.IsDefault);
+            Color borderColor = colors.Options.HighContrast
+                ? colors.WindowText
+                : GetContrastingBorderColor(colors.ButtonShadow);
+
+            DrawDefaultBorder(e, r, borderColor, Control.IsDefault);
 
             if (state == CheckState.Unchecked)
             {
-                Color borderColor = colors.Options.HighContrast
-                    ? colors.WindowText
-                    : ControlPaint.Darker(colors.ButtonShadow, ButtonBorderDarkerOffset);
-
                 ControlPaint.DrawBorderSimple(e, r, borderColor);
             }
             else
@@ -135,7 +135,7 @@ namespace System.Windows.Forms.ButtonInternal
 
             r.Inflate(1, 1);
             DrawDefaultBorder(e, r, colors.Options.HighContrast ? colors.WindowText : colors.WindowFrame, Control.IsDefault);
-            ControlPaint.DrawBorderSimple(e, r, colors.Options.HighContrast ? colors.WindowText : colors.ButtonShadow);
+            ControlPaint.DrawBorderSimple(e, r, colors.Options.HighContrast ? colors.WindowText : GetContrastingBorderColor(colors.ButtonShadow));
         }
 
         #region Layout

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -308,9 +308,6 @@ namespace System.Windows.Forms
             }
         }
 
-        internal static Color Darker(Color color, float offset)
-            => Color.FromArgb(color.A, (int)(color.R * offset), (int)(color.G * offset), (int)(color.B * offset));
-
         /// <summary>
         ///  Creates a Win32 HBITMAP out of the image. You are responsible for deleting the HBITMAP. If the image uses
         ///  transparency, the background will be filled with the specified color.


### PR DESCRIPTION
Fixes #6556, #6560 


## Proposed changes
- The #6556 is reproduced because in the case described in the repro steps, an additional border is drawn by the `DrawDefaultBorder` method. Since they use a different color, the `Button` comes with a two-color border.
- Changed the logic for drawing borders so that the same color is used for both methods as it was before. 
- The #6560 is reproduced because the original color has low contrast.
- Added logic for color darkening.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
* Issue #6556
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/151339038-86d26bc8-7da7-417b-9c51-79e71fb7a62f.png)
**After fix:**
![image](https://user-images.githubusercontent.com/23376742/151339966-a4b5898e-19be-4f5b-808a-47f2306dbc95.png)


* Issue #6560
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/151365982-ba48f261-8dc6-4e90-b0a7-ff80a9b5f6c8.png)
**After fix:**
![image](https://user-images.githubusercontent.com/23376742/151365936-4e22fef0-d7c0-4bae-94dc-8607a6037e8e.png)

## Regression? 

- Yes (from #6021)

## Risk
- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->
- CTI team 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Accessibility Insights
 
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19044.1469]
- .NET Core SDK: 7.0.0-preview.2.22075.9

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6557)