### PR TITLE
Prevent accidental changing of IID.IAccessible

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -1849,7 +1849,7 @@ namespace System.Windows.Forms.Design
                             IntPtr punkAcc = Marshal.GetIUnknownForObject(iacc);
                             try
                             {
-                                m.ResultInternal = Oleacc.LresultFromObject(ref IID.IAccessible, m.WParamInternal, punkAcc);
+                                m.ResultInternal = Oleacc.LresultFromObject(in IID.IAccessible, m.WParamInternal, punkAcc);
                             }
                             finally
                             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Oleacc/Interop.LresultFromObject.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Oleacc/Interop.LresultFromObject.cs
@@ -9,11 +9,11 @@ internal static partial class Interop
     internal static partial class Oleacc
     {
         [DllImport(Libraries.Oleacc, ExactSpelling = true)]
-        public static extern nint LresultFromObject(ref Guid refiid, nint wParam, IntPtr pAcc);
+        public static extern nint LresultFromObject(in Guid refiid, nint wParam, IntPtr pAcc);
 
-        public static nint LresultFromObject(ref Guid refiid, nint wParam, HandleRef pAcc)
+        public static nint LresultFromObject(in Guid refiid, nint wParam, HandleRef pAcc)
         {
-            nint result = LresultFromObject(ref refiid, wParam, pAcc.Handle);
+            nint result = LresultFromObject(in refiid, wParam, pAcc.Handle);
             GC.KeepAlive(pAcc.Wrapper);
             return result;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
@@ -103,7 +103,7 @@ namespace System.Windows.Forms
 
                         try
                         {
-                            m.ResultInternal = Oleacc.LresultFromObject(ref IID.IAccessible, m.WParamInternal, new HandleRef(this, pUnknown));
+                            m.ResultInternal = Oleacc.LresultFromObject(in IID.IAccessible, m.WParamInternal, new HandleRef(this, pUnknown));
                         }
                         finally
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -12081,7 +12081,7 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    m.ResultInternal = Oleacc.LresultFromObject(ref IID.IAccessible, m.WParamInternal, new HandleRef(accessibleObject, pUnknown));
+                    m.ResultInternal = Oleacc.LresultFromObject(in IID.IAccessible, m.WParamInternal, new HandleRef(accessibleObject, pUnknown));
                     Debug.WriteLineIf(CompModSwitches.MSAA.TraceInfo, $"LresultFromObject returned {m.ResultInternal}");
                 }
                 finally


### PR DESCRIPTION
I cannot make `IID.IAccessible` as auto-property, since I have to pass that value by reference. I prefer to mark function as `in` instead of `ref`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6575)