### PR TITLE
Fixing text pattern of a multiline text box

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
@@ -69,6 +69,8 @@ namespace System.Windows.Forms.Automation
 
         public abstract Point PointToScreen(Point pt);
 
+        public abstract Rectangle RectangleToScreen(Rectangle rect);
+
         public abstract void SetSelection(int start, int end);
 
         public static ES GetEditStyle(IHandle hWnd) => (ES)GetWindowLong(hWnd, GWL.STYLE);

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
@@ -598,44 +598,136 @@ this is the third line.";
 
         public static IEnumerable<object[]> UiaTextRange_ITextRangeProvider_GetBoundingRectangles_ReturnsCorrectValue_for_MultiLine_TestData()
         {
-            yield return new object[] { 18, 30, new double[] { 14, 51, 12, 13, 14, 66, 52, 13 } };
-            yield return new object[] { 32, 35, new double[] { 74, 66, 20, 13 } };
+            yield return new object[] { 0, 63, new double[] { 32, 131, 103, 12, 32, 148, 85, 12, 32, 165, 83, 12, 32, 182, 90, 12, 32, 199, 40, 12 } }; // Whole text
+            yield return new object[] { 23, 53, new double[] { 72, 148, 45, 12, 32, 165, 83, 12, 32, 182, 56, 12 } }; // "xt with several lines and num" text is selected
         }
 
+        /// <remark>All returned values of mock methods and properties were taken from a real TextBox.</remark>
         [StaTheory]
         [MemberData(nameof(UiaTextRange_ITextRangeProvider_GetBoundingRectangles_ReturnsCorrectValue_for_MultiLine_TestData))]
         public void UiaTextRange_ITextRangeProvider_GetBoundingRectangles_ReturnsCorrectValue_for_MultiLine(int start, int end, double[] expected)
         {
             string testText =
-@"Test text on line 1.
-Test text on line 2.";
+@"Some long long
+test text with several lines
+and numbers 12345";
+
             Mock<IRawElementProviderSimple> enclosingElementMock = new Mock<IRawElementProviderSimple>(MockBehavior.Strict);
-            enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new Rectangle(10, 33, 96, 56));
-            IRawElementProviderSimple enclosingElement = enclosingElementMock.Object;
+            enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new Rectangle(27, 128, 128, 155));
+
             Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.IsReadingRTL).Returns(false);
+            providerMock.Setup(m => m.TextLength).Returns(testText.Length);
+            providerMock.Setup(m => m.Text).Returns(testText);
+            providerMock.Setup(m => m.BoundingRectangle).Returns(new Rectangle(5, 1, 118, 153));
+            providerMock.Setup(m => m.IsMultiline).Returns(true);
+            providerMock.Setup(m => m.FirstVisibleLine).Returns(0);
+            providerMock.Setup(m => m.LinesPerPage).Returns(9);
             using Font font = new Font("Arial", 9f, FontStyle.Regular);
             providerMock.Setup(m => m.Logfont).Returns(LOGFONTW.FromFont(font));
