### PR TITLE
Adding UIA support for PrintPreviewControl

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ~override System.Windows.Forms.SplitContainer.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.PrintPreviewControl.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObject.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class PrintPreviewControl
+    {
+        internal class PrintPreviewControlAccessibleObject : ControlAccessibleObject
+        {
+            private readonly PrintPreviewControl _owningPrintPreviewControl;
+
+            public PrintPreviewControlAccessibleObject(PrintPreviewControl owner) : base(owner)
+            {
+                _owningPrintPreviewControl = owner;
+            }
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
+                {
+                    UiaCore.UIA.AutomationIdPropertyId
+                        => Owner.Name,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId
+                        => _owningPrintPreviewControl.Focused,
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId
+                        => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                    _ => base.GetPropertyValue(propertyID)
+                };
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewControl.cs
@@ -19,7 +19,7 @@ namespace System.Windows.Forms
     /// </summary>
     [DefaultProperty(nameof(Document))]
     [SRDescription(nameof(SR.DescriptionPrintPreviewControl))]
-    public class PrintPreviewControl : Control
+    public partial class PrintPreviewControl : Control
     {
         Size virtualSize = new Size(1, 1);
         Point position = new Point(0, 0);
@@ -203,6 +203,8 @@ namespace System.Windows.Forms
                 InvalidatePreview();
             }
         }
+
+        internal override bool SupportsUiaProviders => true;
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -443,6 +445,9 @@ namespace System.Windows.Forms
                 OnStartPageChanged(EventArgs.Empty);
             }
         }
+
+        protected override AccessibleObject CreateAccessibilityInstance()
+            => new PrintPreviewControlAccessibleObject(this);
 
         // Recomputes the sizes and positions of pages without forcing a new "preview print"
         private void InvalidateLayout()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PrintPreviewControl.PrintPreviewControlAccessibleObjectTests.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+using static Interop;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.Tests
+{
+    public class PrintPreviewControl_PrintPreviewControlAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void PrintPreviewControlAccessibleObject_Ctor_Default()
+        {
+            using PrintPreviewControl control = new();
+            PrintPreviewControl.PrintPreviewControlAccessibleObject accessibleObject = new(control);
+
+            Assert.Equal(control, accessibleObject.Owner);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UIA.NamePropertyId, "TestName")]
+        [InlineData((int)UIA.AutomationIdPropertyId, "PrintPreviewControl1")]
+        public void PrintPreviewControlAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
+        {
+            using PrintPreviewControl control = new()
+            {
+                Name = "PrintPreviewControl1",
+                AccessibleName = "TestName"
+            };
+
+            Assert.False(control.IsHandleCreated);
+            var accessibleObject = new PrintPreviewControl.PrintPreviewControlAccessibleObject(control);
+            object value = accessibleObject.GetPropertyValue((UIA)propertyID);
+
+            Assert.Equal(expected, value);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void PrintPreviewControlAccessibleObject_GetPropertyValue_Focused_ReturnsExpected()
+        {
+            using PrintPreviewControl control = new();
+
+            var accessibleObject = new PrintPreviewControl.PrintPreviewControlAccessibleObject(control);
+            control.CreateControl();
+            User32.SetFocus(new HandleRef(control, control.Handle));
+            bool value = (bool)accessibleObject.GetPropertyValue(UIA.HasKeyboardFocusPropertyId);
+
+            Assert.True(value);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void PrintPreviewControlAccessibleObject_GetPropertyValue_Unfocused_ReturnsExpected()
+        {
+            using PrintPreviewControl control = new();
+
+            Assert.False(control.IsHandleCreated);
+            var accessibleObject = new PrintPreviewControl.PrintPreviewControlAccessibleObject(control);
+            bool value = (bool)accessibleObject.GetPropertyValue(UIA.HasKeyboardFocusPropertyId);
+
+            Assert.False(value);
+            Assert.False(control.IsHandleCreated);
+        }
+    }
+}


### PR DESCRIPTION
Partially implements #3421


## Proposed changes

- Updated "SupportsUiaProviders" flag.
- Added and implemented printPreviewControlaccessible object
- Added unit tests

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- **Before update:**
![image](https://user-images.githubusercontent.com/74228865/152150519-13efc6d7-64cf-4eda-af41-e0eedcc01ef3.png)
![image](https://user-images.githubusercontent.com/74228865/152150647-6b491eea-3881-4758-9bb1-600f2b50982e.png)

- **After update:**
Provider was changed.
![image](https://user-images.githubusercontent.com/74228865/152152387-0cf5de1d-3947-472b-990c-e88ccf546713.png)
![image](https://user-images.githubusercontent.com/74228865/152152458-3d6e2ee1-e19c-4176-aa3f-c07a7320e091.png)

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Narrator
- Inspect
- Accessibility Insights

 

## Test environment(s) <!-- Remove any that don't apply -->

- Microsoft Windows [Version 10.0.22000.318]
- .NET Core SDK: 7.0.0-alpha.1.21562.1



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6600)