### PR TITLE
Enable nullability in DataGridViewComboBoxEditingControlAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
@@ -164,7 +164,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
+            internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
             {
                 get
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using static Interop;
 
 namespace System.Windows.Forms
@@ -13,21 +11,22 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Defines the DataGridView ComboBox EditingControl accessible object.
         /// </summary>
-        internal class DataGridViewComboBoxEditingControlAccessibleObject : ComboBox.ComboBoxAccessibleObject
+        internal class DataGridViewComboBoxEditingControlAccessibleObject : ComboBoxAccessibleObject
         {
             private readonly DataGridViewComboBoxEditingControl ownerControl;
 
             /// <summary>
             ///  The parent is changed when the editing control is attached to another editing cell.
             /// </summary>
-            private AccessibleObject _parentAccessibleObject;
+            private AccessibleObject? _parentAccessibleObject;
 
-            public DataGridViewComboBoxEditingControlAccessibleObject(DataGridViewComboBoxEditingControl ownerControl) : base(ownerControl)
+            public DataGridViewComboBoxEditingControlAccessibleObject(DataGridViewComboBoxEditingControl ownerControl)
+                : base(ownerControl)
             {
                 this.ownerControl = ownerControl;
             }
 
-            public override AccessibleObject Parent
+            public override AccessibleObject? Parent
             {
                 get
                 {
@@ -35,7 +34,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
                 switch (direction)
                 {
@@ -53,7 +52,7 @@ namespace System.Windows.Forms
                 return base.FragmentNavigate(direction);
             }
 
-            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
+            internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
             {
                 get
                 {
@@ -83,7 +82,7 @@ namespace System.Windows.Forms
             ///  Sets the parent accessible object for the node which can be added or removed to/from hierarchy nodes.
             /// </summary>
             /// <param name="parent">The parent accessible object.</param>
-            internal override void SetParent(AccessibleObject parent)
+            internal override void SetParent(AccessibleObject? parent)
             {
                 _parentAccessibleObject = parent;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
@@ -13,7 +13,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal class DataGridViewComboBoxEditingControlAccessibleObject : ComboBoxAccessibleObject
         {
-            private readonly DataGridViewComboBoxEditingControl ownerControl;
+            private readonly DataGridViewComboBoxEditingControl _ownerControl;
 
             /// <summary>
             ///  The parent is changed when the editing control is attached to another editing cell.
@@ -23,7 +23,7 @@ namespace System.Windows.Forms
             public DataGridViewComboBoxEditingControlAccessibleObject(DataGridViewComboBoxEditingControl ownerControl)
                 : base(ownerControl)
             {
-                this.ownerControl = ownerControl;
+                _ownerControl = ownerControl;
             }
 
             public override AccessibleObject? Parent
@@ -64,7 +64,7 @@ namespace System.Windows.Forms
             {
                 if (patternId == UiaCore.UIA.ExpandCollapsePatternId)
                 {
-                    return ownerControl.DropDownStyle != ComboBoxStyle.Simple;
+                    return _ownerControl.DropDownStyle != ComboBoxStyle.Simple;
                 }
 
                 return base.IsPatternSupported(patternId);
@@ -74,7 +74,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    return ownerControl.DroppedDown ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
+                    return _ownerControl.DroppedDown ? UiaCore.ExpandCollapseState.Expanded : UiaCore.ExpandCollapseState.Collapsed;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.ToolStripComboBoxControl.ToolStripComboBoxControlAccessibleObject.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms
                     return base.FragmentNavigate(direction);
                 }
 
-                internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
+                internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
                 {
                     get
                     {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewComboBoxEditingControlAccessibleObject.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6880)