### PR TITLE
Fixing a JAWS exception in a PropertyGrid (port to 6.0)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObject.cs
@@ -78,8 +78,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                 /// <summary>
                 ///  Gets the top level element.
                 /// </summary>
-                internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
-                    => _owningPropertyGridView.AccessibilityObject;
+                internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
+                    => _owningPropertyGridView.OwnerGrid?.AccessibilityObject;
 
                 internal override object? GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewEdit.GridViewEditAccessibleObjectTests.cs
@@ -183,5 +183,15 @@ namespace System.Windows.Forms.PropertyGridInternal.Tests
             Assert.Equal(expectedRole, actual);
             Assert.False(propertyGrid.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void GridViewTextBoxAccessibleObject_FragmentRoot_ReturnsExpected()
+        {
+            using PropertyGrid propertyGrid = new PropertyGrid();
+            PropertyGridView gridView = propertyGrid.TestAccessor().GridView;
+            AccessibleObject accessibleObject = gridView.EditAccessibleObject;
+
+            Assert.Equal(propertyGrid.AccessibilityObject, accessibleObject.FragmentRoot);
+        }
     }
 }


### PR DESCRIPTION
Fixes #6704

## Proposed changes
- The issue is reproduced because for `FragmentRoot` we return `PropertyGridView.AccessibilityObject` and not `PropertyGrid.AccessibilityObject`.
- Now `FragmentRoot` returns `PropertyGrid.AccessibilityObject`. This matches the behavior of other accessibility objects in the `PropertyGrid`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![154419615-f42458cc-c068-4610-94a3-61cfb5235bf8](https://user-images.githubusercontent.com/23376742/155302428-02940f8d-e32a-4116-9d88-efb009150fa1.gif)

**After fix:**
![Issue-6704](https://user-images.githubusercontent.com/23376742/155302458-89a0b890-d702-404e-ad7c-52feee355cb6.gif)

## Regression? 

- Yes

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team
- Unit-tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- JAWS
- NVDA
- Narrator
- Accessibility Insights
- Inspect 

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19044.1466]
- .NET Core SDK: 6.0.2

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6747)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6762)