### PR TITLE
Pin assembly versions to prevent revving those in servicing releases

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,34 @@
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <IsAnalyzerProject>false</IsAnalyzerProject>
+    <IsAnalyzerProject Condition="!$(IsTestProject) and
+                                  ($(MSBuildProjectName.EndsWith('.Analyzers')) or $(MSBuildProjectName.EndsWith('.Analyzers.CSharp')))"
+                                  >true</IsAnalyzerProject>
+  </PropertyGroup>
+
+  <!--
+    Set assembly version to align with major and minor version, as for the patches and revisions should be manually
+    updated per assembly if it is serviced.
+
+    Note, any components that aren't exposed as references in the targeting pack (like analyzers/generators) those should rev
+    so that they can exist SxS, as the compiler relies on different version to change assembly version for caching purposes.
+
+    Because it is possible to build on a lower version and run on a higher version, we're locking the targeting pack and the runtime
+    assembly vesions to 6.0.2.
+    There's still a risk that some customers building on 6.0.2+ and trying to run on 6.0.0 and 6.0.1 will still have issue, but
+    those issues can be mitigated with a workaround described in https://github.com/dotnet/core/issues/7176.
+    -->
+  <PropertyGroup Condition="'$(IsAnalyzerProject)' != 'true'">
+    <AssemblyVersion>6.0.2.0</AssemblyVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsAnalyzerProject)' == 'true'">
+    <IsRoslynComponent>true</IsRoslynComponent>
+
+    <!-- Mark it so eng/packageContent.targets knows how to correctly package it -->
+    <DefineConstants>WINFORMS_ANALYZERS</DefineConstants>
   </PropertyGroup>
 
   <!-- ApplicationConfiguration specific settings -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>6.0.3</VersionPrefix>
+    <MajorVersion>6</MajorVersion>
+    <MinorVersion>0</MinorVersion>
+    <PatchVersion>3</PatchVersion>
     <!-- version in our package name #.#.#-below.#####.## -->
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>
-    </PreReleaseVersionIteration>
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <!-- Use the compiler in the CLI instead of in the sdk, since the sdk one doesn't work with netcoreapp5.0 yet -->
     <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
   </PropertyGroup>

--- a/pkg/Microsoft.Private.Winforms/Directory.Build.targets
+++ b/pkg/Microsoft.Private.Winforms/Directory.Build.targets
@@ -3,10 +3,12 @@
   <Import Project="..\..\Directory.Build.targets" />
 
   <PropertyGroup>
-    <_PowerShellExe Condition="'$(_PowerShellExe)' == ''">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</_PowerShellExe>
+    <_PowerShellExe Condition="'$(_PowerShellExe)' == ''">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</_PowerShellExe>
     <_ScriptLocation Condition="'$(_ScriptLocation)' == ''">$(MSBuildProjectDirectory)\sdk\dotnet-windowsdesktop\UpdateFileClassification.ps1</_ScriptLocation>
     <_ManifestFile>$(MSBuildProjectDirectory)\sdk\dotnet-windowsdesktop\System.Windows.Forms.FileClassification.props</_ManifestFile>
     <GenerateManifest>false</GenerateManifest>
+    <_IsServicingRelease>false</_IsServicingRelease>
+    <_IsServicingRelease Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</_IsServicingRelease>
   </PropertyGroup>
 
   <!-- 
@@ -23,7 +25,7 @@
     <Error Text="'$(_ManifestFile)' is missing." Condition="!Exists('$(_ManifestFile)')" />
 
     <Exec
