### PR TITLE
Fixed visibility of selected ToolStripButtons in High Contrast mode

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -163,7 +163,7 @@ namespace System.Windows.Forms
                 else if (item.Selected)
                 {
                     g.FillRectangle(SystemBrushes.Highlight, bounds);
-                    g.DrawRectangle(SystemPens.ButtonHighlight, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
+                    DrawHightContrastDashedBorder(g, e.Item);
                     g.DrawRectangle(SystemPens.ButtonHighlight, dropDownRect);
                 }
 
@@ -440,7 +440,7 @@ namespace System.Windows.Forms
 
                     if (button.Selected)
                     {
-                        g.DrawRectangle(SystemPens.Highlight, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
+                        DrawHightContrastDashedBorder(g, button);
                     }
                     else
                     {
@@ -482,8 +482,29 @@ namespace System.Windows.Forms
             else if (e.Item.Selected)
             {
                 g.FillRectangle(SystemBrushes.Highlight, bounds);
-                g.DrawRectangle(SystemPens.ControlLight, bounds.X, bounds.Y, bounds.Width - 1, bounds.Height - 1);
+                DrawHightContrastDashedBorder(g, e.Item);
             }
+        }
+
+        private void DrawHightContrastDashedBorder(Graphics graphics, ToolStripItem item)
+        {
+            var bounds = item.ClientBounds;
+            float[] dashValues = { 2, 2 };
+            int penWidth = 2;
+
+            var focusPen1 = new Pen(SystemColors.ControlText, penWidth)
+            {
+                DashPattern = dashValues
+            };
+
+            var focusPen2 = new Pen(SystemColors.Control, penWidth)
+            {
+                DashPattern = dashValues,
+                DashOffset = 2
+            };
+
+            graphics.DrawRectangle(focusPen1, bounds);
+            graphics.DrawRectangle(focusPen2, bounds);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.Rendering.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.Rendering.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms.Tests
                     bounds: null,
                     points: null,
                     State.Brush(SystemColors.Highlight, Gdi32.BS.SOLID)),
-               Validate.SkipType(Gdi32.EMR.POLYGON16));
+               Validate.Repeat(Validate.SkipType(Gdi32.EMR.POLYPOLYGON16), 2));
         }
 
         [WinFormsFact]
@@ -138,7 +138,8 @@ namespace System.Windows.Forms.Tests
                     bounds: null,
                     points: null,
                     State.Brush(SystemColors.Highlight, Gdi32.BS.SOLID)),
-               Validate.Repeat(Validate.SkipType(Gdi32.EMR.POLYGON16), 2));
+               Validate.Repeat(Validate.SkipType(Gdi32.EMR.POLYPOLYGON16), 2),
+               Validate.Repeat(Validate.SkipType(Gdi32.EMR.POLYGON16), 1));
         }
 
         [WinFormsFact]
@@ -164,7 +165,8 @@ namespace System.Windows.Forms.Tests
                     bounds: null,
                     points: null,
                     State.Brush(SystemColors.Highlight, Gdi32.BS.SOLID)),
-               Validate.Repeat(Validate.SkipType(Gdi32.EMR.POLYGON16), 3));
+               Validate.Repeat(Validate.SkipType(Gdi32.EMR.POLYPOLYGON16), 2),
+               Validate.Repeat(Validate.SkipType(Gdi32.EMR.POLYGON16), 2));
         }
 
         private class ToolStripSystemHighContrastRenderer : ToolStripSystemRenderer


### PR DESCRIPTION
Fixes #5676

## Proposed changes
- Added logic for drawing dotted borders for selected `ToolStripButton` in contrast mode.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before:**
System render mode:
![image](https://user-images.githubusercontent.com/23376742/156178360-9c1033ea-10b5-40a4-9bc9-68d6340ce128.png)

Professional render mode:
![image](https://user-images.githubusercontent.com/23376742/156178376-2107e9e1-029d-4628-bf4c-83a301f6a5b3.png)

**After:**
System render mode:
![image](https://user-images.githubusercontent.com/23376742/156180869-7febda18-7ae1-4e76-b7b1-53e5d534383e.png)

Professional render mode:
![image](https://user-images.githubusercontent.com/23376742/156180609-bc15f60b-0cd8-4fce-9a56-c7af28156d3f.png)

## Regression

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- Manual
- CTI team

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19044.1466]
- . NET Core SDK: 7.0.0-preview.3.22123.2

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6775)