### PR TITLE
Enable nullability in DateTimePickerAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -384,8 +384,8 @@ override System.Windows.Forms.CursorConverter.GetStandardValuesSupported(System.
 ~override System.Windows.Forms.DateTimePicker.BackgroundImage.set -> void
 ~override System.Windows.Forms.DateTimePicker.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.DateTimePicker.CreateParams.get -> System.Windows.Forms.CreateParams
-~override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.KeyboardShortcut.get -> string
-~override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.Value.get -> string
+override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.KeyboardShortcut.get -> string?
+override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.Value.get -> string!
 ~override System.Windows.Forms.DateTimePicker.OnEnabledChanged(System.EventArgs e) -> void
 ~override System.Windows.Forms.DateTimePicker.OnFontChanged(System.EventArgs e) -> void
 ~override System.Windows.Forms.DateTimePicker.OnHandleCreated(System.EventArgs e) -> void
@@ -1702,7 +1702,7 @@ System.Windows.Forms.DataObject.DataObject(string! format, object! data) -> void
 ~System.Windows.Forms.DateTimePicker.CalendarFont.set -> void
 ~System.Windows.Forms.DateTimePicker.CustomFormat.get -> string
 ~System.Windows.Forms.DateTimePicker.CustomFormat.set -> void
-~System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.DateTimePickerAccessibleObject(System.Windows.Forms.DateTimePicker owner) -> void
+System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.DateTimePickerAccessibleObject(System.Windows.Forms.DateTimePicker! owner) -> void
 ~System.Windows.Forms.Design.ComponentEditorForm.ComponentEditorForm(object component, System.Type[] pageTypes) -> void
 ~System.Windows.Forms.Design.ComponentEditorPage.Component.get -> System.ComponentModel.IComponent
 ~System.Windows.Forms.Design.ComponentEditorPage.Component.set -> void

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 ~override System.Windows.Forms.SplitContainer.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 override System.Windows.Forms.PrintPreviewControl.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
-~override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.Name.get -> string
+override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.Name.get -> string!
 ~override System.Windows.Forms.DateTimePicker.OnGotFocus(System.EventArgs e) -> void
 override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.DoDefaultAction() -> void
-~override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.DefaultAction.get -> string
+override System.Windows.Forms.DateTimePicker.DateTimePickerAccessibleObject.DefaultAction.get -> string!
 ~override System.Windows.Forms.TreeView.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.DateTimePickerAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 using static Interop.ComCtl32;
 using static Interop.User32;
@@ -18,14 +16,14 @@ namespace System.Windows.Forms
             {
             }
 
-            public override string KeyboardShortcut
+            public override string? KeyboardShortcut
             {
                 get
                 {
                     // APP COMPAT. When computing DateTimePickerAccessibleObject::get_KeyboardShortcut the previous label
                     // takes precedence over DTP::Text.
                     // This code was copied from the Everett sources.
-                    Label previousLabel = PreviousLabel;
+                    Label? previousLabel = PreviousLabel;
 
                     if (previousLabel is not null)
                     {
@@ -36,7 +34,7 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    string baseShortcut = base.KeyboardShortcut;
+                    string? baseShortcut = base.KeyboardShortcut;
 
                     if ((baseShortcut is null || baseShortcut.Length == 0))
                     {
@@ -59,7 +57,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    string baseValue = base.Value;
+                    string? baseValue = base.Value;
                     if (baseValue is null || baseValue.Length == 0)
                     {
                         return Owner.Text;
@@ -101,7 +99,7 @@ namespace System.Windows.Forms
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyID)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
                     UiaCore.UIA.LocalizedControlTypePropertyId =>


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DateTimePickerAccessibleObject.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6819)