### PR TITLE
Fixing  UIA tree for ToolStripDropDownMenu 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItemAccessibleObject.cs
@@ -208,7 +208,9 @@ namespace System.Windows.Forms
                     return null;
                 case UiaCore.NavigateDirection.FirstChild:
                 case UiaCore.NavigateDirection.LastChild:
-                    return _owner.DropDownItems.Count > 0
+                    // Don't add invisible items to the accessibility tree,
+                    // they might not have been created yet.
+                    return _owner.DropDown.Visible
                         ? _owner.DropDown.AccessibilityObject
                         : null;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject.cs
@@ -10,35 +10,16 @@ namespace System.Windows.Forms
     {
         internal class ToolStripDropDownMenuAccessibleObject : ToolStripDropDownAccessibleObject
         {
-            private readonly ToolStripDropDownMenu _owningToolStripDropDownMenu;
-
             public ToolStripDropDownMenuAccessibleObject(ToolStripDropDownMenu owner) : base(owner)
-            {
-                _owningToolStripDropDownMenu = owner;
-            }
+            { }
 
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
                 => direction switch
                 {
-                    UiaCore.NavigateDirection.Parent => _owningToolStripDropDownMenu.OwnerItem?.AccessibilityObject,
-                    UiaCore.NavigateDirection.FirstChild => GetFirstChild(),
-                    UiaCore.NavigateDirection.LastChild => GetLastChild(),
+                    UiaCore.NavigateDirection.Parent when Owner is ToolStripDropDownMenu menu
+                        => menu.OwnerItem?.AccessibilityObject,
                     _ => base.FragmentNavigate(direction)
                 };
-
-            private AccessibleObject? GetFirstChild()
-                => _owningToolStripDropDownMenu.Items.Count > 0
-                    ? _owningToolStripDropDownMenu.DisplayedItems.Contains(_owningToolStripDropDownMenu.UpScrollButton)
-                        ? _owningToolStripDropDownMenu.UpScrollButton.AccessibilityObject
-                        : _owningToolStripDropDownMenu.Items[0].AccessibilityObject
-                    : null;
-
-            private AccessibleObject? GetLastChild()
-                => _owningToolStripDropDownMenu.Items.Count > 0
-                    ? _owningToolStripDropDownMenu.DisplayedItems.Contains(_owningToolStripDropDownMenu.DownScrollButton)
-                        ? _owningToolStripDropDownMenu.DownScrollButton.AccessibilityObject
-                        : _owningToolStripDropDownMenu.Items[^1].AccessibilityObject
-                    : null;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -327,12 +327,7 @@ namespace System.Windows.Forms
                         return dropDown.AccessibilityObject;
                     }
 
-                    ToolStrip owner = Owner.Parent ?? Owner.Owner;
-                    return owner is not null
-                        ? owner.OverflowItems.Contains(Owner)
-                            ? owner.OverflowButton.DropDown.AccessibilityObject
-                            : owner.AccessibilityObject
-                        : base.Parent;
+                    return (Owner.Parent is not null) ? Owner.Parent.AccessibilityObject : base.Parent;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObject.cs
@@ -10,27 +10,24 @@ namespace System.Windows.Forms
     {
         internal class ToolStripOverflowAccessibleObject : ToolStripDropDownAccessibleObject
         {
-            private readonly ToolStripOverflow _owningToolStripOverflow;
-
             public ToolStripOverflowAccessibleObject(ToolStripOverflow owner) : base(owner)
-            {
-                _owningToolStripOverflow = owner;
-            }
+            { }
 
             public override AccessibleObject? GetChild(int index)
-                => index >= 0 || index < _owningToolStripOverflow.DisplayedItems.Count
-                    ? _owningToolStripOverflow.DisplayedItems[index].AccessibilityObject
+                => Owner is ToolStripOverflow overflow && (index >= 0 || index < overflow.DisplayedItems.Count)
+                    ? overflow.DisplayedItems[index].AccessibilityObject
                     : null;
 
             public override int GetChildCount()
-                => _owningToolStripOverflow.DisplayedItems.Count;
+                => Owner is ToolStripOverflow overflow
+                    ? overflow.DisplayedItems.Count
+                    : 0;
 
-            internal override Interop.UiaCore.IRawElementProviderFragment? FragmentNavigate(NavigateDirection direction)
+            internal override IRawElementProviderFragment? FragmentNavigate(NavigateDirection direction)
                 => direction switch
                 {
-                    NavigateDirection.Parent => _owningToolStripOverflow.ownerItem.AccessibilityObject,
-                    NavigateDirection.FirstChild => GetChildCount() > 0 ? _owningToolStripOverflow.DisplayedItems[0].AccessibilityObject : null,
-                    NavigateDirection.LastChild => GetChildCount() > 0 ? _owningToolStripOverflow.DisplayedItems[^1].AccessibilityObject : null,
+                    NavigateDirection.Parent when Owner is ToolStripOverflow menu
+                        => menu.OwnerItem?.AccessibilityObject,
                     _ => base.FragmentNavigate(direction),
                 };
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.ToolStripOverflowButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.ToolStripOverflowButtonAccessibleObject.cs
@@ -31,7 +31,10 @@ namespace System.Windows.Forms
                 {
                     case UiaCore.NavigateDirection.FirstChild:
                     case UiaCore.NavigateDirection.LastChild:
-                        return _owningToolStripOverflowButton.ParentToolStrip is not null && _owningToolStripOverflowButton.ParentToolStrip.OverflowItems.Count > 0
+                        // Don't show the inner menu while it is invisible.
+                        // Otherwise it will affect accessibility tree,
+                        // especially for items-controls that have not been created yet.
+                        return _owningToolStripOverflowButton.DropDown.Visible
                             ? _owningToolStripOverflowButton.DropDown.AccessibilityObject
                             : null;
                 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObjectTests.cs
@@ -121,6 +121,7 @@ namespace System.Windows.Forms.Tests
             parentItem2.DropDownItems.Add(childItem3);
             parentItem2.DropDownItems.Add(childItem4);
 
+            ownerItem.DropDown.Show();
             AccessibleObject accessibleObject = ownerItem.DropDown.AccessibilityObject;
 
             Assert.Equal(ownerItem.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.Parent));
@@ -134,6 +135,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(accessibleObject, parentItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
             Assert.Equal(accessibleObject, parentItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
 
+            parentItem1.DropDown.Show();
             AccessibleObject accessibleObject1 = parentItem1.DropDown.AccessibilityObject;
 
             Assert.Equal(parentItem1.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.Parent));
@@ -147,6 +149,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(accessibleObject1, childItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
             Assert.Equal(accessibleObject1, childItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
 
+            parentItem2.DropDown.Show();
             AccessibleObject accessibleObject2 = parentItem2.DropDown.AccessibilityObject;
 
             Assert.Equal(parentItem2.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.Parent));
@@ -192,9 +195,6 @@ namespace System.Windows.Forms.Tests
             using ToolStripDropDownItem childItem3 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(childType);
             using ToolStripDropDownItem childItem4 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(childType);
 
-            toolStrip.Items.Add(parentItem1);
-            toolStrip.Items.Add(parentItem2);
-
             parentItem1.DropDownItems.Add(childItem1);
             parentItem1.DropDownItems.Add(childItem2);
             parentItem2.DropDownItems.Add(childItem3);
@@ -204,6 +204,13 @@ namespace System.Windows.Forms.Tests
             toolStrip.OverflowItems.Add(parentItem1);
             toolStrip.OverflowItems.Add(parentItem2);
 
+            // ToolStripSplitStackLayout does it in runtime when Layout method is working.
+            // Use this way as a workaround in tests.
+            // It should be reset in the end of the test to avoid Dispose method errors.
+            parentItem1.ParentInternal = ownerItem.DropDown;
+            parentItem2.ParentInternal = ownerItem.DropDown;
+
+            ownerItem.DropDown.Show();
             AccessibleObject accessibleObject = ownerItem.DropDown.AccessibilityObject;
 
             Assert.Equal(ownerItem.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.Parent));
@@ -217,6 +224,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(accessibleObject, parentItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
             Assert.Equal(accessibleObject, parentItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
 
+            parentItem1.DropDown.Show();
             AccessibleObject accessibleObject1 = parentItem1.DropDown.AccessibilityObject;
 
             Assert.Equal(parentItem1.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.Parent));
@@ -230,6 +238,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(accessibleObject1, childItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
             Assert.Equal(accessibleObject1, childItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
 
+            parentItem2.DropDown.Show();
             AccessibleObject accessibleObject2 = parentItem2.DropDown.AccessibilityObject;
 
             Assert.Equal(parentItem2.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.Parent));
@@ -242,6 +251,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(accessibleObject2, parentItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
             Assert.Equal(accessibleObject2, childItem3.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
             Assert.Equal(accessibleObject2, childItem4.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+
+            // Reset the parent to avoid errors when disposing.
+            parentItem1.ParentInternal = null;
+            parentItem2.ParentInternal = null;
         }
     }
 }


### PR DESCRIPTION
Fixes #6763


## Proposed changes
- The issue is reproduced because we don't actually have interaction between the `ToolStripButtons` (`ToolStripSplitButton`, `ToolStripDropDownButton`, `ToolStripMenuItem`, `ToolStripOverflowButton`) and the `ToolStripDropDownMenu`  of those `ToolStripButtons`.

- Added logic for interacting `ToolStripButtons`with their `ToolStripDropDownMenus` and `ToolStripButtons`with parent `ToolStripDropDownMenu`.

- Added unit tests

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/158980700-a0f62800-3d05-4f59-882b-6f4e08fb42bf.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/158980617-e403db2b-5873-4654-86e3-299d4a6eb86f.png)


## Regression? 

- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect
- Accessibility Insights
- Narrator

## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19044.1466]
- .NET Core SKD: 7.0.0-preview.3.22167.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6863)