### PR TITLE
Enable nullability in IconComparer

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.IconComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.IconComparer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.Globalization;
 
@@ -30,18 +28,18 @@ namespace System.Windows.Forms
                 }
             }
 
-            public int Compare(object obj1, object obj2)
+            public int Compare(object? obj1, object? obj2)
             {
                 //subhag
-                ListViewItem currentItem = (ListViewItem)obj1;
-                ListViewItem nextItem = (ListViewItem)obj2;
+                ListViewItem? currentItem = (ListViewItem?)obj1;
+                ListViewItem? nextItem = (ListViewItem?)obj2;
                 if (sortOrder == SortOrder.Ascending)
                 {
-                    return string.Compare(currentItem.Text, nextItem.Text, false, CultureInfo.CurrentCulture);
+                    return string.Compare(currentItem?.Text, nextItem?.Text, false, CultureInfo.CurrentCulture);
                 }
                 else
                 {
-                    return string.Compare(nextItem.Text, currentItem.Text, false, CultureInfo.CurrentCulture);
+                    return string.Compare(nextItem?.Text, currentItem?.Text, false, CultureInfo.CurrentCulture);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.IconComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.IconComparer.cs
@@ -13,18 +13,18 @@ namespace System.Windows.Forms
         //subhag
         internal class IconComparer : IComparer
         {
-            private SortOrder sortOrder;
+            private SortOrder _sortOrder;
 
             public IconComparer(SortOrder currentSortOrder)
             {
-                sortOrder = currentSortOrder;
+                _sortOrder = currentSortOrder;
             }
 
             public SortOrder SortOrder
             {
                 set
                 {
-                    sortOrder = value;
+                    _sortOrder = value;
                 }
             }
 
@@ -33,7 +33,7 @@ namespace System.Windows.Forms
                 //subhag
                 ListViewItem? currentItem = (ListViewItem?)obj1;
                 ListViewItem? nextItem = (ListViewItem?)obj2;
-                if (sortOrder == SortOrder.Ascending)
+                if (_sortOrder == SortOrder.Ascending)
                 {
                     return string.Compare(currentItem?.Text, nextItem?.Text, false, CultureInfo.CurrentCulture);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -1546,9 +1546,9 @@ namespace System.Windows.Forms
                         {
                             _listItemSorter = new IconComparer(_sorting);
                         }
-                        else if (_listItemSorter is IconComparer)
+                        else if (_listItemSorter is IconComparer iconComparer)
                         {
-                            ((IconComparer)_listItemSorter).SortOrder = _sorting;
+                            iconComparer.SortOrder = _sorting;
                         }
                     }
                     else if (value == SortOrder.None)


### PR DESCRIPTION
## Proposed changes

- Enable nullability in IconComparer.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6932)