### PR TITLE
Pin assembly versions to prevent revving those in servicing releases

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,29 @@
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <IsAnalyzerProject>false</IsAnalyzerProject>
+    <IsAnalyzerProject Condition="!$(IsTestProject) and
+                                  ($(MSBuildProjectName.EndsWith('.Analyzers')) or $(MSBuildProjectName.EndsWith('.Analyzers.CSharp')))"
+                                  >true</IsAnalyzerProject>
+  </PropertyGroup>
+
+  <!--
+    Set assembly version to align with major and minor version, as for the patches and revisions should be manually
+    updated per assembly if it is serviced.
+
+    Note, any components that aren't exposed as references in the targeting pack (like analyzers/generators) those should rev
+    so that they can exist SxS, as the compiler relies on different version to change assembly version for caching purposes.
+    -->
+  <PropertyGroup Condition="'$(IsAnalyzerProject)' != 'true'">
+    <AssemblyVersion>$(MajorVersion).$(MinorVersion).0.0</AssemblyVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsAnalyzerProject)' == 'true'">
+    <IsRoslynComponent>true</IsRoslynComponent>
+
+    <!-- Mark it so eng/packageContent.targets knows how to correctly package it -->
+    <DefineConstants>WINFORMS_ANALYZERS</DefineConstants>
   </PropertyGroup>
 
   <!-- ApplicationConfiguration specific settings -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <MajorVersion>7</MajorVersion>
+    <MinorVersion>0</MinorVersion>
+    <PatchVersion>0</PatchVersion>
     <!-- version in our package name #.#.#-below.#####.## -->
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
     <!-- Use the compiler in the CLI instead of in the sdk, since the sdk one doesn't work with netcoreapp5.0 yet -->
     <UsingToolMicrosoftNetCompilers>false</UsingToolMicrosoftNetCompilers>
   </PropertyGroup>

--- a/pkg/Microsoft.Private.Winforms/Directory.Build.targets
+++ b/pkg/Microsoft.Private.Winforms/Directory.Build.targets
@@ -3,10 +3,12 @@
   <Import Project="..\..\Directory.Build.targets" />
 
   <PropertyGroup>
-    <_PowerShellExe Condition="'$(_PowerShellExe)' == ''">C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</_PowerShellExe>
+    <_PowerShellExe Condition="'$(_PowerShellExe)' == ''">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</_PowerShellExe>
     <_ScriptLocation Condition="'$(_ScriptLocation)' == ''">$(MSBuildProjectDirectory)\sdk\dotnet-windowsdesktop\UpdateFileClassification.ps1</_ScriptLocation>
     <_ManifestFile>$(MSBuildProjectDirectory)\sdk\dotnet-windowsdesktop\System.Windows.Forms.FileClassification.props</_ManifestFile>
-    <GenerateManifest>false</GenerateManifest>
+    <_GenerateManifest>false</_GenerateManifest>
+    <_IsServicingRelease>false</_IsServicingRelease>
+    <_IsServicingRelease Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</_IsServicingRelease>
   </PropertyGroup>
 
   <!-- 
@@ -23,7 +25,7 @@
     <Error Text="'$(_ManifestFile)' is missing." Condition="!Exists('$(_ManifestFile)')" />
 
     <Exec
-        Command="$(_PowerShellExe) -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { &amp;&apos;$(_ScriptLocation)&apos; &apos;@(_NuspecFile)&apos; &apos;$(_ManifestFile)&apos; $(GenerateManifest) } &quot;"
+        Command="$(_PowerShellExe) -NonInteractive -ExecutionPolicy Unrestricted -Command &quot;&amp; { &amp;&apos;$(_ScriptLocation)&apos; &apos;@(_NuspecFile)&apos; &apos;$(_ManifestFile)&apos; $(_GenerateManifest) &apos;$(AssemblyVersion)&apos; $(_IsServicingRelease) } &quot;"
         ContinueOnError="False" />
 
   </Target>

--- a/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/UpdateFileClassification.ps1
+++ b/pkg/Microsoft.Private.Winforms/sdk/dotnet-windowsdesktop/UpdateFileClassification.ps1
@@ -6,6 +6,10 @@ Param(
   [string] $TargetFile,
   [Parameter(Mandatory=$True, Position=3)]
   [string] $GenerateManifest,
+  [Parameter(Mandatory=$True, Position=4)]
+  [string] $ExpectedAssemblyVersion,
+  [Parameter(Mandatory=$True, Position=5)]
+  [string] $IsServicingRelease,
   [Parameter(ValueFromRemainingArguments=$true)][String[]] $properties
 )
 