-            providerMock.Setup(m => m.Text).Returns(testText);
+
+            providerMock.Setup(m => m.GetLineFromCharIndex(0)).Returns(0);
+            providerMock.Setup(m => m.GetLineFromCharIndex(14)).Returns(0);
+            providerMock.Setup(m => m.GetLineFromCharIndex(23)).Returns(1);
+            providerMock.Setup(m => m.GetLineFromCharIndex(31)).Returns(2);
+            providerMock.Setup(m => m.GetLineFromCharIndex(44)).Returns(2);
+            providerMock.Setup(m => m.GetLineFromCharIndex(52)).Returns(3);
+            providerMock.Setup(m => m.GetLineFromCharIndex(58)).Returns(4);
+            providerMock.Setup(m => m.GetLineFromCharIndex(62)).Returns(4);
+
+            providerMock.Setup(m => m.GetPositionFromChar(0)).Returns(new Point(5, 1));
+            providerMock.Setup(m => m.GetPositionFromChar(16)).Returns(new Point(5, 18));
+            providerMock.Setup(m => m.GetPositionFromChar(23)).Returns(new Point(45, 18));
+            providerMock.Setup(m => m.GetPositionFromChar(31)).Returns(new Point(5, 35));
+            providerMock.Setup(m => m.GetPositionFromChar(46)).Returns(new Point(5, 52));
+            providerMock.Setup(m => m.GetPositionFromChar(58)).Returns(new Point(5, 69));
+
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(15, testText)).Returns(new Point(108, 1));
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(30, testText)).Returns(new Point(90, 18));
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(45, testText)).Returns(new Point(88, 35));
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(52, testText)).Returns(new Point(61, 52));
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(57, testText)).Returns(new Point(95, 52));
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(62, testText)).Returns(new Point(45, 69));
+
+            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 2))).Returns(14);
+            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 19))).Returns(31);
+            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 36))).Returns(44);
+            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 53))).Returns(58);
+
+            providerMock.Setup(m => m.GetLineIndex(1)).Returns(16);
+            providerMock.Setup(m => m.GetLineIndex(2)).Returns(31);
+            providerMock.Setup(m => m.GetLineIndex(3)).Returns(46);
+            providerMock.Setup(m => m.GetLineIndex(4)).Returns(58);
+
+            UiaTextRange textRange = new UiaTextRange(enclosingElementMock.Object, providerMock.Object, start, end);
+            var actual = ((ITextRangeProvider)textRange).GetBoundingRectangles();
+            Assert.Equal(expected, actual);
+        }
+
+        public static IEnumerable<object[]> UiaTextRange_ITextRangeProvider_GetBoundingRectangles_ReturnsCorrectValue_for_MultiLine_And_RTL_TestData()
+        {
+            yield return new object[] { 0, 63, new double[] { 47, 131, 103, 12, 67, 148, 83, 12, 67, 165, 83, 12, 62, 182, 88, 12, 110, 199, 40, 12 } }; // Whole text
+            yield return new object[] { 23, 53, new double[] { 107, 148, 43, 12, 67, 165, 83, 12, 64, 182, 56, 12 } }; // "xt with several lines and num" text is selected
+        }
+
+        /// <remark>All returned values of mock methods and properties were taken from a real TextBox.</remark>
+        [StaTheory]
+        [MemberData(nameof(UiaTextRange_ITextRangeProvider_GetBoundingRectangles_ReturnsCorrectValue_for_MultiLine_And_RTL_TestData))]
+        public void UiaTextRange_ITextRangeProvider_GetBoundingRectangles_ReturnsCorrectValue_for_MultiLine_And_RTL(int start, int end, double[] expected)
+        {
+            string testText =
+@"Some long long
+test text with several lines
+and numbers 12345";
+
+            Mock<IRawElementProviderSimple> enclosingElementMock = new Mock<IRawElementProviderSimple>(MockBehavior.Strict);
+            enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new Rectangle(27, 128, 128, 155));
+
+            Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
+            providerMock.Setup(m => m.IsReadingRTL).Returns(true);
             providerMock.Setup(m => m.TextLength).Returns(testText.Length);
+            providerMock.Setup(m => m.Text).Returns(testText);
+            providerMock.Setup(m => m.BoundingRectangle).Returns(new Rectangle(5, 1, 118, 153));
             providerMock.Setup(m => m.IsMultiline).Returns(true);
-            providerMock.Setup(m => m.BoundingRectangle).Returns(new Rectangle(4, 1, 88, 45));
-            providerMock.Setup(m => m.GetLineFromCharIndex(18)).Returns(1);
-            providerMock.Setup(m => m.GetLineFromCharIndex(29)).Returns(2);
-            providerMock.Setup(m => m.GetLineFromCharIndex(32)).Returns(2);
-            providerMock.Setup(m => m.GetLineFromCharIndex(34)).Returns(2);
             providerMock.Setup(m => m.FirstVisibleLine).Returns(0);
