### PR TITLE
Create unique instance for each AutoComplete object

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/StringSource.cs
@@ -40,7 +40,7 @@ namespace System.Windows.Forms
                 out IntPtr autoComplete2Ptr).ThrowIfFailed();
 
             var obj = WinFormsComWrappers.Instance
-                .GetOrCreateObjectForComInstance(autoComplete2Ptr, CreateObjectFlags.None);
+                .GetOrCreateObjectForComInstance(autoComplete2Ptr, CreateObjectFlags.UniqueInstance);
             _autoCompleteObject2 = (WinFormsComWrappers.AutoCompleteWrapper)obj;
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ComboBoxTests.cs
@@ -35,8 +35,8 @@ public class ComboBoxTests : ControlTestBase
             comboBox.AutoCompleteMode = AutoCompleteMode.Suggest;
             comboBox.AutoCompleteMode = AutoCompleteMode.Suggest;
 
-            // Allow a little time to process the keystroke.
-            await Task.Delay(DelayMS);
+
+                return Task.CompletedTask;
         });
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ComboBoxTests.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Windows.Forms.UITests;
+
+public class ComboBoxTests : ControlTestBase
+{
+    // This value may need to be adjusted if tests fail in CI/different environment.
+    private const int DelayMS = 100;
+
+    public ComboBoxTests(ITestOutputHelper testOutputHelper)
+        : base(testOutputHelper)
+    {
+    }
+
+    [WinFormsFact]
+    public async Task ComboBoxTest_ChangeAutoCompleteSource_DoesntThrowAsync()
+    {
+        await RunSingleControlTestAsync<ComboBox>(async (form, comboBox) =>
+        {
+            // Test case captured from here.
+            // https://github.com/dotnet/winforms/issues/6953
+            comboBox.AutoCompleteCustomSource.AddRange(new[]
+            {
+                "_sss",
+                "_sss"
+            });
+            comboBox.AutoCompleteSource = AutoCompleteSource.CustomSource;
+            comboBox.AutoCompleteSource = AutoCompleteSource.CustomSource;
+            comboBox.AutoCompleteMode = AutoCompleteMode.Suggest;
+            comboBox.AutoCompleteMode = AutoCompleteMode.Suggest;
+            comboBox.AutoCompleteMode = AutoCompleteMode.Suggest;
+
+            // Allow a little time to process the keystroke.
+            await Task.Delay(DelayMS);
+        });
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ComboBoxTests.cs
@@ -20,7 +20,7 @@ public class ComboBoxTests : ControlTestBase
     [WinFormsFact]
     public async Task ComboBoxTest_ChangeAutoCompleteSource_DoesntThrowAsync()
     {
-        await RunSingleControlTestAsync<ComboBox>(async (form, comboBox) =>
+        await RunSingleControlTestAsync<ComboBox>((form, comboBox) =>
         {
             // Test case captured from here.
             // https://github.com/dotnet/winforms/issues/6953

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ComboBoxTests.cs
@@ -9,9 +9,6 @@ namespace System.Windows.Forms.UITests;
 
 public class ComboBoxTests : ControlTestBase
 {
-    // This value may need to be adjusted if tests fail in CI/different environment.
-    private const int DelayMS = 100;
-
     public ComboBoxTests(ITestOutputHelper testOutputHelper)
         : base(testOutputHelper)
     {
@@ -35,8 +32,7 @@ public class ComboBoxTests : ControlTestBase
             comboBox.AutoCompleteMode = AutoCompleteMode.Suggest;
             comboBox.AutoCompleteMode = AutoCompleteMode.Suggest;
 
-
-                return Task.CompletedTask;
+            return Task.CompletedTask;
         });
     }
 }


### PR DESCRIPTION
That way we do not re-use released RCW

Fixes #6953

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6958)