### PR TITLE
Enable nullability in ListViewGroupCollection and ListViewGroupItemCollection

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2105,10 +2105,10 @@ System.Windows.Forms.ListViewGroupCollection.Add(string? key, string? headerText
 System.Windows.Forms.ListViewGroupCollection.Add(System.Windows.Forms.ListViewGroup! group) -> int
 System.Windows.Forms.ListViewGroupCollection.AddRange(System.Windows.Forms.ListViewGroup![]! groups) -> void
 System.Windows.Forms.ListViewGroupCollection.AddRange(System.Windows.Forms.ListViewGroupCollection! groups) -> void
-System.Windows.Forms.ListViewGroupCollection.Contains(System.Windows.Forms.ListViewGroup? value) -> bool
+System.Windows.Forms.ListViewGroupCollection.Contains(System.Windows.Forms.ListViewGroup! value) -> bool
 System.Windows.Forms.ListViewGroupCollection.CopyTo(System.Array! array, int index) -> void
 System.Windows.Forms.ListViewGroupCollection.GetEnumerator() -> System.Collections.IEnumerator!
-System.Windows.Forms.ListViewGroupCollection.IndexOf(System.Windows.Forms.ListViewGroup? value) -> int
+System.Windows.Forms.ListViewGroupCollection.IndexOf(System.Windows.Forms.ListViewGroup! value) -> int
 System.Windows.Forms.ListViewGroupCollection.Insert(int index, System.Windows.Forms.ListViewGroup! group) -> void
 System.Windows.Forms.ListViewGroupCollection.Remove(System.Windows.Forms.ListViewGroup! group) -> void
 System.Windows.Forms.ListViewGroupCollection.this[int index].get -> System.Windows.Forms.ListViewGroup!

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2101,20 +2101,20 @@ System.Windows.Forms.ListView.StateImageList.get -> System.Windows.Forms.ImageLi
 System.Windows.Forms.ListView.StateImageList.set -> void
 System.Windows.Forms.ListView.TopItem.get -> System.Windows.Forms.ListViewItem?
 System.Windows.Forms.ListView.TopItem.set -> void
-~System.Windows.Forms.ListViewGroupCollection.Add(string key, string headerText) -> System.Windows.Forms.ListViewGroup
-~System.Windows.Forms.ListViewGroupCollection.Add(System.Windows.Forms.ListViewGroup group) -> int
-~System.Windows.Forms.ListViewGroupCollection.AddRange(System.Windows.Forms.ListViewGroup[] groups) -> void
-~System.Windows.Forms.ListViewGroupCollection.AddRange(System.Windows.Forms.ListViewGroupCollection groups) -> void
-~System.Windows.Forms.ListViewGroupCollection.Contains(System.Windows.Forms.ListViewGroup value) -> bool
-~System.Windows.Forms.ListViewGroupCollection.CopyTo(System.Array array, int index) -> void
-~System.Windows.Forms.ListViewGroupCollection.GetEnumerator() -> System.Collections.IEnumerator
-~System.Windows.Forms.ListViewGroupCollection.IndexOf(System.Windows.Forms.ListViewGroup value) -> int
-~System.Windows.Forms.ListViewGroupCollection.Insert(int index, System.Windows.Forms.ListViewGroup group) -> void
-~System.Windows.Forms.ListViewGroupCollection.Remove(System.Windows.Forms.ListViewGroup group) -> void
-~System.Windows.Forms.ListViewGroupCollection.this[int index].get -> System.Windows.Forms.ListViewGroup
-~System.Windows.Forms.ListViewGroupCollection.this[int index].set -> void
-~System.Windows.Forms.ListViewGroupCollection.this[string key].get -> System.Windows.Forms.ListViewGroup
-~System.Windows.Forms.ListViewGroupCollection.this[string key].set -> void
+System.Windows.Forms.ListViewGroupCollection.Add(string? key, string? headerText) -> System.Windows.Forms.ListViewGroup!
+System.Windows.Forms.ListViewGroupCollection.Add(System.Windows.Forms.ListViewGroup! group) -> int
+System.Windows.Forms.ListViewGroupCollection.AddRange(System.Windows.Forms.ListViewGroup![]! groups) -> void
+System.Windows.Forms.ListViewGroupCollection.AddRange(System.Windows.Forms.ListViewGroupCollection! groups) -> void
+System.Windows.Forms.ListViewGroupCollection.Contains(System.Windows.Forms.ListViewGroup? value) -> bool
+System.Windows.Forms.ListViewGroupCollection.CopyTo(System.Array! array, int index) -> void
+System.Windows.Forms.ListViewGroupCollection.GetEnumerator() -> System.Collections.IEnumerator!
+System.Windows.Forms.ListViewGroupCollection.IndexOf(System.Windows.Forms.ListViewGroup? value) -> int
+System.Windows.Forms.ListViewGroupCollection.Insert(int index, System.Windows.Forms.ListViewGroup! group) -> void
+System.Windows.Forms.ListViewGroupCollection.Remove(System.Windows.Forms.ListViewGroup! group) -> void
+System.Windows.Forms.ListViewGroupCollection.this[int index].get -> System.Windows.Forms.ListViewGroup!
+System.Windows.Forms.ListViewGroupCollection.this[int index].set -> void
+System.Windows.Forms.ListViewGroupCollection.this[string! key].get -> System.Windows.Forms.ListViewGroup?
+System.Windows.Forms.ListViewGroupCollection.this[string! key].set -> void
 ~System.Windows.Forms.ListViewHitTestInfo.Item.get -> System.Windows.Forms.ListViewItem
 ~System.Windows.Forms.ListViewHitTestInfo.ListViewHitTestInfo(System.Windows.Forms.ListViewItem hitItem, System.Windows.Forms.ListViewItem.ListViewSubItem hitSubItem, System.Windows.Forms.ListViewHitTestLocations hitLocation) -> void
 ~System.Windows.Forms.ListViewHitTestInfo.SubItem.get -> System.Windows.Forms.ListViewItem.ListViewSubItem

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -18,7 +16,7 @@ namespace System.Windows.Forms
     {
         private readonly ListView _listView;
 
-        private ArrayList _list;
+        private ArrayList? _list;
 
         internal ListViewGroupCollection(ListView listView)
         {
@@ -35,11 +33,11 @@ namespace System.Windows.Forms
 
         bool IList.IsReadOnly => false;
 
-        private ArrayList List => _list ?? (_list = new ArrayList());
+        private ArrayList List => _list ??= new ArrayList();
 
         public ListViewGroup this[int index]
         {
-            get => (ListViewGroup)List[index];
+            get => (ListViewGroup)List[index]!;
             set
             {
                 ArgumentNullException.ThrowIfNull(value);
@@ -55,7 +53,7 @@ namespace System.Windows.Forms
             }
         }
 
-        public ListViewGroup this[string key]
+        public ListViewGroup? this[string key]
         {
             get
             {
@@ -101,7 +99,7 @@ namespace System.Windows.Forms
             }
         }
 
-        object IList.this[int index]
+        object? IList.this[int index]
         {
             get => this[index];
             set
@@ -135,16 +133,16 @@ namespace System.Windows.Forms
             return index;
         }
 
-        public ListViewGroup Add(string key, string headerText)
+        public ListViewGroup Add(string? key, string? headerText)
         {
             ListViewGroup group = new ListViewGroup(key, headerText);
             Add(group);
             return group;
         }
 
-        int IList.Add(object value)
+        int IList.Add(object? value)
         {
-            if (!(value is ListViewGroup group))
+            if (value is not ListViewGroup group)
             {
                 throw new ArgumentException(SR.ListViewGroupCollectionBadListViewGroup, nameof(value));
             }
@@ -209,11 +207,11 @@ namespace System.Windows.Forms
             _listView.UpdateGroupView();
         }
 
-        public bool Contains(ListViewGroup value) => List.Contains(value);
+        public bool Contains(ListViewGroup? value) => List.Contains(value);
 
-        bool IList.Contains(object value)
+        bool IList.Contains(object? value)
         {
-            if (!(value is ListViewGroup group))
+            if (value is not ListViewGroup group)
             {
                 return false;
             }
@@ -225,16 +223,16 @@ namespace System.Windows.Forms
 
         public IEnumerator GetEnumerator() => List.GetEnumerator();
 
-        public int IndexOf(ListViewGroup value) => List.IndexOf(value);
+        public int IndexOf(ListViewGroup? value) => List.IndexOf(value);
 
-        int IList.IndexOf(object value)
+        int IList.IndexOf(object? value)
         {
-            if (!(value is ListViewGroup group))
+            if (value is not ListViewGroup group)
             {
                 return -1;
             }
 
-            return IndexOf((ListViewGroup)value);
+            return IndexOf(group);
         }
 
         public void Insert(int index, ListViewGroup group)
@@ -257,7 +255,7 @@ namespace System.Windows.Forms
             }
         }
 
-        void IList.Insert(int index, object value)
+        void IList.Insert(int index, object? value)
         {
             if (value is ListViewGroup group)
             {
@@ -289,7 +287,7 @@ namespace System.Windows.Forms
             }
         }
 
-        void IList.Remove(object value)
+        void IList.Remove(object? value)
         {
             if (value is ListViewGroup group)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollection.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms
     {
         private readonly ListView _listView;
 
-        private ArrayList? _list;
+        private List<ListViewGroup>? _list;
 
         internal ListViewGroupCollection(ListView listView)
         {
@@ -33,11 +33,11 @@ namespace System.Windows.Forms
 
         bool IList.IsReadOnly => false;
 
-        private ArrayList List => _list ??= new ArrayList();
+        private List<ListViewGroup> List => _list ??= new List<ListViewGroup>();
 
         public ListViewGroup this[int index]
         {
-            get => (ListViewGroup)List[index]!;
+            get => List[index];
             set
             {
                 ArgumentNullException.ThrowIfNull(value);
@@ -123,7 +123,8 @@ namespace System.Windows.Forms
 
             CheckListViewItems(group);
             group.ListView = _listView;
-            int index = List.Add(group);
+            List.Add(group);
+            int index = List.Count - 1;
             if (_listView.IsHandleCreated)
             {
                 _listView.InsertGroupInListView(List.Count, group);
@@ -207,7 +208,7 @@ namespace System.Windows.Forms
             _listView.UpdateGroupView();
         }
 
-        public bool Contains(ListViewGroup? value) => List.Contains(value);
+        public bool Contains(ListViewGroup value) => List.Contains(value);
 
         bool IList.Contains(object? value)
         {
@@ -219,11 +220,11 @@ namespace System.Windows.Forms
             return Contains(group);
         }
 
-        public void CopyTo(Array array, int index) => List.CopyTo(array, index);
+        public void CopyTo(Array array, int index) => ((ICollection)List).CopyTo(array, index);
 
         public IEnumerator GetEnumerator() => List.GetEnumerator();
 
-        public int IndexOf(ListViewGroup? value) => List.IndexOf(value);
+        public int IndexOf(ListViewGroup value) => List.IndexOf(value);
 
         int IList.IndexOf(object? value)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupItemCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 
 namespace System.Windows.Forms
@@ -11,7 +9,7 @@ namespace System.Windows.Forms
     internal class ListViewGroupItemCollection : ListView.ListViewItemCollection.IInnerList
     {
         private readonly ListViewGroup _group;
-        private ArrayList _items;
+        private ArrayList? _items;
 
         public ListViewGroupItemCollection(ListViewGroup group)
         {
@@ -20,7 +18,7 @@ namespace System.Windows.Forms
 
         public int Count => Items.Count;
 
-        private ArrayList Items => _items ?? (_items = new ArrayList());
+        private ArrayList Items => _items ??= new ArrayList();
 
         public bool OwnerIsVirtualListView => _group.ListView is not null && _group.ListView.VirtualMode;
 
@@ -28,14 +26,14 @@ namespace System.Windows.Forms
 
         public ListViewItem this[int index]
         {
-            get => (ListViewItem)Items[index];
+            get => (ListViewItem)Items[index]!;
             set
             {
                 if (value != Items[index])
                 {
-                    MoveToGroup((ListViewItem)Items[index], null);
+                    MoveToGroup((ListViewItem)Items[index]!, null);
                     Items[index] = value;
-                    MoveToGroup((ListViewItem)Items[index], _group);
+                    MoveToGroup((ListViewItem)Items[index]!, _group);
                 }
             }
         }
@@ -99,7 +97,7 @@ namespace System.Windows.Forms
             return item;
         }
 
-        private void MoveToGroup(ListViewItem item, ListViewGroup newGroup)
+        private void MoveToGroup(ListViewItem item, ListViewGroup? newGroup)
         {
             ListViewGroup oldGroup = item.Group;
             if (oldGroup != newGroup)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupItemCollection.cs
@@ -9,7 +9,7 @@ namespace System.Windows.Forms
     internal class ListViewGroupItemCollection : ListView.ListViewItemCollection.IInnerList
     {
         private readonly ListViewGroup _group;
-        private ArrayList? _items;
+        private List<ListViewItem>? _items;
 
         public ListViewGroupItemCollection(ListViewGroup group)
         {
@@ -18,7 +18,7 @@ namespace System.Windows.Forms
 
         public int Count => Items.Count;
 
-        private ArrayList Items => _items ??= new ArrayList();
+        private List<ListViewItem> Items => _items ??= new List<ListViewItem>();
 
         public bool OwnerIsVirtualListView => _group.ListView is not null && _group.ListView.VirtualMode;
 
@@ -26,14 +26,14 @@ namespace System.Windows.Forms
 
         public ListViewItem this[int index]
         {
-            get => (ListViewItem)Items[index]!;
+            get => Items[index];
             set
             {
                 if (value != Items[index])
                 {
-                    MoveToGroup((ListViewItem)Items[index]!, null);
+                    MoveToGroup(Items[index], null);
                     Items[index] = value;
-                    MoveToGroup((ListViewItem)Items[index]!, _group);
+                    MoveToGroup(Items[index], _group);
                 }
             }
         }
@@ -82,7 +82,7 @@ namespace System.Windows.Forms
 
         public bool Contains(ListViewItem item) => Items.Contains(item);
 
-        public void CopyTo(Array dest, int index) => Items.CopyTo(dest, index);
+        public void CopyTo(Array dest, int index) => ((ICollection)Items).CopyTo(dest, index);
 
         public IEnumerator GetEnumerator() => Items.GetEnumerator();
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ListViewGroupCollection and ListViewGroupItemCollection.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6909)