### PR TITLE
Enable nullability in PrintControllerWithStatusDialog

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -618,10 +618,10 @@ override System.Windows.Forms.Panel.ToString() -> string!
 ~override System.Windows.Forms.PictureBox.Text.get -> string
 ~override System.Windows.Forms.PictureBox.Text.set -> void
 ~override System.Windows.Forms.PictureBox.ToString() -> string
-~override System.Windows.Forms.PrintControllerWithStatusDialog.OnEndPage(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintPageEventArgs e) -> void
-~override System.Windows.Forms.PrintControllerWithStatusDialog.OnEndPrint(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintEventArgs e) -> void
-~override System.Windows.Forms.PrintControllerWithStatusDialog.OnStartPage(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintPageEventArgs e) -> System.Drawing.Graphics
-~override System.Windows.Forms.PrintControllerWithStatusDialog.OnStartPrint(System.Drawing.Printing.PrintDocument document, System.Drawing.Printing.PrintEventArgs e) -> void
+override System.Windows.Forms.PrintControllerWithStatusDialog.OnEndPage(System.Drawing.Printing.PrintDocument! document, System.Drawing.Printing.PrintPageEventArgs! e) -> void
+override System.Windows.Forms.PrintControllerWithStatusDialog.OnEndPrint(System.Drawing.Printing.PrintDocument! document, System.Drawing.Printing.PrintEventArgs! e) -> void
+override System.Windows.Forms.PrintControllerWithStatusDialog.OnStartPage(System.Drawing.Printing.PrintDocument! document, System.Drawing.Printing.PrintPageEventArgs! e) -> System.Drawing.Graphics?
+override System.Windows.Forms.PrintControllerWithStatusDialog.OnStartPrint(System.Drawing.Printing.PrintDocument! document, System.Drawing.Printing.PrintEventArgs! e) -> void
 override System.Windows.Forms.PrintPreviewControl.CreateParams.get -> System.Windows.Forms.CreateParams!
 override System.Windows.Forms.PrintPreviewControl.OnPaint(System.Windows.Forms.PaintEventArgs! pevent) -> void
 override System.Windows.Forms.PrintPreviewControl.OnResize(System.EventArgs! eventargs) -> void
@@ -2246,8 +2246,8 @@ System.Windows.Forms.ListView.TopItem.set -> void
 ~System.Windows.Forms.PictureBox.InitialImage.set -> void
 ~System.Windows.Forms.PictureBox.Load(string url) -> void
 ~System.Windows.Forms.PictureBox.LoadAsync(string url) -> void
-~System.Windows.Forms.PrintControllerWithStatusDialog.PrintControllerWithStatusDialog(System.Drawing.Printing.PrintController underlyingController) -> void
-~System.Windows.Forms.PrintControllerWithStatusDialog.PrintControllerWithStatusDialog(System.Drawing.Printing.PrintController underlyingController, string dialogTitle) -> void
+System.Windows.Forms.PrintControllerWithStatusDialog.PrintControllerWithStatusDialog(System.Drawing.Printing.PrintController! underlyingController) -> void
+System.Windows.Forms.PrintControllerWithStatusDialog.PrintControllerWithStatusDialog(System.Drawing.Printing.PrintController! underlyingController, string! dialogTitle) -> void
 System.Windows.Forms.PrintDialog.Document.get -> System.Drawing.Printing.PrintDocument?
 System.Windows.Forms.PrintDialog.Document.set -> void
 System.Windows.Forms.PrintDialog.PrinterSettings.get -> System.Drawing.Printing.PrinterSettings!

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.BackgroundThread.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.BackgroundThread.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class PrintControllerWithStatusDialog
@@ -14,7 +12,7 @@ namespace System.Windows.Forms
             private readonly PrintControllerWithStatusDialog _parent;
             private readonly Thread _thread;
             private bool _alreadyStopped;
-            private StatusDialog _dialog;
+            private StatusDialog? _dialog;
 
             // Called from any thread
             internal BackgroundThread(PrintControllerWithStatusDialog parent)
