### PR TITLE
Fixing Anchor Info calculations.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -3430,7 +3430,7 @@ namespace System.Windows.Forms
             get => new Size(_width, _height);
             set
             {
-                if (Anchor != CommonProperties.DefaultAnchor)
+                if (CommonProperties.GetNeedsAnchorLayout(this))
                 {
                     // Reset AnchorInfo that may have calculated based on default Size of the control or
                     // with the previous size of the control.  Especially in the designer scenario.                  .

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -3432,9 +3432,9 @@ namespace System.Windows.Forms
             {
                 if (CommonProperties.GetNeedsAnchorLayout(this))
                 {
-                    // Reset AnchorInfo that may have calculated based on default Size of the control or
+                    // Reset AnchorInfo that may have been calculated based on default Size of the control or
                     // with the previous size of the control.  Especially in the designer scenario.                  .
-                    DefaultLayout.SetAnchorInfo(this, null);
+                    DefaultLayout.SetAnchorInfo(element: this, value: null);
                 }
 
                 SetBounds(_x, _y, value.Width, value.Height, BoundsSpecified.Size);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -3428,7 +3428,17 @@ namespace System.Windows.Forms
         public Size Size
         {
             get => new Size(_width, _height);
-            set => SetBounds(_x, _y, value.Width, value.Height, BoundsSpecified.Size);
+            set
+            {
+                if (Anchor != CommonProperties.DefaultAnchor)
+                {
+                    // Reset AnchorInfo that may have calculated based on default Size of the control or
+                    // with the previous size of the control.  Especially in the designer scenario.                  .
+                    DefaultLayout.SetAnchorInfo(this, null);
+                }
+
+                SetBounds(_x, _y, value.Width, value.Height, BoundsSpecified.Size);
+            }
         }
 
         [SRCategory(nameof(SR.CatPropertyChanged))]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+
+namespace System.Windows.Forms.Layout
+{
+    internal partial class DefaultLayout
+    {
+        internal sealed class AnchorInfo
+        {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-
 namespace System.Windows.Forms.Layout
 {
     internal partial class DefaultLayout

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 namespace System.Windows.Forms.Layout
 {
     internal partial class DefaultLayout

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.AnchorInfo.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.Layout
 {
     internal partial class DefaultLayout

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -1023,5 +1023,16 @@ namespace System.Windows.Forms.Layout
         {
             return (anchor & desiredAnchor) == desiredAnchor;
         }
+<<<<<<< HEAD
+=======
+
+        internal sealed class AnchorInfo
+        {
+            public int Left;
+            public int Top;
+            public int Right;
+            public int Bottom;
+        }
+>>>>>>> Fixing AnchorInfo calculations.
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -1023,19 +1023,5 @@ namespace System.Windows.Forms.Layout
         {
             return (anchor & desiredAnchor) == desiredAnchor;
         }
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-
-        internal sealed class AnchorInfo
-        {
-            public int Left;
-            public int Top;
-            public int Right;
-            public int Bottom;
-        }
->>>>>>> Fixing AnchorInfo calculations.
-=======
->>>>>>> Adding integration test for Ancho and Dock layouts.
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -748,7 +748,10 @@ namespace System.Windows.Forms.Layout
 
                 CommonProperties.xSetAnchor(element, value);
 
-                if (CommonProperties.GetNeedsAnchorLayout(element))
+                // Updating AnchoriInfo is only needed when control is ready for layout. InitLayoutCore() does call UpdateAnchorInfo().
+                // At the least, we are checking if control is parented before updating AnchorInfo. This helps avoid calculating
+                // AnchorInfo with default initial values of the Control. They are always overriden when layout happen.
+                if (CommonProperties.GetNeedsAnchorLayout(element) && element is Control control && control.Parent is not null)
                 {
                     UpdateAnchorInfo(element);
                 }
@@ -797,8 +800,15 @@ namespace System.Windows.Forms.Layout
                         {
                             // We are transitioning from docked to not docked, restore the original bounds.
                             element.SetBounds(CommonProperties.GetSpecifiedBounds(element), BoundsSpecified.None);
-                            // Restore Anchor information as its now relevant again.
-                            UpdateAnchorInfo(element);
+
+                            // Updating AnchoriInfo is only needed when control is ready for layout. InitLayoutCore() does call UpdateAnchorInfo().
+                            // At the least, we are checking if control is parented before updating AnchorInfo. This helps avoid calculating
+                            // AnchorInfo with default initial values of the Control. They are always overriden when layout happen.
+                            if (element is Control control && control.Parent is not null)
+                            {
+                                // Restore Anchor information as its now relevant again.
+                                UpdateAnchorInfo(element);
+                            }
                         }
                     }
                     else
@@ -922,7 +932,7 @@ namespace System.Windows.Forms.Layout
             return (AnchorInfo)element.Properties.GetObject(s_layoutInfoProperty);
         }
 
-        private static void SetAnchorInfo(IArrangedElement element, AnchorInfo value)
+        internal static void SetAnchorInfo(IArrangedElement element, AnchorInfo value)
         {
             element.Properties.SetObject(s_layoutInfoProperty, value);
         }
@@ -1014,7 +1024,7 @@ namespace System.Windows.Forms.Layout
             return (anchor & desiredAnchor) == desiredAnchor;
         }
 
-        private sealed class AnchorInfo
+        internal sealed class AnchorInfo
         {
             public int Left;
             public int Top;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -159,7 +159,7 @@ namespace System.Windows.Forms.Layout
             // This in turn will lead to a cascade of native calls and callbacks
             if (CompModSwitches.RichLayout.TraceInfo)
             {
-                Debug.WriteLine($"\t\t'{element}' is anchored at {GetCachedBounds(element).ToString()}");
+                Debug.WriteLine($"\t\t'{element}' is anchored at {GetCachedBounds(element)}");
             }
 
             AnchorInfo layout = GetAnchorInfo(element);
@@ -748,7 +748,7 @@ namespace System.Windows.Forms.Layout
 
                 CommonProperties.xSetAnchor(element, value);
 
-                // Updating AnchoriInfo is only needed when control is ready for layout. Oneway to check this precondition is to
+                // Updating AnchorInfo is only needed when control is ready for layout. Oneway to check this precondition is to
                 // check if the control is parented. This helps avoid calculating AnchorInfo with default initial values of the Control.
                 // AnchorInfo is recalculated everytime there is a layout change.
                 if (CommonProperties.GetNeedsAnchorLayout(element) && element is Control control && control.Parent is not null)
@@ -801,7 +801,7 @@ namespace System.Windows.Forms.Layout
                             // We are transitioning from docked to not docked, restore the original bounds.
                             element.SetBounds(CommonProperties.GetSpecifiedBounds(element), BoundsSpecified.None);
 
-                            // Updating AnchoriInfo is only needed when control is ready for layout. InitLayoutCore() does call UpdateAnchorInfo().
+                            // Updating AnchorInfo is only needed when control is ready for layout. InitLayoutCore() does call UpdateAnchorInfo().
                             // At the least, we are checking if control is parented before updating AnchorInfo. This helps avoid calculating
                             // AnchorInfo with default initial values of the Control. They are always overriden when layout happen.
                             if (element is Control control && control.Parent is not null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -1024,6 +1024,7 @@ namespace System.Windows.Forms.Layout
             return (anchor & desiredAnchor) == desiredAnchor;
         }
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 
         internal sealed class AnchorInfo
@@ -1034,5 +1035,7 @@ namespace System.Windows.Forms.Layout
             public int Bottom;
         }
 >>>>>>> Fixing AnchorInfo calculations.
+=======
+>>>>>>> Adding integration test for Ancho and Dock layouts.
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DockAndAnchorLayout.cs
@@ -748,9 +748,9 @@ namespace System.Windows.Forms.Layout
 
                 CommonProperties.xSetAnchor(element, value);
 
-                // Updating AnchoriInfo is only needed when control is ready for layout. InitLayoutCore() does call UpdateAnchorInfo().
-                // At the least, we are checking if control is parented before updating AnchorInfo. This helps avoid calculating
-                // AnchorInfo with default initial values of the Control. They are always overriden when layout happen.
+                // Updating AnchoriInfo is only needed when control is ready for layout. Oneway to check this precondition is to
+                // check if the control is parented. This helps avoid calculating AnchorInfo with default initial values of the Control.
+                // AnchorInfo is recalculated everytime there is a layout change.
                 if (CommonProperties.GetNeedsAnchorLayout(element) && element is Control control && control.Parent is not null)
                 {
                     UpdateAnchorInfo(element);
@@ -1022,14 +1022,6 @@ namespace System.Windows.Forms.Layout
         public static bool IsAnchored(AnchorStyles anchor, AnchorStyles desiredAnchor)
         {
             return (anchor & desiredAnchor) == desiredAnchor;
-        }
-
-        internal sealed class AnchorInfo
-        {
-            public int Left;
-            public int Top;
-            public int Right;
-            public int Bottom;
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
@@ -36,6 +36,8 @@ namespace System.Windows.Forms.IntegrationTests.Common
         ToolStripsButton,
         TrackBarsButton,
         ScrollBarsButton,
-        ToolTipsButton
+        ToolTipsButton,
+        AnchorLayoutButton,
+        DockLayoutButton
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/AnchorLayoutTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/AnchorLayoutTests.Designer.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows.Forms;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
 
 namespace WinformsControlsTest
 {

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/AnchorLayoutTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/AnchorLayoutTests.Designer.cs
@@ -1,0 +1,167 @@
+﻿using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    partial class AnchorLayoutTests
+    {
+        /// <summary>
+        ///  Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        ///  Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        ///  Required method for Designer support - do not modify
+        ///  the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.button1 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
+            this.button3 = new System.Windows.Forms.Button();
+            this.button4 = new System.Windows.Forms.Button();
+            this.button5 = new System.Windows.Forms.Button();
+            this.button6 = new System.Windows.Forms.Button();
+            this.button7 = new System.Windows.Forms.Button();
+            this.button8 = new System.Windows.Forms.Button();
+            this.button9 = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(12, 12);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(112, 34);
+            this.button1.TabIndex = 0;
+            this.button1.Text = "Top-Left";
+            this.button1.UseVisualStyleBackColor = true;
+            // 
+            // button2
+            // 
+            this.button2.Anchor = System.Windows.Forms.AnchorStyles.Top;
+            this.button2.Location = new System.Drawing.Point(338, 12);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(112, 34);
+            this.button2.TabIndex = 1;
+            this.button2.Text = "Top";
+            this.button2.UseVisualStyleBackColor = true;
+            // 
+            // button3
+            // 
+            this.button3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.button3.Location = new System.Drawing.Point(676, 12);
+            this.button3.Name = "button3";
+            this.button3.Size = new System.Drawing.Size(112, 34);
+            this.button3.TabIndex = 2;
+            this.button3.Text = "Top-Right";
+            this.button3.UseVisualStyleBackColor = true;
+            // 
+            // button4
+            // 
+            this.button4.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.button4.Location = new System.Drawing.Point(12, 198);
+            this.button4.Name = "button4";
+            this.button4.Size = new System.Drawing.Size(112, 34);
+            this.button4.TabIndex = 3;
+            this.button4.Text = "Left";
+            this.button4.UseVisualStyleBackColor = true;
+            // 
+            // button5
+            // 
+            this.button5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.button5.Location = new System.Drawing.Point(12, 404);
+            this.button5.Name = "button5";
+            this.button5.Size = new System.Drawing.Size(112, 34);
+            this.button5.TabIndex = 4;
+            this.button5.Text = "Bottom-Left";
+            this.button5.UseVisualStyleBackColor = true;
+            // 
+            // button6
+            // 
+            this.button6.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.button6.Location = new System.Drawing.Point(338, 198);
+            this.button6.Name = "button6";
+            this.button6.Size = new System.Drawing.Size(112, 34);
+            this.button6.TabIndex = 5;
+            this.button6.Text = "All";
+            this.button6.UseVisualStyleBackColor = true;
+            // 
+            // button7
+            // 
+            this.button7.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.button7.Location = new System.Drawing.Point(676, 198);
+            this.button7.Name = "button7";
+            this.button7.Size = new System.Drawing.Size(112, 34);
+            this.button7.TabIndex = 6;
+            this.button7.Text = "Right";
+            this.button7.UseVisualStyleBackColor = true;
+            // 
+            // button8
+            // 
+            this.button8.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.button8.Location = new System.Drawing.Point(338, 404);
+            this.button8.Name = "button8";
+            this.button8.Size = new System.Drawing.Size(112, 34);
+            this.button8.TabIndex = 7;
+            this.button8.Text = "Bottom";
+            this.button8.UseVisualStyleBackColor = true;
+            // 
+            // button9
+            // 
+            this.button9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.button9.Location = new System.Drawing.Point(676, 404);
+            this.button9.Name = "button9";
+            this.button9.Size = new System.Drawing.Size(112, 34);
+            this.button9.TabIndex = 8;
+            this.button9.Text = "Bottom-Right";
+            this.button9.UseVisualStyleBackColor = true;
+            // 
+            // Form1
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.button9);
+            this.Controls.Add(this.button8);
+            this.Controls.Add(this.button7);
+            this.Controls.Add(this.button6);
+            this.Controls.Add(this.button5);
+            this.Controls.Add(this.button4);
+            this.Controls.Add(this.button3);
+            this.Controls.Add(this.button2);
+            this.Controls.Add(this.button1);
+            this.Name = "Form1";
+            this.Text = "Form1";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Button button1;
+        private Button button2;
+        private Button button3;
+        private Button button4;
+        private Button button5;
+        private Button button6;
+        private Button button7;
+        private Button button8;
+        private Button button9;
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/AnchorLayoutTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows.Forms;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
 
 namespace WinformsControlsTest
 {

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/AnchorLayoutTests.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    public partial class AnchorLayoutTests : Form
+    {
+        public AnchorLayoutTests()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/AnchorLayoutTests.resx
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/AnchorLayoutTests.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DockLayoutTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DockLayoutTests.Designer.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows.Forms;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
 
 namespace WinformsControlsTest
 {

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DockLayoutTests.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DockLayoutTests.Designer.cs
@@ -1,0 +1,114 @@
+﻿using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    partial class DockLayoutTests
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.button1 = new System.Windows.Forms.Button();
+            this.button3 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
+            this.button4 = new System.Windows.Forms.Button();
+            this.button5 = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // button1
+            // 
+            this.button1.Dock = System.Windows.Forms.DockStyle.Left;
+            this.button1.Location = new System.Drawing.Point(0, 0);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(112, 450);
+            this.button1.TabIndex = 0;
+            this.button1.Text = "Left";
+            this.button1.UseVisualStyleBackColor = true;
+            // 
+            // button3
+            // 
+            this.button3.Dock = System.Windows.Forms.DockStyle.Right;
+            this.button3.Location = new System.Drawing.Point(688, 0);
+            this.button3.Name = "button3";
+            this.button3.Size = new System.Drawing.Size(112, 450);
+            this.button3.TabIndex = 2;
+            this.button3.Text = "Right";
+            this.button3.UseVisualStyleBackColor = true;
+            // 
+            // button2
+            // 
+            this.button2.Dock = System.Windows.Forms.DockStyle.Top;
+            this.button2.Location = new System.Drawing.Point(112, 0);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(576, 89);
+            this.button2.TabIndex = 3;
+            this.button2.Text = "Top";
+            this.button2.UseVisualStyleBackColor = true;
+            // 
+            // button4
+            // 
+            this.button4.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.button4.Location = new System.Drawing.Point(112, 384);
+            this.button4.Name = "button4";
+            this.button4.Size = new System.Drawing.Size(576, 66);
+            this.button4.TabIndex = 4;
+            this.button4.Text = "Bottom";
+            this.button4.UseVisualStyleBackColor = true;
+            // 
+            // button5
+            // 
+            this.button5.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.button5.Location = new System.Drawing.Point(112, 89);
+            this.button5.Name = "button5";
+            this.button5.Size = new System.Drawing.Size(576, 295);
+            this.button5.TabIndex = 5;
+            this.button5.Text = "Fill";
+            this.button5.UseVisualStyleBackColor = true;
+            // 
+            // DockLayoutTests
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.button5);
+            this.Controls.Add(this.button4);
+            this.Controls.Add(this.button2);
+            this.Controls.Add(this.button3);
+            this.Controls.Add(this.button1);
+            this.Name = "DockLayoutTests";
+            this.Text = "DockLayoutTests";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Button button1;
+        private Button button3;
+        private Button button2;
+        private Button button4;
+        private Button button5;
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DockLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DockLayoutTests.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    public partial class DockLayoutTests : Form
+    {
+        public DockLayoutTests()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DockLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DockLayoutTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Windows.Forms;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Windows.Forms;
 
 namespace WinformsControlsTest
 {

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DockLayoutTests.resx
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DockLayoutTests.resx
@@ -1,0 +1,60 @@
+﻿<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -179,6 +179,15 @@ namespace WinformsControlsTest
                 MainFormControlsTabOrder.ToolTipsButton,
                 new InitInfo("ToolTips", (obj, e) => new ToolTipTests().Show(this))
             },
+            {
+                MainFormControlsTabOrder.AnchorLayoutButton,
+                new InitInfo("AnchorLayout", (obj, e) => new AnchorLayoutTests().Show(this))
+            },
+            {
+                MainFormControlsTabOrder.DockLayoutButton,
+                new InitInfo("DockLayout", (obj, e) => new DockLayoutTests().Show(this))
+            }
+
         };
 
         protected override void OnShown(EventArgs e)

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -187,7 +187,6 @@ namespace WinformsControlsTest
                 MainFormControlsTabOrder.DockLayoutButton,
                 new InitInfo("DockLayout", (obj, e) => new DockLayoutTests().Show(this))
             }
-
         };
 
         protected override void OnShown(EventArgs e)


### PR DESCRIPTION
Fixes #5774
Updating `AnchoriInfo `is only needed when control is ready for layout. `InitLayoutCore()` does call `UpdateAnchorInfo()`.
At the least, we are checking if control is parented before updating `AnchorInfo`. This helps avoid calculating
`AnchorInfo `with default initial values of the Control. They are always overridden when layout happens.

We have one other issue in the `AnchorInfo `calculations that is being investigated but this change will indirectly fix the #5774.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6778)