### PR TITLE
Fixing issue with announcing expand/collapse action for TreeNode

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6901,4 +6901,10 @@ Stack trace where the illegal operation occurred was:
   <data name="EditDefaultAccessibleName" xml:space="preserve">
     <value>Spinner</value>
   </data>
+    <data name="CollapsedStateName" xml:space="preserve">
+    <value>Collapsed</value>
+  </data>
+  <data name="ExpandedStateName" xml:space="preserve">
+    <value>Expanded</value>
+  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -932,6 +932,11 @@
         <target state="translated">Při zpracování funkce CreateHandle() nelze volat funkci {0}().</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">Prázdnou kolekci nelze použít.</target>
@@ -4859,6 +4864,11 @@ Pokud kliknete na Pokračovat, aplikace bude tuto chybu ignorovat a pokusí se p
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">Při pokusu o vytvoření instance objektu {0} došlo k výjimce {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -932,6 +932,11 @@
         <target state="translated">Der Wert {0}() kann nicht während der Ausführung von CreateHandle() aufgerufen werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">Der Vorgang kann nicht mit einer leeren Sammlung durchgeführt werden.</target>
@@ -4859,6 +4864,11 @@ Wenn Sie auf "Weiter" klicken, ignoriert die Anwendung den Fehler und setzt den 
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">Ausnahme beim Erstellen einer Instanz von {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -932,6 +932,11 @@
         <target state="translated">No se puede llamar al valor {0}() durante CreateHandle().</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">No se puede operar con una colección vacía.</target>
@@ -4859,6 +4864,11 @@ Si hace clic en Continuar, la aplicación pasará por alto este error e intentar
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">Excepción al crear una instancia de {0}. Excepción "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -932,6 +932,11 @@
         <target state="translated">Impossible d'appeler la valeur {0}() pendant un CreateHandle().</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">Impossible d'agir avec une collection vide.</target>
@@ -4859,6 +4864,11 @@ Si vous cliquez sur Continuer, l'application va ignorer cette erreur et tenter d
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">Une exception s'est produite lors de la création d'une instance de {0}. L'exception était "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -932,6 +932,11 @@
         <target state="translated">Impossibile chiamare il valore {0}() durante CreateHandle().</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">Impossibile operare con una raccolta vuota.</target>
@@ -4859,6 +4864,11 @@ Se si sceglie Continua, l'errore verrà ignorato e l'applicazione proverà a con
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">Durante la creazione di un'istanza di {0} si è verificata la seguente eccezione: "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -932,6 +932,11 @@
         <target state="translated">CreateHandle() の実行中は値 {0}() を呼び出せません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">空のコレクションを使用して操作できません。</target>
@@ -4859,6 +4864,11 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">{0} のインスタンスを作成中に例外が発生しました。例外は "{1}" です。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -932,6 +932,11 @@
         <target state="translated">CreateHandle() 중에는 {0}() 값을 호출할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">빈 컬렉션으로 작업할 수 없습니다.</target>
@@ -4859,6 +4864,11 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">{0}의 인스턴스를 만드는 동안 예외가 발생했습니다. 예외는 "{1}"입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -932,6 +932,11 @@
         <target state="translated">Nie można wywołać wartości {0}() w trakcie wykonywania CreateHandle().</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">Nie można operować pustą kolekcją.</target>
@@ -4859,6 +4864,11 @@ Jeśli klikniesz pozycję Kontynuuj, aplikacja zignoruje ten błąd i będzie pr
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">Wystąpił wyjątek podczas próby utworzenia wystąpienia elementu {0}. Wyjątek to: "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -932,6 +932,11 @@
         <target state="translated">O valor {0}() não pode ser chamado durante CreateHandle().</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">Não é possível operar com uma coleção vazia.</target>
@@ -4859,6 +4864,11 @@ Se você clicar em Continuar, o aplicativo ignorará esse erro e tentará contin
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">Ocorreu uma exceção ao tentar criar uma instância de {0}. A exceção era "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -932,6 +932,11 @@
         <target state="translated">Вызов значения {0}() во время выполнения CreateHandle() невозможен.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">Работа с пустой коллекцией невозможна.</target>
@@ -4860,6 +4865,11 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">Исключение при попытке создания экземпляра {0}. Исключение: "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -932,6 +932,11 @@
         <target state="translated">CreateHandle() yapılırken {0}() değeri çağrılamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">Boş koleksiyon ile çalışılamaz.</target>
@@ -4859,6 +4864,11 @@ Devam'a tıkladığınızda uygulama bu hatayı yoksayar ve işlemi sürdürmeye
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">{0} örneği oluşturulmaya çalışılırken özel durum oluştu. Özel durum: "{1}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -932,6 +932,11 @@
         <target state="translated">执行 CreateHandle() 时无法调用值 {0}()。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">无法对空集合进行操作。</target>
@@ -4859,6 +4864,11 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">尝试创建 {0} 的实例时发生异常。异常为“{1}”。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -932,6 +932,11 @@
         <target state="translated">執行 CreateHandle() 時，無法呼叫值 {0}()。</target>
         <note />
       </trans-unit>
+      <trans-unit id="CollapsedStateName">
+        <source>Collapsed</source>
+        <target state="new">Collapsed</target>
+        <note />
+      </trans-unit>
       <trans-unit id="CollectionEmptyException">
         <source>Cannot operate with an empty collection.</source>
         <target state="translated">無法使用空的集合作業。</target>
