### PR TITLE
Speedup BeginInvoke a little.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6979,15 +6979,7 @@ namespace System.Windows.Forms
 
             // We don't want to wait if we're on the same thread, or else we'll deadlock.
             // It is important that syncSameThread always be false for asynchronous calls.
-            bool syncSameThread = false;
-
-            if (User32.GetWindowThreadProcessId(this, out _) == Kernel32.GetCurrentThreadId())
-            {
-                if (synchronous)
-                {
-                    syncSameThread = true;
-                }
-            }
+            bool syncSameThread = synchronous && User32.GetWindowThreadProcessId(this, out _) == Kernel32.GetCurrentThreadId();
 
             // Store the compressed stack information from the thread that is calling the Invoke()
             // so we can assign the same security context to the thread that will actually execute


### PR DESCRIPTION
## Proposed changes

While watching how `BeginInvoke` is implemented, I noticed that `MarshaledInvoke` in the case of an asynchronous call (`BeginInvoke`) always makes two extra Win32 calls. Why call extra code if it's not needed?
Sorry if this doesn't meet your [contribution bar](https://github.com/dotnet/winforms/blob/main/CONTRIBUTING.md#contribution-bar) :blush:

## Customer Impact

`BeginInvoke` will be _slightly_ faster.

## Regression? 

- No

## Risk

- Minimal, if any.


## Test methodology

Existing tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6564)