### PR TITLE
Fixing border color of pressed Popup CheckBox/RadioButton

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonPopupAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonPopupAdapter.cs
@@ -135,7 +135,7 @@ namespace System.Windows.Forms.ButtonInternal
 
             r.Inflate(1, 1);
             DrawDefaultBorder(e, r, colors.Options.HighContrast ? colors.WindowText : colors.WindowFrame, Control.IsDefault);
-            ControlPaint.DrawBorderSimple(e, r, colors.Options.HighContrast ? colors.WindowText : colors.ButtonShadow);
+            ControlPaint.DrawBorderSimple(e, r, colors.Options.HighContrast ? colors.WindowText : ControlPaint.Darker(colors.ButtonShadow, ButtonBorderDarkerOffset));
         }
 
         #region Layout


### PR DESCRIPTION
Fixes #6560

## Proposed changes
- The problem is reproduced because the original color has low contrast.
- Added logic for color darkening.

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/151365982-ba48f261-8dc6-4e90-b0a7-ff80a9b5f6c8.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/151365936-4e22fef0-d7c0-4bae-94dc-8607a6037e8e.png)

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Accessibility Insights
 
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19044.1469]
- .NET Core SDK: 7.0.0-preview.2.22075.9

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6562)