### PR TITLE
Move ToolStripOverflowAccessibleObject to a separate file and enable nullability to it

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObject.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+namespace System.Windows.Forms
+{
+    public partial class ToolStripOverflow
+    {
+        internal class ToolStripOverflowAccessibleObject : ToolStripAccessibleObject
+        {
+            public ToolStripOverflowAccessibleObject(ToolStripOverflow owner)
+                : base(owner)
+            {
+            }
+
+            public override AccessibleObject GetChild(int index)
+            {
+                return ((ToolStripOverflow)Owner).DisplayedItems[index].AccessibilityObject;
+            }
+
+            public override int GetChildCount()
+            {
+                return ((ToolStripOverflow)Owner).DisplayedItems.Count;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class ToolStripOverflow

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.cs
@@ -10,7 +10,7 @@ using System.Windows.Forms.Layout;
 
 namespace System.Windows.Forms
 {
-    public class ToolStripOverflow : ToolStripDropDown, IArrangedElement
+    public partial class ToolStripOverflow : ToolStripDropDown, IArrangedElement
     {
 #if DEBUG
         internal static readonly TraceSwitch PopupLayoutDebug = new TraceSwitch("PopupLayoutDebug", "Debug ToolStripPopup Layout code");
@@ -153,24 +153,6 @@ namespace System.Windows.Forms
             }
 
             SetLargestItemSize(biggestItemSize);
-        }
-
-        internal class ToolStripOverflowAccessibleObject : ToolStripAccessibleObject
-        {
-            public ToolStripOverflowAccessibleObject(ToolStripOverflow owner)
-                : base(owner)
-            {
-            }
-
-            public override AccessibleObject GetChild(int index)
-            {
-                return ((ToolStripOverflow)Owner).DisplayedItems[index].AccessibilityObject;
-            }
-
-            public override int GetChildCount()
-            {
-                return ((ToolStripOverflow)Owner).DisplayedItems.Count;
-            }
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Move ToolStripOverflowAccessibleObject to a separate file and enable nullability to it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6913)