-            providerMock.Setup(m => m.LinesPerPage).Returns(3);
-            providerMock.Setup(m => m.GetLineIndex(1)).Returns(18);
-            providerMock.Setup(m => m.GetPositionFromChar(18)).Returns(new Point(4, 16));
-            providerMock.Setup(m => m.GetPositionFromChar(32)).Returns(new Point(64, 31));
-            providerMock.Setup(m => m.GetLineIndex(2)).Returns(22);
-            providerMock.Setup(m => m.GetPositionFromChar(21)).Returns(new Point(16, 16));
-            providerMock.Setup(m => m.GetPositionFromChar(22)).Returns(new Point(4, 31));
-            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(29, testText)).Returns(new Point(56, 31));
-            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(34, testText)).Returns(new Point(84, 31));
-            UiaTextProvider provider = providerMock.Object;
-            var t = provider.Logfont;
-            UiaTextRange textRange = new UiaTextRange(enclosingElement, provider, start, end);
+            providerMock.Setup(m => m.LinesPerPage).Returns(9);
+            using Font font = new Font("Arial", 9f, FontStyle.Regular);
+            providerMock.Setup(m => m.Logfont).Returns(LOGFONTW.FromFont(font));
+
+            providerMock.Setup(m => m.GetLineFromCharIndex(0)).Returns(0);
+            providerMock.Setup(m => m.GetLineFromCharIndex(14)).Returns(0);
+            providerMock.Setup(m => m.GetLineFromCharIndex(23)).Returns(1);
+            providerMock.Setup(m => m.GetLineFromCharIndex(31)).Returns(2);
+            providerMock.Setup(m => m.GetLineFromCharIndex(44)).Returns(2);
+            providerMock.Setup(m => m.GetLineFromCharIndex(52)).Returns(3);
+            providerMock.Setup(m => m.GetLineFromCharIndex(58)).Returns(4);
+            providerMock.Setup(m => m.GetLineFromCharIndex(62)).Returns(4);
+
+            providerMock.Setup(m => m.GetPositionFromChar(0)).Returns(new Point(22, 1));
+            providerMock.Setup(m => m.GetPositionFromChar(16)).Returns(new Point(42, 18));
+            providerMock.Setup(m => m.GetPositionFromChar(23)).Returns(new Point(82, 18));
+            providerMock.Setup(m => m.GetPositionFromChar(31)).Returns(new Point(42, 35));
+            providerMock.Setup(m => m.GetPositionFromChar(46)).Returns(new Point(37, 52));
+            providerMock.Setup(m => m.GetPositionFromChar(58)).Returns(new Point(83, 69));
+
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(15, testText)).Returns(new Point(125, 1));
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(30, testText)).Returns(new Point(127, 18));
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(45, testText)).Returns(new Point(125, 35));
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(52, testText)).Returns(new Point(93, 52));
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(57, testText)).Returns(new Point(127, 52));
+            providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(62, testText)).Returns(new Point(123, 69));
+
+            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 2))).Returns(14);
+            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 19))).Returns(31);
+            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 36))).Returns(44);
+            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 53))).Returns(58);
+
+            providerMock.Setup(m => m.GetLineIndex(1)).Returns(16);
+            providerMock.Setup(m => m.GetLineIndex(2)).Returns(31);
+            providerMock.Setup(m => m.GetLineIndex(3)).Returns(46);
+            providerMock.Setup(m => m.GetLineIndex(4)).Returns(58);
+
+            UiaTextRange textRange = new UiaTextRange(enclosingElementMock.Object, providerMock.Object, start, end);
             var actual = ((ITextRangeProvider)textRange).GetBoundingRectangles();
             Assert.Equal(expected, actual);
         }

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
@@ -649,11 +649,6 @@ and numbers 12345";
             providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(57, testText)).Returns(new Point(95, 52));
             providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(62, testText)).Returns(new Point(45, 69));
 
-            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 2))).Returns(14);
-            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 19))).Returns(31);
-            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 36))).Returns(44);
-            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 53))).Returns(58);
-
             providerMock.Setup(m => m.GetLineIndex(1)).Returns(16);
             providerMock.Setup(m => m.GetLineIndex(2)).Returns(31);
             providerMock.Setup(m => m.GetLineIndex(3)).Returns(46);
@@ -716,11 +711,6 @@ and numbers 12345";
             providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(52, testText)).Returns(new Point(93, 52));
             providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(57, testText)).Returns(new Point(127, 52));
             providerMock.Setup(m => m.GetPositionFromCharForUpperRightCorner(62, testText)).Returns(new Point(123, 69));
