### PR TITLE
Fix ListViewGroupAccessibleObject.GetNativeGroupId returning incorrect value

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -166,17 +166,14 @@ namespace System.Windows.Forms
                 return LVGS.FOCUSED == (LVGS)User32.SendMessageW(_owningListView, (User32.WM)LVM.GETGROUPSTATE, nativeGroupId, (nint)LVGS.FOCUSED);
             }
 
-            private unsafe int GetNativeGroupId()
+            private int GetNativeGroupId()
             {
-                LVGROUPW lvgroup = new LVGROUPW
+                if (User32.SendMessageW(_owningListView, (User32.WM)LVM.HASGROUP, _owningGroup.ID) == 0)
                 {
-                    cbSize = (uint)sizeof(LVGROUPW),
-                    mask = LVGF.GROUPID,
-                };
+                    return -1;
+                }
 
-                return User32.SendMessageW(_owningListView, (User32.WM)LVM.GETGROUPINFOBYINDEX, CurrentIndex, ref lvgroup) == 0
-                    ? -1
-                    : lvgroup.iGroupId;
+                return _owningGroup.ID;
             }
 
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -270,7 +270,7 @@ namespace System.Windows.Forms.Tests
                 Assert.True(list.IsHandleCreated);
 
                 RECT groupRect = new RECT();
-                User32.SendMessageW(list, (User32.WM)ComCtl32.LVM.GETGROUPRECT, list.Groups.IndexOf(listGroup), ref groupRect);
+                User32.SendMessageW(list, (User32.WM)ComCtl32.LVM.GETGROUPRECT, listGroup.ID, ref groupRect);
 
                 int actualWidth = group1AccObj.Bounds.Width;
                 int expectedWidth = groupRect.Width;
@@ -285,6 +285,40 @@ namespace System.Windows.Forms.Tests
                 Rectangle expectedBounds = groupRect;
                 Assert.Equal(expectedBounds, actualBounds);
             });
+        }
+
+        [WinFormsFact]
+        public void ListViewGroupAccessibleObject_Bounds_ReturnsCorrectValue_PostHandle()
+        {
+            using Form form = new();
+            using ListView listView = new();
+
+            form.Controls.Add(listView);
+            form.Show();
+
+            Assert.True(listView.IsHandleCreated);
+
+            ListViewGroup group = new();
+            listView.Groups.Add(group);
+            listView.Items.Add(new ListViewItem("a", group));
+
+            RECT groupRect = new RECT();
+            User32.SendMessageW(listView, (User32.WM)ComCtl32.LVM.GETGROUPRECT, group.ID, ref groupRect);
+
+            AccessibleObject groupAccObj = group.AccessibilityObject;
+
+            int actualWidth = groupAccObj.Bounds.Width;
+            int expectedWidth = groupRect.Width;
+            Assert.Equal(expectedWidth, actualWidth);
+
+            int actualHeight = groupAccObj.Bounds.Height;
+            int expectedHeight = groupRect.Height;
+            Assert.Equal(expectedHeight, actualHeight);
+
+            Rectangle actualBounds = groupAccObj.Bounds;
+            actualBounds.Location = new Point(0, 0);
+            Rectangle expectedBounds = groupRect;
+            Assert.Equal(expectedBounds, actualBounds);
         }
 
         public static IEnumerable<object[]> ListViewGroupAccessibleObject_TestData()


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6306


## Proposed changes

`ListViewGroupAccessibleObject.GetNativeGroupId` attempted to retrieve information about a group from the native control based on its positional index. However, the position in `ListView.Groups` does not always correspond to the position in the native control (see more information here: https://github.com/dotnet/winforms/issues/6306#issuecomment-1020301155). Specifically, there is a difference when:

- The user adds a `ListView` to a `Form` and groups to the `ListView` using the visual designer, in which case the `ListView` handle will be created after groups have been added
- The user adds a `ListView` to a `Form` and then creates groups programmatically after the form has been displayed. In this case, the `ListView` handle will be created before groups are added

In the former case, the native control will not contain the default group, while in the latter case it will. This changes the positional index of groups in the native control. 

We can bypass all of the concern regarding position by simply using `ListViewGroup.ID`, which is an incrementing unique identifier passed to Win32 as `LVGROUP.iGroupId` upon creation.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The accessibility rectangle for `ListViewGroups` should show correctly in cases where groups are added after handle creation

## Risk

- Should be minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Here we can see pre-fix that highlighting group 1 with Accessibility Insights returns information for group 2

![image](https://user-images.githubusercontent.com/13544395/151389950-5dea1f8f-9088-45f8-9d98-3cd41cdb9b2b.png)


### After

Here we can see post-fix that highlighting group 1 with Accessibility Insights returns the correct information

![image](https://user-images.githubusercontent.com/13544395/151390140-130d1261-7e2f-4253-9aa8-cd5f5e81cb17.png)

## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Accessibility Insights for Windows tool

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6563)