### PR TITLE
Refactoring AutomationId at the accessible object classes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -391,6 +391,8 @@ namespace System.Windows.Forms
 
         internal virtual UiaCore.IRawElementProviderSimple? HostRawElementProvider => null;
 
+        private protected virtual string? AutomationId => null;
+
         /// <summary>
         ///  Returns the value of the specified <paramref name="propertyID"/> from the element.
         /// </summary>
@@ -428,6 +430,7 @@ namespace System.Windows.Forms
                 UiaCore.UIA.IsPasswordPropertyId => false,
                 UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
                 UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut ?? string.Empty,
+                UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                 _ => null
             };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Button.ButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Button.ButtonAccessibleObject.cs
@@ -17,8 +17,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UIA propertyID)
                 => propertyID switch
                 {
-                    UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UIA.ControlTypePropertyId
                         // If we don't set a default role for Button and ButtonBase accessible objects
                         // it will be retrieved from Windows.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.CheckBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.CheckBoxAccessibleObject.cs
@@ -70,8 +70,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         =>
                         // This is necessary for compatibility with MSAA proxy:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -34,6 +34,8 @@ namespace System.Windows.Forms
                 InitHandle(ownerControl);
             }
 
+            private protected override string AutomationId => Owner.Name;
+
             // If the control is used as an item of a ToolStrip via ToolStripControlHost,
             // its accessible object should provide info about the owning ToolStrip and items-siblings
             // to build a correct ToolStrip accessibility tree.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -609,7 +609,7 @@ namespace System.Windows.Forms
                     GetHashCode()
                 };
 
-            private string AutomationId
+            private protected override string AutomationId
             {
                 get
                 {
@@ -683,7 +683,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.DataItemControlTypeId,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused, // Announce the cell when focusing.
                     UiaCore.UIA.IsEnabledPropertyId => _owner?.DataGridView?.Enabled ?? false,
-                    UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.GridItemContainingGridPropertyId => _owner?.DataGridView?.AccessibilityObject,
                     _ => base.GetPropertyValue(propertyID),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.GroupBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.GroupBoxAccessibleObject.cs
@@ -31,8 +31,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         => true,
                     _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.LabelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.LabelAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using static Interop;
-
 namespace System.Windows.Forms
 {
     public partial class Label
@@ -31,13 +29,6 @@ namespace System.Windows.Forms
                     return AccessibleRole.StaticText;
                 }
             }
-
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                => propertyID switch
-                {
-                    UiaCore.UIA.AutomationIdPropertyId => _owningLabel.Name,
-                    _ => base.GetPropertyValue(propertyID)
-                };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -207,7 +207,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId => _owningListView.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
                     // If we don't set a default role for the accessible object

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms
                 _owningGroupIsDefault = owningGroupIsDefault;
             }
 
-            private string AutomationId
+            private protected override string AutomationId
                 => string.Format("{0}-{1}", typeof(ListViewGroup).Name, CurrentIndex);
 
             public override Rectangle Bounds
@@ -182,7 +182,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.GroupControlTypeId,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListView.Focused && Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -37,7 +37,7 @@ namespace System.Windows.Forms
                 ? _owningItem.Group ?? _owningListView.DefaultGroup
                 : null;
 
-            private string AutomationId
+            private protected override string AutomationId
                 => string.Format("{0}-{1}", typeof(ListViewItem).Name, CurrentIndex);
 
             public override Rectangle Bounds
@@ -167,7 +167,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ListItemControlTypeId,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => OwningListItemFocused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -125,7 +125,6 @@ namespace System.Windows.Forms
                         // object has the "text" control type, because it is just a container for the edit field.
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TextControlTypeId,
                         UiaCore.UIA.ProcessIdPropertyId => Environment.ProcessId,
-                        UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                         UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListView.Focused && _owningListView.FocusedItem == _owningItem,
                         UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                         UiaCore.UIA.IsEnabledPropertyId => _owningListView.Enabled,
@@ -157,7 +156,7 @@ namespace System.Windows.Forms
                     return base.IsPatternSupported(patternId);
                 }
 
-                private string AutomationId
+                private protected override string AutomationId
                     => string.Format("{0}-{1}", typeof(ListViewItem.ListViewSubItem).Name, ParentInternal.GetChildIndex(this));
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Panel.PanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Panel.PanelAccessibleObject.cs
@@ -37,8 +37,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                => propertyID switch
                {
-                   UiaCore.UIA.AutomationIdPropertyId
-                       => Owner.Name,
                    UiaCore.UIA.IsKeyboardFocusablePropertyId
                        => false,
                    _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
@@ -24,8 +24,6 @@ namespace System.Windows.Forms
                         => Owner.AccessibleRole == AccessibleRole.Default
                            ? UiaCore.UIA.PaneControlTypeId
                            : base.GetPropertyValue(propertyID),
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         => true,
                     _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.RadioButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.RadioButtonAccessibleObject.cs
@@ -50,8 +50,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:
                         // IsKeyboardFocusable = true regardless the control is enabled/disabled.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
@@ -134,7 +134,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId => _owningScrollBar.Name,
                     // If we don't set a default role for the accessible object
                     // it will be retrieved from Windows.
                     // And we don't have a 100% guarantee it will be correct, hence set it ourselves.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitterAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitterAccessibleObject.cs
@@ -17,8 +17,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.ControlTypePropertyId
                         // If we don't set a default role for the accessible object
                         // it will be retrieved from Windows.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabControlAccessibleObject.cs
@@ -135,7 +135,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UIA propertyID)
                 => propertyID switch
                 {
-                    UIA.AutomationIdPropertyId => _owningTabControl.Name,
                     UIA.HasKeyboardFocusPropertyId => _owningTabControl.Focused,
                     UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
@@ -83,7 +83,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId => _owningTabPage.Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTabPage.Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarAccessibleObject.cs
@@ -156,7 +156,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => _owningTrackBar.AccessibleRole == AccessibleRole.Default
                                                             ? UiaCore.UIA.SliderControlTypeId
                                                             : base.GetPropertyValue(propertyID),
-                    UiaCore.UIA.AutomationIdPropertyId => _owningTrackBar.Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTrackBar.Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:


### PR DESCRIPTION
Fixes #6603

## Proposed changes
- The `AutomationId` property is moved to the `AccessibleObject` base class
- This property returns `null` at `AccessibleObject`
- It is returned at the `GetPropertyValue` method of `AccessibleObject` for the case `AutomationIdPropertyId`
- The current implementations in the 4 classes derived from AO are kept the same way, but they are marked as overrides
- Returning of the `Owner.Name` is moved to the `ControlAccessibleObjectObject` class to make it universal for all its descendants
- All duplicate code with the same logic is cleaned out in the derived classes
- No unit tests are added yet, but they will be after these changes will be discussed
- Initial discussion on this topic is here: https://github.com/dotnet/winforms/pull/6429#issuecomment-1009286397

## Customer Impact
- Tests based on the old implementation of AutomationId could become obsolete

## Regression? 
- No

## Risk
- Minimal

## Test methodology
- Unit tests
- CTI testing

## Test environment(s)
.NET SDK 7.0.0-preview-2.22103.2
Microsoft Windows [Version 10.0.19043.1466]

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6641)