### PR TITLE
Enable nullability in ColorDialog

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -68,7 +68,7 @@ override System.Windows.Forms.ButtonBase.Text.set -> void
 ~override System.Windows.Forms.CheckedListBox.OnKeyPress(System.Windows.Forms.KeyPressEventArgs e) -> void
 ~override System.Windows.Forms.CheckedListBox.OnMeasureItem(System.Windows.Forms.MeasureItemEventArgs e) -> void
 ~override System.Windows.Forms.CheckedListBox.OnSelectedIndexChanged(System.EventArgs e) -> void
-~override System.Windows.Forms.ColorDialog.ToString() -> string
+override System.Windows.Forms.ColorDialog.ToString() -> string!
 ~override System.Windows.Forms.ColumnHeaderConverter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) -> bool
 ~override System.Windows.Forms.ColumnHeaderConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) -> object
 ~override System.Windows.Forms.ComboBox.BackgroundImage.get -> System.Drawing.Image
@@ -1391,8 +1391,8 @@ System.Windows.Forms.ButtonBase.ImageList.set -> void
 ~System.Windows.Forms.CheckedListBox.ObjectCollection.ObjectCollection(System.Windows.Forms.CheckedListBox owner) -> void
 ~System.Windows.Forms.CheckedListBox.ValueMember.get -> string
 ~System.Windows.Forms.CheckedListBox.ValueMember.set -> void
-~System.Windows.Forms.ColorDialog.CustomColors.get -> int[]
-~System.Windows.Forms.ColorDialog.CustomColors.set -> void
+System.Windows.Forms.ColorDialog.CustomColors.get -> int[]!
+System.Windows.Forms.ColorDialog.CustomColors.set -> void
 ~System.Windows.Forms.ComboBox.AutoCompleteCustomSource.get -> System.Windows.Forms.AutoCompleteStringCollection
 ~System.Windows.Forms.ComboBox.AutoCompleteCustomSource.set -> void
 ~System.Windows.Forms.ComboBox.DataSource.get -> object

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColorDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColorDialog.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using static Interop;
@@ -76,6 +75,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [SRDescription(nameof(SR.CDcustomColorsDescr))]
+        [AllowNull]
         public int[] CustomColors
         {
             get => (int[])_customColors.Clone();
@@ -84,7 +84,7 @@ namespace System.Windows.Forms
                 int length = value is null ? 0 : Math.Min(value.Length, 16);
                 if (length > 0)
                 {
-                    Array.Copy(value, 0, _customColors, 0, length);
+                    Array.Copy(value!, 0, _customColors, 0, length);
                 }
 
                 for (int i = length; i < 16; i++)


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ColorDialog.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6676)