### PR TITLE
Empty finalizers removed.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.HtmlElementShim.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.HtmlElementShim.cs
@@ -134,12 +134,15 @@ namespace System.Windows.Forms
             protected override void Dispose(bool disposing)
             {
                 base.Dispose(disposing);
-                if (_htmlElement is not null)
+                if (disposing)
                 {
-                    Marshal.FinalReleaseComObject(_htmlElement.NativeHtmlElement);
-                }
+                    if (_htmlElement?.NativeHtmlElement is not null)
+                    {
+                        Marshal.FinalReleaseComObject(_htmlElement.NativeHtmlElement);
+                    }
 
-                _htmlElement = null;
+                    _htmlElement = null;
+                }
             }
 
             protected override object GetEventSender()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlShim.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlShim.cs
@@ -27,11 +27,6 @@ namespace System.Windows.Forms
         {
         }
 
-        ~HtmlShim()
-        {
-            Dispose(false);
-        }
-
         private EventHandlerList Events
         {
             get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlShimManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlShimManager.cs
@@ -259,10 +259,5 @@ namespace System.Windows.Forms
                 htmlWindowShims = null;
             }
         }
-
-        ~HtmlShimManager()
-        {
-            Dispose(false);
-        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.FeedbackRectangle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.FeedbackRectangle.cs
@@ -69,11 +69,6 @@ namespace System.Windows.Forms
             {
                 Dispose(true);
             }
-
-            ~FeedbackRectangle()
-            {
-                Dispose(false);
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes #6858


## Proposed changes
Remove unnecessary empty finalizers.

- [ResXResourceReader](https://github.com/dotnet/winforms/blob/55e1755b579395e7e22fecf340905c79ccfa9b1a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs#L194)
- [ResXResourceWriter](https://github.com/dotnet/winforms/blob/55e1755b579395e7e22fecf340905c79ccfa9b1a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs#L549)
- [ApplicationContext](https://github.com/dotnet/winforms/blob/55e1755b579395e7e22fecf340905c79ccfa9b1a/src/System.Windows.Forms/src/System/Windows/Forms/ApplicationContext.cs#L91)
- [DataGridViewBand](https://github.com/dotnet/winforms/blob/55e1755b579395e7e22fecf340905c79ccfa9b1a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs#L817)
- [DataGridViewCell](https://github.com/dotnet/winforms/blob/55e1755b579395e7e22fecf340905c79ccfa9b1a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs#L1313)
- [HtmlShim](https://github.com/dotnet/winforms/blob/55e1755b579395e7e22fecf340905c79ccfa9b1a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlShim.cs#L107)
- [HtmlShimManager](https://github.com/dotnet/winforms/blob/55e1755b579395e7e22fecf340905c79ccfa9b1a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlShimManager.cs#L229)
- [FeedbackRectangle](https://github.com/dotnet/winforms/blob/55e1755b579395e7e22fecf340905c79ccfa9b1a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.FeedbackRectangle.cs#L55)

## Customer Impact
GC will be more faster - overall improve performance (most impact on `DataGridView`).
Simple `DataGridView` app, updating (replacing) `DataSource` every 1 sec with 10k unshared rows.

![image](https://user-images.githubusercontent.com/17767561/159126815-c4fee2d4-c41c-4fbe-870e-24f1d730d874.png)
~20sec measure time.

Left before, right -  after:
![image](https://user-images.githubusercontent.com/17767561/159127155-948b23ee-424e-401b-8f84-9027eb4d834c.png)

Before:
![image](https://user-images.githubusercontent.com/17767561/159127229-97a488ca-e0f2-48fd-a2fb-db0ed7adafcd.png)

After:
![image](https://user-images.githubusercontent.com/17767561/159127211-77b10655-14e6-40c1-b740-691fed26615e.png)


## Regression? 

- No

## Risk

  We have a _problem_ here: some of this finalizers are **public** api:
  - `~ResXResourceReader()`
  - `~ResXResourceWriter()`
  - `~ApplicationContext()`
  - `~DataGridViewCell()`
  - `~DataGridViewBand()` (absent in PublicAPI.Shipped.txt)

Theoretically if some one had subclass this classes with real unmanaged resources, they may not implement their own finalizer but relay on fact that finalizer of base class will call `Dispose(false)`. And in this case it will be a breaking change 😔
So, in the end we can safety remove finalizers only in `HtmlShimManager`, `FeedbackRectangle`. `HtmlShim` is a question here - all his 3 child have `Marshal.FinalReleaseComObject` in Dispose, but only `HtmlElementShim` do it unconditionally in all cases:
 https://github.com/dotnet/winforms/blob/2e9abddc2bab0c22430ae62d4a348ed6ffef329b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.HtmlElementShim.cs#L134-L143
https://github.com/dotnet/winforms/blob/2e9abddc2bab0c22430ae62d4a348ed6ffef329b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.HtmlDocumentShim.cs#L112-L124
https://github.com/dotnet/winforms/blob/2e9abddc2bab0c22430ae62d4a348ed6ffef329b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.HtmlWindowShim.cs#L103-L115
<br/>

During investigation I found 2 [runtime](https://github.com/dotnet/runtime) types (**heavily** used in WinForms), that have same problem (in fact, there are many more):
- `System.ComponentModel.Component` (public api)
- `System.ComponentModel.Container`  (public api)

The most important question is what to do with the public api? As you can see, in case of `DataGridView`, **the benefit is very significant**. And if do such a braking change is not an option than we will need to rise https://github.com/dotnet/winforms/issues/6859 priority...<br/><br/><br/>

P.S. Spent a few hours to run the application on the main branch - without effect 😥 Latest `dotnet-sdk-7.0.100-preview.3.22167.1-win-x64.exe` sdk is broken - it's need `7.0.0-preview.3.22158.1` to launch (no framework installed 😁) and with second available `dotnet-sdk-7.0.100-preview.2.22156.6-win-x64.exe`: 
![image](https://user-images.githubusercontent.com/17767561/159127784-f2a01cfa-818d-4214-8831-fc3bbf5763a7.png)
So, had to test on 6.0 branch...
I think that [debug](https://github.com/dotnet/winforms/blob/main/docs/debugging.md) doc mast be updated with clarification on this (debug apps with changes in main branch):
- you need to install preview sdk (**exact** (must update dynamically?) version and where to get it)
- set preview sdk in VS settings

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6878)