### PR TITLE
Enable nullability in classes that inherit from NativeWindow

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ACNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ACNativeWindow.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.Diagnostics;
 using System.Runtime.InteropServices;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindow.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using static Interop;
 using static Interop.User32;
@@ -116,7 +114,8 @@ namespace System.Windows.Forms
                     }
                 }
                 else
-                {  // m.lparam != OBJID_CLIENT, so do default message processing
+                {
+                    // m.lparam != OBJID_CLIENT, so do default message processing
                     DefWndProc(ref m);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlNativeWindow.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms
 
             internal ControlNativeWindow(Control control)
             {
-                _control = control;
+                _control = control.OrThrowIfNull();
                 WindowTarget = this;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlNativeWindow.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Runtime.InteropServices;
 using static Interop;
 
@@ -74,12 +72,7 @@ namespace System.Windows.Forms
             // non-released controls will show what control wasn't released.
             public override string ToString()
             {
-                if (_control is not null)
-                {
-                    return _control.GetType().FullName;
-                }
-
-                return base.ToString();
+                return _control.GetType().FullName!;
             }
 #endif
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -30,8 +28,8 @@ namespace System.Windows.Forms
             private readonly Control _parent;
             private readonly ErrorProvider _provider;
             private Rectangle _windowBounds;
-            private Timer _timer;
-            private NativeWindow _tipWindow;
+            private Timer? _timer;
+            private NativeWindow? _tipWindow;
 
             /// <summary>
             ///  Construct an error window for this provider and control parent.
@@ -50,7 +48,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    AccessibleObject accessibleObject = (AccessibleObject)Properties.GetObject(s_accessibilityProperty);
+                    AccessibleObject? accessibleObject = (AccessibleObject?)Properties.GetObject(s_accessibilityProperty);
 
                     if (accessibleObject is null)
                     {
@@ -73,8 +71,11 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                var toolInfo = new ComCtl32.ToolInfoWrapper<ErrorWindow>(this, item.Id, ComCtl32.TTF.SUBCLASS, item.Error);
-                toolInfo.SendMessage(_tipWindow, (User32.WM)ComCtl32.TTM.ADDTOOLW);
+                if (_tipWindow is not null)
+                {
+                    var toolInfo = new ComCtl32.ToolInfoWrapper<ErrorWindow>(this, item.Id, ComCtl32.TTF.SUBCLASS, item.Error);
+                    toolInfo.SendMessage(_tipWindow, (User32.WM)ComCtl32.TTM.ADDTOOLW);
+                }
 
                 Update(timerCaused: false);
             }
@@ -223,7 +224,7 @@ namespace System.Windows.Forms
             /// <summary>
             ///  This is called when an error icon is flashing, and the view needs to be updated.
             /// </summary>
-            private void OnTimer(object sender, EventArgs e)
+            private void OnTimer(object? sender, EventArgs e)
             {
                 int blinkPhase = 0;
                 for (int i = 0; i < _items.Count; i++)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.NotifyIconNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.NotifyIconNativeWindow.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static Interop;
@@ -17,22 +15,21 @@ namespace System.Windows.Forms
         /// </summary>
         private class NotifyIconNativeWindow : NativeWindow
         {
-            internal NotifyIcon reference;
-            private GCHandle rootRef;   // We will root the control when we do not want to be eligible for garbage collection.
+            internal NotifyIcon _reference;
+            private GCHandle _rootRef;   // We will root the control when we do not want to be eligible for garbage collection.
 
             /// <summary>
             ///  Create a new NotifyIcon, and bind the window to the NotifyIcon component.
             /// </summary>
             internal NotifyIconNativeWindow(NotifyIcon component)
             {
-                reference = component;
+                _reference = component;
             }
 
             ~NotifyIconNativeWindow()
             {
                 // This same post is done in Control's Dispose method, so if you change
                 // it, change it there too.
-                //
                 if (Handle != IntPtr.Zero)
                 {
                     User32.PostMessageW(this, User32.WM.CLOSE);
@@ -46,16 +43,16 @@ namespace System.Windows.Forms
             {
                 if (locked)
                 {
-                    if (!rootRef.IsAllocated)
+                    if (!_rootRef.IsAllocated)
                     {
-                        rootRef = GCHandle.Alloc(reference, GCHandleType.Normal);
+                        _rootRef = GCHandle.Alloc(_reference, GCHandleType.Normal);
                     }
                 }
                 else
                 {
-                    if (rootRef.IsAllocated)
+                    if (_rootRef.IsAllocated)
                     {
-                        rootRef.Free();
+                        _rootRef.Free();
                     }
                 }
             }
@@ -70,8 +67,8 @@ namespace System.Windows.Forms
             /// </summary>
             protected override void WndProc(ref Message m)
             {
-                Debug.Assert(reference is not null, "NotifyIcon was garbage collected while it was still visible.  How did we let that happen?");
-                reference.WndProc(ref m);
+                Debug.Assert(_reference is not null, "NotifyIcon was garbage collected while it was still visible.  How did we let that happen?");
+                _reference.WndProc(ref m);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.WebBrowserBaseNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.WebBrowserBaseNativeWindow.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 using static Interop;
 
@@ -16,11 +14,11 @@ namespace System.Windows.Forms
         /// </summary>
         private class WebBrowserBaseNativeWindow : NativeWindow
         {
-            private readonly WebBrowserBase WebBrowserBase;
+            private readonly WebBrowserBase _webBrowserBase;
 
             public WebBrowserBaseNativeWindow(WebBrowserBase ax)
             {
-                WebBrowserBase = ax;
+                _webBrowserBase = ax;
             }
 
             /// <summary>
@@ -44,11 +42,11 @@ namespace System.Windows.Forms
                 User32.WINDOWPOS* wp = (User32.WINDOWPOS*)m.LParamInternal;
                 wp->x = 0;
                 wp->y = 0;
-                Size s = WebBrowserBase.webBrowserBaseChangingSize;
+                Size s = _webBrowserBase.webBrowserBaseChangingSize;
                 if (s.Width == -1)
                 {   // Invalid value. Use WebBrowserBase.Bounds instead, when this is the case.
-                    wp->cx = WebBrowserBase.Width;
-                    wp->cy = WebBrowserBase.Height;
+                    wp->cx = _webBrowserBase.Width;
+                    wp->cy = _webBrowserBase.Height;
                 }
                 else
                 {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in classes that inherit from NativeWindow.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6626)