### PR TITLE
Moving 3 properties at `GetPropertyValue` method to the base `AccessibleObject` class

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -425,6 +425,9 @@ namespace System.Windows.Forms
                 UiaCore.UIA.LegacyIAccessibleDefaultActionPropertyId => !string.IsNullOrEmpty(DefaultAction) ? DefaultAction : null,
                 UiaCore.UIA.LegacyIAccessibleNamePropertyId => !string.IsNullOrEmpty(Name) ? Name : null,
                 UiaCore.UIA.ValueValuePropertyId => !string.IsNullOrEmpty(Value) ? Value : null,
+                UiaCore.UIA.IsPasswordPropertyId => false,
+                UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
+                UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut ?? string.Empty,
                 _ => null
             };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
@@ -123,16 +123,12 @@ namespace System.Windows.Forms
                         return BoundingRectangle;
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.ButtonControlTypeId;
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return KeyboardShortcut;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return _owner.Focused;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _owner.Enabled;
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
                     default:
                         return base.GetPropertyValue(propertyID);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
@@ -87,8 +87,6 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.EditControlTypeId;
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return _owner.Focused;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
@@ -97,8 +95,6 @@ namespace System.Windows.Forms
                         return _owner.Enabled;
                     case UiaCore.UIA.AutomationIdPropertyId:
                         return COMBO_BOX_EDIT_AUTOMATION_ID;
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
                     case UiaCore.UIA.NativeWindowHandlePropertyId:
                         return _handle;
                     case UiaCore.UIA.IsOffscreenPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
@@ -138,8 +138,6 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.ListControlTypeId;
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return false; // Narrator should keep the keyboard focus on th ComboBox itself but not on the DropDown.
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
@@ -148,8 +146,6 @@ namespace System.Windows.Forms
                         return _owningComboBox.Enabled;
                     case UiaCore.UIA.AutomationIdPropertyId:
                         return COMBO_BOX_LIST_AUTOMATION_ID;
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
                     case UiaCore.UIA.NativeWindowHandlePropertyId:
                         return _childListControlhandle;
                     case UiaCore.UIA.IsOffscreenPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildTextUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildTextUiaProvider.cs
