### PR TITLE
Added "Skip" attribute for fail unit tests in arm64 and x86

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ImageListTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ImageListTests.cs
@@ -23,7 +23,8 @@ namespace System.Windows.Forms.UITests
         {
         }
 
-        [WinFormsFact]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6635")]
+        [WinFormsFact(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6635")]
         public void ImageList_FinalizerReleasesNativeHandle_ReturnsExpected()
         {
             // Warm up to create any GDI handles that are necessary, e.g. fonts, brushes, etc.

--- a/src/System.Windows.Forms/tests/TestUtilities/ConditionalWinFormsFactAttribute.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/ConditionalWinFormsFactAttribute.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System
+{
+    public class ConditionalWinFormsFactAttribute : WinFormsFactAttribute
+    {
+        private Architecture _unsupportedArchitecture;
+        private bool _isSkipRequired;
+        private string _skipReason;
+
+        public override string Skip
+        {
+            get => base.Skip;
+            set
+            {
+                _skipReason = value;
+
+                if (_isSkipRequired)
+                {
+                    base.Skip = value;
+                }
+
+                // Don't skip a test case if the skip condition is false.
+            }
+        }
+
+        /// <summary>
+        ///  Defines the architecture to skip the test on. This is complementary to <see cref="Skip"/> parameter.
+        /// </summary>
+        public Architecture UnsupportedArchitecture
+        {
+            get => _unsupportedArchitecture;
+            set
+            {
+                _unsupportedArchitecture = value;
+                _isSkipRequired = RuntimeInformation.ProcessArchitecture == value;
+                if (_isSkipRequired && _skipReason is not null)
+                {
+                    Skip = _skipReason;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/TestUtilities/ConditionalWinFormsTheoryAttribute.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/ConditionalWinFormsTheoryAttribute.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System
+{
+    public class ConditionalWinFormsTheoryAttribute : WinFormsTheoryAttribute
+    {
+        private Architecture _unsupportedArchitecture;
+        private bool _isSkipRequired;
+        private string _skipReason;
+
+        public override string Skip
+        {
+            get => base.Skip;
+            set
+            {
+                _skipReason = value;
+
+                if (_isSkipRequired)
+                {
+                    base.Skip = value;
+                }
+
+                // Don't skip a test case if the skip condition is false.
+            }
+        }
+
+        /// <summary>
+        ///  Defines the architecture to skip the test on. This is complementary to <see cref="Skip"/> parameter.
+        /// </summary>
+        public Architecture UnsupportedArchitecture
+        {
+            get => _unsupportedArchitecture;
+            set
+            {
+                _unsupportedArchitecture = value;
+                _isSkipRequired = RuntimeInformation.ProcessArchitecture == value;
+                if (_isSkipRequired && _skipReason is not null)
+                {
+                    Skip = _skipReason;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 
@@ -170,7 +171,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
+        [ConditionalWinFormsTheory(UnsupportedArchitecture = Architecture.Arm64,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(ColumnHeadersHeight_SetWithHandle_TestData))]
         public void DataGridView_ColumnHeadersHeight_SetWithHandle_GetReturnsExpected(DataGridViewColumnHeadersHeightSizeMode columnHeadersWidthSizeMode, bool columnHeadersVisible, bool autoSize, int value, int expectedValue, int expectedInvalidatedCallCount)
         {
@@ -238,7 +240,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
+        [ConditionalWinFormsTheory(UnsupportedArchitecture = Architecture.Arm64,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(ColumnHeadersHeight_SetWithParentWithHandle_TestData))]
         public void DataGridView_ColumnHeadersHeight_SetWithParentWithHandle_GetReturnsExpected(DataGridViewColumnHeadersHeightSizeMode columnHeadersWidthSizeMode, bool columnHeadersVisible, bool autoSize, int value, int expectedValue, int expectedInvalidatedCallCount, int expectedLayoutCallCount, int expectedParentLayoutCallCount)
         {
@@ -527,7 +530,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
+        [ConditionalWinFormsTheory(UnsupportedArchitecture = Architecture.Arm64,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(ColumnHeadersHeightSizeMode_SetWithHandle_TestData))]
         public void DataGridView_ColumnHeadersHeightSizeMode_SetWithHandle_GetReturnsExpected(bool columnHeadersVisible, DataGridViewColumnHeadersHeightSizeMode value, int expectedColumnHeadersHeight, int expectedInvalidatedCallCount)
         {
@@ -562,7 +566,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
+        [ConditionalWinFormsTheory(UnsupportedArchitecture = Architecture.Arm64,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [InlineData(DataGridViewColumnHeadersHeightSizeMode.DisableResizing, DataGridViewColumnHeadersHeightSizeMode.AutoSize)]
         [InlineData(DataGridViewColumnHeadersHeightSizeMode.EnableResizing, DataGridViewColumnHeadersHeightSizeMode.AutoSize)]
         public void DataGridView_ColumnHeadersHeightSizeMode_SetNonResizeThenResize_RestoresOldValue(DataGridViewColumnHeadersHeightSizeMode originalColumnHeadersHeightSizeMode, DataGridViewColumnHeadersHeightSizeMode value)
@@ -1101,7 +1106,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
+        [ConditionalWinFormsTheory(UnsupportedArchitecture = Architecture.Arm64,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(RowHeadersWidth_SetWithHandle_TestData))]
         public void DataGridView_RowHeadersWidth_SetWithHandle_GetReturnsExpected(DataGridViewRowHeadersWidthSizeMode rowHeadersWidthSizeMode, bool rowHeadersVisible, bool autoSize, int value, int expectedValue, int expectedInvalidatedCallCount)
         {
@@ -1468,7 +1474,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
+        [ConditionalWinFormsTheory(UnsupportedArchitecture = Architecture.Arm64,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(RowHeadersWidthSizeMode_SetWithHandle_TestData))]
         public void DataGridView_RowHeadersWidthSizeMode_SetWithHandle_GetReturnsExpected(bool rowHeadersVisible, DataGridViewRowHeadersWidthSizeMode value, int expectedRowHeadersWidth, int expectedInvalidatedCallCount)
         {
@@ -1503,7 +1510,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
+        [ConditionalWinFormsTheory(UnsupportedArchitecture = Architecture.Arm64,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [InlineData(DataGridViewRowHeadersWidthSizeMode.DisableResizing, DataGridViewRowHeadersWidthSizeMode.AutoSizeToAllHeaders)]
         [InlineData(DataGridViewRowHeadersWidthSizeMode.DisableResizing, DataGridViewRowHeadersWidthSizeMode.AutoSizeToDisplayedHeaders)]
         [InlineData(DataGridViewRowHeadersWidthSizeMode.DisableResizing, DataGridViewRowHeadersWidthSizeMode.AutoSizeToFirstHeader)]
@@ -1960,7 +1968,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
+        [ConditionalWinFormsTheory(UnsupportedArchitecture = Architecture.Arm64,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(OnColumnHeadersHeightChanged_TestData))]
         public void DataGridView_OnColumnHeadersHeightChanged_InvokeWithHandle_CallsColumnHeadersHeightChanged(DataGridViewColumnHeadersHeightSizeMode columnHeadersWidthSizeMode, bool columnHeadersVisible, EventArgs eventArgs)
         {
@@ -2438,7 +2447,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
+        [ConditionalWinFormsTheory(UnsupportedArchitecture = Architecture.Arm64,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(OnRowHeadersWidthChanged_TestData))]
         public void DataGridView_OnRowHeadersWidthChanged_InvokeWithHandle_CallsRowHeadersWidthChanged(DataGridViewRowHeadersWidthSizeMode rowHeadersWidthSizeMode, bool rowHeadersVisible, EventArgs eventArgs)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -169,7 +169,8 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [WinFormsTheory]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
+        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(ColumnHeadersHeight_SetWithHandle_TestData))]
         public void DataGridView_ColumnHeadersHeight_SetWithHandle_GetReturnsExpected(DataGridViewColumnHeadersHeightSizeMode columnHeadersWidthSizeMode, bool columnHeadersVisible, bool autoSize, int value, int expectedValue, int expectedInvalidatedCallCount)
         {
@@ -236,7 +237,8 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [WinFormsTheory]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
+        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(ColumnHeadersHeight_SetWithParentWithHandle_TestData))]
         public void DataGridView_ColumnHeadersHeight_SetWithParentWithHandle_GetReturnsExpected(DataGridViewColumnHeadersHeightSizeMode columnHeadersWidthSizeMode, bool columnHeadersVisible, bool autoSize, int value, int expectedValue, int expectedInvalidatedCallCount, int expectedLayoutCallCount, int expectedParentLayoutCallCount)
         {
@@ -524,7 +526,8 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { false, DataGridViewColumnHeadersHeightSizeMode.EnableResizing, DefaultColumnHeadersHeight, 0 };
         }
 
-        [WinFormsTheory]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
+        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(ColumnHeadersHeightSizeMode_SetWithHandle_TestData))]
         public void DataGridView_ColumnHeadersHeightSizeMode_SetWithHandle_GetReturnsExpected(bool columnHeadersVisible, DataGridViewColumnHeadersHeightSizeMode value, int expectedColumnHeadersHeight, int expectedInvalidatedCallCount)
         {
@@ -558,7 +561,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
-        [WinFormsTheory]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
+        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [InlineData(DataGridViewColumnHeadersHeightSizeMode.DisableResizing, DataGridViewColumnHeadersHeightSizeMode.AutoSize)]
         [InlineData(DataGridViewColumnHeadersHeightSizeMode.EnableResizing, DataGridViewColumnHeadersHeightSizeMode.AutoSize)]
         public void DataGridView_ColumnHeadersHeightSizeMode_SetNonResizeThenResize_RestoresOldValue(DataGridViewColumnHeadersHeightSizeMode originalColumnHeadersHeightSizeMode, DataGridViewColumnHeadersHeightSizeMode value)
@@ -1096,7 +1100,8 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [WinFormsTheory]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
+        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(RowHeadersWidth_SetWithHandle_TestData))]
         public void DataGridView_RowHeadersWidth_SetWithHandle_GetReturnsExpected(DataGridViewRowHeadersWidthSizeMode rowHeadersWidthSizeMode, bool rowHeadersVisible, bool autoSize, int value, int expectedValue, int expectedInvalidatedCallCount)
         {
@@ -1462,7 +1467,8 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { false, DataGridViewRowHeadersWidthSizeMode.EnableResizing, DefaultRowHeadersWidth, 0 };
         }
 
-        [WinFormsTheory]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
+        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(RowHeadersWidthSizeMode_SetWithHandle_TestData))]
         public void DataGridView_RowHeadersWidthSizeMode_SetWithHandle_GetReturnsExpected(bool rowHeadersVisible, DataGridViewRowHeadersWidthSizeMode value, int expectedRowHeadersWidth, int expectedInvalidatedCallCount)
         {
@@ -1496,7 +1502,8 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
-        [WinFormsTheory]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
+        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [InlineData(DataGridViewRowHeadersWidthSizeMode.DisableResizing, DataGridViewRowHeadersWidthSizeMode.AutoSizeToAllHeaders)]
         [InlineData(DataGridViewRowHeadersWidthSizeMode.DisableResizing, DataGridViewRowHeadersWidthSizeMode.AutoSizeToDisplayedHeaders)]
         [InlineData(DataGridViewRowHeadersWidthSizeMode.DisableResizing, DataGridViewRowHeadersWidthSizeMode.AutoSizeToFirstHeader)]
@@ -1952,7 +1959,8 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
-        [WinFormsTheory]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
+        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(OnColumnHeadersHeightChanged_TestData))]
         public void DataGridView_OnColumnHeadersHeightChanged_InvokeWithHandle_CallsColumnHeadersHeightChanged(DataGridViewColumnHeadersHeightSizeMode columnHeadersWidthSizeMode, bool columnHeadersVisible, EventArgs eventArgs)
         {
@@ -2429,7 +2437,8 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
-        [WinFormsTheory]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6597")]
+        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6597")]
         [MemberData(nameof(OnRowHeadersWidthChanged_TestData))]
         public void DataGridView_OnRowHeadersWidthChanged_InvokeWithHandle_CallsRowHeadersWidthChanged(DataGridViewRowHeadersWidthSizeMode rowHeadersWidthSizeMode, bool rowHeadersVisible, EventArgs eventArgs)
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -6876,7 +6876,8 @@ namespace System.Windows.Forms.Tests
         // NOTE: do not convert this into a theory as it will run hundreds of tests
         // and with that will cycle through hundreds of UI controls.
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6609")]
-        [WinFormsFact(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6609")]
+        [ConditionalWinFormsFact(UnsupportedArchitecture = Architecture.X86,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6609")]
         public void RichTextBox_Text_GetWithHandle_ReturnsExpected()
         {
             using (var control = new RichTextBox())

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -6875,7 +6875,8 @@ namespace System.Windows.Forms.Tests
 
         // NOTE: do not convert this into a theory as it will run hundreds of tests
         // and with that will cycle through hundreds of UI controls.
-        [WinFormsFact]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6609")]
+        [WinFormsFact(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6609")]
         public void RichTextBox_Text_GetWithHandle_ReturnsExpected()
         {
             using (var control = new RichTextBox())

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -7118,7 +7118,8 @@ namespace System.Windows.Forms.Tests
             Assert.True(control.IsHandleCreated);
         }
 
-        [WinFormsFact]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6610")]
+        [WinFormsFact(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6610")]
         public void ToolStrip_WndProc_InvokeMouseActivateWithHandle_Success()
         {
             using var control = new SubToolStrip();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -7119,7 +7119,8 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6610")]
-        [WinFormsFact(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6610")]
+        [ConditionalWinFormsFact(UnsupportedArchitecture = Architecture.Arm64,
+            Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6610")]
         public void ToolStrip_WndProc_InvokeMouseActivateWithHandle_Success()
         {
             using var control = new SubToolStrip();


### PR DESCRIPTION
Related Issues:
- #6597
- #6609 
- #6610
- #6635 

## Proposed changes
- Skipped unit tests that fail sometimes in arm64 and x86 environments, that blocks fixes deployment.

## Customer Impact
- No

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CI build


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6599)