-
-            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 2))).Returns(14);
-            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 19))).Returns(31);
-            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 36))).Returns(44);
-            providerMock.Setup(m => m.GetCharIndexFromPosition(new(123, 53))).Returns(58);
 
             providerMock.Setup(m => m.GetLineIndex(1)).Returns(16);
             providerMock.Setup(m => m.GetLineIndex(2)).Returns(31);

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
@@ -524,6 +524,7 @@ this is the third line.";
             enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new Rectangle(10, 33, 96, 19));
             IRawElementProviderSimple enclosingElement = enclosingElementMock.Object;
             Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
+            providerMock.Setup(p => p.Text).Returns("");
             providerMock.Setup(p => p.TextLength).Returns(0);
             UiaTextProvider provider = providerMock.Object;
             UiaTextRange textRange = new UiaTextRange(enclosingElement, provider, start: 0, end: 0);
@@ -538,7 +539,9 @@ this is the third line.";
             enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new Rectangle(10, 33, 96, 19));
             IRawElementProviderSimple enclosingElement = enclosingElementMock.Object;
             Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
+            providerMock.Setup(p => p.Text).Returns("abcde");
             providerMock.Setup(p => p.TextLength).Returns(5);
+            providerMock.Setup(p => p.IsMultiline).Returns(false);
             UiaTextProvider provider = providerMock.Object;
             UiaTextRange textRange = new UiaTextRange(enclosingElement, provider, start: 0, end: 0);
             var actual = ((ITextRangeProvider)textRange).GetBoundingRectangles();
@@ -552,6 +555,7 @@ this is the third line.";
             enclosingElementMock.Setup(m => m.GetPropertyValue(UIA.BoundingRectanglePropertyId)).Returns(new Rectangle(10, 33, 96, 19));
             IRawElementProviderSimple enclosingElement = enclosingElementMock.Object;
             Mock<UiaTextProvider> providerMock = new Mock<UiaTextProvider>(MockBehavior.Strict);
+            providerMock.Setup(p => p.Text).Returns("abc");
             providerMock.Setup(p => p.TextLength).Returns(3);
             providerMock.Setup(p => p.PointToScreen(It.IsAny<Point>())).Returns(Point.Empty);
             using Font font = new Font("Arial", 9f, FontStyle.Regular);
@@ -626,6 +630,10 @@ and numbers 12345";
             using Font font = new Font("Arial", 9f, FontStyle.Regular);
             providerMock.Setup(m => m.Logfont).Returns(LOGFONTW.FromFont(font));
 
+            // Offset by enclosing element's coordinates
+            providerMock.Setup(m => m.RectangleToScreen(It.IsAny<Rectangle>()))
+                .Returns((Rectangle rect) => new Rectangle(rect.X + 27, rect.Y + 128, rect.Width, rect.Height));
+
             providerMock.Setup(m => m.GetLineFromCharIndex(0)).Returns(0);
             providerMock.Setup(m => m.GetLineFromCharIndex(14)).Returns(0);
             providerMock.Setup(m => m.GetLineFromCharIndex(23)).Returns(1);
@@ -688,6 +696,10 @@ and numbers 12345";
             providerMock.Setup(m => m.LinesPerPage).Returns(9);
             using Font font = new Font("Arial", 9f, FontStyle.Regular);
             providerMock.Setup(m => m.Logfont).Returns(LOGFONTW.FromFont(font));
+
+            // Offset by enclosing element's coordinates
+            providerMock.Setup(m => m.RectangleToScreen(It.IsAny<Rectangle>()))
+                .Returns((Rectangle rect) => new Rectangle(rect.X + 27, rect.Y + 128, rect.Width, rect.Height));
 
             providerMock.Setup(m => m.GetLineFromCharIndex(0)).Returns(0);
             providerMock.Setup(m => m.GetLineFromCharIndex(14)).Returns(0);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
@@ -335,6 +335,8 @@ namespace System.Windows.Forms
                 return new UiaTextRange(_owningComboBox.ChildEditAccessibleObject, this, start, start);
             }
 
