### PR TITLE
Fix ComboBox text not clearing on last Item removal

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
@@ -247,19 +247,33 @@ namespace System.Windows.Forms
 
             internal void ClearInternal()
             {
+                bool itemWasSelected = _owner.SelectedIndex > -1;
+                string text = _owner.Text;
+
                 if (_owner.IsHandleCreated)
                 {
                     _owner.NativeClear();
                 }
 
                 InnerList.Clear();
-
                 OwnerComboBoxAccessibleObject?.ItemAccessibleObjects.Clear();
 
                 _owner._selectedIndex = -1;
                 if (_owner.AutoCompleteSource == AutoCompleteSource.ListItems)
                 {
                     _owner.SetAutoComplete(false, true /*recreateHandle*/);
+                }
+
+                // Raise events after internal state of control is consistent
+                if (itemWasSelected)
+                {
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        _owner.UpdateText();
+                    }
+
+                    _owner.OnSelectedItemChanged(EventArgs.Empty);
+                    _owner.OnSelectedIndexChanged(EventArgs.Empty);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
@@ -400,6 +400,11 @@ namespace System.Windows.Forms
                         _owner.UpdateText();
                     }
                 }
+                else if (InnerList.Count == 0)
+                {
+                    // Text is not cleared when the last item is removed. This is native behavior that must be compensated
+                    _owner.UpdateText();
+                }
 
                 if (_owner.AutoCompleteSource == AutoCompleteSource.ListItems)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
@@ -383,6 +383,11 @@ namespace System.Windows.Forms
                 if (_owner.IsHandleCreated)
                 {
                     _owner.NativeRemoveAt(index);
+                    if (InnerList.Count == 1)
+                    {
+                        // Text is not cleared when the last item is removed. This is native behavior that must be compensated
+                        _owner.UpdateText();
+                    }
                 }
 
                 OwnerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
@@ -399,11 +404,6 @@ namespace System.Windows.Forms
                         _owner._selectedIndex = -1;
                         _owner.UpdateText();
                     }
-                }
-                else if (InnerList.Count == 0)
-                {
-                    // Text is not cleared when the last item is removed. This is native behavior that must be compensated
-                    _owner.UpdateText();
                 }
 
                 if (_owner.AutoCompleteSource == AutoCompleteSource.ListItems)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -1285,8 +1285,7 @@ namespace System.Windows.Forms
                     {
                         SelectedIndex = -1;
                     }
-                    else if (value is not null &&
-                        (selectedItem is null || (string.Compare(value, GetItemText(selectedItem), false, CultureInfo.CurrentCulture) != 0)))
+                    else if (selectedItem is null || (string.Compare(value, GetItemText(selectedItem), false, CultureInfo.CurrentCulture) != 0))
                     {
                         int index = FindStringIgnoreCase(value);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -1933,7 +1933,7 @@ namespace System.Windows.Forms.Tests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]
