### PR TITLE
Enable nullability in NumericUpDownAcceleration and NumericUpDownAccelerationCollection

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2227,12 +2227,12 @@ System.Windows.Forms.ListViewItem.ListViewSubItemCollection.this[int index].set 
 ~System.Windows.Forms.NotifyIcon.Text.get -> string
 ~System.Windows.Forms.NotifyIcon.Text.set -> void
 ~System.Windows.Forms.NumericUpDown.Accelerations.get -> System.Windows.Forms.NumericUpDownAccelerationCollection
-~System.Windows.Forms.NumericUpDownAccelerationCollection.Add(System.Windows.Forms.NumericUpDownAcceleration acceleration) -> void
-~System.Windows.Forms.NumericUpDownAccelerationCollection.AddRange(params System.Windows.Forms.NumericUpDownAcceleration[] accelerations) -> void
-~System.Windows.Forms.NumericUpDownAccelerationCollection.Contains(System.Windows.Forms.NumericUpDownAcceleration acceleration) -> bool
-~System.Windows.Forms.NumericUpDownAccelerationCollection.CopyTo(System.Windows.Forms.NumericUpDownAcceleration[] array, int index) -> void
-~System.Windows.Forms.NumericUpDownAccelerationCollection.Remove(System.Windows.Forms.NumericUpDownAcceleration acceleration) -> bool
-~System.Windows.Forms.NumericUpDownAccelerationCollection.this[int index].get -> System.Windows.Forms.NumericUpDownAcceleration
+System.Windows.Forms.NumericUpDownAccelerationCollection.Add(System.Windows.Forms.NumericUpDownAcceleration! acceleration) -> void
+System.Windows.Forms.NumericUpDownAccelerationCollection.AddRange(params System.Windows.Forms.NumericUpDownAcceleration![]! accelerations) -> void
+System.Windows.Forms.NumericUpDownAccelerationCollection.Contains(System.Windows.Forms.NumericUpDownAcceleration! acceleration) -> bool
+System.Windows.Forms.NumericUpDownAccelerationCollection.CopyTo(System.Windows.Forms.NumericUpDownAcceleration![]! array, int index) -> void
+System.Windows.Forms.NumericUpDownAccelerationCollection.Remove(System.Windows.Forms.NumericUpDownAcceleration! acceleration) -> bool
+System.Windows.Forms.NumericUpDownAccelerationCollection.this[int index].get -> System.Windows.Forms.NumericUpDownAcceleration!
 ~System.Windows.Forms.OpenFileDialog.OpenFile() -> System.IO.Stream
 ~System.Windows.Forms.OpenFileDialog.SafeFileName.get -> string
 ~System.Windows.Forms.OpenFileDialog.SafeFileNames.get -> string[]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDownAcceleration.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDownAcceleration.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDownAcceleration.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDownAcceleration.cs
@@ -11,8 +11,8 @@ namespace System.Windows.Forms
     /// </summary>
     public class NumericUpDownAcceleration
     {
-        private int seconds;        // Ideally we would use UInt32 but it is not CLS-compliant.
-        private decimal increment;  // Ideally we would use UInt32 but NumericUpDown uses Decimal values.
+        private int _seconds;        // Ideally we would use UInt32 but it is not CLS-compliant.
+        private decimal _increment;  // Ideally we would use UInt32 but NumericUpDown uses Decimal values.
 
         public NumericUpDownAcceleration(int seconds, decimal increment)
         {
@@ -26,8 +26,8 @@ namespace System.Windows.Forms
                 throw new ArgumentOutOfRangeException(nameof(increment), increment, SR.NumericUpDownLessThanZeroError);
             }
 
-            this.seconds = seconds;
-            this.increment = increment;
+            _seconds = seconds;
+            _increment = increment;
         }
 
         /// <summary>
@@ -38,16 +38,16 @@ namespace System.Windows.Forms
         {
             get
             {
-                return seconds;
+                return _seconds;
             }
             set
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(seconds), value, SR.NumericUpDownLessThanZeroError);
+                    throw new ArgumentOutOfRangeException(nameof(_seconds), value, SR.NumericUpDownLessThanZeroError);
                 }
 
-                seconds = value;
+                _seconds = value;
             }
         }
 
@@ -58,17 +58,17 @@ namespace System.Windows.Forms
         {
             get
             {
-                return increment;
+                return _increment;
             }
 
             set
             {
                 if (value < decimal.Zero)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(increment), value, SR.NumericUpDownLessThanZeroError);
+                    throw new ArgumentOutOfRangeException(nameof(_increment), value, SR.NumericUpDownLessThanZeroError);
                 }
 
-                increment = value;
+                _increment = value;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDownAccelerationCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDownAccelerationCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.ComponentModel;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDownAccelerationCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NumericUpDownAccelerationCollection.cs
@@ -14,7 +14,7 @@ namespace System.Windows.Forms
     [ListBindable(false)]
     public class NumericUpDownAccelerationCollection : MarshalByRefObject, ICollection<NumericUpDownAcceleration>, IEnumerable<NumericUpDownAcceleration>
     {
-        readonly List<NumericUpDownAcceleration> items;
+        private readonly List<NumericUpDownAcceleration> _items;
 
         /// <summary>
         ///  Adds an item (NumericUpDownAcceleration object) to the ICollection.
@@ -27,9 +27,9 @@ namespace System.Windows.Forms
             // Keep the array sorted, insert in the right spot.
             int index = 0;
 
-            while (index < items.Count)
+            while (index < _items.Count)
             {
-                if (acceleration.Seconds < items[index].Seconds)
+                if (acceleration.Seconds < _items[index].Seconds)
                 {
                     break;
                 }
@@ -37,7 +37,7 @@ namespace System.Windows.Forms
                 index++;
             }
 
-            items.Insert(index, acceleration);
+            _items.Insert(index, acceleration);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace System.Windows.Forms
         /// </summary>
         public void Clear()
         {
-            items.Clear();
+            _items.Clear();
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace System.Windows.Forms
         /// </summary>
         public bool Contains(NumericUpDownAcceleration acceleration)
         {
-            return items.Contains(acceleration);
+            return _items.Contains(acceleration);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace System.Windows.Forms
         /// </summary>
         public void CopyTo(NumericUpDownAcceleration[] array, int index)
         {
-            items.CopyTo(array, index);
+            _items.CopyTo(array, index);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
         /// </summary>
         public int Count
         {
-            get { return items.Count; }
+            get { return _items.Count; }
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace System.Windows.Forms
         /// </summary>
         public bool Remove(NumericUpDownAcceleration acceleration)
         {
-            return items.Remove(acceleration);
+            return _items.Remove(acceleration);
         }
 
         /// <summary>
@@ -94,12 +94,12 @@ namespace System.Windows.Forms
         /// </summary>
         IEnumerator<NumericUpDownAcceleration> IEnumerable<NumericUpDownAcceleration>.GetEnumerator()
         {
-            return items.GetEnumerator();
+            return _items.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable)items).GetEnumerator();
+            return ((IEnumerable)_items).GetEnumerator();
         }
 
         ///  NumericUpDownAccelerationCollection methods.
@@ -109,7 +109,7 @@ namespace System.Windows.Forms
         /// </summary>
         public NumericUpDownAccelerationCollection()
         {
-            items = new List<NumericUpDownAcceleration>();
+            _items = new List<NumericUpDownAcceleration>();
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace System.Windows.Forms
         /// </summary>
         public NumericUpDownAcceleration this[int index]
         {
-            get { return items[index]; }
+            get { return _items[index]; }
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in NumericUpDownAcceleration and NumericUpDownAccelerationCollection.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6893)