### PR TITLE
Explicitly use ComWrappers for file dialogs

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.FileDialogWrapper.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.FileDialogWrapper.cs
@@ -26,7 +26,7 @@ internal partial class Interop
                 _wrappedInstance = IntPtr.Zero;
             }
 
-            HRESULT Shell32.IFileDialog.Show(IntPtr parent)
+            public HRESULT Show(IntPtr parent)
             {
                 return ((delegate* unmanaged<IntPtr, IntPtr, HRESULT>)(*(*(void***)_wrappedInstance + 3)))
                     (_wrappedInstance, parent);
@@ -50,7 +50,7 @@ internal partial class Interop
                     (_wrappedInstance, iFileType);
             }
 
-            void Shell32.IFileDialog.GetFileTypeIndex(out uint piFileType)
+            public void GetFileTypeIndex(out uint piFileType)
             {
                 fixed (uint* piFileType_local = &piFileType)
                 {
@@ -169,7 +169,7 @@ internal partial class Interop
                 }
             }
 
-            void Shell32.IFileDialog.GetResult(out Shell32.IShellItem? ppsi)
+            public void GetResult(out Shell32.IShellItem? ppsi)
             {
                 IntPtr ppsi_local;
                 ((delegate* unmanaged<IntPtr, IntPtr*, HRESULT>)(*(*(void***)_wrappedInstance + 20)))

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.FileOpenDialogWrapper.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.FileOpenDialogWrapper.cs
@@ -17,7 +17,7 @@ internal partial class Interop
 
             HRESULT Shell32.IFileOpenDialog.Show(IntPtr parent)
             {
-                return ((Shell32.IFileDialog)this).Show(parent);
+                return this.Show(parent);
             }
 
             HRESULT Shell32.IFileOpenDialog.SetFileTypes(uint cFileTypes, Shell32.COMDLG_FILTERSPEC[] rgFilterSpec)
@@ -137,10 +137,16 @@ internal partial class Interop
 
             void Shell32.IFileOpenDialog.GetResults(out Shell32.IShellItemArray? ppenum)
             {
+                GetResults(out Interop.WinFormsComWrappers.ShellItemArrayWrapper? wrapper);
+                ppenum = wrapper;
+            }
+
+            public void GetResults(out Interop.WinFormsComWrappers.ShellItemArrayWrapper? ppenum)
+            {
                 IntPtr ppenum_local;
                 ((delegate* unmanaged<IntPtr, IntPtr*, HRESULT>)(*(*(void***)_wrappedInstance + 27)))
                     (_wrappedInstance, &ppenum_local).ThrowIfFailed();
-                ppenum = ppenum_local == IntPtr.Zero ? null : (Shell32.IShellItemArray)WinFormsComWrappers.Instance.GetOrCreateObjectForComInstance(ppenum_local, CreateObjectFlags.UniqueInstance);
+                ppenum = ppenum_local == IntPtr.Zero ? null : (Interop.WinFormsComWrappers.ShellItemArrayWrapper)WinFormsComWrappers.Instance.GetOrCreateObjectForComInstance(ppenum_local, CreateObjectFlags.UniqueInstance);
             }
 
             HRESULT Shell32.IFileOpenDialog.GetSelectedItems(out Shell32.IShellItemArray? ppsai)

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.FileSaveDialogWrapper.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.FileSaveDialogWrapper.cs
@@ -6,7 +6,7 @@ internal partial class Interop
 {
     internal unsafe partial class WinFormsComWrappers
     {
-        private sealed class FileSaveDialogWrapper : FileDialogWrapper, Shell32.IFileSaveDialog
+        internal sealed class FileSaveDialogWrapper : FileDialogWrapper, Shell32.IFileSaveDialog
         {
             public FileSaveDialogWrapper(IntPtr wrappedInstance)
                 : base(wrappedInstance)

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.ShellItemArrayWrapper.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.ShellItemArrayWrapper.cs
@@ -9,7 +9,7 @@ internal partial class Interop
 {
     internal unsafe partial class WinFormsComWrappers
     {
-        private class ShellItemArrayWrapper : Shell32.IShellItemArray, IDisposable
+        internal class ShellItemArrayWrapper : Shell32.IShellItemArray, IDisposable
         {
             private IntPtr _wrappedInstance;
 
@@ -67,7 +67,7 @@ internal partial class Interop
                 }
             }
 
-            void Shell32.IShellItemArray.GetCount(out uint pdwNumItems)
+            public void GetCount(out uint pdwNumItems)
             {
                 fixed (uint* pdwNumItems_local = &pdwNumItems)
                 {
@@ -76,7 +76,7 @@ internal partial class Interop
                 }
             }
 
-            void Shell32.IShellItemArray.GetItemAt(uint dwIndex, out Shell32.IShellItem ppsi)
+            public void GetItemAt(uint dwIndex, out Shell32.IShellItem ppsi)
             {
                 IntPtr ppsi_local;
                 ((delegate* unmanaged<IntPtr, uint, IntPtr*, HRESULT>)(*(*(void***)_wrappedInstance + 8)))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private protected abstract IFileDialog CreateVistaDialog();
+        private protected abstract Interop.WinFormsComWrappers.FileDialogWrapper CreateVistaDialog();
 
         private bool TryRunDialogVista(IntPtr hWndOwner, out bool returnValue)
         {
@@ -138,9 +138,9 @@ namespace System.Windows.Forms
             return ret;
         }
 
-        private protected abstract string[] ProcessVistaFiles(IFileDialog dialog);
+        private protected abstract string[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog);
 
-        private bool HandleVistaFileOk(IFileDialog dialog)
+        private bool HandleVistaFileOk(Interop.WinFormsComWrappers.FileDialogWrapper dialog)
         {
             int saveOptions = _options;
             int saveFilterIndex = FilterIndex;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.VistaDialogEvents.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.VistaDialogEvents.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms
 
             public HRESULT OnFileOk(IFileDialog pfd)
             {
-                return _ownerDialog.HandleVistaFileOk(pfd) ? HRESULT.S_OK : HRESULT.S_FALSE;
+                return _ownerDialog.HandleVistaFileOk((Interop.WinFormsComWrappers.FileDialogWrapper)pfd) ? HRESULT.S_OK : HRESULT.S_FALSE;
             }
 
             public HRESULT OnFolderChanging(IFileDialog pfd, IShellItem psiFolder)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -263,7 +263,7 @@ namespace System.Windows.Forms
 
         private bool TryRunDialogVista(IntPtr owner, out bool returnValue)
         {
-            IFileOpenDialog dialog;
+            Interop.WinFormsComWrappers.FileOpenDialogWrapper dialog;
             try
             {
                 // Creating the Vista dialog can fail on Windows Server Core, even if the
@@ -281,7 +281,7 @@ namespace System.Windows.Forms
 
                 var obj = WinFormsComWrappers.Instance
                     .GetOrCreateObjectForComInstance(lpDialogUnknownPtr, CreateObjectFlags.UniqueInstance);
-                dialog = (IFileOpenDialog)obj;
+                dialog = (Interop.WinFormsComWrappers.FileOpenDialogWrapper)obj;
             }
             catch (COMException)
             {
@@ -310,7 +310,7 @@ namespace System.Windows.Forms
             }
             finally
             {
-                ((IDisposable)dialog).Dispose();
+                dialog.Dispose();
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -137,12 +137,12 @@ namespace System.Windows.Forms
             return result;
         }
 
-        private protected override string[] ProcessVistaFiles(IFileDialog dialog)
+        private protected override string[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog)
         {
-            IFileOpenDialog openDialog = (IFileOpenDialog)dialog;
+            var openDialog = (Interop.WinFormsComWrappers.FileOpenDialogWrapper)dialog;
             if (Multiselect)
             {
-                openDialog.GetResults(out IShellItemArray results);
+                openDialog.GetResults(out Interop.WinFormsComWrappers.ShellItemArrayWrapper results);
                 try
                 {
                     results.GetCount(out uint count);
@@ -157,7 +157,7 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-                    ((IDisposable)results).Dispose();
+                    results.Dispose();
                 }
             }
             else
@@ -167,7 +167,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private protected override IFileDialog CreateVistaDialog()
+        private protected override Interop.WinFormsComWrappers.FileDialogWrapper CreateVistaDialog()
         {
             HRESULT hr = Ole32.CoCreateInstance(
                 in CLSID.FileOpenDialog,
@@ -182,7 +182,7 @@ namespace System.Windows.Forms
 
             var obj = WinFormsComWrappers.Instance
                 .GetOrCreateObjectForComInstance(lpDialogUnknownPtr, CreateObjectFlags.None);
-            return (IFileOpenDialog)obj;
+            return (Interop.WinFormsComWrappers.FileDialogWrapper)obj;
         }
 
         [Browsable(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
@@ -164,14 +164,14 @@ namespace System.Windows.Forms
             return result;
         }
 
-        private protected override string[] ProcessVistaFiles(IFileDialog dialog)
+        private protected override string[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog)
         {
-            IFileSaveDialog saveDialog = (IFileSaveDialog)dialog;
+            var saveDialog = (Interop.WinFormsComWrappers.FileSaveDialogWrapper)dialog;
             dialog.GetResult(out IShellItem item);
             return new string[] { GetFilePathFromShellItem(item) };
         }
 
-        private protected override IFileDialog CreateVistaDialog()
+        private protected override Interop.WinFormsComWrappers.FileDialogWrapper CreateVistaDialog()
         {
             HRESULT hr = Ole32.CoCreateInstance(
                 in CLSID.FileSaveDialog,
@@ -186,7 +186,7 @@ namespace System.Windows.Forms
 
             var obj = WinFormsComWrappers.Instance
                 .GetOrCreateObjectForComInstance(lpDialogUnknownPtr, CreateObjectFlags.None);
-            return (IFileSaveDialog)obj;
+            return (Interop.WinFormsComWrappers.FileDialogWrapper)obj;
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
@@ -810,9 +810,9 @@ namespace System.Windows.Forms.Tests
                 return RunFileDialogAction(ofn);
             }
 
-            private protected override IFileDialog CreateVistaDialog() => null;
+            private protected override Interop.WinFormsComWrappers.FileDialogWrapper CreateVistaDialog() => null;
 
-            private protected override string[] ProcessVistaFiles(IFileDialog dialog) => null;
+            private protected override string[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog) => null;
 
             public new void OnFileOk(CancelEventArgs e) => base.OnFileOk(e);
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FileDialogTests.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
-using static Interop.Shell32;
 
 namespace System.Windows.Forms.Tests
 {


### PR DESCRIPTION
Do not use COM interfaces for file dialogs at all except IFileDialogEvents
Right now each CoClass created using CoCreateInstance represented as unique RCW
That RCW still uses interfaces, but all important methods are implicitly declares
No explicit interface method of IFileDialog, IOpenFileDialog and ISaveFileDialog
are used.
IShellItem and IShellItemArray still used, but that usage comes from IXXXFileDialog
interfaces. If I remove them, I can be explicit about wrappers.

After this point, there two options
- Leave interfaces as is, wasteful RCW, good for documentation
- Remove interfaces, simplify RCW even more. Keeping track of method table would be problematic.

Related to #5163


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6692)