### PR TITLE
Use RegexGenerator in WinForms

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionItem.cs
@@ -13,16 +13,19 @@ namespace System.ComponentModel.Design
     ///  Tasks typically walk the user through some multi-step process, such as configuring a data source for a component.
     ///  Designer tasks are shown in a custom piece of UI (Chrome).
     /// </summary>
-    public abstract class DesignerActionItem
+    public abstract partial class DesignerActionItem
     {
         private IDictionary _properties;
 
         public DesignerActionItem(string displayName, string category, string description)
         {
-            DisplayName = displayName is null ? null : Regex.Replace(displayName, @"\(\&.\)", "");
+            DisplayName = displayName is null ? null : SanitizeNameRegex().Replace(displayName, "");
             Category = category;
             Description = description;
         }
+
+        [RegexGenerator(@"\(\&.\)")]
+        private static partial Regex SanitizeNameRegex();
 
         public bool AllowAssociate { get; set; }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4738,12 +4738,7 @@ namespace System.Windows.Forms
         private void SnapFocus(IntPtr otherHwnd)
         {
 #if DEBUG
-            if (s_snapFocusDebug.TraceVerbose)
-            {
-                string stackTrace = new StackTrace().ToString();
-                Regex regex = new Regex("FocusInternal");
-                Debug.WriteLine(!regex.IsMatch(stackTrace), "who is setting focus to us?");
-            }
+            Debug.WriteLineIf(s_snapFocusDebug.TraceVerbose, !Regex.IsMatch(Environment.StackTrace, "FocusInternal"), "who is setting focus to us?");
 #endif
             // we need to know who sent us focus so we know who to send it back to later.
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettingsManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettingsManager.cs
@@ -190,13 +190,13 @@ namespace System.Windows.Forms
                 if (!string.IsNullOrEmpty(itemNames))
                 {
                     string[] keys = itemNames.Split(',');
-                    Regex r = new Regex("(\\S+)");
+                    Regex r = ContiguousNonWhitespace();
 
                     // Shuffle items according to string.
                     for (int i = 0; ((i < toolStrip.Items.Count) && (i < keys.Length)); i++)
                     {
                         Match match = r.Match(keys[i]);
-                        if (match is not null && match.Success)
+                        if (match.Success)
                         {
                             string key = match.Value;
                             if (!string.IsNullOrEmpty(key) && itemLocationHash.ContainsKey(key))
@@ -208,6 +208,9 @@ namespace System.Windows.Forms
                 }
             }
         }
+
+        [RegexGenerator("\\S+")]
+        private static partial Regex ContiguousNonWhitespace();
 
         private Dictionary<string, ToolStrip> BuildItemOriginationHash()
         {


### PR DESCRIPTION
The regex source generator is new in .NET 7.  It does all the parsing and compilation of the regex that would have been done at run-time instead at compile time, improving startup and enabling additional optimizations that wouldn't otherwise be performed.  This updates the regexes used in winforms to use the generator.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6643)