-        Command="$(_PowerShellExe) -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { &amp;&apos;$(_ScriptLocation)&apos; &apos;@(_NuspecFile)&apos; &apos;$(_ManifestFile)&apos; $(GenerateManifest) } &quot;"
+        Command="$(_PowerShellExe) -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { &amp;&apos;$(_ScriptLocation)&apos; &apos;@(_NuspecFile)&apos; &apos;$(_ManifestFile)&apos; $(GenerateManifest) &apos;$(AssemblyVersion)&apos; $(_IsServicingRelease) } &quot;"
         ContinueOnError="False" />
 
   </Target>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/UpdateFileClassification.ps1
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/UpdateFileClassification.ps1
@@ -6,6 +6,10 @@ Param(
   [string] $TargetFile,
   [Parameter(Mandatory=$True, Position=3)]
   [string] $GenerateManifest,
+  [Parameter(Mandatory=$True, Position=4)]
+  [string] $ExpectedAssemblyVersion,
+  [Parameter(Mandatory=$True, Position=5)]
+  [string] $IsServicingRelease,
   [Parameter(ValueFromRemainingArguments=$true)][String[]] $properties
 )
 
@@ -22,7 +26,7 @@ $assemblies = $xmlDoc.package.files.file | `
                 -and !$_.target.EndsWith('\Accessibility.dll', [System.StringComparison]::OrdinalIgnoreCase)
         } | `
     Select-Object -Unique @{Name="Path";Expression={Split-Path $_.target -Leaf}} | `
-    Select-Object  -ExpandProperty Path;
+    Select-Object -ExpandProperty Path;
 
 # this isn't explicitly present in the list
 $assemblies += 'System.Drawing.Common.dll';
@@ -30,6 +34,9 @@ $assemblies += 'System.Drawing.Common.dll';
 
 $needGenerate = $null;
 [bool]::TryParse($GenerateManifest, [ref]$needGenerate) | Out-Null;
+$servicingRelease = $null;
+[bool]::TryParse($IsServicingRelease, [ref]$servicingRelease) | Out-Null;
+
 
 if (!$needGenerate) {
     <#
@@ -74,3 +81,57 @@ else {
 </Project>";
     $output | Out-File -FilePath $TargetFile -Encoding utf8 -Force;
 }
+
+
+# 
+# Verify that components that are exposed as references in the targeting packs don't have their versions revved.
+# See https://github.com/dotnet/winforms/pull/6667 for more details.
+[xml] $xmlDoc = Get-Content -Path $NuspecFile -Force;
+
+# Iterate over files that MUST NOT have their versions revved with every release
+$nonRevAssemblies = $xmlDoc.package.files.file | `
+    Where-Object { 
+            ($_.target.StartsWith('lib\') -or $_.target.StartsWith('ref\')) `
+                -and $_.target.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('resources.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('\Accessibility.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('\Microsoft.VisualBasic.dll', [System.StringComparison]::OrdinalIgnoreCase)
+        } | `
+    Select-Object -Unique src | `
+    Select-Object -ExpandProperty src;
+
+$nonRevAssemblies | `
+    sort-object | `
+    foreach-object {
+        $assembly = $_;
+        [string] $version = ([Reflection.AssemblyName]::GetAssemblyName($assembly).Version).ToString()
+
+        Write-Host "$assembly`: $version"
+        if (![string]::Equals($version, $ExpectedAssemblyVersion)) {
+            throw "$assembly is not versioned correctly. Expected: '$ExpectedAssemblyVersion', found: '$version'."
+            exit -1;
+        }
+    }
+
+# Iterate over files that MUST have their versions revved with every release
+$revAssemblies = $xmlDoc.package.files.file | `
+    Where-Object { 
+            $_.target.StartsWith('sdk\analyzers\') `
+                -and $_.target.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('resources.dll', [System.StringComparison]::OrdinalIgnoreCase)
+        } | `
+    Select-Object -Unique src | `
+    Select-Object -ExpandProperty src;
+
+$revAssemblies | `
+    sort-object | `
+    foreach-object {
+        $assembly = $_;
+        [string] $version = ([Reflection.AssemblyName]::GetAssemblyName($assembly).Version).ToString()
+
+        Write-Host "$assembly`: $version"
+        if ($servicingRelease -and [string]::Equals($version, $ExpectedAssemblyVersion)) {
+            throw "$assembly is not versioned correctly. '$version' is not expected."
+            exit -1;
+        }
+    }

--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System.Windows.Forms.Analyzers.CSharp.csproj
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System.Windows.Forms.Analyzers.CSharp.csproj
@@ -6,12 +6,6 @@
     <LangVersion>Preview</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);RS2007</NoWarn>
-
-    <IsRoslynComponent>true</IsRoslynComponent>
-
-    <!-- Mark it so eng/packageContent.targets knows how to correctly package it -->
-    <IsAnalyzerProject>true</IsAnalyzerProject>
-    <DefineConstants>WINFORMS_ANALYZERS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Analyzers/src/System.Windows.Forms.Analyzers.csproj
+++ b/src/System.Windows.Forms.Analyzers/src/System.Windows.Forms.Analyzers.csproj
@@ -5,12 +5,6 @@
     <LangVersion>Preview</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);RS2007</NoWarn>
