### PR TITLE
Fix NRE in ToolStripItem.InvalidateItemLayout

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -2328,10 +2328,10 @@ namespace System.Windows.Forms
             if (Owner is not null)
             {
                 LayoutTransaction.DoLayout(Owner, this, affectedProperty);
-                /* DoLayout may cause the ToolStrip size to change. If the ToolStrip is an MdiControlStrip, the
-                 * active Mdi child is maximized, and DoLayout causes the size to change then Form.MdiControlStrip
-                 * (Owner) will be disposed and replaced with a new one. This means the current ToolStripItem will
-                 * also be disposed and have no owner on the next line. See issue #6535 */
+                // DoLayout may cause the ToolStrip size to change. If the ToolStrip is an MdiControlStrip, the
+                // active Mdi child is maximized, and DoLayout causes the size to change then Form.MdiControlStrip
+                // (Owner) will be disposed and replaced with a new one. This means the current ToolStripItem will
+                // also be disposed and have no owner on the next line. See https://github.com/dotnet/winforms/issues/6535
                 Owner?.Invalidate();
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -2328,7 +2328,11 @@ namespace System.Windows.Forms
             if (Owner is not null)
             {
                 LayoutTransaction.DoLayout(Owner, this, affectedProperty);
-                Owner.Invalidate();
+                /* DoLayout may cause the ToolStrip size to change. If the ToolStrip is an MdiControlStrip, the
+                 * active Mdi child is maximized, and DoLayout causes the size to change then Form.MdiControlStrip
+                 * (Owner) will be disposed and replaced with a new one. This means the current ToolStripItem will
+                 * also be disposed and have no owner on the next line. See issue #6535 */
+                Owner?.Invalidate();
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
@@ -327,7 +327,11 @@ namespace System.Windows.Forms.Tests
             Reflection.PropertyInfo mdiControlStripProperty = typeof(Form).GetProperty("MdiControlStrip", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance);
             MdiControlStrip originalMdiControlStrip = (MdiControlStrip)mdiControlStripProperty.GetValue(mdiParent);
 
-            mdiChild.Icon = Icon.FromHandle(new Bitmap(256, 256).GetHicon()); // Force size change with large icon
+            // Force size change with large icon
+            IntPtr hicon = new Bitmap(256, 256).GetHicon();
+            Icon largeIcon = (Icon)Icon.FromHandle(hicon).Clone();
+            User32.DestroyIcon(hicon);
+            mdiChild.Icon = largeIcon;
 
             MdiControlStrip currentMdiControlStrip = (MdiControlStrip)mdiControlStripProperty.GetValue(mdiParent);
             Assert.NotEqual(originalMdiControlStrip, currentMdiControlStrip);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
@@ -310,6 +310,29 @@ namespace System.Windows.Forms.Tests
             Assert.True(menuItemCount == 4);
         }
 
+        [WinFormsFact]
+        public void MdiControlStrip_MaximizedChildWindow_RecreatesOnSizeChanged()
+        {
+            using var mdiParent = new Form() { IsMdiContainer = true, Text = "Parent" };
+            using var mdiChild = new Form() { MdiParent = mdiParent, Text = "Child" };
+            using var menuStrip = new MenuStrip();
+
+            mdiParent.Controls.Add(menuStrip);
+            mdiParent.MainMenuStrip = menuStrip;
+
+            mdiParent.Show();
+            mdiChild.Show();
+            mdiChild.WindowState = FormWindowState.Maximized;
+
+            Reflection.PropertyInfo mdiControlStripProperty = typeof(Form).GetProperty("MdiControlStrip", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance);
+            MdiControlStrip originalMdiControlStrip = (MdiControlStrip)mdiControlStripProperty.GetValue(mdiParent);
+
+            mdiChild.Icon = Icon.FromHandle(new Bitmap(256, 256).GetHicon()); // Force size change with large icon
+
+            MdiControlStrip currentMdiControlStrip = (MdiControlStrip)mdiControlStripProperty.GetValue(mdiParent);
+            Assert.NotEqual(originalMdiControlStrip, currentMdiControlStrip);
+        }
+
         private class SubMdiControlStrip : MdiControlStrip
         {
             public new const int ScrollStateAutoScrolling = MenuStrip.ScrollStateAutoScrolling;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
@@ -324,8 +324,7 @@ namespace System.Windows.Forms.Tests
             mdiChild.Show();
             mdiChild.WindowState = FormWindowState.Maximized;
 
-            Reflection.PropertyInfo mdiControlStripProperty = typeof(Form).GetProperty("MdiControlStrip", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance);
-            MdiControlStrip originalMdiControlStrip = (MdiControlStrip)mdiControlStripProperty.GetValue(mdiParent);
+            MdiControlStrip originalMdiControlStrip = mdiParent.TestAccessor().Dynamic.MdiControlStrip;
 
             // Force size change with large icon
             IntPtr hicon = new Bitmap(256, 256).GetHicon();
@@ -333,7 +332,7 @@ namespace System.Windows.Forms.Tests
             User32.DestroyIcon(hicon);
             mdiChild.Icon = largeIcon;
 
-            MdiControlStrip currentMdiControlStrip = (MdiControlStrip)mdiControlStripProperty.GetValue(mdiParent);
+            MdiControlStrip currentMdiControlStrip = mdiParent.TestAccessor().Dynamic.MdiControlStrip;
             Assert.NotEqual(originalMdiControlStrip, currentMdiControlStrip);
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6535


## Proposed changes

PR #4650 introduced a refresh of the `MdiControlStrip` icon when a maximized MDI child form's icon changes. That surfaced a bug ultimately resulting in a `NullReferenceException`. The fix is trivial, with most work spent understanding the root cause and proving the fix to be correct.

The NRE was triggered when a maximized MDI child form's icon changed if the new icon's size caused the `MdiControlStip`'s size to change. The Rube Goldberg-like chain of events went like this:

- The `ToolStripItem` containing the icon would invalidate its layout
- This would trigger a call to `LayoutTransaction.DoLayout` on the item's owner (the `MdiControlStrip`)
- The `MdiControlStrip` would resize
- The area available to the maximized MDI child form would change due to `MdiControlStrip` taking up more/less space
- The MDI child would receive a `WM_SIZE` message
- The MDI child would call `MdiParentInternal.UpdateMdiControlStrip` in `Form.WmSize`
- The MDI parent would dispose the current `MdiControlStip` and create a new one (it does this unconditionally)
- The disposed `MdiControlStrip` would dispose all of its associated `Items` and clear its `Items` property
- Clearing `Items` would set each `ToolStripItem.Owner` to `null`
- The stack would unwind and the `ToolStripItem` would attempt to call `Owner.Invalidate` with `Owner` being a `null` reference

Because the `ToolStripItem` and its former parent `ToolStrip` are both disposed at this point, we can just use a null conditional on `Owner.Invalidate`. 

I had considered checking `ToolStripItem.IsDisposed` as a possible alternative fix, but that just indirectly verifies the condition we are concerned about. `ToolStripItem.IsDisposed` will be `true` and `Owner` will be `null`. Might as well check `Owner` directly since that's the thing that will trigger the NRE.


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Customer should not experience an NRE when changing the icon of a maximized MDI child when doing so results in a size change of the `MdiControlStrip` containing it

## Regression? 

- Yes 

## Risk

- Minimal

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Unit test added. Fails pre-fix and passes post-fix

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6588)