### PR TITLE
Add some tests for classes that inherit from Control.ControlCollection

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ReadOnlyControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ReadOnlyControlCollection.cs
@@ -12,7 +12,8 @@ internal class ReadOnlyControlCollection : Control.ControlCollection
 {
     private readonly bool _isReadOnly;
 
-    public ReadOnlyControlCollection(Control owner, bool isReadOnly) : base(owner)
+    public ReadOnlyControlCollection(Control owner, bool isReadOnly)
+        : base(owner)
     {
         _isReadOnly = isReadOnly;
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TypedControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TypedControlCollection.cs
@@ -14,13 +14,15 @@ internal class TypedControlCollection : ReadOnlyControlCollection
     private readonly Type _typeOfControl;
     private readonly Control _ownerControl;
 
-    public TypedControlCollection(Control owner, Type typeOfControl, bool isReadOnly) : base(owner, isReadOnly)
+    public TypedControlCollection(Control owner, Type typeOfControl, bool isReadOnly)
+        : base(owner, isReadOnly)
     {
         _typeOfControl = typeOfControl;
         _ownerControl = owner;
     }
 
-    public TypedControlCollection(Control owner, Type typeOfControl) : base(owner, /*isReadOnly*/false)
+    public TypedControlCollection(Control owner, Type typeOfControl)
+        : base(owner, isReadOnly: false)
     {
         _typeOfControl = typeOfControl;
         _ownerControl = owner;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.ControlCollection.cs
@@ -14,8 +14,9 @@ public class ControlControlCollectionTests
     [WinFormsFact]
     public void ControlCollection_Ctor_Control()
     {
-        using var owner = new Control();
-        var collection = new Control.ControlCollection(owner);
+        using Control owner = new();
+        Control.ControlCollection collection = new(owner);
+
         Assert.Empty(collection);
         Assert.False(collection.IsReadOnly);
         Assert.Same(owner, collection.Owner);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridView.DataGridViewControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridView.DataGridViewControlCollectionTests.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public class DataGridView_DataGridViewControlCollectionTests
+{
+    [WinFormsFact]
+    public void DataGridViewControlCollection_Ctor_Control()
+    {
+        using DataGridView owner = new();
+        DataGridView.DataGridViewControlCollection collection = new(owner);
+
+        Assert.Empty(collection);
+        Assert.False(collection.IsReadOnly);
+        Assert.Same(owner, collection.Owner);
+    }
+
+    [WinFormsFact]
+    public void DataGridViewControlCollection_Ctor_NullOwner_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>("owner", () => new DataGridView.DataGridViewControlCollection(null));
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Form.ControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Form.ControlCollectionTests.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public class Form_ControlCollection
+{
+    [WinFormsFact]
+    public void ControlCollection_Ctor_Control()
+    {
+        using Form owner = new();
+        Form.ControlCollection collection = new(owner);
+
+        Assert.Empty(collection);
+        Assert.False(collection.IsReadOnly);
+        Assert.Same(owner, collection.Owner);
+    }
+
+    [WinFormsFact]
+    public void ControlCollection_Ctor_NullOwner_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>("owner", () => new Form.ControlCollection(null));
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiClient.ControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiClient.ControlCollectionTests.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public class MdiClient_ControlCollectionTests
+{
+    [WinFormsFact]
+    public void ControlCollection_Ctor_Control()
+    {
+        using MdiClient owner = new();
+        MdiClient.ControlCollection collection = new(owner);
+
+        Assert.Empty(collection);
+        Assert.False(collection.IsReadOnly);
+        Assert.Same(owner, collection.Owner);
+    }
+
+    [WinFormsFact]
+    public void ControlCollection_Ctor_NullOwner_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>("owner", () => new MdiClient.ControlCollection(null));
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ReadOnlyControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ReadOnlyControlCollectionTests.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public class ReadOnlyControlCollectionTests
+{
+    [WinFormsFact]
+    public void ReadOnlyControlCollection_Ctor_Control()
+    {
+        using Control owner = new ();
+        ReadOnlyControlCollection collection = new(owner, false);
+
+        Assert.Empty(collection);
+        Assert.False(collection.IsReadOnly);
+        Assert.Same(owner, collection.Owner);
+    }
+
+    [WinFormsFact]
+    public void ReadOnlyControlCollection_Ctor_NullOwner_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>("owner", () => new ReadOnlyControlCollection(null, false));
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitContainer.SplitContainerTypedControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitContainer.SplitContainerTypedControlCollectionTests.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public class SplitContainer_SplitContainerTypedControlCollectionTests
+{
+    [WinFormsFact]
+    public void SplitContainerTypedControlCollection_Ctor_Control()
+    {
+        using SplitContainer owner = new ();
+        SplitContainer.SplitContainerTypedControlCollection collection = new(owner, typeof(SplitterPanel), false);
+
+        Assert.Empty(collection);
+        Assert.False(collection.IsReadOnly);
+        Assert.Same(owner, collection.Owner);
+    }
+
+    [WinFormsFact]
+    public void SplitContainerTypedControlCollection_Ctor_NullOwner_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>("owner", () => new SplitContainer.SplitContainerTypedControlCollection(null, typeof(SplitterPanel), false));
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TypedControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TypedControlCollectionTests.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Windows.Forms.Tests;
+
+public class TypedControlCollectionTests
+{
+    [WinFormsFact]
+    public void TypedControlCollection_Ctor_Control()
+    {
+        using Panel owner = new();
+        TypedControlCollection collection = new(owner, typeof(Panel), false);
+
+        Assert.Empty(collection);
+        Assert.False(collection.IsReadOnly);
+        Assert.Same(owner, collection.Owner);
+    }
+
+    [WinFormsFact]
+    public void TypedControlCollection_Ctor_NullOwner_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>("owner", () => new TypedControlCollection(null, typeof(Panel), false));
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Add some tests for classes that inherit from Control.ControlCollection.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6935)