### PR TITLE
Fixing issue with announcing of PropertyGrid expanded state

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6898,4 +6898,7 @@ Stack trace where the illegal operation occurred was:
   <data name="FolderBrowserDialogShowPinnedPlaces" xml:space="preserve">
     <value>Controls whether the items shown by default in the view's navigation pane are shown.</value>
   </data>
+  <data name="ExpandedStateName" xml:space="preserve">
+    <value>Expanded</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -4856,6 +4856,11 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
         <target state="translated">Při pokusu o vytvoření instance objektu {0} došlo k výjimce {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">Externí výjimka</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -4856,6 +4856,11 @@ Wenn Sie auf "Weiter" klicken, ignoriert die Anwendung den Fehler und setzt den 
         <target state="translated">Ausnahme beim Erstellen einer Instanz von {0}: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">Externe Ausnahme.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -4856,6 +4856,11 @@ Si hace clic en Continuar, la aplicación pasará por alto este error e intentar
         <target state="translated">Excepción al crear una instancia de {0}. Excepción "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">Excepción externa</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -4856,6 +4856,11 @@ Si vous cliquez sur Continuer, l'application va ignorer cette erreur et tenter d
         <target state="translated">Une exception s'est produite lors de la création d'une instance de {0}. L'exception était "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">Exception externe</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -4856,6 +4856,11 @@ Se si sceglie Continua, l'errore verrà ignorato e l'applicazione proverà a con
         <target state="translated">Durante la creazione di un'istanza di {0} si è verificata la seguente eccezione: "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">Eccezione esterna</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -4856,6 +4856,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">{0} のインスタンスを作成中に例外が発生しました。例外は "{1}" です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">外部例外</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -4856,6 +4856,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">{0}의 인스턴스를 만드는 동안 예외가 발생했습니다. 예외는 "{1}"입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">외부 예외</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -4856,6 +4856,11 @@ Jeśli klikniesz pozycję Kontynuuj, aplikacja zignoruje ten błąd i będzie pr
         <target state="translated">Wystąpił wyjątek podczas próby utworzenia wystąpienia elementu {0}. Wyjątek to: "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">Wyjątek zewnętrzny</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -4856,6 +4856,11 @@ Se você clicar em Continuar, o aplicativo ignorará esse erro e tentará contin
         <target state="translated">Ocorreu uma exceção ao tentar criar uma instância de {0}. A exceção era "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">Exceção externa</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -4857,6 +4857,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">Исключение при попытке создания экземпляра {0}. Исключение: "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">Внешнее исключение</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -4856,6 +4856,11 @@ Devam'a tıkladığınızda uygulama bu hatayı yoksayar ve işlemi sürdürmeye
         <target state="translated">{0} örneği oluşturulmaya çalışılırken özel durum oluştu. Özel durum: "{1}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">Dış özel durum</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -4856,6 +4856,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">尝试创建 {0} 的实例时发生异常。异常为“{1}”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">外部异常</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -4856,6 +4856,11 @@ If you click Continue, the application will ignore this error and attempt to con
         <target state="translated">當嘗試建立 {0} 的執行個體時發生例外狀況。例外狀況為 "{1}"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExternalException">
         <source>External exception</source>
         <target state="translated">外部例外狀況</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1494,10 +1494,10 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (gridEntry is not null && IsAccessibilityObjectCreated)
             {
                 gridEntry.AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
-                gridEntry.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
-                    UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
-                    UiaCore.ExpandCollapseState.Collapsed,
-                    UiaCore.ExpandCollapseState.Expanded);
+                gridEntry.AccessibilityObject.RaiseAutomationNotification(
+                    Automation.AutomationNotificationKind.Other,
+                    Automation.AutomationNotificationProcessing.ImportantMostRecent,
+                    SR.ExpandedStateName);
             }
 
             // Control is a top level window. Standard way of setting parent on the control is prohibited for top-level controls.


### PR DESCRIPTION
Fixes #6656

## Proposed changes
- I think the problem is being reproduced due to competitive requests to Narrator. Periodically it announces expanded state information and periodically skips.
- A possible fix is to replace the standard method `RaiseAutomationPropertyChangedEvent` with the `RaiseAutomationNotification` method. In this case, we force the expanded state information to be announced, which helps avoid a possible contention problem.

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/155125271-bb3f3afd-2d5c-4545-b872-eb5e4b8b1422.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/155126068-5c41933a-c7b0-4421-8a93-bc120b49a4fb.png)

## Regression? 

- Yes (we have unstable behavior)

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team 
- Manually

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator
- JAWS
- NVDA

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19044.1466]
- .NET Core SDK: 7.0.0-preview.3.22119.4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6737)