### PR TITLE
Fixing ToolStripScrollBtton display issue

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -2,3 +2,4 @@ System.Windows.Forms.BindingMemberInfo.Equals(System.Windows.Forms.BindingMember
 System.Windows.Forms.LinkArea.Equals(System.Windows.Forms.LinkArea other) -> bool
 System.Windows.Forms.TableLayoutPanelCellPosition.Equals(System.Windows.Forms.TableLayoutPanelCellPosition other) -> bool
 override System.Windows.Forms.Form.OnGotFocus(System.EventArgs! e) -> void
+~override System.Windows.Forms.ToolStripDropDownMenu.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6004,6 +6004,12 @@ Stack trace where the illegal operation occurred was:
   <data name="ToolStripSaveSettingsDescr" xml:space="preserve">
     <value>Specifies whether the ToolStrip should persist user settings via IPersistComponentSettings.</value>
   </data>
+  <data name="ToolStripScrollButtonDownAccessibleName" xml:space="preserve">
+    <value>Line down</value>
+  </data>
+  <data name="ToolStripScrollButtonUpAccessibleName" xml:space="preserve">
+    <value>Line up</value>
+  </data>
   <data name="ToolStripSettingsKeyDescr" xml:space="preserve">
     <value>Specifies the settings key to use to save settings.</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -10311,6 +10311,16 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Určuje, zda má ovládací prvek ToolStrip zachovat uživatelská nastavení prostřednictvím rozhraní IPersistComponentSettings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">Určuje klávesu nastavení, která se má používat k uložení nastavení.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -10311,6 +10311,16 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Gibt an, ob der ToolStrip Benutzereinstellungen über IPersistComponentSettings beibehalten soll.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">Gibt den Einstellungsschlüssel an, der zum Speichern von Einstellungen verwendet werden soll.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -10311,6 +10311,16 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">Especifica si ToolStrip debería conservar la configuración de usuario mediante IPersistComponentSettings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">Especifica la clave de configuración que se va a utilizar para guardar la configuración.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -10311,6 +10311,16 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">Spécifie si le ToolStrip doit rendre persistant les paramètres utilisateur via IPersistComponentSettings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">Spécifie la clé des paramètres à utiliser pour enregistrer les paramètres.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -10311,6 +10311,16 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">Specifica se per ToolStrip devono essere mantenute le impostazioni utente tramite IPersistComponentSettings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">Specifica il tasto da utilizzare per salvare le impostazioni.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -10311,6 +10311,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">IPersistComponentSettings をとおして、ToolStrip がユーザー設定を保持するかどうかを指定します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">設定を保存するために使用する設定キーを指定します。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -10311,6 +10311,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">ToolStrip이 IPersistComponentSettings를 통해 사용자 설정을 유지할지 여부를 지정합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">설정을 저장하는 데 사용할 설정 키를 지정합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -10311,6 +10311,16 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Określa, czy element ToolStrip ma utrwalić ustawienia użytkownika przy użyciu elementu IPersistComponentSettings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">Określa klucz ustawień używany do zapisania ustawień.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -10311,6 +10311,16 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">Especifica se ToolStrip deve preservar as configurações de usuário via IPersistComponentSettings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">Especifica a chave de configurações a ser usada para salvar as configurações.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -10312,6 +10312,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Определяет, должен ли элемент ToolStrip сохранять пользовательские настройки при помощи IPersistComponentSettings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">Определяет клавишу настройки для сохранения параметров.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -10311,6 +10311,16 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">ToolStrip'in kullanıcı ayarlarını IPersistComponentSettings aracılığıyla kalıcı yapıp yapmayacağını belirtir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">Ayarları kaydetmek üzere kullanılacak ayarlar anahtarını belirtir.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -10311,6 +10311,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">指定 ToolStrip 是否应通过 IPersistComponentSettings 保持用户设置。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">指定用于保存设置的设置键。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -10311,6 +10311,16 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">指定 ToolStrip 是否應該透過 IPersistComponentSettings 保存使用者設定。</target>
         <note />
       </trans-unit>
+      <trans-unit id="ToolStripScrollButtonDownAccessibleName">
+        <source>Line down</source>
+        <target state="new">Line down</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ToolStripScrollButtonUpAccessibleName">
+        <source>Line up</source>
+        <target state="new">Line up</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ToolStripSettingsKeyDescr">
         <source>Specifies the settings key to use to save settings.</source>
         <target state="translated">指定儲存設定時所要使用的設定索引鍵。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.ToolStripAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.ToolStripAccessibleObject.cs
@@ -204,7 +204,7 @@ namespace System.Windows.Forms
 
                 AccessibleObject? GetItemAccessibleObject(ToolStripItem item)
                 {
-                    if (item is ToolStripControlHost controlHostItem)
+                    if (item is ToolStripControlHost controlHostItem and not ToolStripScrollButton)
                     {
                         if (ShouldItemBeSkipped(controlHostItem.Control))
                         {
@@ -324,7 +324,9 @@ namespace System.Windows.Forms
                     }
 
                     // Items can be either in DisplayedItems or in OverflowItems (if overflow)
-                    items = (placement == ToolStripItemPlacement.Main) ? _owningToolStrip.DisplayedItems : _owningToolStrip.OverflowItems;
+                    items = placement == ToolStripItemPlacement.Main || child.Owner is ToolStripScrollButton
+                        ? _owningToolStrip.DisplayedItems
+                        : _owningToolStrip.OverflowItems;
                 }
 
                 // First we walk through the head aligned items.
@@ -424,12 +426,7 @@ namespace System.Windows.Forms
                     || (hostedControl is Label label && string.IsNullOrEmpty(label.Text));
 
             internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
-            {
-                get
-                {
-                    return this;
-                }
-            }
+                => this;
 
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItemAccessibleObject.cs
@@ -184,7 +184,7 @@ namespace System.Windows.Forms
                         break;
                     }
 
-                    int index = dropDown.Items.IndexOf(_owner);
+                    int index = dropDown.DisplayedItems.IndexOf(_owner);
 
                     if (index == -1)
                     {
@@ -194,9 +194,9 @@ namespace System.Windows.Forms
 
                     index += direction == UiaCore.NavigateDirection.NextSibling ? 1 : -1;
 
-                    if (index >= 0 && index < dropDown.Items.Count)
+                    if (index >= 0 && index < dropDown.DisplayedItems.Count)
                     {
-                        ToolStripItem item = dropDown.Items[index];
+                        ToolStripItem item = dropDown.DisplayedItems[index];
                         if (item is ToolStripControlHost controlHostItem)
                         {
                             return controlHostItem.ControlAccessibilityObject;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItemAccessibleObject.cs
@@ -206,6 +206,11 @@ namespace System.Windows.Forms
                     }
 
                     return null;
+                case UiaCore.NavigateDirection.FirstChild:
+                case UiaCore.NavigateDirection.LastChild:
+                    return _owner.DropDownItems.Count > 0
+                        ? _owner.DropDown.AccessibilityObject
+                        : null;
             }
 
             return base.FragmentNavigate(direction);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class ToolStripDropDownMenu : ToolStripDropDown
+    {
+        internal class ToolStripDropDownMenuAccessibleObject : ToolStripDropDownAccessibleObject
+        {
+            private readonly ToolStripDropDownMenu _owningToolStrip;
+
+            public ToolStripDropDownMenuAccessibleObject(ToolStripDropDownMenu owner) : base(owner)
+            {
+                _owningToolStrip = owner;
+            }
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                return direction switch
+                {
+                    UiaCore.NavigateDirection.Parent => _owningToolStrip.OwnerItem?.AccessibilityObject,
+                    UiaCore.NavigateDirection.FirstChild => _owningToolStrip.Items.Count > 0 ? _owningToolStrip.Items[0].AccessibilityObject : null,
+                    UiaCore.NavigateDirection.LastChild => _owningToolStrip.Items.Count > 0 ? _owningToolStrip.Items[^1].AccessibilityObject : null,
+                    _ => base.FragmentNavigate(direction)
+                };
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObject.cs
@@ -10,23 +10,35 @@ namespace System.Windows.Forms
     {
         internal class ToolStripDropDownMenuAccessibleObject : ToolStripDropDownAccessibleObject
         {
-            private readonly ToolStripDropDownMenu _owningToolStrip;
+            private readonly ToolStripDropDownMenu _owningToolStripDropDownMenu;
 
             public ToolStripDropDownMenuAccessibleObject(ToolStripDropDownMenu owner) : base(owner)
             {
-                _owningToolStrip = owner;
+                _owningToolStripDropDownMenu = owner;
             }
 
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
-            {
-                return direction switch
+                => direction switch
                 {
-                    UiaCore.NavigateDirection.Parent => _owningToolStrip.OwnerItem?.AccessibilityObject,
-                    UiaCore.NavigateDirection.FirstChild => _owningToolStrip.Items.Count > 0 ? _owningToolStrip.Items[0].AccessibilityObject : null,
-                    UiaCore.NavigateDirection.LastChild => _owningToolStrip.Items.Count > 0 ? _owningToolStrip.Items[^1].AccessibilityObject : null,
+                    UiaCore.NavigateDirection.Parent => _owningToolStripDropDownMenu.OwnerItem?.AccessibilityObject,
+                    UiaCore.NavigateDirection.FirstChild => GetFirstChild(),
+                    UiaCore.NavigateDirection.LastChild => GetLastChild(),
                     _ => base.FragmentNavigate(direction)
                 };
-            }
+
+            private AccessibleObject? GetFirstChild()
+                => _owningToolStripDropDownMenu.Items.Count > 0
+                    ? _owningToolStripDropDownMenu.DisplayedItems.Contains(_owningToolStripDropDownMenu.UpScrollButton)
+                        ? _owningToolStripDropDownMenu.UpScrollButton.AccessibilityObject
+                        : _owningToolStripDropDownMenu.Items[0].AccessibilityObject
+                    : null;
+
+            private AccessibleObject? GetLastChild()
+                => _owningToolStripDropDownMenu.Items.Count > 0
+                    ? _owningToolStripDropDownMenu.DisplayedItems.Contains(_owningToolStripDropDownMenu.DownScrollButton)
+                        ? _owningToolStripDropDownMenu.DownScrollButton.AccessibilityObject
+                        : _owningToolStripDropDownMenu.Items[^1].AccessibilityObject
+                    : null;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.cs
@@ -64,6 +64,11 @@ namespace System.Windows.Forms
         {
         }
 
+        protected override AccessibleObject CreateAccessibilityInstance()
+        {
+            return new ToolStripDropDownMenuAccessibleObject(this);
+        }
+
         /// <summary>
         ///  Constructor to autogenerate
         /// </summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.cs
@@ -65,9 +65,7 @@ namespace System.Windows.Forms
         }
 
         protected override AccessibleObject CreateAccessibilityInstance()
-        {
-            return new ToolStripDropDownMenuAccessibleObject(this);
-        }
+            => new ToolStripDropDownMenuAccessibleObject(this);
 
         /// <summary>
         ///  Constructor to autogenerate
@@ -135,21 +133,8 @@ namespace System.Windows.Forms
             }
         }
 
-        private ToolStripScrollButton DownScrollButton
-        {
-            get
-            {
-                if (downScrollButton is null)
-                {
-                    downScrollButton = new ToolStripScrollButton(false)
-                    {
-                        ParentInternal = this
-                    };
-                }
-
-                return downScrollButton;
-            }
-        }
+        internal ToolStripScrollButton DownScrollButton
+            => downScrollButton ??= new ToolStripScrollButton(false) { ParentInternal = this };
 
         /// <summary>
         ///  the rectangle representing
@@ -242,21 +227,8 @@ namespace System.Windows.Forms
         internal Rectangle TextRectangle
             => textRectangle;
 
-        private ToolStripScrollButton UpScrollButton
-        {
-            get
-            {
-                if (upScrollButton is null)
-                {
-                    upScrollButton = new ToolStripScrollButton(true)
-                    {
-                        ParentInternal = this
-                    };
-                }
-
-                return upScrollButton;
-            }
-        }
+        internal ToolStripScrollButton UpScrollButton
+            => upScrollButton ??= new ToolStripScrollButton(true) { ParentInternal = this };
 
         /// <summary>
         ///  this takes a native menu and builds up a managed toolstrip around it.
@@ -815,7 +787,7 @@ namespace System.Windows.Forms
             base.SetDisplayedItems();
             if (RequiresScrollButtons)
             {
-                DisplayedItems.Add(UpScrollButton);
+                DisplayedItems.Insert(0, UpScrollButton);
                 DisplayedItems.Add(DownScrollButton);
                 UpdateScrollButtonLocations();
                 UpScrollButton.Visible = true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -362,10 +362,8 @@ namespace System.Windows.Forms
                             return null;
                         }
 
-                        int increment = direction == UiaCore.NavigateDirection.NextSibling ? 1 : -1;
                         AccessibleObject? sibling = null;
-
-                        index += increment;
+                        index += direction == UiaCore.NavigateDirection.NextSibling ? 1 : -1;
                         int itemsCount = GetChildFragmentCount();
                         if (index >= 0 && index < itemsCount)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -327,7 +327,12 @@ namespace System.Windows.Forms
                         return dropDown.AccessibilityObject;
                     }
 
-                    return (Owner.Parent is not null) ? Owner.Parent.AccessibilityObject : base.Parent;
+                    ToolStrip owner = Owner.Parent ?? Owner.Owner;
+                    return owner is not null
+                        ? owner.OverflowItems.Contains(Owner)
+                            ? owner.OverflowButton.DropDown.AccessibilityObject
+                            : owner.AccessibilityObject
+                        : base.Parent;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObject.cs
@@ -2,26 +2,37 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using static Interop.UiaCore;
+
 namespace System.Windows.Forms
 {
     public partial class ToolStripOverflow
     {
-        internal class ToolStripOverflowAccessibleObject : ToolStripAccessibleObject
+        internal class ToolStripOverflowAccessibleObject : ToolStripDropDownAccessibleObject
         {
-            public ToolStripOverflowAccessibleObject(ToolStripOverflow owner)
-                : base(owner)
+            private readonly ToolStripOverflow _owningToolStripOverflow;
+
+            public ToolStripOverflowAccessibleObject(ToolStripOverflow owner) : base(owner)
             {
+                _owningToolStripOverflow = owner;
             }
 
-            public override AccessibleObject GetChild(int index)
-            {
-                return ((ToolStripOverflow)Owner).DisplayedItems[index].AccessibilityObject;
-            }
+            public override AccessibleObject? GetChild(int index)
+                => index >= 0 || index < _owningToolStripOverflow.DisplayedItems.Count
+                    ? _owningToolStripOverflow.DisplayedItems[index].AccessibilityObject
+                    : null;
 
             public override int GetChildCount()
-            {
-                return ((ToolStripOverflow)Owner).DisplayedItems.Count;
-            }
+                => _owningToolStripOverflow.DisplayedItems.Count;
+
+            internal override Interop.UiaCore.IRawElementProviderFragment? FragmentNavigate(NavigateDirection direction)
+                => direction switch
+                {
+                    NavigateDirection.Parent => _owningToolStripOverflow.ownerItem.AccessibilityObject,
+                    NavigateDirection.FirstChild => GetChildCount() > 0 ? _owningToolStripOverflow.DisplayedItems[0].AccessibilityObject : null,
+                    NavigateDirection.LastChild => GetChildCount() > 0 ? _owningToolStripOverflow.DisplayedItems[^1].AccessibilityObject : null,
+                    _ => base.FragmentNavigate(direction),
+                };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.ToolStripOverflowButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.ToolStripOverflowButtonAccessibleObject.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -10,8 +11,11 @@ namespace System.Windows.Forms
     {
         internal class ToolStripOverflowButtonAccessibleObject : ToolStripDropDownItemAccessibleObject
         {
+            private readonly ToolStripOverflowButton _owningToolStripOverflowButton;
+
             public ToolStripOverflowButtonAccessibleObject(ToolStripOverflowButton owner) : base(owner)
             {
+                _owningToolStripOverflowButton = owner;
             }
 
             [AllowNull]
@@ -19,6 +23,20 @@ namespace System.Windows.Forms
             {
                 get => Owner.AccessibleName ?? SR.ToolStripOptions;
                 set => base.Name = value;
+            }
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                switch (direction)
+                {
+                    case UiaCore.NavigateDirection.FirstChild:
+                    case UiaCore.NavigateDirection.LastChild:
+                        return _owningToolStripOverflowButton.ParentToolStrip is not null && _owningToolStripOverflowButton.ParentToolStrip.OverflowItems.Count > 0
+                            ? _owningToolStripOverflowButton.DropDown.AccessibilityObject
+                            : null;
+                }
+
+                return base.FragmentNavigate(direction);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.StickyLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.StickyLabel.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    internal partial class ToolStripScrollButton
+    {
+        internal class StickyLabel : Label
+        {
+            private readonly bool _upDirection;
+
+            internal StickyLabel(bool up)
+            {
+                _upDirection = up;
+            }
+
+            internal ToolStripScrollButton? OwnerScrollButton { get; set; }
+
+            internal bool UpDirection
+                => _upDirection;
+
+            public static bool FreezeLocationChange
+                => false;
+
+            protected override AccessibleObject CreateAccessibilityInstance()
+                => new StickyLabelAccessibleObject(this);
+
+            protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
+            {
+                if (((specified & BoundsSpecified.Location) != 0) && FreezeLocationChange)
+                {
+                    return;
+                }
+
+                base.SetBoundsCore(x, y, width, height, specified);
+            }
+
+            protected override void WndProc(ref Message m)
+            {
+                if (m.Msg >= (int)User32.WM.KEYFIRST && m.Msg <= (int)User32.WM.KEYLAST)
+                {
+                    DefWndProc(ref m);
+                    return;
+                }
+
+                base.WndProc(ref m);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.StickyLabelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.StickyLabelAccessibleObject.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    internal partial class ToolStripScrollButton
+    {
+        internal class StickyLabelAccessibleObject : Label.LabelAccessibleObject
+        {
+            private StickyLabel _owner;
+
+            public StickyLabelAccessibleObject(StickyLabel owner) : base(owner)
+            {
+                _owner = owner;
+            }
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                if (_owner.OwnerScrollButton?.Parent is not ToolStripDropDownMenu toolStripDropDownMenu)
+                {
+                    return null;
+                }
+
+                return direction switch
+                {
+                    UiaCore.NavigateDirection.Parent => toolStripDropDownMenu.AccessibilityObject,
+                    UiaCore.NavigateDirection.NextSibling
+                        => _owner.UpDirection && toolStripDropDownMenu.Items.Count > 0
+                            ? toolStripDropDownMenu.Items[0].AccessibilityObject
+                            : null,
+                    UiaCore.NavigateDirection.PreviousSibling
+                        => !_owner.UpDirection && toolStripDropDownMenu.Items.Count > 0
+                            ? toolStripDropDownMenu.Items[^1].AccessibilityObject
+                            : null,
+                    _ => null
+                };
+            }
+
+            internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
+                => _owner.OwnerScrollButton?.Owner?.AccessibilityObject;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.StickyLabelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.StickyLabelAccessibleObject.cs
@@ -41,6 +41,18 @@ namespace System.Windows.Forms
 
             internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
                 => _owner.OwnerScrollButton?.Owner?.AccessibilityObject;
+
+            public override string? Name => _owner.UpDirection
+                ? SR.ToolStripScrollButtonUpAccessibleName
+                : SR.ToolStripScrollButtonDownAccessibleName;
+
+            public override string? DefaultAction => SR.AccessibleActionPress;
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID) => propertyID switch
+            {
+                UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ButtonControlTypeId,
+                _ => base.GetPropertyValue(propertyID),
+            };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.cs
@@ -5,14 +5,13 @@
 #nullable disable
 
 using System.Drawing;
-using static Interop;
 
 namespace System.Windows.Forms
 {
     /// <summary>
     ///  A non selectable ToolStrip item
     /// </summary>
-    internal class ToolStripScrollButton : ToolStripControlHost
+    internal partial class ToolStripScrollButton : ToolStripControlHost
     {
         private readonly bool up = true;
 
@@ -31,18 +30,23 @@ namespace System.Windows.Forms
 
         public ToolStripScrollButton(bool up) : base(CreateControlInstance(up))
         {
+            if (Control is StickyLabel stickyLabel)
+            {
+                stickyLabel.OwnerScrollButton = this;
+            }
+
             this.up = up;
         }
 
+        protected override AccessibleObject CreateAccessibilityInstance()
+           => this.Control.AccessibilityObject;
+
         private static Control CreateControlInstance(bool up)
-        {
-            StickyLabel label = new StickyLabel
+            => new StickyLabel(up)
             {
                 ImageAlign = ContentAlignment.MiddleCenter,
                 Image = (up) ? UpImage : DownImage
             };
-            return label;
-        }
 
         /// <summary>
         ///  Deriving classes can override this to configure a default size for their control.
@@ -78,12 +82,7 @@ namespace System.Windows.Forms
         }
 
         internal StickyLabel Label
-        {
-            get
-            {
-                return Control as StickyLabel;
-            }
-        }
+            => Control as StickyLabel;
 
         private static Image UpImage
         {
@@ -183,39 +182,6 @@ namespace System.Windows.Forms
             if (ParentInternal is ToolStripDropDownMenu parent && Label.Enabled)
             {
                 parent.ScrollInternal(up);
-            }
-        }
-
-        internal class StickyLabel : Label
-        {
-            public StickyLabel()
-            {
-            }
-
-            public static bool FreezeLocationChange
-            {
-                get => false;
-            }
-
-            protected override void SetBoundsCore(int x, int y, int width, int height, BoundsSpecified specified)
-            {
-                if (((specified & BoundsSpecified.Location) != 0) && FreezeLocationChange)
-                {
-                    return;
-                }
-
-                base.SetBoundsCore(x, y, width, height, specified);
-            }
-
-            protected override void WndProc(ref Message m)
-            {
-                if (m.Msg >= (int)User32.WM.KEYFIRST && m.Msg <= (int)User32.WM.KEYLAST)
-                {
-                    DefWndProc(ref m);
-                    return;
-                }
-
-                base.WndProc(ref m);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton .ToolStripSplitButtonUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton .ToolStripSplitButtonUiaProvider.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using static Interop;
+using static Interop.UiaCore;
 
 namespace System.Windows.Forms
 {
@@ -18,44 +18,32 @@ namespace System.Windows.Forms
             }
 
             public override void DoDefaultAction()
-            {
-                _accessibleObject.DoDefaultAction();
-            }
+                => _accessibleObject.DoDefaultAction();
 
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-            {
-                return _accessibleObject.GetPropertyValue(propertyID);
-            }
+            internal override object? GetPropertyValue(UIA propertyID)
+                => _accessibleObject.GetPropertyValue(propertyID);
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override bool IsPatternSupported(UiaCore.UIA patternId)
-            {
-                return _accessibleObject.IsPatternSupported(patternId);
-            }
+            internal override bool IsPatternSupported(UIA patternId)
+                => _accessibleObject.IsPatternSupported(patternId);
 
             internal override void Expand()
-            {
-                DoDefaultAction();
-            }
+                => DoDefaultAction();
 
             internal override void Collapse()
-            {
-                _accessibleObject.Collapse();
-            }
+                => _accessibleObject.Collapse();
 
-            internal override UiaCore.ExpandCollapseState ExpandCollapseState
-            {
-                get
+            internal override ExpandCollapseState ExpandCollapseState
+                => _accessibleObject.ExpandCollapseState;
+
+            internal override IRawElementProviderFragment? FragmentNavigate(NavigateDirection direction)
+                => direction switch
                 {
-                    return _accessibleObject.ExpandCollapseState;
-                }
-            }
-
-            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
-            {
-                return _accessibleObject.FragmentNavigate(direction);
-            }
+                    NavigateDirection.FirstChild => base.FragmentNavigate(direction),
+                    NavigateDirection.LastChild => base.FragmentNavigate(direction),
+                    _ => _accessibleObject.FragmentNavigate(direction)
+                };
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownMenu.ToolStripDropDownMenuAccessibleObjectTests.cs
@@ -1,0 +1,247 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ToolStripDropDownMenu_ToolStripDropDownMenuAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        public static IEnumerable<object[]> ToolStripDropDownMenuAccessible_FragmentNavigate_WithoutItem_TestData()
+        {
+            IEnumerable<Type> types = ReflectionHelper.GetPublicNotAbstractClasses<ToolStripDropDownItem>().Select(type => type);
+            foreach (Type itemType in types)
+            {
+                foreach (bool createControl in new[] { true, false })
+                {
+                    yield return new object[] { itemType, createControl };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStripDropDownMenuAccessible_FragmentNavigate_WithoutItem_TestData))]
+        public void ToolStripDropDownMenuAccessible_FragmentNavigate_ReturnExpected_WithoutItem(Type itemType, bool createControl)
+        {
+            using ToolStrip toolStrip = new();
+
+            if (createControl)
+            {
+                toolStrip.CreateControl();
+            }
+
+            using ToolStripDropDownItem item = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(itemType);
+            toolStrip.Items.Add(item);
+
+            AccessibleObject accessibleObject = item.DropDown.AccessibilityObject;
+
+            Assert.Equal(item.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Null(item.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(item.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(createControl, toolStrip.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ToolStripDropDownMenuAccessible_FragmentNavigate_ReturnExpected_WithoutItem_ToolStripOverflowButton(bool createControl)
+        {
+            using ToolStrip toolStrip = new();
+
+            if (createControl)
+            {
+                toolStrip.CreateControl();
+            }
+
+            ToolStripOverflowButton item = toolStrip.OverflowButton;
+
+            AccessibleObject accessibleObject = item.DropDown.AccessibilityObject;
+
+            Assert.Equal(item.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Null(item.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(item.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.Equal(createControl, toolStrip.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ToolStripDropDownMenuAccessible_FragmentNavigate_TestData()
+        {
+            IEnumerable<Type> types = ReflectionHelper.GetPublicNotAbstractClasses<ToolStripDropDownItem>().Select(type => type);
+            foreach (Type ownerType in types)
+            {
+                foreach (Type parentType in types)
+                {
+                    foreach (Type childType in types)
+                    {
+                        foreach (bool createControl in new[] { true, false })
+                        {
+                            yield return new object[] { ownerType, parentType, childType, createControl };
+                        }
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStripDropDownMenuAccessible_FragmentNavigate_TestData))]
+        public void ToolStripDropDownMenuAccessible_FragmentNavigate_ReturnExpected(Type ownerType, Type parentType, Type childType, bool createControl)
+        {
+            using ToolStrip toolStrip = new();
+
+            if (createControl)
+            {
+                toolStrip.CreateControl();
+            }
+
+            using ToolStripDropDownItem ownerItem = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(ownerType);
+            using ToolStripDropDownItem parentItem1 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(parentType);
+            using ToolStripDropDownItem parentItem2 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(parentType);
+            using ToolStripDropDownItem childItem1 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(childType);
+            using ToolStripDropDownItem childItem2 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(childType);
+            using ToolStripDropDownItem childItem3 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(childType);
+            using ToolStripDropDownItem childItem4 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(childType);
+
+            toolStrip.Items.Add(ownerItem);
+            ownerItem.DropDownItems.Add(parentItem1);
+            ownerItem.DropDownItems.Add(parentItem2);
+            parentItem1.DropDownItems.Add(childItem1);
+            parentItem1.DropDownItems.Add(childItem2);
+            parentItem2.DropDownItems.Add(childItem3);
+            parentItem2.DropDownItems.Add(childItem4);
+
+            AccessibleObject accessibleObject = ownerItem.DropDown.AccessibilityObject;
+
+            Assert.Equal(ownerItem.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(parentItem1.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(parentItem2.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(accessibleObject, ownerItem.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, ownerItem.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.Equal(accessibleObject, parentItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(accessibleObject, parentItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+
+            AccessibleObject accessibleObject1 = parentItem1.DropDown.AccessibilityObject;
+
+            Assert.Equal(parentItem1.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(childItem1.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(childItem2.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(accessibleObject1, parentItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject1, parentItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.Equal(accessibleObject1, childItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(accessibleObject1, childItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+
+            AccessibleObject accessibleObject2 = parentItem2.DropDown.AccessibilityObject;
+
+            Assert.Equal(parentItem2.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(childItem3.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(childItem4.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(accessibleObject2, parentItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, parentItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.Equal(accessibleObject2, childItem3.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(accessibleObject2, childItem4.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+
+            Assert.Equal(createControl, toolStrip.IsHandleCreated);
+        }
+
+        public static IEnumerable<object[]> ToolStripDropDownMenuAccessible_FragmentNavigate_ToolStripOverflowButton_TestData()
+        {
+            IEnumerable<Type> types = ReflectionHelper.GetPublicNotAbstractClasses<ToolStripDropDownItem>().Select(type => type);
+            foreach (Type parentType in types)
+            {
+                foreach (Type childType in types)
+                {
+                    foreach (bool createControl in new[] { true, false })
+                    {
+                        yield return new object[] { parentType, childType };
+                    }
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStripDropDownMenuAccessible_FragmentNavigate_ToolStripOverflowButton_TestData))]
+        public void ToolStripDropDownMenuAccessible_FragmentNavigate_ReturnExpected_ToolStripOverflowButton(Type parentType, Type childType)
+        {
+            using ToolStrip toolStrip = new();
+            toolStrip.CreateControl();
+
+            using ToolStripDropDownItem parentItem1 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(parentType);
+            using ToolStripDropDownItem parentItem2 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(parentType);
+            using ToolStripDropDownItem childItem1 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(childType);
+            using ToolStripDropDownItem childItem2 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(childType);
+            using ToolStripDropDownItem childItem3 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(childType);
+            using ToolStripDropDownItem childItem4 = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(childType);
+
+            toolStrip.Items.Add(parentItem1);
+            toolStrip.Items.Add(parentItem2);
+
+            parentItem1.DropDownItems.Add(childItem1);
+            parentItem1.DropDownItems.Add(childItem2);
+            parentItem2.DropDownItems.Add(childItem3);
+            parentItem2.DropDownItems.Add(childItem4);
+
+            using ToolStripOverflowButton ownerItem = toolStrip.OverflowButton;
+            toolStrip.OverflowItems.Add(parentItem1);
+            toolStrip.OverflowItems.Add(parentItem2);
+
+            AccessibleObject accessibleObject = ownerItem.DropDown.AccessibilityObject;
+
+            Assert.Equal(ownerItem.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(parentItem1.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(parentItem2.AccessibilityObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(accessibleObject, ownerItem.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject, ownerItem.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.Equal(accessibleObject, parentItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(accessibleObject, parentItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+
+            AccessibleObject accessibleObject1 = parentItem1.DropDown.AccessibilityObject;
+
+            Assert.Equal(parentItem1.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(childItem1.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(childItem2.AccessibilityObject, accessibleObject1.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(accessibleObject1, parentItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject1, parentItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.Equal(accessibleObject1, childItem1.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(accessibleObject1, childItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+
+            AccessibleObject accessibleObject2 = parentItem2.DropDown.AccessibilityObject;
+
+            Assert.Equal(parentItem2.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject2.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(childItem3.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(childItem4.AccessibilityObject, accessibleObject2.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(accessibleObject2, parentItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(accessibleObject2, parentItem2.AccessibilityObject.FragmentNavigate(NavigateDirection.LastChild));
+            Assert.Equal(accessibleObject2, childItem3.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(accessibleObject2, childItem4.AccessibilityObject.FragmentNavigate(NavigateDirection.Parent));
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripOverflow.ToolStripOverflowAccessibleObjectTests.cs
@@ -31,7 +31,7 @@ namespace System.Windows.Forms.Tests
             AccessibleObject accessibleObject = toolStripOverflow.AccessibilityObject;
             object actual = accessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
 
-            Assert.Equal(UiaCore.UIA.ToolBarControlTypeId, actual);
+            Assert.Equal(UiaCore.UIA.MenuControlTypeId, actual);
             Assert.False(toolStripOverflow.IsHandleCreated);
         }
 
@@ -44,7 +44,7 @@ namespace System.Windows.Forms.Tests
 
             object actual = toolStripOverflow.AccessibilityObject.Role;
 
-            Assert.Equal(AccessibleRole.ToolBar, actual);
+            Assert.Equal(AccessibleRole.MenuPopup, actual);
             Assert.False(toolStripOverflow.IsHandleCreated);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripScrollButton.ToolStripScrollButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripScrollButton.ToolStripScrollButtonAccessibleObjectTests.cs
@@ -106,6 +106,36 @@ namespace System.Windows.Forms.Tests
             Assert.Null(itemAccessibleObject2.FragmentNavigate(NavigateDirection.NextSibling));
         }
 
+        [WinFormsFact]
+        public void ToolStripScrollButtonAccessibleObject_Properties_ReturnExpected()
+        {
+            using ToolStrip toolStrip = new();
+            using ToolStripDropDownItem ownerItem = new ToolStripDropDownButton();
+            SubToolStripDropDownMenu dropDownMenu = new SubToolStripDropDownMenu(ownerItem, true, true);
+
+            toolStrip.Items.Add(ownerItem);
+            ownerItem.TestAccessor().Dynamic.dropDown = dropDownMenu;
+            ownerItem.DropDownItems.Add(new ToolStripDropDownButton("Item 1"));
+            ownerItem.DropDownItems.Add(new ToolStripDropDownButton("Item 2"));
+            dropDownMenu.UpdateDisplayedItems();
+
+            AccessibleObject upScrollButtonAccessibleObject = dropDownMenu.UpScrollButton.AccessibilityObject;
+            AccessibleObject downScrollButtonAccessibleObject = dropDownMenu.DownScrollButton.AccessibilityObject;
+
+            var expectedUpButtonName = SR.ToolStripScrollButtonUpAccessibleName;
+            var expectedDownButtonName = SR.ToolStripScrollButtonDownAccessibleName;
+            var expectedDefaultAction = SR.AccessibleActionPress;
+            var expectedControlType = UIA.ButtonControlTypeId;
+
+            Assert.Equal(expectedUpButtonName, upScrollButtonAccessibleObject.Name);
+            Assert.Equal(expectedDefaultAction, upScrollButtonAccessibleObject.DefaultAction);
+            Assert.Equal(expectedControlType, upScrollButtonAccessibleObject.GetPropertyValue(UIA.ControlTypePropertyId));
+
+            Assert.Equal(expectedDownButtonName, downScrollButtonAccessibleObject.Name);
+            Assert.Equal(expectedDefaultAction, downScrollButtonAccessibleObject.DefaultAction);
+            Assert.Equal(expectedControlType, downScrollButtonAccessibleObject.GetPropertyValue(UIA.ControlTypePropertyId));
+        }
+
         private class SubToolStripDropDownMenu : ToolStripDropDownMenu
         {
             private readonly bool _requiresScrollButtons;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripScrollButton.ToolStripScrollButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripScrollButton.ToolStripScrollButtonAccessibleObjectTests.cs
@@ -1,0 +1,123 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ToolStripScrollButtonAccessibleObject_ToolStripScrollButtonAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        public static IEnumerable<object[]> ToolStripScrollButtonAccessibleObject_FragmentNavigate_TestData()
+        {
+            IEnumerable<Type> types = ReflectionHelper.GetPublicNotAbstractClasses<ToolStripDropDownItem>().Select(type => type);
+            foreach (Type itemType in types)
+            {
+                foreach (bool createControl in new[] { true, false })
+                {
+                    yield return new object[] { itemType, createControl };
+                }
+            }
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStripScrollButtonAccessibleObject_FragmentNavigate_TestData))]
+        public void ToolStripScrollButtonAccessibleObject_FragmentNavigate_ReturnsExpected(Type itemType, bool createControl)
+        {
+            using ToolStrip toolStrip = new();
+
+            if (createControl)
+            {
+                toolStrip.CreateControl();
+            }
+
+            using ToolStripDropDownItem ownerItem = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(itemType);
+            SubToolStripDropDownMenu dropDownMenu = new SubToolStripDropDownMenu(ownerItem, true, true);
+
+            toolStrip.Items.Add(ownerItem);
+            ownerItem.TestAccessor().Dynamic.dropDown = dropDownMenu;
+            ownerItem.DropDownItems.Add(new ToolStripDropDownButton("Item 1"));
+            ownerItem.DropDownItems.Add(new ToolStripDropDownButton("Item 2"));
+            ownerItem.DropDownItems.Add(new ToolStripDropDownButton("Item 3"));
+            dropDownMenu.UpdateDisplayedItems();
+
+            AccessibleObject accessibleObject = dropDownMenu.AccessibilityObject;
+            AccessibleObject upScrollButtonAccessibleObject = dropDownMenu.UpScrollButton.AccessibilityObject;
+            AccessibleObject itemAccessibleObject1 = dropDownMenu.Items[0].AccessibilityObject;
+            AccessibleObject itemAccessibleObject2 = dropDownMenu.Items[1].AccessibilityObject;
+            AccessibleObject itemAccessibleObject3 = dropDownMenu.Items[2].AccessibilityObject;
+            AccessibleObject downScrollButtonAccessibleObject = dropDownMenu.DownScrollButton.AccessibilityObject;
+
+            Assert.Equal(upScrollButtonAccessibleObject, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(downScrollButtonAccessibleObject, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(upScrollButtonAccessibleObject, itemAccessibleObject1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(itemAccessibleObject2, itemAccessibleObject1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(itemAccessibleObject2, itemAccessibleObject3.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(downScrollButtonAccessibleObject, itemAccessibleObject3.FragmentNavigate(NavigateDirection.NextSibling));
+
+            Assert.Equal(accessibleObject, upScrollButtonAccessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Equal(itemAccessibleObject1, upScrollButtonAccessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Null(upScrollButtonAccessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(upScrollButtonAccessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(upScrollButtonAccessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(accessibleObject, downScrollButtonAccessibleObject.FragmentNavigate(NavigateDirection.Parent));
+            Assert.Null(downScrollButtonAccessibleObject.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(itemAccessibleObject3, downScrollButtonAccessibleObject.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(downScrollButtonAccessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Null(downScrollButtonAccessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Equal(createControl, toolStrip.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(ToolStripScrollButtonAccessibleObject_FragmentNavigate_TestData))]
+        public void ToolStripScrollButtonAccessibleObject_FragmentNavigate_ReturnsNull_If_ScrollButtonsHidden(Type itemType, bool createControl)
+        {
+            using ToolStrip toolStrip = new();
+
+            if (createControl)
+            {
+                toolStrip.CreateControl();
+            }
+
+            using ToolStripDropDownItem ownerItem = ReflectionHelper.InvokePublicConstructor<ToolStripDropDownItem>(itemType);
+            SubToolStripDropDownMenu dropDownMenu = new SubToolStripDropDownMenu(ownerItem, true, false);
+
+            toolStrip.Items.Add(ownerItem);
+            ownerItem.TestAccessor().Dynamic.dropDown = dropDownMenu;
+            ownerItem.DropDownItems.Add(new ToolStripDropDownButton("Item 1"));
+            ownerItem.DropDownItems.Add(new ToolStripDropDownButton("Item 2"));
+
+            dropDownMenu.UpdateDisplayedItems();
+
+            AccessibleObject accessibleObject = dropDownMenu.AccessibilityObject;
+            AccessibleObject itemAccessibleObject1 = dropDownMenu.Items[0].AccessibilityObject;
+            AccessibleObject itemAccessibleObject2 = dropDownMenu.Items[1].AccessibilityObject;
+
+            Assert.Equal(itemAccessibleObject1, accessibleObject.FragmentNavigate(NavigateDirection.FirstChild));
+            Assert.Equal(itemAccessibleObject2, accessibleObject.FragmentNavigate(NavigateDirection.LastChild));
+
+            Assert.Null(itemAccessibleObject1.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Equal(itemAccessibleObject2, itemAccessibleObject1.FragmentNavigate(NavigateDirection.NextSibling));
+            Assert.Equal(itemAccessibleObject1, itemAccessibleObject2.FragmentNavigate(NavigateDirection.PreviousSibling));
+            Assert.Null(itemAccessibleObject2.FragmentNavigate(NavigateDirection.NextSibling));
+        }
+
+        private class SubToolStripDropDownMenu : ToolStripDropDownMenu
+        {
+            private readonly bool _requiresScrollButtons;
+
+            internal SubToolStripDropDownMenu(ToolStripItem ownerItem, bool isAutoGenerated, bool requiresScrollButtons) : base(ownerItem, isAutoGenerated)
+            {
+                _requiresScrollButtons = requiresScrollButtons;
+            }
+
+            internal override bool RequiresScrollButtons => _requiresScrollButtons;
+
+            internal void UpdateDisplayedItems() => base.SetDisplayedItems();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6652

## Proposed changes
- The issue is reproduced because we don't have support for `ToolStripScrollButton` accessibility objects in the .NET Core.
- Added `StickyLabelAccessibleObject` for `ToolStripScrollButton`.
- Added support for `StickyLabelAccessibleObject` by other `ToolStrip` accessibility objects.
- Added unit tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact
**Before fix:**
![image](https://user-images.githubusercontent.com/23376742/160356389-dd883d71-9373-4af7-ac7c-002d385d6352.png)

**After fix:**
![image](https://user-images.githubusercontent.com/23376742/160359319-5c0f90e3-cca3-4df6-9dae-da31667ab8f6.png)


## Regression? 
- No

## Risk
- Minimal


## Test methodology <!-- How did you ensure quality? -->
- Unit tests
- CTI team

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Inspect
- Accessibility Insights
- Narrator
- NVDA
- JAWS
 
## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19044.1526]
- .NET Core SDK: 7.0.0-preview.4.22174.1


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6920)