### PR TITLE
Fixing Text property of the DateTimePicker

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -830,7 +830,7 @@ namespace System.Windows.Forms
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string Text
         {
-            get => base.Text;
+            get => Value.ToString(CustomFormat);
             set
             {
                 // Clause to check length

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObjectTests.cs
@@ -104,11 +104,11 @@ namespace System.Windows.Forms.Tests
         public void DateTimePickerAccessibleObject_GetPropertyValue_ReturnsExpected()
         {
             using DateTimePicker dateTimePicker = new();
-            DateTime dt = new DateTime(2000, 1, 1);
-            dateTimePicker.TestAccessor().Dynamic._text = dt.ToLongDateString();
+            DateTime dt = new(2000, 1, 1);
+            dateTimePicker.Value = dt;
             AccessibleObject accessibleObject = dateTimePicker.AccessibilityObject;
 
-            Assert.Equal(dt.ToLongDateString(), accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.Equal(dt.ToString(), accessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
             Assert.True((bool)accessibleObject.GetPropertyValue(UiaCore.UIA.IsExpandCollapsePatternAvailablePropertyId));
             Assert.False(dateTimePicker.IsHandleCreated);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePickerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePickerTests.cs
@@ -110,7 +110,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(new Size(200, control.PreferredHeight), control.Size);
             Assert.Equal(0, control.TabIndex);
             Assert.True(control.TabStop);
-            Assert.Empty(control.Text);
+            Assert.Equal(DateTime.Now.ToString(), control.Text);
             Assert.Equal(0, control.Top);
             Assert.Null(control.TopLevelControl);
             Assert.False(control.UseWaitCursor);
@@ -216,6 +216,65 @@ namespace System.Windows.Forms.Tests
                 DateTime dateTime = systemTime;
                 Assert.Equal(DateTime.MinValue, dateTime);
             }
+        }
+
+        [WinFormsFact]
+        public void DateTimePicker_CustomFormat_Null_Text_ReturnsExpected()
+        {
+            using DateTimePicker dateTimePicker = new();
+            DateTime dt = new(2000, 1, 2, 3, 4, 5);
+            dateTimePicker.Value = dt;
+
+            Assert.Null(dateTimePicker.CustomFormat);
+            Assert.Equal(dt.ToString(), dateTimePicker.Text);
+        }
+
+        [WinFormsFact]
+        public void DateTimePicker_CustomFormat_LongDatePattern_Text_ReturnsExpected()
+        {
+            using DateTimePicker dateTimePicker = new();
+            DateTime dt = new(2000, 1, 2, 3, 4, 5);
+            dateTimePicker.Value = dt;
+            Globalization.DateTimeFormatInfo dateTimeFormat = Globalization.CultureInfo.CurrentCulture.DateTimeFormat;
+            dateTimePicker.CustomFormat = dateTimeFormat.LongDatePattern;
+
+            Assert.Equal(dt.ToLongDateString(), dateTimePicker.Text);
+        }
+
+        [WinFormsFact]
+        public void DateTimePicker_CustomFormat_ShortDatePattern_Text_ReturnsExpected()
+        {
+            using DateTimePicker dateTimePicker = new();
+            DateTime dt = new(2000, 1, 2, 3, 4, 5);
+            dateTimePicker.Value = dt;
+            Globalization.DateTimeFormatInfo dateTimeFormat = Globalization.CultureInfo.CurrentCulture.DateTimeFormat;
+            dateTimePicker.CustomFormat = dateTimeFormat.ShortDatePattern;
+
+            Assert.Equal(dt.ToShortDateString(), dateTimePicker.Text);
+        }
+
+        [WinFormsFact]
+        public void DateTimePicker_CustomFormat_LongTimePattern_Text_ReturnsExpected()
+        {
+            using DateTimePicker dateTimePicker = new();
+            DateTime dt = new(2000, 1, 2, 3, 4, 5);
+            dateTimePicker.Value = dt;
+            Globalization.DateTimeFormatInfo dateTimeFormat = Globalization.CultureInfo.CurrentCulture.DateTimeFormat;
+            dateTimePicker.CustomFormat = dateTimeFormat.LongTimePattern;
+
+            Assert.Equal(dt.ToLongTimeString(), dateTimePicker.Text);
+        }
+
+        [WinFormsFact]
+        public void DateTimePicker_CustomFormat_ShortTimePattern_Text_ReturnsExpected()
+        {
+            using DateTimePicker dateTimePicker = new();
+            DateTime dt = new(2000, 1, 2, 3, 4, 5);
+            dateTimePicker.Value = dt;
+            Globalization.DateTimeFormatInfo dateTimeFormat = Globalization.CultureInfo.CurrentCulture.DateTimeFormat;
+            dateTimePicker.CustomFormat = dateTimeFormat.ShortTimePattern;
+
+            Assert.Equal(dt.ToShortTimeString(), dateTimePicker.Text);
         }
 
         public class SubDateTimePicker : DateTimePicker


### PR DESCRIPTION
Fixes #6590

## Proposed changes
- Return formatted `Value` in the getter of the `Text` property to make the behavior of this property consistent with the documentation:
![image](https://user-images.githubusercontent.com/87859299/152965809-c7869757-b5e1-4699-ba06-3e146acc074f.png)
https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.datetimepicker.text?view=windowsdesktop-6.0

## Customer Impact
- `Text` property will return a formatted Value instead of an empty string:
![image](https://user-images.githubusercontent.com/87859299/152966392-c0d88486-142d-4da3-a222-c2fce86b2de3.png)

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Unit tests
- CTI testing

## Test environment(s) <!-- Remove any that don't apply -->
.NET SDK 7.0.0-preview-2.22103.2
Microsoft Windows [Version 10.0.19043.1466]

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6637)