### PR TITLE
Remove no longer needed workaround

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/NativeHost.ManagedControl/NativeHost.ManagedControl.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/NativeHost.ManagedControl/NativeHost.ManagedControl.csproj
@@ -14,9 +14,4 @@
     <ProjectReference Include="..\..\..\src\System.Windows.Forms.csproj" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <!-- workaround for https://github.com/dotnet/sdk/pull/19764 -->
-    <EnableDynamicLoading>true</EnableDynamicLoading>
-  </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
EnableDynamicLoading properly set right now in the Microsoft.NET.Sdk.targets

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6824)