### PR TITLE
Pedantically construct paths for XML files

### DIFF
--- a/eng/packageContent.targets
+++ b/eng/packageContent.targets
@@ -32,27 +32,28 @@
       <DocFile>
         <!-- map LCID to culture name that VS expects -->
         <Culture>unknown</Culture>
-        <Culture Condition="'%(LCID)' == '1028'">zh-hant/</Culture>
-        <Culture Condition="'%(LCID)' == '1031'">de/</Culture>
+        <Culture Condition="'%(LCID)' == '1028'">zh-hant</Culture>
+        <Culture Condition="'%(LCID)' == '1031'">de</Culture>
         <!-- english is placed in the root -->
         <Culture Condition="'%(LCID)' == '1033'"></Culture>
-        <Culture Condition="'%(LCID)' == '1036'">fr/</Culture>
-        <Culture Condition="'%(LCID)' == '1040'">it/</Culture>
-        <Culture Condition="'%(LCID)' == '1041'">ja/</Culture>
-        <Culture Condition="'%(LCID)' == '1042'">ko/</Culture>
-        <Culture Condition="'%(LCID)' == '1049'">ru/</Culture>
-        <Culture Condition="'%(LCID)' == '2052'">zh-hans/</Culture>
-        <Culture Condition="'%(LCID)' == '3082'">es/</Culture>
+        <Culture Condition="'%(LCID)' == '1036'">fr</Culture>
+        <Culture Condition="'%(LCID)' == '1040'">it</Culture>
+        <Culture Condition="'%(LCID)' == '1041'">ja</Culture>
+        <Culture Condition="'%(LCID)' == '1042'">ko</Culture>
+        <Culture Condition="'%(LCID)' == '1049'">ru</Culture>
+        <Culture Condition="'%(LCID)' == '2052'">zh-hans</Culture>
+        <Culture Condition="'%(LCID)' == '3082'">es</Culture>
       </DocFile>
       <DocFile>
-        <SubFolder>%(Culture)/</SubFolder>
+        <SubFolder Condition="'%(Culture)' != ''">%(Culture)\</SubFolder>
+        <SubFolder Condition="'%(Culture)' == ''"></SubFolder>
       </DocFile>
     </ItemGroup>
 
     <Error Condition="'%(DocFile.Culture)' == 'unknown'" Text="Unknown language folder '%(LCID)' for doc files '@(DocFile)'" />
     
     <Copy SourceFiles="@(DocFile)"
-          DestinationFiles="$(_IntellisenseXmlDir)\%(SubFolder)%(FileName)%(Extension)"
+          DestinationFiles="$(_IntellisenseXmlDir)%(SubFolder)%(FileName)%(Extension)"
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="true" />
 


### PR DESCRIPTION
Without these changes in binlog I see paths with `\\/` which is distraction and Explorer and a lot of other apps do not like paths like this.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6862)