### PR TITLE
Operate open file dialog using ComWrappers

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.CoCreateInstance.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Ole32/Interop.CoCreateInstance.cs
@@ -18,10 +18,10 @@ internal partial class Interop
 
         [DllImport(Libraries.Ole32, ExactSpelling = true)]
         public static extern HRESULT CoCreateInstance(
-            ref Guid rclsid,
+            in Guid rclsid,
             IntPtr punkOuter,
             CLSCTX dwClsContext,
-            ref Guid riid,
+            in Guid riid,
             out IntPtr ppv);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IFileDialogEventsVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IFileDialogEventsVtbl.cs
@@ -1,0 +1,140 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal unsafe partial class WinFormsComWrappers
+    {
+        internal static class IFileDialogEventsVtbl
+        {
+            public static IntPtr Create(IntPtr fpQueryInterface, IntPtr fpAddRef, IntPtr fpRelease)
+            {
+                IntPtr* vtblRaw = (IntPtr*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IFileDialogEventsVtbl), IntPtr.Size * 10);
+                vtblRaw[0] = fpQueryInterface;
+                vtblRaw[1] = fpAddRef;
+                vtblRaw[2] = fpRelease;
+                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, int>)&OnFileOk;
+                vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, int>)&OnFolderChanging;
+                vtblRaw[5] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, int>)&OnFolderChange;
+                vtblRaw[6] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, int>)&OnSelectionChange;
+                vtblRaw[7] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, Shell32.FDESVR*, int>)&OnShareViolation;
+                vtblRaw[8] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, int>)&OnTypeChange;
+                vtblRaw[9] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, Shell32.FDEOR*, int>)&OnOverwrite;
+
+                return (IntPtr)vtblRaw;
+            }
+
+            [UnmanagedCallersOnly]
+            public static int OnFileOk(IntPtr thisPtr, IntPtr pfd)
+            {
+                try
+                {
+                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
+                    return (int)inst.OnFileOk(fd);
+                }
+                catch (Exception ex)
+                {
+                    return ex.HResult;
+                }
+            }
+
+            [UnmanagedCallersOnly]
+            public static int OnFolderChanging(IntPtr thisPtr, IntPtr pfd, IntPtr psiFolder)
+            {
+                try
+                {
+                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
+                    Shell32.IShellItem siFolder = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance(psiFolder, CreateObjectFlags.Unwrap);
+                    return (int)inst.OnFolderChanging(fd, siFolder);
+                }
+                catch (Exception ex)
+                {
+                    return ex.HResult;
+                }
+            }
+
+            [UnmanagedCallersOnly]
+            public static int OnFolderChange(IntPtr thisPtr, IntPtr pfd)
+            {
+                try
+                {
+                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
+                    return (int)inst.OnFolderChange(fd);
+                }
+                catch (Exception ex)
+                {
+                    return ex.HResult;
+                }
+            }
+
+            [UnmanagedCallersOnly]
+            public static int OnSelectionChange(IntPtr thisPtr, IntPtr pfd)
+            {
+                try
+                {
+                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
+                    return (int)inst.OnSelectionChange(fd);
+                }
+                catch (Exception ex)
+                {
+                    return ex.HResult;
+                }
+            }
+
+            [UnmanagedCallersOnly]
+            public static int OnShareViolation(IntPtr thisPtr, IntPtr pfd, IntPtr psi, Shell32.FDESVR* pResponse)
+            {
+                try
+                {
+                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
+                    Shell32.IShellItem si = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance(psi, CreateObjectFlags.Unwrap);
+                    return (int)inst.OnShareViolation(fd, si, pResponse);
+                }
+                catch (Exception ex)
+                {
+                    return ex.HResult;
+                }
+            }
+
+            [UnmanagedCallersOnly]
+            public static int OnTypeChange(IntPtr thisPtr, IntPtr pfd)
+            {
+                try
+                {
+                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
+                    return (int)inst.OnTypeChange(fd);
+                }
+                catch (Exception ex)
+                {
+                    return ex.HResult;
+                }
+            }
+
+            [UnmanagedCallersOnly]
+            public static int OnOverwrite(IntPtr thisPtr, IntPtr pfd, IntPtr psi, Shell32.FDEOR* pResponse)
+            {
+                try
+                {
+                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
+                    Shell32.IShellItem si = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance(psi, CreateObjectFlags.Unwrap);
+                    return (int)inst.OnOverwrite(fd, si, pResponse);
+                }
+                catch (Exception ex)
+                {
+                    return ex.HResult;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -269,10 +269,10 @@ namespace System.Windows.Forms
                 // Creating the Vista dialog can fail on Windows Server Core, even if the
                 // Server Core App Compatibility FOD is installed.
                 HRESULT hr = Ole32.CoCreateInstance(
-                    ref CLSID.FileOpenDialog,
+                    in CLSID.FileOpenDialog,
                     IntPtr.Zero,
                     Ole32.CLSCTX.INPROC_SERVER | Ole32.CLSCTX.LOCAL_SERVER | Ole32.CLSCTX.REMOTE_SERVER,
-                    ref NativeMethods.ActiveX.IID_IUnknown,
+                    in NativeMethods.ActiveX.IID_IUnknown,
                     out IntPtr lpDialogUnknownPtr);
                 if (!hr.Succeeded())
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -163,16 +163,18 @@ namespace System.Windows.Forms
         private protected override IFileDialog CreateVistaDialog()
         {
             HRESULT hr = Ole32.CoCreateInstance(
-                ref CLSID.FileOpenDialog,
+                in CLSID.FileOpenDialog,
                 IntPtr.Zero,
                 Ole32.CLSCTX.INPROC_SERVER | Ole32.CLSCTX.LOCAL_SERVER | Ole32.CLSCTX.REMOTE_SERVER,
-                ref NativeMethods.ActiveX.IID_IUnknown,
-                out object obj);
+                in NativeMethods.ActiveX.IID_IUnknown,
+                out IntPtr lpDialogUnknownPtr);
             if (!hr.Succeeded())
             {
                 Marshal.ThrowExceptionForHR((int)hr);
             }
 
+            var obj = WinFormsComWrappers.Instance
+                .GetOrCreateObjectForComInstance(lpDialogUnknownPtr, CreateObjectFlags.None);
             return (IFileOpenDialog)obj;
         }
 


### PR DESCRIPTION
That's piggyback on the previous work. I have to provide CCW for `IFileDialogEvents`. The multiselect did not use `ComWrappers`, since it requires me to provide RCW for `IShellItemArray`, but selection works using build-in COM.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6574)