### PR TITLE
Remove publishing TRX files from public CI

### DIFF
--- a/eng/pipelines/post-build.yml
+++ b/eng/pipelines/post-build.yml
@@ -6,6 +6,7 @@ parameters:
   enablePublishTestResults: true
   enablePublishBuildAssets: true
   enablePublishUsingPipelines: true
+  testResultsFormat: 'xunit'
 
 steps:
   - ${{ if eq(parameters.enableRichCodeNavigation, true) }}:


### PR DESCRIPTION
There no TRX files produced during tests runs anywhere.
Practically this is does not affects anything (<1sec), buy whole idea "to have step which do nothing" seems to be off.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6867)