+            public override Rectangle RectangleToScreen(Rectangle rect) => _owningComboBox.RectangleToScreen(rect);
+
             public override void SetSelection(int start, int end)
             {
                 if (!_owningComboBox.IsHandleCreated)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -206,10 +206,7 @@ namespace System.Windows.Forms
                     ? _owningTextBoxBase.Text
                     : string.Empty;
 
-            public override int TextLength
-                => _owningTextBoxBase.IsHandleCreated
-                    ? (int)SendMessageW(_owningTextBoxBase, WM.GETTEXTLENGTH)
-                    : -1;
+            public override int TextLength => Text.Length;
 
             public override WS_EX WindowExStyle
                 => _owningTextBoxBase.IsHandleCreated
@@ -306,7 +303,15 @@ namespace System.Windows.Forms
                 Point ptStart = new Point(rectangle.X + 1, rectangle.Y + 1);
                 Point ptEnd = new Point(rectangle.Right - 1, rectangle.Bottom - 1);
 
-                visibleStart = _owningTextBoxBase.GetCharIndexFromPosition(ptStart);
+                if (IsMultiline)
+                {
+                    visibleStart = GetLineIndex(FirstVisibleLine);
+                }
+                else
+                {
+                    visibleStart = _owningTextBoxBase.GetCharIndexFromPosition(ptStart);
+                }
+
                 visibleEnd = _owningTextBoxBase.GetCharIndexFromPosition(ptEnd) + 1; // Add 1 to get a caret position after received character
 
                 return;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -96,6 +96,8 @@ namespace System.Windows.Forms
                 return new UiaTextRange(_owningTextBoxBase.AccessibilityObject, this, start, start);
             }
 
+            public override Rectangle RectangleToScreen(Rectangle rect) => _owningTextBoxBase.RectangleToScreen(rect);
+
             public override UiaCore.ITextRangeProvider DocumentRange => new UiaTextRange(_owningTextBoxBase.AccessibilityObject, this, start: 0, TextLength);
 
             public override UiaCore.SupportedTextSelection SupportedTextSelection => UiaCore.SupportedTextSelection.Single;
@@ -306,13 +308,19 @@ namespace System.Windows.Forms
                 if (IsMultiline)
                 {
                     visibleStart = GetLineIndex(FirstVisibleLine);
+
+                    int lastVisibleLine = FirstVisibleLine + LinesPerPage - 1;
+                    visibleEnd = GetLineIndex(lastVisibleLine + 1); // Index of the next line is the end caret position of the previous line.
+                    if (visibleEnd == -1)
+                    {
+                        visibleEnd = Text.Length;
+                    }
                 }
                 else
                 {
                     visibleStart = _owningTextBoxBase.GetCharIndexFromPosition(ptStart);
+                    visibleEnd = _owningTextBoxBase.GetCharIndexFromPosition(ptEnd) + 1; // Add 1 to get a caret position after received character
                 }
-
-                visibleEnd = _owningTextBoxBase.GetCharIndexFromPosition(ptEnd) + 1; // Add 1 to get a caret position after received character
 
                 return;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -310,7 +310,8 @@ namespace System.Windows.Forms
                     visibleStart = GetLineIndex(FirstVisibleLine);
 
                     int lastVisibleLine = FirstVisibleLine + LinesPerPage - 1;
-                    visibleEnd = GetLineIndex(lastVisibleLine + 1); // Index of the next line is the end caret position of the previous line.
+                    // Index of the next line is the end caret position of the previous line.
+                    visibleEnd = GetLineIndex(lastVisibleLine + 1);
                     if (visibleEnd == -1)
                     {
                         visibleEnd = Text.Length;
@@ -319,7 +320,8 @@ namespace System.Windows.Forms
                 else
                 {
                     visibleStart = _owningTextBoxBase.GetCharIndexFromPosition(ptStart);
-                    visibleEnd = _owningTextBoxBase.GetCharIndexFromPosition(ptEnd) + 1; // Add 1 to get a caret position after received character
+                    // Add 1 to get a caret position after received character.
+                    visibleEnd = _owningTextBoxBase.GetCharIndexFromPosition(ptEnd) + 1;
                 }
 
                 return;

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
@@ -39,6 +39,7 @@ namespace System.Windows.Forms.IntegrationTests.Common
         ToolTipsButton,
         AnchorLayoutButton,
         DockLayoutButton,
-        DragAndDrop
+        DragAndDrop,
+        TextBoxesButton
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -190,6 +190,10 @@ namespace WinformsControlsTest
             {
                 MainFormControlsTabOrder.DragAndDrop,
                 new InitInfo("Drag and Drop", (obj, e) => new DragDrop().Show(this))
+            },
+            {
+                MainFormControlsTabOrder.TextBoxesButton,
+                new InitInfo("TextBoxes", (obj, e) => new TextBoxes().Show(this))
             }
         };
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TextBoxes.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TextBoxes.Designer.cs
@@ -76,7 +76,7 @@ contains several
 lines
 with
 
