### PR TITLE
Option to not use WebRequest for PictureBox

### DIFF
--- a/src/System.Windows.Forms/src/ILLink.Substitutions.xml
+++ b/src/System.Windows.Forms/src/ILLink.Substitutions.xml
@@ -1,0 +1,10 @@
+﻿<linker>
+	<assembly fullname="System.Windows.Forms">
+		<!-- System.Windows.Forms.PictureBox.UseWebRequest enables downloading images from network. It is enabled by default. -->
+		<type fullname="System.Windows.Forms.PictureBox" feature="System.Windows.Forms.PictureBox.UseWebRequest" featurevalue="false">
+			<method signature="System.Boolean UseWebRequest()" body="stub" value="false" />
+			<method signature="System.Void StartLoadViaWebRequest()" body="stub" />
+			<method signature="System.Void LoadImageViaWebClient()" body="stub" />
+		</type>
+	</assembly>
+</linker>

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -4534,6 +4534,9 @@ Stack trace where the illegal operation occurred was:
   <data name="PictureBoxWaitOnLoadDescr" xml:space="preserve">
     <value>Controls whether processing will stop until the image is loaded.</value>
   </data>
+  <data name="PictureBoxRemoteLocationNotSupported" xml:space="preserve">
+    <value>Loading from remote location not supported.</value>
+  </data>
   <data name="PopupControlBadParentArgument" xml:space="preserve">
     <value>Cannot set the ParentPopup to be yourself.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -7696,6 +7696,11 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Událost aktivovaná při změně hodnoty vlastnosti SizeMode ovládacího prvku PictureBox</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">Určuje, jak prvek PictureBox ošetří umístění obrázku a nastavení velikosti ovládacího prvku.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -7696,6 +7696,11 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Das ausgelöste Ereignis, wenn der Wert der SizeMode-Eigenschaft für PictureBox geändert wird.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">Steuert, wie die PictureBox die Bildplatzierung und die Größenanpassung für das Steuerelement behandelt.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -7696,6 +7696,11 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Evento que se desencadena cuando se cambia el valor de la propiedad SizeMode de PictureBox.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">Controla cómo tratará PictureBox la ubicación de las imágenes y el tamaño del control.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -7696,6 +7696,11 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Événement déclenché lorsque la valeur de la propriété SizeMode du PictureBox est modifiée.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">Contrôle la façon dont le PictureBox gère le placement de l'image et le dimensionnement du contrôle.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -7696,6 +7696,11 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Evento generato quando il valore della proprietà SizeMode di PictureBox viene modificato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">Determina in che modo il controllo PictureBox gestirà la posizione e il dimensionamento dell'immagine.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -7696,6 +7696,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">SizeMode プロパティの値が PictureBox で変更されたときに発生するイベントです。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">PictureBox がイメージの配置とコントロール サイズの変更をどのように扱うかを制御します。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -7696,6 +7696,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">SizeMode 속성 값이 PictureBox에서 변경되면 이벤트가 발생합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">PictureBox에서 이미지 배치와 컨트롤 크기 조정을 처리하는 방법을 제어합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -7696,6 +7696,11 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Zdarzenie wywoływane, gdy wartość właściwości SizeMode zostanie zmieniona w elemencie PictureBox.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">Określa, w jaki sposób element PictureBox będzie obsługiwać umieszczanie obrazu i zmianę rozmiaru formantu.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -7696,6 +7696,11 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">Evento gerado quando o valor da propriedade SizeMode é alterado em PictureBox.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">Controla como PictureBox tratará o posicionamento de imagem e o dimensionamento de controle.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -7697,6 +7697,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Событие, возникающее при изменении свойства SizeMode в элементе PictureBox.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">Определяет, как будет обрабатываться размещение рисунка в данной области рисунка и изменение размеров элемента управления.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -7696,6 +7696,11 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">PictureBox'da SizeMode özelliğinin değeri değiştiğinde harekete geçirilen olay.</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">PictureBox'ın resim yerleşimini ve denetim boyutlandırmayı nasıl işleyeceğini denetler.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -7696,6 +7696,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">在 PictureBox 的 SizeMode 属性值更改时引发的事件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">控制 PictureBox 将如何处理图像位置和控件大小。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -7696,6 +7696,11 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">SizeMode 屬性值在 PictureBox 上變更時引發的事件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="PictureBoxRemoteLocationNotSupported">