-        public void Combox_SelectedItem_HandlesItemRemoval(int selectedIndex)
+        public void ComboBox_SelectedItem_HandlesItemRemoval(int selectedIndex)
         {
             using ComboBox comboBox = new();
             for (int i = 0; i < 3; i++)
@@ -1951,6 +1951,66 @@ namespace System.Windows.Forms.Tests
             Assert.Null(comboBox.SelectedItem);
             Assert.Empty(comboBox.Text);
             Assert.False(comboBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ComboBox_SelectedItem_HandlesLastItemRemoval(bool createHandle)
+        {
+            using ComboBox comboBox = new();
+            if (createHandle)
+            {
+                Assert.True(comboBox.Handle != IntPtr.Zero);
+            }
+
+            for (int i = 0; i < 2; i++)
+            {
+                comboBox.Items.Add(i.ToString());
+            }
+
+            for (int i = 0; i < 2; i++)
+            {
+                comboBox.SelectedItem = comboBox.Items[0];
+                Assert.Equal(0, comboBox.SelectedIndex);
+                Assert.Equal(i.ToString(), comboBox.SelectedItem);
+                Assert.Equal(i.ToString(), comboBox.Text);
+
+                comboBox.Items.Remove(comboBox.SelectedItem);
+                Assert.Equal(-1, comboBox.SelectedIndex);
+                Assert.Null(comboBox.SelectedItem);
+                Assert.Empty(comboBox.Text);
+            }
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ComboBox_SelectedItem_TextDoesNotChangeOnRemoveOther(bool createHandle)
+        {
+            using ComboBox comboBox = new();
+            if (createHandle)
+            {
+                Assert.True(comboBox.Handle != IntPtr.Zero);
+            }
+
+            for (int i = 0; i < 3; i++)
+            {
+                comboBox.Items.Add(i.ToString());
+            }
+
+            comboBox.SelectedItem = comboBox.Items[1];
+            Assert.Equal(1, comboBox.SelectedIndex);
+            Assert.Equal("1", comboBox.SelectedItem);
+            Assert.Equal("1", comboBox.Text);
+
+            comboBox.Items.RemoveAt(2);
+            Assert.Equal(1, comboBox.SelectedIndex);
+            Assert.Equal("1", comboBox.SelectedItem);
+            Assert.Equal("1", comboBox.Text);
+
+            comboBox.Items.RemoveAt(0);
+            Assert.Equal(0, comboBox.SelectedIndex);
+            Assert.Equal("1", comboBox.SelectedItem);
+            Assert.Equal("1", comboBox.Text);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -1974,6 +1974,111 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ComboBox_SelectedItem_HandlesItemsClear(bool createHandle)
+        {
+            using ComboBox comboBox = new();
+            if (createHandle)
+            {
+                Assert.True(comboBox.Handle != IntPtr.Zero);
+            }
+
+            for (int i = 0; i < 2; i++)
+            {
+                comboBox.Items.Add(i.ToString());
+            }
+
+            comboBox.SelectedItem = comboBox.Items[1];
+            Assert.Equal(1, comboBox.SelectedIndex);
+            Assert.Equal("1", comboBox.SelectedItem);
+            Assert.Equal("1", comboBox.Text);
+
+            int eventCount = 0;
+            int textChangedOrder = 0;
+            int selectedValueChangedOrder = 0;
+            int selectedIndexChangedOrder = 0;
+
+            comboBox.TextChanged += (_, _) => textChangedOrder = ++eventCount;
+            comboBox.SelectedValueChanged += (_, _) => selectedValueChangedOrder = ++eventCount;
+            comboBox.SelectedIndexChanged += (_, _) => selectedIndexChangedOrder = ++eventCount;
+
+            comboBox.Items.Clear();
+            Assert.Equal(-1, comboBox.SelectedIndex);
+            Assert.Null(comboBox.SelectedItem);
+            Assert.Empty(comboBox.Text);
+            Assert.Equal(1, textChangedOrder);
+            Assert.Equal(2, selectedValueChangedOrder);
+            Assert.Equal(3, selectedIndexChangedOrder);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ComboBox_SelectedItem_HandlesItemsClear_NoEventsIfNoItemSelected(bool createHandle)
+        {
+            using ComboBox comboBox = new();
+            if (createHandle)
+            {
+                Assert.True(comboBox.Handle != IntPtr.Zero);
+            }
+
+            for (int i = 0; i < 2; i++)
+            {
+                comboBox.Items.Add(i.ToString());
+            }
+
+            Assert.Equal(-1, comboBox.SelectedIndex);
+            Assert.Null(comboBox.SelectedItem);
+            Assert.Empty(comboBox.Text);
+
+            int eventCount = 0;
+            int textChangedOrder = 0;
+            int selectedValueChangedOrder = 0;
+            int selectedIndexChangedOrder = 0;
+
+            comboBox.TextChanged += (_, _) => textChangedOrder = ++eventCount;
+            comboBox.SelectedValueChanged += (_, _) => selectedValueChangedOrder = ++eventCount;
+            comboBox.SelectedIndexChanged += (_, _) => selectedIndexChangedOrder = ++eventCount;
+
+            comboBox.Items.Clear();
+            Assert.Equal(0, textChangedOrder);
+            Assert.Equal(0, selectedValueChangedOrder);
+            Assert.Equal(0, selectedIndexChangedOrder);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
+        public void ComboBox_SelectedItem_HandlesItemsClear_TextChangedDoesNotFireEmpty(bool createHandle)
+        {
+            using ComboBox comboBox = new();
+            if (createHandle)
+            {
+                Assert.True(comboBox.Handle != IntPtr.Zero);
+            }
+
+            comboBox.Items.Add(string.Empty);
+
+            comboBox.SelectedItem = comboBox.Items[0];
+            Assert.Equal(0, comboBox.SelectedIndex);
+
+            int eventCount = 0;
+            int textChangedOrder = 0;
+            int selectedValueChangedOrder = 0;
+            int selectedIndexChangedOrder = 0;
+
+            comboBox.TextChanged += (_, _) => textChangedOrder = ++eventCount;
+            comboBox.SelectedValueChanged += (_, _) => selectedValueChangedOrder = ++eventCount;
+            comboBox.SelectedIndexChanged += (_, _) => selectedIndexChangedOrder = ++eventCount;
+
+            comboBox.Items.Clear();
+            Assert.Equal(-1, comboBox.SelectedIndex);
+            Assert.Null(comboBox.SelectedItem);
+            Assert.Empty(comboBox.Text);
+            Assert.Equal(0, textChangedOrder);
+            Assert.Equal(1, selectedValueChangedOrder);
+            Assert.Equal(2, selectedIndexChangedOrder);
+        }
+
+        [WinFormsTheory]
+        [CommonMemberData(typeof(CommonTestHelper), nameof(CommonTestHelper.GetBoolTheoryData))]
         public void ComboBox_SelectedItem_HandlesItemRemoval(bool createHandle)
         {
             using ComboBox comboBox = new();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6621


## Proposed changes

`ComboBox.Text` does not clear when the last item is removed. This was tested on Win32 and confirmed to be native behavior. PR addresses by checking for last item removal and updating `Text` accordingly.

It should be noted that this likely goes back to the beginning of .NET, so this is a change to longstanding behavior. It does, however, seem to be correct when measured by the principle of least astonishment.

~~Separate issue: existing behavior does not raise `TextChanged` or `SelectedIndexChanged` when `SelectedItem` is removed. Consideration should be given as to whether this should be changed.~~

Modified to raise events. Unit tests ensure that events are raised in the correct order and only raised once. 

There is an edge which is also covered. `TextChanged` does not fire if changing between items with the same text. This includes adding an item with `string.Emtpy` as its value, selecting it, and then setting `SelectedIndex` to -1. To match that behavior, we ensure that `TextChanged` does not fire when `SelectedItem` is removed if `SelectedItem` is `string.Emtpy`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

Text will clear on last item removal, consistent with what it does when a non-last item is removed.

## Regression? 

-  No

## Risk

- It is likely that apps have been designed to compensate for this already by clearing `Text` on last item removal in an event handler. That should not create a conflict
- It is possible that apps exist which were designed to depend on this behavior, in which case it could be a breaking change. Admittedly, this would be a very odd dependency

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Unit tests added

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6673)