### PR TITLE
Removed old constraint related to CAS.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -498,14 +498,6 @@ namespace System.Windows.Forms
                 {
                     accessibleObject = CreateAccessibilityInstance();
 
-                    // This is a security check. We want to enforce that we only return
-                    // ControlAccessibleObject and not some other derived class.
-                    if (accessibleObject is not ControlAccessibleObject)
-                    {
-                        Debug.Fail("Accessible objects for controls must be derived from ControlAccessibleObject.");
-                        return null;
-                    }
-
                     Properties.SetObject(s_accessibilityProperty, accessibleObject);
                 }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.Properties.cs
@@ -58,7 +58,9 @@ namespace System.Windows.Forms.Tests
         public static IEnumerable<object[]> AccessibilityObject_CustomCreateAccessibilityInstance_TestData()
         {
             yield return new object[] { null, null };
-            yield return new object[] { new AccessibleObject(), null };
+
+            var accessibleObject = new AccessibleObject();
+            yield return new object[] { accessibleObject, accessibleObject };
 
             var controlAccessibleObject = new Control.ControlAccessibleObject(new Control());
             yield return new object[] { controlAccessibleObject, controlAccessibleObject };


### PR DESCRIPTION
This should had been removed when we removed CAS-related code. ControlAccessibleObject was demanding unmanaged code permissions and that is why we did not allow controls to override it. In .NET CAS is deprecated, and this type check is not relevant any more.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6782)