### PR TITLE
Fixing TextBox accessible object leaks

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
@@ -12,11 +12,35 @@ namespace System.Windows.Forms
     {
         internal class TextBoxBaseAccessibleObject : ControlAccessibleObject
         {
-            private readonly TextBoxBaseUiaTextProvider _textProvider;
+            private TextBoxBaseUiaTextProvider? _textProvider;
 
             public TextBoxBaseAccessibleObject(TextBoxBase owner) : base(owner)
             {
                 _textProvider = new TextBoxBaseUiaTextProvider(owner);
+            }
+
+            internal void ClearObjects()
+            {
+                _textProvider = null;
+
+                // A place for future memory leak fixing:
+                //
+                // 1) This method should be added to the ControlAccessibleObject class:
+                //    internal void ClearOwnerControl()
+                //    {
+                //        this.Owner = null;
+                //    }
+                //
+                // 2) Owner property shoud be changed from this
+                //        public Control Owner { get; }
+                //    to something like this
+                //        public Control? Owner { get; private set; }
+                //
+                // 3) These changes will produce different sorts of warnings:
+                //     non-nullable member will became nullable, additional checks for null should be added, etc.
+                //
+                // 4) This method call should be uncommented
+                //        ClearOwnerControl();
             }
 
             internal override bool IsIAccessibleExSupported() => true;
@@ -32,29 +56,32 @@ namespace System.Windows.Forms
             internal override bool IsReadOnly
                 => Owner is TextBoxBase textBoxBase && textBoxBase.ReadOnly;
 
-            internal override ITextRangeProvider DocumentRangeInternal
-                => _textProvider.DocumentRange;
+            internal override ITextRangeProvider? DocumentRangeInternal
+                => _textProvider?.DocumentRange;
 
             internal override ITextRangeProvider[]? GetTextSelection()
-                => _textProvider.GetSelection();
+                => _textProvider?.GetSelection();
 
             internal override ITextRangeProvider[]? GetTextVisibleRanges()
-                => _textProvider.GetVisibleRanges();
+                => _textProvider?.GetVisibleRanges();
 
             internal override ITextRangeProvider? GetTextRangeFromChild(IRawElementProviderSimple childElement)
-                => _textProvider.RangeFromChild(childElement);
+                => _textProvider?.RangeFromChild(childElement);
 
             internal override ITextRangeProvider? GetTextRangeFromPoint(Point screenLocation)
-                => _textProvider.RangeFromPoint(screenLocation);
+                => _textProvider?.RangeFromPoint(screenLocation);
 
             internal override SupportedTextSelection SupportedTextSelectionInternal
-                => _textProvider.SupportedTextSelection;
+                => _textProvider?.SupportedTextSelection ?? SupportedTextSelection.None;
 
             internal override ITextRangeProvider? GetTextCaretRange(out BOOL isActive)
-                => _textProvider.GetCaretRange(out isActive);
+            {
+                isActive = BOOL.FALSE;
+                return _textProvider?.GetCaretRange(out isActive);
+            }
 
-            internal override ITextRangeProvider GetRangeFromAnnotation(IRawElementProviderSimple annotationElement)
-                => _textProvider.RangeFromAnnotation(annotationElement);
+            internal override ITextRangeProvider? GetRangeFromAnnotation(IRawElementProviderSimple annotationElement)
+                => _textProvider?.RangeFromAnnotation(annotationElement);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -2198,6 +2198,23 @@ namespace System.Windows.Forms
                     }
 
                     break;
+                case WM.DESTROY:
+                    base.WndProc(ref m);
+                    if (IsAccessibilityObjectCreated && !RecreatingHandle)
+                    {
+                        if (OsVersion.IsWindows8OrGreater)
+                        {
+                            HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
+                            Debug.Assert(result == 0);
+                        }
+
+                        if (AccessibilityObject is TextBoxBaseAccessibleObject accessibleObject)
+                        {
+                            accessibleObject.ClearObjects();
+                        }
+                    }
+
+                    break;
                 default:
                     base.WndProc(ref m);
                     break;

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -755,6 +755,38 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void TextBoxBase_Dispose_ClearsTextProvider()
+        {
+            using TextBox control = new();
+            control.CreateControl();
+            TextBoxBase.TextBoxBaseUiaTextProvider provider = control.AccessibilityObject.TestAccessor().Dynamic._textProvider;
+
+            Assert.IsType<TextBoxBase.TextBoxBaseUiaTextProvider>(provider);
+
+            control.Dispose();
+            provider = control.AccessibilityObject.TestAccessor().Dynamic._textProvider;
+
+            Assert.Null(provider);
+        }
+
+        [WinFormsFact]
+        public void TextBoxBase_RecreateControl_DoesntClearTextProvider()
+        {
+            using TextBox control = new();
+            control.CreateControl();
+            TextBoxBase.TextBoxBaseUiaTextProvider provider = control.AccessibilityObject.TestAccessor().Dynamic._textProvider;
+
+            Assert.IsType<TextBoxBase.TextBoxBaseUiaTextProvider>(provider);
+
+            control.RecreateHandleCore();
+            provider = control.AccessibilityObject.TestAccessor().Dynamic._textProvider;
+
+            // The control's accessible object and its providers shouldn't be cleaned when recreating of the control
+            // because this object and all its providers will continue to be used. 
+            Assert.IsType<TextBoxBase.TextBoxBaseUiaTextProvider>(provider);
+        }
+
+        [WinFormsFact]
         public void TextBoxBase_CanUndo_GetDisposed_ThrowsObjectDisposedException()
         {
             using var control = new TextBox();


### PR DESCRIPTION
Fixes #6885

## Proposed changes
- Use the `UiaDisconnectProvider` method cascade through the hierarchy of the classes to free objects held by accessibility tool
- Nullify needed objects

## Customer Impact
- TextBox memory will stop leaking

## Regression? 
- No

## Risk
- Minimal

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/87859299/159485312-4729b9b1-19bd-425c-ace0-f44b484beb53.png)

### After
![image](https://user-images.githubusercontent.com/87859299/159485380-9b3d1f61-0460-40ea-b2a6-e3eff3695745.png)

### Future
![image](https://user-images.githubusercontent.com/87859299/159487064-78e2893a-ad41-4f2b-92d5-c1f4951b3dfa.png)

This fix isn't clearing all possible memory leaks. In the future nulling the `Owner` property at the `ControlAccessibleObject` class could be added:
1. This method should be added to the ControlAccessibleObject class:
```
                internal void ClearOwnerControl()
                {
                    this.Owner = null;
                }
```
2. Owner property shoud be changed from this
`public Control Owner { get; }`
to something like this
`public Control? Owner { get; private set; }`
3. Calling of the `ClearOwnerControl` should be added/uncommented at the `ClearObjects` method of the `TextBoxBaseAccessibleObject` class
4. These changes will produce different sorts of warnings: non-nullable member will became nullable, additinal checks for null should be added, etc. We discussed it with @vladimir-krestov and decided, that it's better to fix this leak after Vladimir will add new `TextPattern` functionality to the Core branch.

## Test methodology
- Manual testing (_using WinDbg, see the screenshots above_)
- CTI team

## Test environment(s)
- Microsoft Windows [Version 10.0.19043.1586]
- .NET 7.0.0-preview.3.22159.12

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6886)