### PR TITLE
Enable nullability in DataGridViewSelectedRowCellsAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewSelectedRowCellsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewSelectedRowCellsAccessibleObject.cs
@@ -10,17 +10,17 @@ namespace System.Windows.Forms
     {
         private class DataGridViewSelectedRowCellsAccessibleObject : AccessibleObject
         {
-            private readonly DataGridViewRow owner;
-            private int[]? runtimeId;
+            private readonly DataGridViewRow _owner;
+            private int[]? _runtimeId;
 
             internal DataGridViewSelectedRowCellsAccessibleObject(DataGridViewRow owner)
             {
-                this.owner = owner;
+                _owner = owner;
             }
 
             public override string Name => SR.DataGridView_AccSelectedRowCellsName;
 
-            public override AccessibleObject Parent => owner.AccessibilityObject;
+            public override AccessibleObject Parent => _owner.AccessibilityObject;
 
             public override AccessibleRole Role => AccessibleRole.Grouping;
 
@@ -32,16 +32,16 @@ namespace System.Windows.Forms
             public override string Value => Name;
 
             internal override int[] RuntimeId
-                => runtimeId ??= new int[] { RuntimeIDFirstItem, Parent.GetHashCode(), GetHashCode() };
+                => _runtimeId ??= new int[] { RuntimeIDFirstItem, Parent.GetHashCode(), GetHashCode() };
 
             public override AccessibleObject? GetChild(int index)
             {
                 if (index < GetChildCount())
                 {
                     int selectedCellsCount = -1;
-                    for (int i = 1; i < owner.AccessibilityObject.GetChildCount(); i++)
+                    for (int i = 1; i < _owner.AccessibilityObject.GetChildCount(); i++)
                     {
-                        AccessibleObject? child = owner.AccessibilityObject.GetChild(i);
+                        AccessibleObject? child = _owner.AccessibilityObject.GetChild(i);
                         if (child is not null && (child.State & AccessibleStates.Selected) == AccessibleStates.Selected)
                         {
                             selectedCellsCount++;
@@ -67,9 +67,9 @@ namespace System.Windows.Forms
                 int selectedCellsCount = 0;
 
                 // start the enumeration from 1, because the first acc obj in the data grid view row is the row header cell
-                for (int i = 1; i < owner.AccessibilityObject.GetChildCount(); i++)
+                for (int i = 1; i < _owner.AccessibilityObject.GetChildCount(); i++)
                 {
-                    AccessibleObject? child = owner.AccessibilityObject.GetChild(i);
+                    AccessibleObject? child = _owner.AccessibilityObject.GetChild(i);
                     if (child is not null && (child.State & AccessibleStates.Selected) == AccessibleStates.Selected)
                     {
                         selectedCellsCount++;
@@ -83,9 +83,9 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetFocused()
             {
-                if (owner.DataGridView?.CurrentCell is not null && owner.DataGridView.CurrentCell.Selected)
+                if (_owner.DataGridView?.CurrentCell is not null && _owner.DataGridView.CurrentCell.Selected)
                 {
-                    return owner.DataGridView.CurrentCell.AccessibilityObject;
+                    return _owner.DataGridView.CurrentCell.AccessibilityObject;
                 }
                 else
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewSelectedRowCellsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewSelectedRowCellsAccessibleObject.cs
@@ -10,17 +10,17 @@ namespace System.Windows.Forms
     {
         private class DataGridViewSelectedRowCellsAccessibleObject : AccessibleObject
         {
-            private readonly DataGridViewRow _owner;
+            private readonly DataGridViewRow _owningDataGridViewRow;
             private int[]? _runtimeId;
 
             internal DataGridViewSelectedRowCellsAccessibleObject(DataGridViewRow owner)
             {
-                _owner = owner;
+                _owningDataGridViewRow = owner;
             }
 
             public override string Name => SR.DataGridView_AccSelectedRowCellsName;
 
-            public override AccessibleObject Parent => _owner.AccessibilityObject;
+            public override AccessibleObject Parent => _owningDataGridViewRow.AccessibilityObject;
 
             public override AccessibleRole Role => AccessibleRole.Grouping;
 
@@ -39,9 +39,9 @@ namespace System.Windows.Forms
                 if (index < GetChildCount())
                 {
                     int selectedCellsCount = -1;
-                    for (int i = 1; i < _owner.AccessibilityObject.GetChildCount(); i++)
+                    for (int i = 1; i < _owningDataGridViewRow.AccessibilityObject.GetChildCount(); i++)
                     {
-                        AccessibleObject? child = _owner.AccessibilityObject.GetChild(i);
+                        AccessibleObject? child = _owningDataGridViewRow.AccessibilityObject.GetChild(i);
                         if (child is not null && (child.State & AccessibleStates.Selected) == AccessibleStates.Selected)
                         {
                             selectedCellsCount++;
@@ -67,9 +67,9 @@ namespace System.Windows.Forms
                 int selectedCellsCount = 0;
 
                 // start the enumeration from 1, because the first acc obj in the data grid view row is the row header cell
-                for (int i = 1; i < _owner.AccessibilityObject.GetChildCount(); i++)
+                for (int i = 1; i < _owningDataGridViewRow.AccessibilityObject.GetChildCount(); i++)
                 {
-                    AccessibleObject? child = _owner.AccessibilityObject.GetChild(i);
+                    AccessibleObject? child = _owningDataGridViewRow.AccessibilityObject.GetChild(i);
                     if (child is not null && (child.State & AccessibleStates.Selected) == AccessibleStates.Selected)
                     {
                         selectedCellsCount++;
@@ -83,9 +83,9 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetFocused()
             {
-                if (_owner.DataGridView?.CurrentCell is not null && _owner.DataGridView.CurrentCell.Selected)
+                if (_owningDataGridViewRow.DataGridView?.CurrentCell is not null && _owningDataGridViewRow.DataGridView.CurrentCell.Selected)
                 {
-                    return _owner.DataGridView.CurrentCell.AccessibilityObject;
+                    return _owningDataGridViewRow.DataGridView.CurrentCell.AccessibilityObject;
                 }
                 else
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewSelectedRowCellsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewSelectedRowCellsAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 
 namespace System.Windows.Forms
@@ -13,7 +11,7 @@ namespace System.Windows.Forms
         private class DataGridViewSelectedRowCellsAccessibleObject : AccessibleObject
         {
             private readonly DataGridViewRow owner;
-            private int[] runtimeId;
+            private int[]? runtimeId;
 
             internal DataGridViewSelectedRowCellsAccessibleObject(DataGridViewRow owner)
             {
@@ -36,21 +34,22 @@ namespace System.Windows.Forms
             internal override int[] RuntimeId
                 => runtimeId ??= new int[] { RuntimeIDFirstItem, Parent.GetHashCode(), GetHashCode() };
 
-            public override AccessibleObject GetChild(int index)
+            public override AccessibleObject? GetChild(int index)
             {
                 if (index < GetChildCount())
                 {
                     int selectedCellsCount = -1;
                     for (int i = 1; i < owner.AccessibilityObject.GetChildCount(); i++)
                     {
-                        if ((owner.AccessibilityObject.GetChild(i).State & AccessibleStates.Selected) == AccessibleStates.Selected)
+                        AccessibleObject? child = owner.AccessibilityObject.GetChild(i);
+                        if (child is not null && (child.State & AccessibleStates.Selected) == AccessibleStates.Selected)
                         {
                             selectedCellsCount++;
                         }
 
                         if (selectedCellsCount == index)
                         {
-                            return owner.AccessibilityObject.GetChild(i);
+                            return child;
                         }
                     }
 
@@ -70,7 +69,8 @@ namespace System.Windows.Forms
                 // start the enumeration from 1, because the first acc obj in the data grid view row is the row header cell
                 for (int i = 1; i < owner.AccessibilityObject.GetChildCount(); i++)
                 {
-                    if ((owner.AccessibilityObject.GetChild(i).State & AccessibleStates.Selected) == AccessibleStates.Selected)
+                    AccessibleObject? child = owner.AccessibilityObject.GetChild(i);
+                    if (child is not null && (child.State & AccessibleStates.Selected) == AccessibleStates.Selected)
                     {
                         selectedCellsCount++;
                     }
@@ -81,7 +81,7 @@ namespace System.Windows.Forms
 
             public override AccessibleObject GetSelected() => this;
 
-            public override AccessibleObject GetFocused()
+            public override AccessibleObject? GetFocused()
             {
                 if (owner.DataGridView?.CurrentCell is not null && owner.DataGridView.CurrentCell.Selected)
                 {
@@ -93,7 +93,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override AccessibleObject Navigate(AccessibleNavigation navigationDirection)
+            public override AccessibleObject? Navigate(AccessibleNavigation navigationDirection)
             {
                 switch (navigationDirection)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewSelectedRowCellsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewSelectedRowCellsAccessibleObject.cs
@@ -83,9 +83,10 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetFocused()
             {
-                if (_owningDataGridViewRow.DataGridView?.CurrentCell is not null && _owningDataGridViewRow.DataGridView.CurrentCell.Selected)
+                DataGridViewCell? currentCell = _owningDataGridViewRow.DataGridView?.CurrentCell;
+                if (currentCell is not null && currentCell.Selected)
                 {
-                    return _owningDataGridViewRow.DataGridView.CurrentCell.AccessibilityObject;
+                    return currentCell.AccessibilityObject;
                 }
                 else
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCellsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCellsAccessibleObjectTests.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Forms.Tests
                 .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
             var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { null }, null);
 
-            Assert.Null(accessibleObject.TestAccessor().Dynamic.owner);
+            Assert.Null(accessibleObject.TestAccessor().Dynamic._owner);
             Assert.Equal(AccessibleRole.Grouping, accessibleObject.Role);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCellsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewSelectedRowCellsAccessibleObjectTests.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Forms.Tests
                 .GetNestedType("DataGridViewSelectedRowCellsAccessibleObject", BindingFlags.NonPublic | BindingFlags.Instance);
             var accessibleObject = (AccessibleObject)Activator.CreateInstance(type, BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { null }, null);
 
-            Assert.Null(accessibleObject.TestAccessor().Dynamic._owner);
+            Assert.Null(accessibleObject.TestAccessor().Dynamic._owningDataGridViewRow);
             Assert.Equal(AccessibleRole.Grouping, accessibleObject.Role);
         }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewSelectedRowCellsAccessibleObject.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6917)