### PR TITLE
Fixing PropertyGrid memory leaks

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -1016,6 +1016,23 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private void CreateUI() => UpdateUIBasedOnFont(layoutRequired: false);
 
+        internal void DisconnectChildren()
+        {
+            Debug.Assert(OsVersion.IsWindows8OrGreater);
+            UiaCore.UiaDisconnectProvider(_editTextBox?.AccessibilityObject);
+            if (_allGridEntries != null)
+            {
+                foreach (GridEntry gridEntry in _allGridEntries)
+                {
+                    // needs additional testing
+                    HRESULT result = UiaCore.UiaDisconnectProvider(gridEntry.AccessibilityObject);
+                    Debug.Assert(result == 0);
+                }
+            }
+
+            _allGridEntries = null;
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)


### PR DESCRIPTION
Fixes #6943

## Proposed changes
- Amount of leaked objects decreased from 595 to 39
- Use the `UiaDisconnectProvider` method through the hierarchy of the classes to free objects held by accessibility tool
- Only static comparers should be left at memory as amount of memory allocated for them isn't increasing after several recurrences of the repro steps described in issue

**This PR requires further development:**
- 39 objects are still left in memory, some of them are accessible objects. They should be tried to clean, except for the Comparers/Sorters which are most possibly are static system objects.
- Quite possible that nullifying `_gridView` and other objects won't be necessary when all provider will be disconnected property
- I've met a crash at the code line `Debug.Assert(result == 0)` for the result of disconnecting the third button of the `_viewSortButtons` collection if debugger is detached, and E_FAIL result if attached - it requires further investigation
- There was a crash scenario at NetFx:  start AI, run internal test app, click "Dialogs" button, click "Print dialog" button, then "Folder browser dialog" - disconnecting `gridEntry.AccessibilityObject` at the `DisconnectChildren` method at the `PropertyGridView` class caused NRE. I couldn't reproduce this issue at the Core branch, but it's better to double check it.

## Customer Impact
- PropertyGrid memory will stop leaking

## Regression? 
- No

## Risk
- Minimal

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/87859299/161106770-95acc204-9862-4e96-95b4-7477be4571a2.png)

### After
![image](https://user-images.githubusercontent.com/87859299/161106794-301eafc1-626d-407a-aa98-fd1e38ebeb3a.png)

## Test methodology
- Manual testing (_using WinDbg, see the screenshots above_)
- CTI team

## Test environment(s)
- Microsoft Windows [Version 10.0.19043.1586]
- .NET 7.0.0-preview.3.22159.12

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6946)