-withspaces and
+withspaces,tabs     and
 numbers
 12345";
             // 
@@ -100,7 +100,7 @@ contains several
 lines
 with
 
-withspaces and
+withspaces,tabs     and
 numbers
 12345";
             // 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TextBoxes.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TextBoxes.Designer.cs
@@ -1,0 +1,178 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace WinformsControlsTest
+{
+    partial class TextBoxes
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.textBox = new System.Windows.Forms.TextBox();
+            this.RTLTextBox = new System.Windows.Forms.TextBox();
+            this.multilineTextBox = new System.Windows.Forms.TextBox();
+            this.RTLMultilineTextBox = new System.Windows.Forms.TextBox();
+            this.richTextBox = new System.Windows.Forms.RichTextBox();
+            this.RTLRichTextBox = new System.Windows.Forms.RichTextBox();
+            this.SuspendLayout();
+            // 
+            // textBox
+            // 
+            this.textBox.Location = new System.Drawing.Point(20, 20);
+            this.textBox.Name = "textBox";
+            this.textBox.Size = new System.Drawing.Size(120, 30);
+            this.textBox.TabIndex = 0;
+            this.textBox.Text = "Some long long text for a TextBox";
+            // 
+            // RTLTextBox
+            // 
+            this.RTLTextBox.Location = new System.Drawing.Point(160, 20);
+            this.RTLTextBox.Name = "RTLTextBox";
+            this.RTLTextBox.Size = new System.Drawing.Size(120, 30);
+            this.RTLTextBox.TabIndex = 1;
+            this.RTLTextBox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.RTLTextBox.Text = "Some long long text for a RTL TextBox";
+            // 
+            // multilineTextBox
+            // 
+            this.multilineTextBox.Location = new System.Drawing.Point(20, 60);
+            this.multilineTextBox.Name = "multilineTextBox";
+            this.multilineTextBox.Size = new System.Drawing.Size(120, 110);
+            this.multilineTextBox.TabIndex = 2;
+            this.multilineTextBox.Multiline = true;
+            this.multilineTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.multilineTextBox.Text = @"Some long
+long text
+for
+
+a multiline TextBox
+that
+
+contains several
+lines
+with
+
+withspaces and
+numbers
+12345";
+            // 
+            // RTLMultilineTextBox
+            // 
+            this.RTLMultilineTextBox.Location = new System.Drawing.Point(160, 60);
+            this.RTLMultilineTextBox.Name = "RTLMultilineTextBox";
+            this.RTLMultilineTextBox.Size = new System.Drawing.Size(120, 110);
+            this.RTLMultilineTextBox.TabIndex = 3;
+            this.RTLMultilineTextBox.Multiline = true;
+            this.RTLMultilineTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.RTLMultilineTextBox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.RTLMultilineTextBox.Text = @"Some long
+long text
+for
+
+a multiline TextBox
+that
+
+contains several
+lines
+with
+
+withspaces and
+numbers
+12345";
+            // 
+            // richTextBox
+            // 
+            this.richTextBox.Location = new System.Drawing.Point(20, 190);
+            this.richTextBox.Name = "richTextBox";
+            this.richTextBox.Size = new System.Drawing.Size(120, 110);
+            this.richTextBox.TabIndex = 4;
+            this.richTextBox.Text = @"Some long
+long text
+for
+
+a RichTextBox
+
+that
+contains several
+lines
+with
+
+withspaces and
+numbers
+12345";
+            // 
+            // RTLRichTextBox
+            // 
+            this.RTLRichTextBox.Location = new System.Drawing.Point(160, 190);
+            this.RTLRichTextBox.Name = "RTLRichTextBox";
+            this.RTLRichTextBox.Size = new System.Drawing.Size(120, 110);
+            this.RTLRichTextBox.TabIndex = 5;
+            this.RTLRichTextBox.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.RTLRichTextBox.Text = @"Some long
+long text
+for
+
+a RichTextBox
+
+that
+contains several
+lines
+with
+
+withspaces and
+numbers
+12345";
+            // 
+            // Form
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(300, 330);
+            this.Controls.Add(this.textBox);
+            this.Controls.Add(this.RTLTextBox);
+            this.Controls.Add(this.multilineTextBox);
+            this.Controls.Add(this.RTLMultilineTextBox);
+            this.Controls.Add(this.richTextBox);
+            this.Controls.Add(this.RTLRichTextBox);
+            this.Name = "TextBoxes";
+            this.Text = "TextBoxes";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TextBox textBox;
+        private System.Windows.Forms.TextBox RTLTextBox;
+        private System.Windows.Forms.TextBox multilineTextBox;
+        private System.Windows.Forms.TextBox RTLMultilineTextBox;
+        private System.Windows.Forms.RichTextBox richTextBox;
+        private System.Windows.Forms.RichTextBox RTLRichTextBox;
+    }
+}
+

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TextBoxes.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TextBoxes.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    public partial class TextBoxes : Form
+    {
+        public TextBoxes()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TextBoxes.resx
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TextBoxes.resx
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProviderTests.cs
@@ -559,20 +559,6 @@ namespace System.Windows.Forms.Tests
             Assert.True(textBoxBase.IsHandleCreated);
         }
 
