### PR TITLE
Auto scale explicitly specified font as per the Settings display text scale.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -1408,7 +1408,7 @@ namespace System.Windows.Forms
 
             // Check if font is inherited from parent and is not being scaled by Parent (e.g. Winforms designer
             // in Visual Studio). In this case we need to scale Control explicitly with respect to new scaled Font.
-            if (TryGetExplicitlySetFont(out _))
+            if (TryGetExplicitlySetFont(out _) && GetCurrentFontAutoScale() == FontAutoScale.SystemOnly)
             {
                 return;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FontAutoScale.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FontAutoScale.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    /// <summary>
+    ///  Specifies the font auto scaling mode used by a control.
+    /// </summary>
+    public enum FontAutoScale
+    {
+        /// <summary>
+        ///  Scale only if control using system font.
+        /// </summary>
+        SystemOnly,
+
+        /// <summary>
+        ///  Scale if control using system or explicitly specified font.
+        /// </summary>
+        SystemAndExplicit,
+
+        /// <summary>
+        ///  Font scale according to their parent's scaling mode.
+        ///  If there is no parent, this behaves as if <see cref="FontAutoScale.SystemOnly"/> were set.
+        /// </summary>
+        Inherit
+    }
+}


### PR DESCRIPTION
This is a draft implementation of auto scaling explicitly specified control font as per the Settings display text scale. As already done with app default font.

Fixes #3263 implicitly.


## Proposed changes

- Add public enumeration `FontAutoScale`:
```cs
/// <summary>
///  Specifies the font auto scaling mode used by a control.
/// </summary>
public enum FontAutoScale
{
    /// <summary>
    ///  Scale only if control using system font.
    /// </summary>
    SystemOnly,

    /// <summary>
    ///  Scale if control using system or explicitly specified font.
    /// </summary>
    SystemAndExplicit,

    /// <summary>
    ///  Font scale according to their parent's scaling mode.
    ///  If there is no parent, this behaves as if <see cref="FontAutoScale.SystemOnly"/> were set.
    /// </summary>
    Inherit
}
```
- Add public property `FontAutoScale` to `Control` class:
```cs
/// <summary>
///  Determines the font auto scaling mode of this control.
/// </summary>
public FontAutoScale FontAutoScale { get; set; }
```
- Add public property `ExplicitFont` to `Control` class. Not required, but probably desirable:
```cs
/// <summary>
/// Gets the Font that was explicitly set on control by the application. null if the font was not explicitly set.
/// </summary>
public Font ExplicitFont { get; }
```

## Customer Impact

Customers will be able to use custom fonts without losing the ability to scale using the system font:
![image](https://user-images.githubusercontent.com/17767561/151715293-4bf1358d-aeed-4a18-86b4-f463a249664c.png)


## Regression? 

- No

## Risk

- Risk of regression is low because we leave the old default behavior (only those controls whose font is not explicitly set are scaled).
- Risk of bugs in new functionality - probably above average.


## Screenshots
<details><summary>CLICK ME</summary>
<p>

### Before (150% text size)
`.Net6` `SystemAware` and `AutoScaleMode.Font`
![old_150](https://user-images.githubusercontent.com/17767561/151715511-a3a3b1a5-5403-4c9b-b569-09af3c957126.png)

### After (150% text size)
All explicitly specified fonts are specially made different from the system - italic or bold, controls with system font are marked with text: `system font`. All `FontAutoScale` modes also displayed on controls.
`.Net7` `SystemAware` and `AutoScaleMode.Font`
![new_150_2](https://user-images.githubusercontent.com/17767561/151716686-a7445103-e3ef-4a6f-8790-5a5c8ad0b302.png)

### Before / After gif (125% text size)
`.Net7` `SystemAware` and `AutoScaleMode.Font`
![125](https://user-images.githubusercontent.com/17767561/152638186-4cce8d63-3c58-4d1a-8106-c266c4d9bc23.gif)

`.Net7` `SystemAware` and `AutoScaleMode.Dpi`
![125_dpi](https://user-images.githubusercontent.com/17767561/152638662-ffe4832c-89cd-4b28-a3b8-71fabd763791.gif)

### Before / After video (125% text size and DPI 125 -> 100%)
`.Net7` `PerMonitorV2` and `AutoScaleMode.Font` - all work fine until we switch DPI on the fly (and than change `FontAutoScale`) - need to investigate...

https://user-images.githubusercontent.com/17767561/152640763-87d16945-6317-4812-b805-716d154a0bf1.mp4

</p>
</details>


## Test methodology
Manual. Testing app (with binary's for simplicity): 
[FontScale.zip](https://github.com/dotnet/winforms/files/8009751/FontScale.zip)



To do.

## Accessibility testing

Not necessary - correct me if I'm wrong.

## To do
- General assessment - is such functionality needed?
- Evaluation of whether I correctly understood everything about HDPI in WinForms.
- `PerMonitorV2` - everything breaks after we switch DPI on the fly - need to investigate...
- Discuss what to do with complex (which may have several different fonts) controls such as `DataGridView`, `ListView`... Without additional implementation in each of them, scaling will work only if one font is specified for the entire control.
- Properties, enums, methods naming and descriptions.
- Mixed mode DpiAwarenessModes (thread level DpiAwareness in the application).
- Testing.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6580)