### PR TITLE
Removing empty AccessKey properties which appeared after refactoring

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -427,7 +427,7 @@ namespace System.Windows.Forms
                 UiaCore.UIA.ValueValuePropertyId => !string.IsNullOrEmpty(Value) ? Value : null,
                 UiaCore.UIA.IsPasswordPropertyId => false,
                 UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
-                UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut ?? string.Empty,
+                UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut,
                 _ => null
             };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
@@ -87,6 +87,8 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.EditControlTypeId;
+                    case UiaCore.UIA.AccessKeyPropertyId:
+                        return string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return _owner.Focused;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
@@ -138,6 +138,8 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.ListControlTypeId;
+                    case UiaCore.UIA.AccessKeyPropertyId:
+                        return string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return false; // Narrator should keep the keyboard focus on th ComboBox itself but not on the DropDown.
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildTextUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildTextUiaProvider.cs
@@ -115,6 +115,8 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.TextControlTypeId;
+                    case UiaCore.UIA.AccessKeyPropertyId:
+                        return string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return _owner.Focused;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -121,6 +121,8 @@ namespace System.Windows.Forms
                         return BoundingRectangle;
                     case UiaCore.UIA.ControlTypePropertyId:
                         return UiaCore.UIA.ListItemControlTypeId;
+                    case UiaCore.UIA.AccessKeyPropertyId:
+                        return KeyboardShortcut ?? string.Empty;
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return _owningComboBox.Focused && _owningComboBox.SelectedIndex == GetCurrentIndex();
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.TopRowAccessibleObject.cs
@@ -286,6 +286,8 @@ namespace System.Windows.Forms
                         return false;
                     case UiaCore.UIA.IsContentElementPropertyId:
                         return true;
+                    case UiaCore.UIA.AccessKeyPropertyId:
+                        return string.Empty;
                 }
 
                 return base.GetPropertyValue(propertyId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -685,6 +685,7 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsEnabledPropertyId => _owner?.DataGridView?.Enabled ?? false,
                     UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
+                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     UiaCore.UIA.GridItemContainingGridPropertyId => _owner?.DataGridView?.AccessibilityObject,
                     _ => base.GetPropertyValue(propertyID),
                 };

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnHeaderCell.DataGridViewColumnHeaderCellAccessibleObject.cs
@@ -274,6 +274,7 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsEnabledPropertyId => Owner?.DataGridView?.Enabled ?? false,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     var x when x == UiaCore.UIA.HasKeyboardFocusPropertyId || x == UiaCore.UIA.IsPasswordPropertyId => false,
+                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     _ => base.GetPropertyValue(propertyId)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -500,6 +500,8 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         return string.Empty;
+                    case UiaCore.UIA.AccessKeyPropertyId:
+                        return string.Empty;
                 }
 
                 return base.GetPropertyValue(propertyId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowHeaderCell.DataGridViewRowHeaderCellAccessibleObject.cs
@@ -277,6 +277,7 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsEnabledPropertyId => Owner?.DataGridView?.Enabled ?? false,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
+                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     _ => base.GetPropertyValue(propertyId),
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTopLeftHeaderCell.DataGridViewTopLeftHeaderCellAccessibleObject.cs
@@ -302,6 +302,8 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                     case UiaCore.UIA.IsOffscreenPropertyId:
                         return false;
+                    case UiaCore.UIA.AccessKeyPropertyId:
+                        return string.Empty;
                 }
 
                 return base.GetPropertyValue(propertyId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ItemAccessibleObject.cs
@@ -216,6 +216,7 @@ namespace System.Windows.Forms
                  => propertyID switch
                  {
                      UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ListItemControlTypeId,
+                     UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                      UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListBox.Focused && _owningListBox.FocusedIndex == CurrentIndex,
                      UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                      UiaCore.UIA.IsEnabledPropertyId => _owningListBox.Enabled,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -334,6 +334,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     // button is one of the first children of PropertyGridView.
 
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TreeItemControlTypeId,
+                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningGridEntry.HasFocus,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.IsEnabledPropertyId => true,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarChildAccessibleObject.cs
@@ -78,6 +78,7 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
+                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
                     UiaCore.UIA.IsEnabledPropertyId => OwningScrollBar.Enabled,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
@@ -117,6 +117,7 @@ namespace System.Windows.Forms
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TabItemControlTypeId,
                     UiaCore.UIA.AutomationIdPropertyId => _owningTabPage.Name,
+                    UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut ?? string.Empty,
                     UiaCore.UIA.IsEnabledPropertyId => OwningTabControl?.Enabled ?? false,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarChildAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarChildAccessibleObject.cs
@@ -75,6 +75,7 @@ namespace System.Windows.Forms
                     UiaCore.UIA.IsEnabledPropertyId => OwningTrackBar.Enabled,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => false,
+                    UiaCore.UIA.AccessKeyPropertyId => string.Empty,
                     _ => base.GetPropertyValue(propertyID)
                 };
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1257,7 +1257,7 @@ namespace System.Windows.Forms.Tests
             }
 
             AccessibleObject controlAccessibleObject = control.AccessibilityObject;
-            string expectedValue = s_controlsNotUseTextForAccessibility.Contains(type) ? string.Empty : "Alt+n";
+            string expectedValue = s_controlsNotUseTextForAccessibility.Contains(type) ? null : "Alt+n";
 
             Assert.Equal(expectedValue, controlAccessibleObject.GetPropertyValue(UiaCore.UIA.AccessKeyPropertyId));
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
@@ -700,8 +700,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true, "&Name", "Alt+n")]
         [InlineData(false, "&Name", "Alt+n")]
-        [InlineData(true, "Name", "")]
-        [InlineData(false, "Name", "")]
+        [InlineData(true, "Name", null)]
+        [InlineData(false, "Name", null)]
         public void TabControlAccessibleObject_GetPropertyValue_AccessKey_ReturnExpected(bool createControl, string text, string expectedKeyboardShortcut)
         {
             using TabControl tabControl = new() { Text = text };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
@@ -462,8 +462,8 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true, "&Name", "Alt+n")]
         [InlineData(false, "&Name", "Alt+n")]
-        [InlineData(true, "Name", "")]
-        [InlineData(false, "Name", "")]
+        [InlineData(true, "Name", null)]
+        [InlineData(false, "Name", null)]
         public void TabPageAccessibleObject_GetPropertyValue_AccessKey_ReturnExpected(bool createControl, string text, string expectedKeyboardShortcut)
         {
             using TabPage tabPage = new() { Text = text };


### PR DESCRIPTION
Fixes #6760

## Proposed changes
- `AccessibleObject` returns just `KeyboartShortcut` without additional conditions, so if it's `null`, the `null` value will be returned, not the `string.Empty` value like in the previous PR
- Behavior for accessible objects which return `string.Empty` is restored, so there will be no changes for them

## Customer Impact
- Accessibility tools will have the same behavior as before refactoring

## Regression? 
- Yes, from PR #6640

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manual (viewed properties with the Inspect tool)
- Unit test
- CTI testing

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19043.1526]
- .NET 7.0.0-preview-3.22123.2

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6761)