### PR TITLE
Remove using empty base AO ctor

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms
             private int[]? runtimeId;
             private DataGridView? _ownerDataGridView;
 
-            public DataGridViewTopRowAccessibleObject() : base()
+            public DataGridViewTopRowAccessibleObject()
             {
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainItemAccessibleObject.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms
             private string? _name;
             private readonly DomainItemListAccessibleObject _parent;
 
-            public DomainItemAccessibleObject(string? name, AccessibleObject parent) : base()
+            public DomainItemAccessibleObject(string? name, AccessibleObject parent)
             {
                 _name = name;
                 _parent = (DomainItemListAccessibleObject)parent.OrThrowIfNull();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainItemListAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainItemListAccessibleObject.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms
             const string DefaultName = "Items";
             private readonly DomainUpDownAccessibleObject _parent;
 
-            public DomainItemListAccessibleObject(DomainUpDownAccessibleObject parent) : base()
+            public DomainItemListAccessibleObject(DomainUpDownAccessibleObject parent)
             {
                 _parent = parent;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.Link.LinkAccessibleObject.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Forms
                 private readonly Link _owningLink;
                 private readonly LinkLabel _owningLinkLabel;
 
-                public LinkAccessibleObject(Link link, LinkLabel owner) : base()
+                public LinkAccessibleObject(Link link, LinkLabel owner)
                 {
                     _owningLink = link.OrThrowIfNull();
                     _owningLinkLabel = owner.OrThrowIfNull();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -19,7 +19,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             private delegate void SelectDelegate(AccessibleSelection flags);
 
-            public GridEntryAccessibleObject(GridEntry owner) : base()
+            public GridEntryAccessibleObject(GridEntry owner)
             {
                 Debug.Assert(owner is not null, "GridEntryAccessibleObject must have a valid owner GridEntry");
                 _owningGridEntry = owner;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Resolve comment from pr #6432 


## Proposed changes

- Remove call empty ctor of Accessible Object class in inherited classes.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- No


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6571)