@@ -22,7 +26,7 @@ $assemblies = $xmlDoc.package.files.file | `
                 -and !$_.target.EndsWith('\Accessibility.dll', [System.StringComparison]::OrdinalIgnoreCase)
         } | `
     Select-Object -Unique @{Name="Path";Expression={Split-Path $_.target -Leaf}} | `
-    Select-Object  -ExpandProperty Path;
+    Select-Object -ExpandProperty Path;
 
 # this isn't explicitly present in the list
 $assemblies += 'System.Drawing.Common.dll';
@@ -30,6 +34,9 @@ $assemblies += 'System.Drawing.Common.dll';
 
 $needGenerate = $null;
 [bool]::TryParse($GenerateManifest, [ref]$needGenerate) | Out-Null;
+$servicingRelease = $null;
+[bool]::TryParse($IsServicingRelease, [ref]$servicingRelease) | Out-Null;
+
 
 if (!$needGenerate) {
     <#
@@ -74,3 +81,57 @@ else {
 </Project>";
     $output | Out-File -FilePath $TargetFile -Encoding utf8 -Force;
 }
+
+
+# 
+# Verify that components that are exposed as references in the targeting packs don't have their versions revved.
+# See https://github.com/dotnet/winforms/pull/6667 for more details.
+[xml] $xmlDoc = Get-Content -Path $NuspecFile -Force;
+
+# Iterate over files that MUST NOT have their versions revved with every release
+$nonRevAssemblies = $xmlDoc.package.files.file | `
+    Where-Object { 
+            ($_.target.StartsWith('lib\') -or $_.target.StartsWith('ref\')) `
+                -and $_.target.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('resources.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('\Accessibility.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('\Microsoft.VisualBasic.dll', [System.StringComparison]::OrdinalIgnoreCase)
+        } | `
+    Select-Object -Unique src | `
+    Select-Object -ExpandProperty src;
+
+$nonRevAssemblies | `
+    sort-object | `
+    foreach-object {
+        $assembly = $_;
+        [string] $version = ([Reflection.AssemblyName]::GetAssemblyName($assembly).Version).ToString()
+
+        Write-Host "$assembly`: $version"
+        if (![string]::Equals($version, $ExpectedAssemblyVersion)) {
+            throw "$assembly is not versioned correctly. Expected: '$ExpectedAssemblyVersion', found: '$version'."
+            exit -1;
+        }
+    }
+
+# Iterate over files that MUST have their versions revved with every release
+$revAssemblies = $xmlDoc.package.files.file | `
+    Where-Object { 
+            $_.target.StartsWith('sdk\analyzers\') `
+                -and $_.target.EndsWith('.dll', [System.StringComparison]::OrdinalIgnoreCase) `
+                -and !$_.target.EndsWith('resources.dll', [System.StringComparison]::OrdinalIgnoreCase)
+        } | `
+    Select-Object -Unique src | `
+    Select-Object -ExpandProperty src;
+
+$revAssemblies | `
+    sort-object | `
+    foreach-object {
+        $assembly = $_;
+        [string] $version = ([Reflection.AssemblyName]::GetAssemblyName($assembly).Version).ToString()
+
+        Write-Host "$assembly`: $version"
+        if ($servicingRelease -and [string]::Equals($version, $ExpectedAssemblyVersion)) {
+            throw "$assembly is not versioned correctly. '$version' is not expected."
+            exit -1;
+        }
+    }

--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System.Windows.Forms.Analyzers.CSharp.csproj
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System.Windows.Forms.Analyzers.CSharp.csproj
@@ -6,12 +6,6 @@
     <LangVersion>Preview</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);RS2007</NoWarn>
-
-    <IsRoslynComponent>true</IsRoslynComponent>
-
-    <!-- Mark it so eng/packageContent.targets knows how to correctly package it -->
-    <IsAnalyzerProject>true</IsAnalyzerProject>
-    <DefineConstants>WINFORMS_ANALYZERS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Analyzers/src/System.Windows.Forms.Analyzers.csproj
+++ b/src/System.Windows.Forms.Analyzers/src/System.Windows.Forms.Analyzers.csproj
@@ -5,12 +5,6 @@
     <LangVersion>Preview</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);RS2007</NoWarn>
-
-    <IsRoslynComponent>true</IsRoslynComponent>
-
-    <!-- Mark it so eng/packageContent.targets knows how to correctly package it -->
-    <IsAnalyzerProject>true</IsAnalyzerProject>
-    <DefineConstants>WINFORMS_ANALYZERS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Relates to #6663


## Proposed changes

Ping assembly versions similar to https://github.com/dotnet/runtime/blob/bbc766a7c65716305919bc691d696b1e46fa6f62/eng/Versions.props#L14 and https://github.com/dotnet/aspnetcore/blob/c0575788ecadd6e5cfeb4eab635c13b5fd433d37/Directory.Build.targets#L88 to avoid revving assembly versions in servicing releases.




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6668)