+        <source>Loading from remote location not supported.</source>
+        <target state="new">Loading from remote location not supported.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PictureBoxSizeModeDescr">
         <source>Controls how the PictureBox will handle image placement and control sizing.</source>
         <target state="translated">控制 PictureBox 如何處理影像放置位置以及控制大小。</target>

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -52,6 +52,9 @@
     <EmbeddedResource Update="Resources\System\Windows\Forms\PrintPreviewDialog.resx">
       <LogicalName>System.Windows.Forms.PrintPreviewDialog.resources</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="ILLink.Substitutions.xml">
+      <LogicalName>ILLink.Substitutions.xml</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -597,8 +597,7 @@ namespace System.Windows.Forms
                             int progress = (int)(100 * (((float)_totalBytesRead) / ((float)_contentLength)));
                             if (_currentAsyncLoadOperation is not null)
                             {
-                                _currentAsyncLoadOperation.Post(_loadProgressDelegate,
-                                        new ProgressChangedEventArgs(progress, null));
+                                _currentAsyncLoadOperation.Post(_loadProgressDelegate, new ProgressChangedEventArgs(progress, null));
                             }
                         }
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -486,7 +486,7 @@ namespace System.Windows.Forms
                     }
                     else
                     {
-                        throw new NotSupportedException("Loading from remove location disabled.");
+                        throw new NotSupportedException(SR.PictureBoxRemoteLocationNotSupported);
                     }
                 }
             }
@@ -583,7 +583,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    throw new NotSupportedException("Loading from remove location disabled.");
+                    throw new NotSupportedException(SR.PictureBoxRemoteLocationNotSupported);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -606,8 +606,7 @@ namespace System.Windows.Forms
                         _tempDownloadStream.Seek(0, SeekOrigin.Begin);
                         if (_currentAsyncLoadOperation is not null)
                         {
-                            _currentAsyncLoadOperation.Post(_loadProgressDelegate,
-                                        new ProgressChangedEventArgs(100, null));
+                            _currentAsyncLoadOperation.Post(_loadProgressDelegate, new ProgressChangedEventArgs(100, null));
                         }
 
                         PostCompleted(null, false);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -620,11 +620,9 @@ namespace System.Windows.Forms
                         {
                             _currentAsyncLoadOperation.Post(_loadProgressDelegate, new ProgressChangedEventArgs(100, null));
                         }
-
-                        PostCompleted(null, false);
                     }
                 }
-                while (bytesRead != 0);
+                while (bytesRead > 0);
                 PostCompleted(null, false);
             }
             catch (Exception error)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -579,7 +579,7 @@ namespace System.Windows.Forms
                 var uri = CalculateUri(_imageLocation);
                 if (uri.IsFile)
                 {
-                    LoadFromFileAsync();
+                    Task.Run(() => LoadFromFileAsync());
                 }
                 else
                 {
@@ -588,7 +588,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private async void LoadFromFileAsync()
+        private async Task LoadFromFileAsync()
         {
             try
             {


### PR DESCRIPTION
Indirectly related to #1756 because if that would work, I would be able to fix #1756 using the same approach.
WebRequest bring ton of code to WinForms which is old, and not really interesting. NativeAOT suffer from this.

Inspired by https://github.com/dotnet/runtime/pull/38397

By itself if applying `<RuntimeHostConfigurationOption Include="System.Windows.Forms.PictureBox.UseWebRequest" Value="false" Trim="true" />` it will shave 1Mb from 20Mb  of my sample application which compiled under NativeAOT. I include all controls in that application.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6684)