-        [WinFormsTheory]
-        [InlineData("")]
-        [InlineData("Text")]
-        [InlineData("Some test text")]
-        public void TextBoxBaseUiaTextProvider_TextLength_ReturnsMinusOne_WithoutHandle(string text)
-        {
-            using TextBoxBase textBoxBase = new SubTextBoxBase();
-            textBoxBase.Text = text;
-            TextBoxBaseUiaTextProvider provider = new TextBoxBaseUiaTextProvider(textBoxBase);
-
-            Assert.Equal(-1, provider.TextLength);
-            Assert.False(textBoxBase.IsHandleCreated);
-        }
-
         [WinFormsFact]
         public void TextBoxBaseUiaTextProvider_WindowExStyle_ReturnsCorrectValue()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProviderTests.cs
@@ -644,8 +644,8 @@ namespace System.Windows.Forms.Tests
                 yield return new object[] { new Size(0, 0), 0, 0 };
                 yield return new object[] { new Size(0, 20), 0, 0 };
                 yield return new object[] { new Size(30, 30), 0, 5 };
-                yield return new object[] { new Size(50, 20), 0, 11 };
-                yield return new object[] { new Size(120, 20), 0, 26 };
+                yield return new object[] { new Size(50, 20), 0, 5 };
+                yield return new object[] { new Size(120, 20), 0, 19 };
                 yield return new object[] { new Size(50, 80), 0, 26 };
             }
             else
@@ -661,7 +661,8 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [MemberData(nameof(TextBoxBaseUiaTextProvider_GetVisibleRangePoints_ForMultilineTextBox_TestData))]
-        public void TextBoxBaseUiaTextProvider_GetVisibleRangePoints_ForMultilineTextBox_ReturnsCorrectValue(Size size, int expectedStart, int expectedEnd)
+        public void TextBoxBaseUiaTextProvider_GetVisibleRangePoints_ForMultilineTextBox_ReturnsCorrectValue(
+            Size size, int expectedStart, int expectedEnd)
         {
             using SubTextBoxBase textBoxBase = new SubTextBoxBase()
             {


### PR DESCRIPTION
Fixes #6661


## Proposed changes

- Rework `GetMultilineBoundingRectangles` method to:
     + calculate correct rectangles
     + make it simpler

## Customer Impact

- Now a user can see more correct text ranges in a muliline TextBox

## Regression? 

- No

## Risk

- Minimal



## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- TextPattern doesn't show empty lines;
- In RTL mode some text ranges are not shown:
![image](https://user-images.githubusercontent.com/49272759/153413157-266b5196-af25-44bd-bbd9-23b4b28b5675.png)


### After

- UIA shows all text ranges correctly:
![image](https://user-images.githubusercontent.com/49272759/153413179-123b82b2-4d74-493c-9be6-bda8aa8c86a1.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- CTI
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using Narrator and Isnpect


## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10
- .NET 7.0.0-preview.2.22108.17


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6669)