### PR TITLE
Correctly retrieve the embedded resource

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.CustomColorDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.CustomColorDialog.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using static Interop;
@@ -13,14 +14,14 @@ namespace System.Drawing.Design
     {
         private class CustomColorDialog : ColorDialog
         {
+            private static readonly Assembly s_assembly = typeof(ColorEditor).Module.Assembly;
+            private static readonly string s_resourceName = $"{s_assembly.GetName().Name}.colordlg.data";
             private IntPtr _hInstance;
 
             public CustomColorDialog()
             {
                 // colordlg.data was copied from VB6's dlg-4300.dlg
-                using Stream stream = typeof(ColorEditor).Module.Assembly.GetManifestResourceStream(
-                    typeof(ColorEditor),
-                    "colordlg.data");
+                using Stream stream = s_assembly.GetManifestResourceStream(s_resourceName);
 
                 int size = (int)(stream.Length - stream.Position);
                 byte[] buffer = new byte[size];

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ColorEditorTests.CustomColorDialogTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ColorEditorTests.CustomColorDialogTests.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using System.Windows.Forms;
+using Xunit;
+
+namespace System.Drawing.Design.Tests
+{
+    public partial class ColorEditor_CustomColorDialogTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void CustomColorDialog_Ctor_Default()
+        {
+            Type? typeCustomColorDialog = typeof(ColorEditor).Assembly.GetTypes().SingleOrDefault(t => t.Name == "CustomColorDialog");
+            Assert.NotNull(typeCustomColorDialog);
+
+            using ColorDialog dialog = (ColorDialog)Activator.CreateInstance(typeCustomColorDialog!)!;
+            Assert.NotNull(dialog);
+        }
+    }
+}

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ColorEditorTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/Drawing/Design/ColorEditorTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace System.Drawing.Design.Tests
 {
-    public class ColorEditorTests : IClassFixture<ThreadExceptionFixture>
+    public partial class ColorEditorTests : IClassFixture<ThreadExceptionFixture>
     {
         [Fact]
         public void ColorEditor_Ctor_Default()

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.Designer.cs
@@ -36,6 +36,7 @@ namespace WinformsControlsTest
             this.propertyGrid1 = new System.Windows.Forms.PropertyGrid();
             this.btnSaveFileDialog = new System.Windows.Forms.Button();
             this.btnOpenFileDialog = new System.Windows.Forms.Button();
+            this.btnColorDialog = new System.Windows.Forms.Button();
             this.btnThreadExceptionDialog = new System.Windows.Forms.Button();
             this.btnPrintDialog = new System.Windows.Forms.Button();
             this.btnFolderBrowserDialog = new System.Windows.Forms.Button();
@@ -67,6 +68,16 @@ namespace WinformsControlsTest
             this.btnOpenFileDialog.Text = "Open &file dialog";
             this.btnOpenFileDialog.UseVisualStyleBackColor = true;
             this.btnOpenFileDialog.Click += new System.EventHandler(this.btnOpenFileDialog_Click);
+            // 
+            // btnColorDialog
+            // 
+            this.btnColorDialog.Location = new System.Drawing.Point(3, 32);
+            this.btnColorDialog.Name = "btnColorDialog";
+            this.btnColorDialog.Size = new System.Drawing.Size(163, 23);
+            this.btnColorDialog.TabIndex = 2;
+            this.btnColorDialog.Text = "&Color dialog";
+            this.btnColorDialog.UseVisualStyleBackColor = true;
+            this.btnColorDialog.Click += new System.EventHandler(this.btnColorDialog_Click);
             // 
             // btnThreadExceptionDialog
             // 
@@ -110,6 +121,7 @@ namespace WinformsControlsTest
             // 
             // flowLayoutPanel1
             // 
+            this.flowLayoutPanel1.Controls.Add(this.btnColorDialog);
             this.flowLayoutPanel1.Controls.Add(this.btnThreadExceptionDialog);
             this.flowLayoutPanel1.Controls.Add(this.btnPrintDialog);
             this.flowLayoutPanel1.Controls.Add(this.btnFolderBrowserDialog);
@@ -150,6 +162,7 @@ namespace WinformsControlsTest
         private System.Windows.Forms.PropertyGrid propertyGrid1;
         private System.Windows.Forms.Button btnSaveFileDialog;
         private System.Windows.Forms.Button btnOpenFileDialog;
+        private System.Windows.Forms.Button btnColorDialog;
         private System.Windows.Forms.Button btnThreadExceptionDialog;
         private System.Windows.Forms.Button btnPrintDialog;
         private System.Windows.Forms.Button btnFolderBrowserDialog;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/Dialogs.cs
@@ -6,6 +6,8 @@
 
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Drawing;
+using System.Drawing.Design;
 using System.Windows.Forms;
 
 namespace WinformsControlsTest
@@ -25,7 +27,7 @@ namespace WinformsControlsTest
 
             _btnOpen = new("&Open dialog")
             {
-                Image = (System.Drawing.Bitmap?)(resources.GetObject("OpenDialog")),
+                Image = (Bitmap?)resources.GetObject("OpenDialog"),
                 Enabled = false,
             };
 
@@ -49,6 +51,14 @@ namespace WinformsControlsTest
             toolbar.Items.Add(_btnOpen);
         }
 
+        private void DisposeIfNeeded()
+        {
+            if (propertyGrid1.SelectedObject is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+
         private ToolStrip GetToolbar()
         {
             foreach (Control control in propertyGrid1.Controls)
@@ -63,28 +73,48 @@ namespace WinformsControlsTest
             throw new MissingMemberException("Unable to find the toolstrip in the PropertyGrid.");
         }
 
+        private void btnColorDialog_Click(object sender, EventArgs e)
+        {
+            DisposeIfNeeded();
+            propertyGrid1.SelectedObject = null;
+
+            Type? typeCustomColorDialog = typeof(ColorEditor).Assembly.GetTypes().SingleOrDefault(t => t.Name == "CustomColorDialog");
+            if (typeCustomColorDialog is null)
+            {
+                throw new Exception("Unable to locate 'CustomColorDialog' type.");
+            }
+
+            using ColorDialog dialog = (ColorDialog)Activator.CreateInstance(typeCustomColorDialog)!;
+            dialog.ShowDialog(this);
+        }
+
         private void btnOpenFileDialog_Click(object sender, EventArgs e)
         {
+            DisposeIfNeeded();
             propertyGrid1.SelectedObject = openFileDialog1;
         }
 
         private void btnSaveFileDialog_Click(object sender, EventArgs e)
         {
+            DisposeIfNeeded();
             propertyGrid1.SelectedObject = saveFileDialog1;
         }
 
         private void btnFolderBrowserDialog_Click(object sender, EventArgs e)
         {
+            DisposeIfNeeded();
             propertyGrid1.SelectedObject = folderBrowserDialog1;
         }
 
         private void btnPrintDialog_Click(object sender, EventArgs e)
         {
+            DisposeIfNeeded();
             propertyGrid1.SelectedObject = printDialog1;
         }
 
         private void btnThreadExceptionDialog_Click(object sender, EventArgs e)
         {
+            DisposeIfNeeded();
             propertyGrid1.SelectedObject = null;
 
             using ThreadExceptionDialog dialog = new(new Exception("Really long exception description string, because we want to see if it properly wraps around or is truncated."));


### PR DESCRIPTION
Resolves #6915

The regression was caused by the migration of types and resources from System.Drawing.Design to System.Windows.Forms.Design, and the resource is now getting embedded as `System.Windows.Forms.Design.colordlg.data` instead of `System.Drawing.Design.colordlg.data`.
* .NET 6 version embeds the resource as follows:
![image](https://user-images.githubusercontent.com/4403806/160717228-d0498625-dac0-4060-97d7-2778da94fd8d.png)
* The .NET Framework version embeds it as:
![image](https://user-images.githubusercontent.com/4403806/160717151-c35f64ff-92b2-48e5-8586-9e6800a7f566.png)

There are few ways of addressing this regression - update the `GetManifestResourceStream()` call and pass an updated resource name, or embed the resource under a different name. The latter felt a little more opaque from the maintenance perspective.

I presume we missed this because:
* we had no test coverage for this dialog as it can only be invoked via the `PropertyGrid` when editing a color, and it's not possible to invoke the dialog directly,
* color editing is not believed to be a major use case in runtime scenarios.

## Customer Impact

- Customers will be able to use custom color editor again

    **Actual Result:** an error dialog pops up:
    ![image](https://user-images.githubusercontent.com/26474449/160323335-db7c0850-607b-4b92-9a2d-fa53801d046f.png)

    **Fixed result:** Define color dialog pops up, following is the behavior in framework app
    ![image](https://user-images.githubusercontent.com/26474449/160323646-21b348b5-b53e-4dff-bbd3-c855d72ddb4e.png)

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- manual tests
- automated tests

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6925)