### PR TITLE
Enable nullability in some COM2 converters

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ColorConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ColorConverter.cs
@@ -2,10 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
-
 using System.Drawing;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop
@@ -29,20 +26,18 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  Converts the native value into a managed value
         /// </summary>
-        public override object ConvertNativeToManaged(object nativeValue, Com2PropertyDescriptor pd)
+        public override object ConvertNativeToManaged(object? nativeValue, Com2PropertyDescriptor pd)
         {
-            object baseValue = nativeValue;
             int intVal = 0;
 
             // get the integer value out of the native...
-            //
-            if (nativeValue is uint)
+            if (nativeValue is uint nativeValueAsUint)
             {
-                intVal = (int)(uint)nativeValue;
+                intVal = (int)nativeValueAsUint;
             }
-            else if (nativeValue is int)
+            else if (nativeValue is int nativeValueAsInt)
             {
-                intVal = (int)nativeValue;
+                intVal = nativeValueAsInt;
             }
 
             return ColorTranslator.FromOle(intVal);
@@ -51,21 +46,20 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  Converts the managed value into a native value
         /// </summary>
-        public override object ConvertManagedToNative(object managedValue, Com2PropertyDescriptor pd, ref bool cancelSet)
+        public override object ConvertManagedToNative(object? managedValue, Com2PropertyDescriptor pd, ref bool cancelSet)
         {
             // don't cancel the set
             cancelSet = false;
 
             // we default to black.
-            //
             if (managedValue is null)
             {
                 managedValue = Color.Black;
             }
 
-            if (managedValue is Color)
+            if (managedValue is Color managedValueAsColor)
             {
-                return ColorTranslator.ToOle(((Color)managedValue));
+                return ColorTranslator.ToOle(managedValueAsColor);
             }
 
             Debug.Fail("Don't know how to set type:" + managedValue.GetType().Name);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2DataTypeToManagedDataTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2DataTypeToManagedDataTypeConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     /// <summary>
@@ -30,11 +28,11 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  Converts the native value into a managed value
         /// </summary>
-        public abstract object ConvertNativeToManaged(object nativeValue, Com2PropertyDescriptor pd);
+        public abstract object? ConvertNativeToManaged(object? nativeValue, Com2PropertyDescriptor pd);
 
         /// <summary>
         ///  Converts the managed value into a native value
         /// </summary>
-        public abstract object ConvertManagedToNative(object managedValue, Com2PropertyDescriptor pd, ref bool cancelSet);
+        public abstract object? ConvertManagedToNative(object? managedValue, Com2PropertyDescriptor pd, ref bool cancelSet);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2FontConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2FontConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 using static Interop.Ole32;
 
@@ -15,7 +13,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
     internal class Com2FontConverter : Com2DataTypeToManagedDataTypeConverter
     {
         private IntPtr _lastHandle = IntPtr.Zero;
-        private Font _lastFont;
+        private Font? _lastFont;
 
         public override bool AllowExpand => true;
 
@@ -27,10 +25,10 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  Converts the native value into a managed value
         /// </summary>
-        public override object ConvertNativeToManaged(object nativeValue, Com2PropertyDescriptor pd)
+        public override object ConvertNativeToManaged(object? nativeValue, Com2PropertyDescriptor pd)
         {
             // we're getting an IFont here
-            if (!(nativeValue is IFont nativeFont))
+            if (nativeValue is not IFont nativeFont)
             {
                 _lastHandle = IntPtr.Zero;
                 _lastFont = Control.DefaultFont;
@@ -69,7 +67,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  Converts the managed value into a native value
         /// </summary>
-        public override object ConvertManagedToNative(object managedValue, Com2PropertyDescriptor pd, ref bool cancelSet)
+        public override object? ConvertManagedToNative(object? managedValue, Com2PropertyDescriptor pd, ref bool cancelSet)
         {
             // we default to black.
             if (managedValue is null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PictureConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PictureConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Drawing;
 using static Interop;
@@ -16,9 +14,9 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
     /// </summary>
     internal class Com2PictureConverter : Com2DataTypeToManagedDataTypeConverter
     {
-        private object _lastManaged;
+        private object? _lastManaged;
         private IntPtr _lastNativeHandle;
-        private WeakReference _pictureRef;
+        private WeakReference? _pictureRef;
 
         private Type _pictureType = typeof(Bitmap);
 
@@ -44,7 +42,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  Converts the native value into a managed value
         /// </summary>
-        public override object ConvertNativeToManaged(object nativeValue, Com2PropertyDescriptor pd)
+        public override object? ConvertNativeToManaged(object? nativeValue, Com2PropertyDescriptor pd)
         {
             if (nativeValue is null)
             {
@@ -93,14 +91,14 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  Converts the managed value into a native value
         /// </summary>
-        public override object ConvertManagedToNative(object managedValue, Com2PropertyDescriptor pd, ref bool cancelSet)
+        public override object? ConvertManagedToNative(object? managedValue, Com2PropertyDescriptor pd, ref bool cancelSet)
         {
             // Don't cancel the set
             cancelSet = false;
 
             if (_lastManaged?.Equals(managedValue) == true)
             {
-                object target = _pictureRef?.Target;
+                object? target = _pictureRef?.Target;
                 if (target is not null)
                 {
                     return target;


### PR DESCRIPTION
## Proposed changes

- Enable nullability in some COM2 converters.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6837)