@@ -115,15 +115,12 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.TextControlTypeId;
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return _owner.Focused;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _owner.Enabled;
-                    case UiaCore.UIA.IsPasswordPropertyId:
                     case UiaCore.UIA.IsOffscreenPropertyId:
                         return false;
                     default:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -121,8 +121,6 @@ namespace System.Windows.Forms
                         return BoundingRectangle;
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.ListItemControlTypeId;
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return KeyboardShortcut ?? string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return _owningComboBox.Focused && _owningComboBox.SelectedIndex == GetCurrentIndex();
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
@@ -133,8 +131,6 @@ namespace System.Windows.Forms
                         return true;
                     case UiaCore.UIA.IsContentElementPropertyId:
                         return true;
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
                     case UiaCore.UIA.SelectionItemIsSelectedPropertyId:
                         return (State & AccessibleStates.Selected) != 0;
                     case UiaCore.UIA.SelectionItemSelectionContainerPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -484,10 +484,6 @@ namespace System.Windows.Forms
                     {
                         case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                             return Owner.CanSelect;
-                        case UiaCore.UIA.IsPasswordPropertyId:
-                            return false;
-                        case UiaCore.UIA.AccessKeyPropertyId:
-                            return KeyboardShortcut;
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObject.cs
@@ -94,8 +94,6 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.IsControlElementPropertyId:
                     case UiaCore.UIA.IsContentElementPropertyId:
                         return true;
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
                     case UiaCore.UIA.AccessKeyPropertyId:
                         return _panel.AccessibilityObject.KeyboardShortcut;
                     case UiaCore.UIA.ProviderDescriptionPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
@@ -286,10 +286,6 @@ namespace System.Windows.Forms
                         return false;
                     case UiaCore.UIA.IsContentElementPropertyId:
                         return true;
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return string.Empty;
                 }
 
                 return base.GetPropertyValue(propertyId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -685,8 +685,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsEnabledPropertyId => _owner?.DataGridView?.Enabled ?? false,
                     UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
-                    UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     UiaCore.UIA.GridItemContainingGridPropertyId => _owner?.DataGridView?.AccessibilityObject,
                     _ => base.GetPropertyValue(propertyID),
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.cs
@@ -274,7 +274,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsEnabledPropertyId => Owner?.DataGridView?.Enabled ?? false,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     var x when x == UiaCore.UIA.HasKeyboardFocusPropertyId || x == UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     _ => base.GetPropertyValue(propertyId)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -499,9 +499,6 @@ namespace System.Windows.Forms
                         return Owner?.DataGridView?.Enabled ?? false;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
-                    case UiaCore.UIA.AccessKeyPropertyId:
                         return string.Empty;
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
@@ -277,8 +277,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsEnabledPropertyId => Owner?.DataGridView?.Enabled ?? false,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
-                    UiaCore.UIA.IsPasswordPropertyId => false,
-                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     _ => base.GetPropertyValue(propertyId),
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.cs
@@ -300,11 +300,8 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return Owner?.DataGridView?.Enabled ?? false;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
-                    case UiaCore.UIA.IsPasswordPropertyId:
                     case UiaCore.UIA.IsOffscreenPropertyId:
                         return false;
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return string.Empty;
                 }
 
                 return base.GetPropertyValue(propertyId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -216,11 +216,9 @@ namespace System.Windows.Forms
                  => propertyID switch
                  {
                      UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ListItemControlTypeId,
-                     UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                      UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListBox.Focused && _owningListBox.FocusedIndex == CurrentIndex,
                      UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                      UiaCore.UIA.IsEnabledPropertyId => _owningListBox.Enabled,
-                     UiaCore.UIA.IsPasswordPropertyId => false,
                      UiaCore.UIA.NativeWindowHandlePropertyId => _owningListBox.IsHandleCreated ? _owningListBox.Handle : IntPtr.Zero,
                      _ => base.GetPropertyValue(propertyID)
                  };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -183,7 +183,6 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.AutomationIdPropertyId => AutomationId,
-                    UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.GroupControlTypeId,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListView.Focused && Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -168,7 +168,6 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.AutomationIdPropertyId => AutomationId,
-                    UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ListItemControlTypeId,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => OwningListItemFocused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -124,7 +124,6 @@ namespace System.Windows.Forms
                         // has the "edit" control type, and it supports the Text pattern. And its owning subitem accessible
                         // object has the "text" control type, because it is just a container for the edit field.
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TextControlTypeId,
-                        UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
                         UiaCore.UIA.ProcessIdPropertyId => Environment.ProcessId,
                         UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                         UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListView.Focused && _owningListView.FocusedItem == _owningItem,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -334,12 +334,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                     // button is one of the first children of PropertyGridView.
 
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TreeItemControlTypeId,
-                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningGridEntry.HasFocus,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.IsEnabledPropertyId => true,
                     UiaCore.UIA.AutomationIdPropertyId => GetHashCode().ToString(),
-                    UiaCore.UIA.IsPasswordPropertyId => false,
                     _ => base.GetPropertyValue(propertyID),
                 };
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewListBoxItemAccessibleObject.cs
@@ -24,12 +24,6 @@ namespace System.Windows.Forms.PropertyGridInternal
             internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
                 => _owningGridViewListBox.AccessibilityObject;
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
-            {
-                UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut,
-                _ => base.GetPropertyValue(propertyID),
-            };
-
             /// <inheritdoc />
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
                 => patternId == UiaCore.UIA.InvokePatternId || base.IsPatternSupported(patternId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
@@ -87,7 +87,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     UiaCore.UIA.HasKeyboardFocusPropertyId => Owner.Focused,
                     UiaCore.UIA.IsEnabledPropertyId => !IsReadOnly,
                     UiaCore.UIA.ClassNamePropertyId => Owner.GetType().ToString(),
-                    UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
                     _ => base.GetPropertyValue(propertyID),
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarChildAccessibleObject.cs
@@ -78,10 +78,8 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
                     UiaCore.UIA.IsEnabledPropertyId => OwningScrollBar.Enabled,
-                    UiaCore.UIA.IsPasswordPropertyId => false,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => false,
                     _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
@@ -117,8 +117,6 @@ namespace System.Windows.Forms
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TabItemControlTypeId,
                     UiaCore.UIA.AutomationIdPropertyId => _owningTabPage.Name,
-                    UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut ?? string.Empty,
-                    UiaCore.UIA.IsPasswordPropertyId => false,
                     UiaCore.UIA.IsEnabledPropertyId => OwningTabControl?.Enabled ?? false,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -119,10 +119,6 @@ namespace System.Windows.Forms
                         return _ownerItem.CanSelect;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return _ownerItem.Selected;
-                    case UiaCore.UIA.AccessKeyPropertyId:
-                        return KeyboardShortcut;
-                    case UiaCore.UIA.IsPasswordPropertyId:
-                        return false;
                 }
 
                 return base.GetPropertyValue(propertyID);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarChildAccessibleObject.cs