-
-    <IsRoslynComponent>true</IsRoslynComponent>
-
-    <!-- Mark it so eng/packageContent.targets knows how to correctly package it -->
-    <IsAnalyzerProject>true</IsAnalyzerProject>
-    <DefineConstants>WINFORMS_ANALYZERS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Resolves #6663


## Proposed changes

* Lock runtime and targeting pack assemblies at 6.0.2.0 so that any applications, libraries or NuGets built against 6.0.2 or later can work. 
This assembly versions pinning is similar to https://github.com/dotnet/runtime/blob/bbc766a7c65716305919bc691d696b1e46fa6f62/eng/Versions.props#L14 and https://github.com/dotnet/aspnetcore/blob/c0575788ecadd6e5cfeb4eab635c13b5fd433d37/Directory.Build.targets#L88.
* Add a validation step when we run packaging to verify that the assemblies we package into the transport package are correctly versioned, i.e., analyzers/generators are revved for every release for sxs, and those part of the ref pack are pinned to X.Y.2.0.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Currently Windows Forms applications built against 6.0.2 won't run on 6.0 GA or 6.0.1
With the fix applications, libraries or NuGets built against 6.0.2 or later can work. Any applications built on 6.0.2 or later that need to target 6.0.0 or 6.0.1 will need to use the workaround provided in https://github.com/dotnet/core/issues/7176. It is not ideal, but is believed to have a lesser impact than going back to 6.0.0.0 versions, and have 6.0.2 broken.

## Regression? 

- Yes 

## Risk

- Medium. With this fix we'll stop supporting the folks that compiled against 6.0.2 or later and target 6.0.0 or 6.0.1 without the workaround.
In general, since 6.0.1 and 6.0.2 are security releases, customers are encouraged to update to the latest version.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

6.0.1
![image](https://user-images.githubusercontent.com/4403806/153317658-411d1444-8469-4907-9c7b-087e4cde7426.png)
![image](https://user-images.githubusercontent.com/4403806/153317581-5c7b0409-4d39-4725-af5d-394173591f29.png)

6.0.2
![image](https://user-images.githubusercontent.com/4403806/153317450-b39ca98c-5a13-4db7-9dd0-f864dded6254.png)
![image](https://user-images.githubusercontent.com/4403806/153317487-9ab16baf-708c-4caa-b8ef-16c527da7e55.png)

### After

A private built for this fix:
![image](https://user-images.githubusercontent.com/4403806/153530590-bb37f0a6-e696-4a4f-9a3f-1f3a5a98a51e.png)
![image](https://user-images.githubusercontent.com/4403806/153530627-22354c1a-32f2-4cc1-90f4-132ba1cef1c0.png)
![image](https://user-images.githubusercontent.com/4403806/153530664-ecfaf89e-fcb9-457a-b74e-f496a11b975a.png)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6667)