### PR TITLE
Enable nullability in NumericUpDownAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.NumericUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDown.NumericUpDownAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms
@@ -19,7 +17,7 @@ namespace System.Windows.Forms
                 _owningNumericUpDown = owner;
             }
 
-            public override AccessibleObject GetChild(int index)
+            public override AccessibleObject? GetChild(int index)
             {
                 // TextBox child
                 if (index == 0)


### PR DESCRIPTION
## Proposed changes

- Enable nullability in NumericUpDownAccessibleObject.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6787)