@@ -73,10 +73,8 @@ namespace System.Windows.Forms
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
                     UiaCore.UIA.IsEnabledPropertyId => OwningTrackBar.Enabled,
-                    UiaCore.UIA.IsPasswordPropertyId => false,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => false,
-                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1245,7 +1245,7 @@ namespace System.Windows.Forms.Tests
 
             control.Text = "&Name";
             AccessibleObject controlAccessibleObject = control.AccessibilityObject;
-            string expectedValue = s_controlsNotUseTextForAccessibility.Contains(type) ? null : "Alt+n";
+            string expectedValue = s_controlsNotUseTextForAccessibility.Contains(type) ? string.Empty : "Alt+n";
 
             Assert.Equal(expectedValue, controlAccessibleObject.GetPropertyValue(UiaCore.UIA.AccessKeyPropertyId));
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridView.DataGridViewEditingPanelAccessibleObjectTests.cs
@@ -118,6 +118,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(SR.DataGridView_AccEditingPanelAccName, editingPanel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId));
             Assert.Equal(SR.DataGridView_AccEditingPanelAccName, editingPanel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleNamePropertyId));
             Assert.Null(editingPanel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.False((bool)editingPanel.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsPasswordPropertyId));
             Assert.False(editingPanel.IsHandleCreated);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -106,6 +106,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AccessibleRole.Grouping, defaultGroupAccessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleRolePropertyId));
             Assert.Equal(AccessibleRole.Grouping, groupAccessibleObject.GetPropertyValue(UiaCore.UIA.LegacyIAccessibleRolePropertyId));
             Assert.Null(groupAccessibleObject.GetPropertyValue(UiaCore.UIA.ValueValuePropertyId));
+            Assert.Equal(NativeMethods.WinFormFrameworkId, groupAccessibleObject.GetPropertyValue(UiaCore.UIA.FrameworkIdPropertyId));
             Assert.False(list.IsHandleCreated);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObjectTests.cs
@@ -152,6 +152,17 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             Assert.False(propertyGrid.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void GridViewTextBoxAccessibleObject_GetPropertyValue_FrameworkIdPropertyId_ReturnsExpected()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
+            AccessibleObject accessibleObject = gridView.EditAccessibleObject;
+
+            Assert.Equal(NativeMethods.WinFormFrameworkId, accessibleObject.GetPropertyValue(UiaCore.UIA.FrameworkIdPropertyId));
+            Assert.False(propertyGrid.IsHandleCreated);
+        }
+
         [WinFormsTheory]
         [InlineData(true, AccessibleRole.Text)]
         [InlineData(false, AccessibleRole.None)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
@@ -700,8 +700,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true, "&Name", "Alt+n")]
         [InlineData(false, "&Name", "Alt+n")]
-        [InlineData(true, "Name", null)]
-        [InlineData(false, "Name", null)]
+        [InlineData(true, "Name", "")]
+        [InlineData(false, "Name", "")]
         public void TabControlAccessibleObject_GetPropertyValue_AccessKey_ReturnExpected(bool createControl, string text, string expectedKeyboardShortcut)
         {
             using TabControl tabControl = new() { Text = text };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
@@ -462,8 +462,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true, "&Name", "Alt+n")]
         [InlineData(false, "&Name", "Alt+n")]
-        [InlineData(true, "Name", null)]
-        [InlineData(false, "Name", null)]
+        [InlineData(true, "Name", "")]
+        [InlineData(false, "Name", "")]
         public void TabPageAccessibleObject_GetPropertyValue_AccessKey_ReturnExpected(bool createControl, string text, string expectedKeyboardShortcut)
         {
             using TabPage tabPage = new() { Text = text };


### PR DESCRIPTION
Fixes #6582

## Proposed changes
- `IsPasswordPropertyId`, `FrameworkIdPropertyId` and `AccessKeyPropertyId` are refactored by moving to the base `AccessibleObject` class
- `AccessKeyPropertyId` is returning an empty string now if `KeyboardShortcut` is null, I guess that's a suitable change of behavior because it allows us to clean a lot of places in the code where an empty string is returned, also the `GetPropertyValue` method is an `internal` method anyway, and UIA tools like Inspect and Accessibility Insights treat `null` and `string.Empty` the same way, in the codebase `KeyboardShortcut` is checked for both null/string.Empty.

## Customer Impact
- None

## Regression? 
- No

## Risk
- Minimal

## Test methodology
- Unit tests
- CTI testing

## Test environment(s)
.NET SDK 7.0.0-preview-2.22103.2
Microsoft Windows [Version 10.0.19043.1466]

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6640)