### PR TITLE
Enable nullability in ConnectionPointCookie

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1285,7 +1285,7 @@ static System.Windows.Forms.Screen.PrimaryScreen.get -> System.Windows.Forms.Scr
 ~System.Windows.Forms.AxHost.AxHost(string clsid, int flags) -> void
 ~System.Windows.Forms.AxHost.ClsidAttribute.ClsidAttribute(string clsid) -> void
 ~System.Windows.Forms.AxHost.ClsidAttribute.Value.get -> string
-~System.Windows.Forms.AxHost.ConnectionPointCookie.ConnectionPointCookie(object source, object sink, System.Type eventInterface) -> void
+System.Windows.Forms.AxHost.ConnectionPointCookie.ConnectionPointCookie(object! source, object! sink, System.Type! eventInterface) -> void
 ~System.Windows.Forms.AxHost.ContainingControl.get -> System.Windows.Forms.ContainerControl
 ~System.Windows.Forms.AxHost.ContainingControl.set -> void
 ~System.Windows.Forms.AxHost.DrawToBitmap(System.Drawing.Bitmap bitmap, System.Drawing.Rectangle targetBounds) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.ConnectionPointCookie.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.ConnectionPointCookie.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -15,7 +13,7 @@ namespace System.Windows.Forms
     {
         public class ConnectionPointCookie
         {
-            private Ole32.IConnectionPoint _connectionPoint;
+            private Ole32.IConnectionPoint? _connectionPoint;
             private uint _cookie;
             internal int _threadId;
 
@@ -142,13 +140,13 @@ namespace System.Windows.Forms
                 {
                     if (!AppDomain.CurrentDomain.IsFinalizingForUnload())
                     {
-                        SynchronizationContext context = SynchronizationContext.Current;
+                        SynchronizationContext? context = SynchronizationContext.Current;
                         context?.Post(new SendOrPostCallback(AttemptDisconnect), null);
                     }
                 }
             }
 
-            void AttemptDisconnect(object trash)
+            void AttemptDisconnect(object? trash)
             {
                 if (_threadId == Environment.CurrentManagedThreadId)
                 {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ConnectionPointCookie.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6879)