### PR TITLE
Fixing incorrect name for NumericUpDown editor

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6898,4 +6898,7 @@ Stack trace where the illegal operation occurred was:
   <data name="FolderBrowserDialogShowPinnedPlaces" xml:space="preserve">
     <value>Controls whether the items shown by default in the view's navigation pane are shown.</value>
   </data>
+  <data name="EditDefaultAccessibleName" xml:space="preserve">
+    <value>Spinner</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -4594,6 +4594,11 @@ Chcete-li nahradit toto výchozí dialogové okno, nastavte popisovač události
         <target state="translated">Registrace DragDrop se nezdařila.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">Jazyk inputLanguage není systémem rozpoznán.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -4594,6 +4594,11 @@ Behandeln Sie das DataError-Ereignis, um dieses Standarddialogfeld zu ersetzen.<
         <target state="translated">Fehler bei der DragDrop-Registrierung</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">Die inputLanguage wird vom System nicht erkannt.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -4594,6 +4594,11 @@ Para reemplazar este cuadro de diálogo predeterminado controle el evento DataEr
         <target state="translated">Error al registrar DragDrop.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">El sistema no reconoce este inputLanguage.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -4594,6 +4594,11 @@ Pour remplacer cette boîte de dialogue par défaut, traitez l'événement DataE
         <target state="translated">Échec de l'inscription DragDrop.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">inputLanguage n'est pas reconnu par le système.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -4594,6 +4594,11 @@ Per sostituire questa finestra di dialogo predefinita, gestire l'evento DataErro
         <target state="translated">Registrazione DragDrop non riuscita.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">inputLanguage non riconosciuto dal sistema.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -4594,6 +4594,11 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">DragDrop 登録は成功しませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">システムは inputLanguage を認識できません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -4594,6 +4594,11 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">DragDrop을 등록하지 못했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">시스템에서 inputLanguage를 인식할 수 없습니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -4594,6 +4594,11 @@ Aby zamienić to domyślne okno dialogowe, obsłuż zdarzenie DataError.</target
         <target state="translated">Nie można zarejestrować elementu DragDrop.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">Element inputLanguage nie został rozpoznany przez system.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -4594,6 +4594,11 @@ Para substituir a caixa de diálogo padrão, manipule o evento DataError.</targe
         <target state="translated">O registro de DragDrop não teve êxito.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">inputLanguage não é reconhecido pelo sistema.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -4594,6 +4594,11 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">Регистрация DragDrop невозможна.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">inputLanguage не распознан системой.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -4594,6 +4594,11 @@ Bu varsayılan iletişim kutusunu değiştirmek için, lütfen DataError olayın
         <target state="translated">DragDrop kaydı yapılamadı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">inputLanguage sistem tarafından tanınmıyor.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -4594,6 +4594,11 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">DragDrop 注册失败。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">系统无法识别 inputLanguage。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -4594,6 +4594,11 @@ To replace this default dialog please handle the DataError event.</source>
         <target state="translated">DragDrop 登錄失敗。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EditDefaultAccessibleName">
+        <source>Spinner</source>
+        <target state="new">Spinner</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ErrorBadInputLanguage">
         <source>inputLanguage is not recognized by the system.</source>
         <target state="translated">系統無法辨識此 inputLanguage。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownEdit.UpDownEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownEdit.UpDownEditAccessibleObject.cs
@@ -28,7 +28,13 @@ namespace System.Windows.Forms
 
                 public override string? Name
                 {
-                    get => _parent.AccessibilityObject.Name;
+                    get => _parent.AccessibilityObject.Name
+                        ?? _parent switch
+                        {
+                            NumericUpDown _ => SR.EditDefaultAccessibleName,
+                            DomainUpDown _ => SR.EditDefaultAccessibleName,
+                            _ => null
+                        };
                     set => _parent.AccessibilityObject.Name = value;
                 }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownEdit.UpDownEditAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownEdit.UpDownEditAccessibleObjectTests.cs
@@ -71,6 +71,28 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void UpDownEditAccessibleObject_Default_Name_ReturnsExpected_NumericUpDown()
+        {
+            using NumericUpDown upDown = new();
+            using UpDownBase.UpDownEdit upDownEdit = new UpDownBase.UpDownEdit(upDown);
+            AccessibleObject accessibleObject = upDownEdit.AccessibilityObject;
+            Assert.Equal(SR.EditDefaultAccessibleName, accessibleObject.Name);
+            Assert.False(upDown.IsHandleCreated);
+            Assert.False(upDownEdit.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void UpDownEditAccessibleObject_Default_Name_ReturnsExpected_DomainUpDown()
+        {
+            using DomainUpDown upDown = new();
+            using UpDownBase.UpDownEdit upDownEdit = new UpDownBase.UpDownEdit(upDown);
+            AccessibleObject accessibleObject = upDownEdit.AccessibilityObject;
+            Assert.Equal(SR.EditDefaultAccessibleName, accessibleObject.Name);
+            Assert.False(upDown.IsHandleCreated);
+            Assert.False(upDownEdit.IsHandleCreated);
+        }
+
+        [WinFormsFact]
         public void UpDownEditAccessibleObject_KeyboardShortcut_ReturnsParentsKeyboardShortcut()
         {
             using UpDownBase upDown = new SubUpDownBase();


### PR DESCRIPTION
Fixes #6359


## Proposed changes
- The issue is reproduced when the NumericUpDown.AccessibleObject has no name. In this case, we simply announce the "edit" for text field. This behavior can be considered expected by default. But in accordance with the behavior of the combobox, I suggest announcing the default name for the editor (spinner) if the NumericUpDown.AccessibleObject  did not return a name.
- Added default name for text field inside NumericUpDown.
- Added unit tests

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/154681102-90d5e330-5521-42c7-9265-9d4ab90f7918.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/154681006-e0ba622b-1df1-42ba-a111-b587b9edf9bf.png)

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
-  Unit tests
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator
- NVDA
- JAWS
- Inspect
- Accessibility Insights

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19044.1466]
- .NET Core SDK: 7.0.0-preview.2.22113.2

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6718)