### PR TITLE
Implementing uia provider support for DTP control

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 ~override System.Windows.Forms.SplitContainer.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.PrintPreviewControl.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
+~override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.Name.get -> string
+~override System.Windows.Forms.DateTimePicker.OnGotFocus(System.EventArgs e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
@@ -51,6 +51,10 @@ namespace System.Windows.Forms
                 }
             }
 
+            // Note: returns empty string instead of null, because the date value replaces null,
+            // so name is not empty in this case even if AccessibleName is not set.
+            public override string Name => Owner.AccessibleName ?? string.Empty;
+
             public override string Value
             {
                 get
@@ -114,6 +118,7 @@ namespace System.Windows.Forms
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
                 => (patternId == UiaCore.UIA.TogglePatternId && ((DateTimePicker)Owner).ShowCheckBox) ||
                     patternId == UiaCore.UIA.ExpandCollapsePatternId ||
+                    patternId == UiaCore.UIA.ValuePatternId ||
                     base.IsPatternSupported(patternId);
 
             #region Toggle Pattern

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -18,24 +18,32 @@ namespace System.Windows.Forms.Tests
         // This behavior is consistent with .NET Framework 4.7.2
         private static Type[] s_controlsNotUseTextForAccessibility = new Type[]
         {
-                typeof(CheckedListBox),
-                typeof(ComboBox),
-                typeof(DataGridViewComboBoxEditingControl),
-                typeof(DataGridViewTextBoxEditingControl),
-                typeof(DateTimePicker),
-                typeof(DomainUpDown),
-                typeof(HScrollBar),
-                typeof(ListBox),
-                typeof(ListView),
-                typeof(MaskedTextBox),
-                typeof(NumericUpDown),
-                typeof(ProgressBar),
-                typeof(RichTextBox),
-                typeof(TextBox),
-                typeof(TrackBar),
-                typeof(TreeView),
-                typeof(VScrollBar),
-                typeof(WebBrowser),
+            typeof(CheckedListBox),
+            typeof(ComboBox),
+            typeof(DataGridViewComboBoxEditingControl),
+            typeof(DataGridViewTextBoxEditingControl),
+            typeof(DateTimePicker),
+            typeof(DomainUpDown),
+            typeof(HScrollBar),
+            typeof(ListBox),
+            typeof(ListView),
+            typeof(MaskedTextBox),
+            typeof(NumericUpDown),
+            typeof(ProgressBar),
+            typeof(RichTextBox),
+            typeof(TextBox),
+            typeof(TrackBar),
+            typeof(TreeView),
+            typeof(VScrollBar),
+            typeof(WebBrowser),
+        };
+
+        // These controls have special conditions for setting the Text property.
+        // Please check if the control type isn't contained here in cases where text change is needed
+        // otherwise an error can be thrown.
+        private static Type[] s_controlsIgnoringTextChangesForTests = new Type[]
+        {
+            typeof(DateTimePicker),
         };
 
         [WinFormsFact]
@@ -1243,7 +1251,11 @@ namespace System.Windows.Forms.Tests
                 return;
             }
 
-            control.Text = "&Name";
+            if (!s_controlsIgnoringTextChangesForTests.Contains(type))
+            {
+                control.Text = "&Name";
+            }
+
             AccessibleObject controlAccessibleObject = control.AccessibilityObject;
             string expectedValue = s_controlsNotUseTextForAccessibility.Contains(type) ? string.Empty : "Alt+n";
 
@@ -1313,7 +1325,8 @@ namespace System.Windows.Forms.Tests
             var typeDefaultValues = new Dictionary<Type, string>
             {
                 { typeof(DataGridViewTextBoxEditingControl), SR.DataGridView_AccEditingControlAccName },
-                { typeof(PrintPreviewDialog), SR.PrintPreviewDialog_PrintPreview }
+                { typeof(PrintPreviewDialog), SR.PrintPreviewDialog_PrintPreview },
+                { typeof(DateTimePicker), string.Empty },
             };
 
             foreach (Type type in ReflectionHelper.GetPublicNotAbstractClasses<Control>())

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
@@ -242,5 +242,53 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(UiaCore.ExpandCollapseState.Collapsed, accessibleObject.ExpandCollapseState);
             Assert.True(dateTimePicker.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId)]
+        [InlineData((int)UiaCore.UIA.ValuePatternId)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        public void DateTimePickerAccessibleObject_IsPatternSupported_ReturnsExpected_IfDoNotShowCheckbox(int patternId)
+        {
+            using DateTimePicker dateTimePicker = new() { ShowCheckBox = false };
+
+            AccessibleObject accessibleObject = dateTimePicker.AccessibilityObject;
+
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.False(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.TogglePatternId)]
+        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId)]
+        [InlineData((int)UiaCore.UIA.ValuePatternId)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
+        public void DateTimePickerAccessibleObject_IsPatternSupported_ReturnsExpected_IfShowCheckbox(int patternId)
+        {
+            using DateTimePicker dateTimePicker = new() { ShowCheckBox = true };
+
+            AccessibleObject accessibleObject = dateTimePicker.AccessibilityObject;
+
+            Assert.True(accessibleObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.False(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DateTimePickerAccessibleObject_Name_ReturnsEmptyString_IfControlAccessibleNameIsNotNull()
+        {
+            using DateTimePicker dateTimePicker = new();
+
+            Assert.Equal(string.Empty, dateTimePicker.AccessibilityObject.Name);
+            Assert.False(dateTimePicker.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DateTimePickerAccessibleObject_Name_ReturnsExpected_IfControlAccessibleNameIsNotNull()
+        {
+            string testAccessibleName = "TestDateTimePicker";
+            using DateTimePicker dateTimePicker = new() { AccessibleName = testAccessibleName };
+
+            Assert.Equal(testAccessibleName, dateTimePicker.AccessibilityObject.Name);
+            Assert.False(dateTimePicker.IsHandleCreated);
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Implements part of #3421

## Proposed changes

- Switched on `SupportsUiaProviders` property of `DateTimePicker` class.
- Added needed automation events to fix behavior in Narrator.
- Reworked `DateTimePickerAccessibleObject`, added unit tests.
- Added workaround to check `AccessKey` for dtp in `ControlAccessibleObjectTests`.  

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improving development experience for `DateTimePicker` control accessibility.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

Changes in accessibility tools.

### Accessibility Insights

#### Before

![AI](https://user-images.githubusercontent.com/58004471/154308654-bb4188c2-f161-46b7-8d09-a056cc0ab779.png)

#### After

![a](https://user-images.githubusercontent.com/58004471/154308717-d4241a34-72aa-4204-8939-647c15ac9a0f.png)

### Narrator & Buddy

The behavior in Narrator was restored after the fix. Seems was resolved problem described in issue #5487.

![NB New](https://user-images.githubusercontent.com/58004471/154308776-604d4c8d-5ee2-4eba-8329-4207964596e7.png)

### Calendar issue

The Narrator doesn't work with dtp calendar. Seems, it is native control problem, because the Narrator doesn't work with dtp in MFC app at all. You can see it on following gif below.
I attach the test MFC app with dtp: [MFCApplication.zip](https://github.com/dotnet/winforms/files/8098994/MFCApplication.zip)

![DateTimePickerMFC](https://user-images.githubusercontent.com/58004471/154727575-e896fc1e-73c0-42c4-a163-645b63ac0ee3.gif)






## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit testing
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Inspect
- Accessibility Insights
- Narrator
 

## Test environment(s) <!-- Remove any that don't apply -->

- .Net version: 7.0.100-preview.1.22078.7
- OS version: 10.0.19044

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6620)