### PR TITLE
Fixing MonthCalendar accessible object leaks

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Drawing;
 using static Interop;
 using static Interop.ComCtl32;
@@ -36,6 +37,23 @@ namespace System.Windows.Forms
                 // otherwise the calendar accessibility tree will be rebuilt.
                 // So save this value one time to avoid sending messages to Windows every time.
                 _initName = initName;
+            }
+
+            internal void DisconnectChildren()
+            {
+                Debug.Assert(OsVersion.IsWindows8OrGreater);
+                if (_calendarHeaderAccessibleObject is not null)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(_calendarHeaderAccessibleObject);
+                    Debug.Assert(result == 0);
+                }
+
+                if (_calendarBodyAccessibleObject is not null)
+                {
+                    _calendarBodyAccessibleObject.DisconnectChildren();
+                    HRESULT result = UiaCore.UiaDisconnectProvider(_calendarBodyAccessibleObject);
+                    Debug.Assert(result == 0);
+                }
             }
 
             public override Rectangle Bounds

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
@@ -51,6 +51,22 @@ namespace System.Windows.Forms
             public override Rectangle Bounds
                 => _monthCalendarAccessibleObject.GetCalendarPartRectangle(MCGIP.CALENDARBODY, _calendarIndex);
 
+            internal void DisconnectChildren()
+            {
+                Debug.Assert(OsVersion.IsWindows8OrGreater);
+                if (_rowsAccessibleObjects == null)
+                {
+                    return;
+                }
+
+                foreach (CalendarRowAccessibleObject row in _rowsAccessibleObjects)
+                {
+                    row.DisconnectChildren();
+                    HRESULT result = UiaCore.UiaDisconnectProvider(row);
+                    Debug.Assert(result == 0);
+                }
+            }
+
             internal void ClearChildCollection()
             {
                 if (RowsAccessibleObjects is not null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
 using static Interop;
@@ -96,6 +97,27 @@ namespace System.Windows.Forms
             }
 
             internal void ClearChildCollection() => _cellsAccessibleObjects = null;
+
+            internal void DisconnectChildren()
+            {
+                Debug.Assert(OsVersion.IsWindows8OrGreater);
+                if (_weekNumberCellAccessibleObject is not null)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(_weekNumberCellAccessibleObject);
+                    Debug.Assert(result == 0);
+                }
+
+                if (_cellsAccessibleObjects is null)
+                {
+                    return;
+                }
+
+                foreach (CalendarCellAccessibleObject cell in _cellsAccessibleObjects)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(cell);
+                    Debug.Assert(result == 0);
+                }
+            }
 
             public override string? Description
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Drawing;
 using static Interop;
 using static Interop.ComCtl32;
@@ -76,6 +77,47 @@ namespace System.Windows.Forms
                     }
 
                     return _calendarsAccessibleObjects;
+                }
+            }
+
+            // This function should be called from a single place in the root of MonthCalendar object that already tests for availability of this API
+            internal void DisconnectChildren()
+            {
+                Debug.Assert(OsVersion.IsWindows8OrGreater);
+                if (_previousButtonAccessibleObject is not null)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(_previousButtonAccessibleObject);
+                    Debug.Assert(result == 0);
+                }
+
+                if (_nextButtonAccessibleObject is not null)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(_nextButtonAccessibleObject);
+                    Debug.Assert(result == 0);
+                }
+
+                if (_todayLinkAccessibleObject is not null)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(_todayLinkAccessibleObject);
+                    Debug.Assert(result == 0);
+                }
+
+                if (_focusedCellAccessibleObject is not null)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(_focusedCellAccessibleObject);
+                    Debug.Assert(result == 0);
+                }
+
+                if (_calendarsAccessibleObjects is null)
+                {
+                    return;
+                }
+
+                foreach (CalendarAccessibleObject calendarAccessibleObject in _calendarsAccessibleObjects)
+                {
+                    calendarAccessibleObject.DisconnectChildren();
+                    HRESULT result = UiaCore.UiaDisconnectProvider(calendarAccessibleObject);
+                    Debug.Assert(result == 0);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -2325,6 +2325,19 @@ namespace System.Windows.Forms
                     break;
                 case User32.WM.DESTROY:
                     base.WndProc(ref m);
+                    if (IsHandleCreated && IsAccessibilityObjectCreated)
+                    {
+                        UiaCore.UiaReturnRawElementProvider(Handle, wParam: IntPtr.Zero, lParam: IntPtr.Zero, el: null);
+
+                        if (OsVersion.IsWindows8OrGreater)
+                        {
+                            ((MonthCalendarAccessibleObject)AccessibilityObject).DisconnectChildren();
+
+                            HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
+                            Debug.Assert(result == 0);
+                        }
+                    }
+
                     break;
                 case User32.WM.PAINT:
                     base.WndProc(ref m);


### PR DESCRIPTION
Fixes #6852

## Proposed changes
- Use the `UiaDisconnectProvider` method cascade through the hierarchy of the classes to free objects held by accessibility tool
- Only static comparers are left at memory and their amount aren't increasing after several recurrences of the repro steps described in issue

## Customer Impact
- MonthCalendar memory will stop leaking

## Regression? 
- No

## Risk
- Minimal

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/87859299/158603580-db28afad-cfaf-479b-b013-0b8932d72e72.png)

### After
![image](https://user-images.githubusercontent.com/87859299/158603619-b75a85fd-ebc3-4a02-96cf-54a639b8ab9c.png)

## Test methodology
- Manual testing (_using WinDbg, see the screenshots above_)
- CTI team

## Test environment(s)
- Microsoft Windows [Version 10.0.19043.1586]
- .NET 7.0.0-preview.3.22159.12

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6853)