@@ -4859,6 +4864,11 @@ If you click Continue, the application will ignore this error and attempt to con
       <trans-unit id="ExceptionCreatingObject">
         <source>Exception occurred while trying to create an instance of {0}. The exception was "{1}".</source>
         <target state="translated">當嘗試建立 {0} 的執行個體時發生例外狀況。例外狀況為 "{1}"。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ExpandedStateName">
+        <source>Expanded</source>
+        <target state="new">Expanded</target>
         <note />
       </trans-unit>
       <trans-unit id="ExternalException">

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
@@ -44,15 +44,12 @@ namespace System.Windows.Forms
                             : SR.AccessibleActionCheck;
                     }
 
-                    UiaCore.ExpandCollapseState expandCollapseState = ExpandCollapseState;
-                    if (expandCollapseState == UiaCore.ExpandCollapseState.LeafNode)
+                    return ExpandCollapseState switch
                     {
-                        return string.Empty;
-                    }
-
-                    return expandCollapseState == UiaCore.ExpandCollapseState.Expanded
-                        ? SR.AccessibleActionCollapse
-                        : SR.AccessibleActionExpand;
+                        UiaCore.ExpandCollapseState.LeafNode => string.Empty,
+                        UiaCore.ExpandCollapseState.Expanded => SR.AccessibleActionCollapse,
+                        _ => SR.AccessibleActionExpand
+                    };
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -227,6 +227,12 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
+        ///  This flag is necessary to avoid announcing the node status message
+        ///  during a bulk action (e.g. <see cref="TreeNode.ExpandAll"/> method)
+        /// </summary>
+        internal bool IsAnnouncementStopped { get; private set; }
+
+        /// <summary>
         ///  The bounding rectangle for the node (text area only). The coordinates
         ///  are relative to the upper left corner of the TreeView control.
         /// </summary>
@@ -1767,11 +1773,14 @@ namespace System.Windows.Forms
         /// </summary>
         public void ExpandAll()
         {
+            IsAnnouncementStopped = true;
             Expand();
             for (int i = 0; i < childCount; i++)
             {
                 children[i].ExpandAll();
             }
+
+            IsAnnouncementStopped = false;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2250,13 +2250,13 @@ namespace System.Windows.Forms
         {
             onAfterCollapse?.Invoke(this, e);
 
-            // Raise an event to announce the expand-collapse state change.
-            if (IsAccessibilityObjectCreated)
+            if (IsAccessibilityObjectCreated && !e.Node.IsAnnouncementStopped)
             {
-                e.Node.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
-                    UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
-                    oldValue: UiaCore.ExpandCollapseState.Expanded,
-                    newValue: UiaCore.ExpandCollapseState.Collapsed);
+                // Raise an event to announce the expand-collapse state change.
+                e.Node.AccessibilityObject.InternalRaiseAutomationNotification(
+                    Automation.AutomationNotificationKind.ActionCompleted,
+                    Automation.AutomationNotificationProcessing.CurrentThenMostRecent,
+                    SR.CollapsedStateName);
             }
         }
 
@@ -2275,13 +2275,13 @@ namespace System.Windows.Forms
         {
             onAfterExpand?.Invoke(this, e);
 
-            // Raise anevent to announce the expand-collapse state change.
-            if (IsAccessibilityObjectCreated)
+            if (IsAccessibilityObjectCreated && !e.Node.IsAnnouncementStopped)
             {
-                e.Node.AccessibilityObject.RaiseAutomationPropertyChangedEvent(
-                    UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,
-                    oldValue: UiaCore.ExpandCollapseState.Collapsed,
-                    newValue: UiaCore.ExpandCollapseState.Expanded);
+                // Raise an event to announce the expand-collapse state change.
+                e.Node.AccessibilityObject.InternalRaiseAutomationNotification(
+                    Automation.AutomationNotificationKind.ActionCompleted,
+                    Automation.AutomationNotificationProcessing.CurrentThenMostRecent,
+                    SR.ExpandedStateName);
             }
         }
 


### PR DESCRIPTION
Fixes #6732

## Proposed changes
- The issue is reproduced due to the incorrect operation of the `RaiseAutomationPropertyChangedEvent` for the `TreeNode`. Under different conditions, the message may not be announced or announced twice.
- Using `InternalRaiseAutomationNotification` helps to get around this issue, as it ensures that the message is called from .NET Core side, and not from the side of the native control.
- Added `AnnouncementStopped` flag to avoid announcing `TreeNode` status message on bulk action (e.g. `ExpandAll` method)
- Added unit tests

## Customer Impact
**Before fix:**
![154913766-afd3b6f7-cc49-41f1-9e1e-511b52930d85](https://user-images.githubusercontent.com/23376742/161024611-7014de42-c467-449f-8a71-4488fbd11ddb.gif)

**After fix:**
![PR-6940](https://user-images.githubusercontent.com/23376742/161031306-9ddf65f1-66ca-4f60-894e-6c7dbbcc2bfc.gif)

## Regression? 
- No

## Risk
- Minimal

## Test methodology <!-- How did you ensure quality? -->
- CTI team
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Narrator
- JAWS
- NVDA

 ## Test environment(s) <!-- Remove any that don't apply -->
- Microsoft Windows [Version 10.0.19044.1526]
- .NET Core SDK: 7.0.0-preview.4.22179.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6940)