### PR TITLE
Remove Image null check before calling ImageAnimator.UpdateFrames

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -1158,10 +1158,7 @@ namespace System.Windows.Forms
             if (GetStyle(ControlStyles.UserPaint))
             {
                 Animate();
-                if (Image is not null)
-                {
-                    ImageAnimator.UpdateFrames(Image);
-                }
+                ImageAnimator.UpdateFrames(Image);
 
                 PaintControl(pevent);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1292,10 +1292,7 @@ namespace System.Windows.Forms
         protected override void OnPaint(PaintEventArgs e)
         {
             Animate();
-            if (Image is not null)
-            {
-                ImageAnimator.UpdateFrames(Image);
-            }
+            ImageAnimator.UpdateFrames(Image);
 
             Rectangle face = LayoutUtils.DeflateRect(ClientRectangle, Padding);
             Image? i = Image;


### PR DESCRIPTION
## Proposed changes

- Remove Image null check before calling ImageAnimator.UpdateFrames
- Reflects the changes from https://github.com/dotnet/runtime/pull/65949.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6806)