@@ -56,8 +54,6 @@ namespace System.Windows.Forms
             // on correct thread
             private void Run()
             {
-                //
-
                 try
                 {
                     lock (this)
@@ -94,8 +90,10 @@ namespace System.Windows.Forms
             private void ThreadUnsafeUpdateLabel()
             {
                 // "page {0} of {1}"
-                _dialog._label1.Text = string.Format(SR.PrintControllerWithStatusDialog_NowPrinting,
-                                                   _parent._pageNumber, _parent._document.DocumentName);
+                _dialog!._label1.Text = string.Format(
+                    SR.PrintControllerWithStatusDialog_NowPrinting,
+                    _parent._pageNumber,
+                    _parent._document?.DocumentName);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.StatusDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.StatusDialog.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 
 namespace System.Windows.Forms
@@ -14,7 +13,7 @@ namespace System.Windows.Forms
         {
             internal Label _label1;
             private Button _button1;
-            private TableLayoutPanel _tableLayoutPanel1;
+            private TableLayoutPanel? _tableLayoutPanel1;
             private readonly BackgroundThread _backgroundThread;
 
             internal StatusDialog(BackgroundThread backgroundThread, string dialogTitle)
@@ -37,6 +36,8 @@ namespace System.Windows.Forms
                 }
             }
 
+            [MemberNotNull(nameof(_label1))]
+            [MemberNotNull(nameof(_button1))]
             private void InitializeComponent()
             {
                 if (IsRTLResources)
@@ -95,7 +96,7 @@ namespace System.Windows.Forms
                 Controls.Add(_tableLayoutPanel1);
             }
 
-            private void button1_Click(object sender, EventArgs e)
+            private void button1_Click(object? sender, EventArgs e)
             {
                 _button1.Enabled = false;
                 _label1.Text = SR.PrintControllerWithStatusDialog_Canceling;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 using System.Drawing.Printing;
 
@@ -12,13 +10,13 @@ namespace System.Windows.Forms
     public partial class PrintControllerWithStatusDialog : PrintController
     {
         private readonly PrintController _underlyingController;
-        private PrintDocument _document;
-        private BackgroundThread _backgroundThread;
+        private PrintDocument? _document;
+        private BackgroundThread? _backgroundThread;
         private int _pageNumber;
         private readonly string _dialogTitle;
 
         public PrintControllerWithStatusDialog(PrintController underlyingController)
-        : this(underlyingController, SR.PrintControllerWithStatusDialog_DialogTitlePrint)
+            : this(underlyingController, SR.PrintControllerWithStatusDialog_DialogTitlePrint)
         {
         }
 
@@ -52,7 +50,7 @@ namespace System.Windows.Forms
         {
             base.OnStartPrint(document, e);
 
-            this._document = document;
+            _document = document;
             _pageNumber = 1;
 
             if (SystemInformation.UserInteractive)
@@ -63,7 +61,6 @@ namespace System.Windows.Forms
             // OnStartPrint does the security check... lots of
             // extra setup to make sure that we tear down
             // correctly...
-            //
             try
             {
                 _underlyingController.OnStartPrint(document, e);
@@ -89,7 +86,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Implements StartPage by delegating to the underlying controller.
         /// </summary>
-        public override Graphics OnStartPage(PrintDocument document, PrintPageEventArgs e)
+        public override Graphics? OnStartPage(PrintDocument document, PrintPageEventArgs e)
         {
             base.OnStartPage(document, e);
 
@@ -98,7 +95,7 @@ namespace System.Windows.Forms
                 _backgroundThread.UpdateLabel();
             }
 
-            Graphics result = _underlyingController.OnStartPage(document, e);
+            Graphics? result = _underlyingController.OnStartPage(document, e);
             if (_backgroundThread is not null && _backgroundThread._canceled)
             {
                 e.Cancel = true;


### PR DESCRIPTION
## Proposed changes

- Enable nullability in PrintControllerWithStatusDialog.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6803)