### PR TITLE
Remove Message.GetLParam since it is linker unfriendly

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARFORMAT2W.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARFORMAT2W.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Pack = RichEditPack)]
         public unsafe struct CHARFORMAT2W
         {
             private const int LF_FACESIZE = 32;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARRANGE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARRANGE.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct CHARRANGE
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARRANGE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARRANGE.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct CHARRANGE
         {
             public int cpMin;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARRANGE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.CHARRANGE.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
         public struct CHARRANGE
         {
             public int cpMin;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.EDITSTREAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.EDITSTREAM.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct EDITSTREAM
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.EDITSTREAM.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.EDITSTREAM.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
         public struct EDITSTREAM
         {
             public UIntPtr dwCookie;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENDROPFILES.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENDROPFILES.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 internal partial class Interop
 {
     internal static partial class Richedit
     {
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct ENDROPFILES
         {
             public User32.NMHDR nmhdr;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENDROPFILES.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENDROPFILES.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct ENDROPFILES
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENDROPFILES.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENDROPFILES.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
         public struct ENDROPFILES
         {
             public User32.NMHDR nmhdr;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENLINK.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENLINK.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        public struct ENLINK
+        {
+            public User32.NMHDR nmhdr;
+            public int msg;
+            public nuint wParam;
+            public nint lParam;
+            public CHARRANGE charrange;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENLINK.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENLINK.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
         public struct ENLINK
         {
             public User32.NMHDR nmhdr;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENLINK.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENLINK.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct ENLINK
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENPROTECTED.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENPROTECTED.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal static partial class Richedit
+    {
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        public struct ENPROTECTED
+        {
+            public User32.NMHDR nmhdr;
+            public int msg;
+            public nuint wParam;
+            public nint lParam;
+            public CHARRANGE chrg;
+        }
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENPROTECTED.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENPROTECTED.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct ENPROTECTED
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENPROTECTED.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.ENPROTECTED.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
         public struct ENPROTECTED
         {
             public User32.NMHDR nmhdr;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.FINDTEXTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.FINDTEXTW.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Pack = RichEditPack)]
         public unsafe struct FINDTEXTW
         {
             public CHARRANGE chrg;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.FINDTEXTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.FINDTEXTW.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Pack = 4)]
         public unsafe struct FINDTEXTW
         {
             public CHARRANGE chrg;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.FINDTEXTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.FINDTEXTW.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Pack = 4)]
         public unsafe struct FINDTEXTW
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTEX.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTEX.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
         public struct GETTEXTEX
         {
             public uint cb;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTEX.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTEX.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        [StructLayout(LayoutKind.Sequential)]
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct GETTEXTEX
         {
             public uint cb;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTEX.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTEX.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct GETTEXTEX
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTLENGTHEX.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTLENGTHEX.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 internal partial class Interop
 {
     internal static partial class Richedit
     {
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct GETTEXTLENGTHEX
         {
             public GTL flags;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTLENGTHEX.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GETTEXTLENGTHEX.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct GETTEXTLENGTHEX
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GTL.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.GTL.cs
@@ -14,7 +14,7 @@ internal partial class Interop
             PRECISE = 2,
             CLOSE = 4,
             NUMCHARS = 8,
-            NUMBYTES = 6,
+            NUMBYTES = 16,
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.PARAFORMAT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.PARAFORMAT.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
         public unsafe struct PARAFORMAT
         {
             public uint cbSize;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.PARAFORMAT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.PARAFORMAT.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public unsafe struct PARAFORMAT
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.PARAFORMAT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.PARAFORMAT.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 internal partial class Interop
 {
     internal static partial class Richedit
     {
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public unsafe struct PARAFORMAT
         {
             public uint cbSize;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.REQRESIZE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.REQRESIZE.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 internal partial class Interop
 {
     internal static partial class Richedit
     {
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct REQRESIZE
         {
             public User32.NMHDR nmhdr;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.REQRESIZE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.REQRESIZE.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
         public struct REQRESIZE
         {
             public User32.NMHDR nmhdr;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.REQRESIZE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.REQRESIZE.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct REQRESIZE
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.RichEditPack.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.RichEditPack.cs
@@ -2,17 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Runtime.InteropServices;
-
 internal partial class Interop
 {
     internal static partial class Richedit
     {
-        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
-        public struct GETTEXTLENGTHEX
-        {
-            public GTL flags;
-            public uint codepage;
-        }
+        // All structures from richedit.h are packed at 4
+        public const int RichEditPack = 4;
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.SELCHANGE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.SELCHANGE.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
         public struct SELCHANGE
         {
             public User32.NMHDR nmhdr;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.SELCHANGE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.SELCHANGE.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct SELCHANGE
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.SELCHANGE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.SELCHANGE.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 internal partial class Interop
 {
     internal static partial class Richedit
     {
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct SELCHANGE
         {
             public User32.NMHDR nmhdr;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.TEXTRANGE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.TEXTRANGE.cs
@@ -8,8 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
-        // All structures from richedit.h is packed at 4
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        [StructLayout(LayoutKind.Sequential, Pack = RichEditPack)]
         public struct TEXTRANGE
         {
             public Richedit.CHARRANGE chrg;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.TEXTRANGE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.TEXTRANGE.cs
@@ -2,10 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.InteropServices;
+
 internal partial class Interop
 {
     internal static partial class Richedit
     {
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct TEXTRANGE
         {
             public Richedit.CHARRANGE chrg;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.TEXTRANGE.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Richedit/Interop.TEXTRANGE.cs
@@ -8,6 +8,7 @@ internal partial class Interop
 {
     internal static partial class Richedit
     {
+        // All structures from richedit.h is packed at 4
         [StructLayout(LayoutKind.Sequential, Pack = 4)]
         public struct TEXTRANGE
         {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -122,26 +122,6 @@ namespace System.Windows.Forms
             public int FlagsEx;
         }
 
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
-        public struct ENLINK
-        {
-            public User32.NMHDR nmhdr;
-            public int msg;
-            public IntPtr wParam;
-            public IntPtr lParam;
-            public Richedit.CHARRANGE charrange;
-        }
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto, Pack = 4)]
-        public struct ENPROTECTED
-        {
-            public User32.NMHDR nmhdr;
-            public int msg;
-            public IntPtr wParam;
-            public IntPtr lParam;
-            public Richedit.CHARRANGE chrg;
-        }
-
         public class ActiveX
         {
             public const int ALIGN_MIN = 0x0;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/NativeMethods.cs
@@ -122,38 +122,24 @@ namespace System.Windows.Forms
             public int FlagsEx;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public class ENLINK
+        [StructLayout(LayoutKind.Sequential, Pack = 4)]
+        public struct ENLINK
         {
             public User32.NMHDR nmhdr;
             public int msg;
-            public IntPtr wParam = IntPtr.Zero;
-            public IntPtr lParam = IntPtr.Zero;
+            public IntPtr wParam;
+            public IntPtr lParam;
             public Richedit.CHARRANGE charrange;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        public class ENLINK64
-        {
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 56)]
-            public byte[] contents = new byte[56];
-        }
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
-        public class ENPROTECTED
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto, Pack = 4)]
+        public struct ENPROTECTED
         {
             public User32.NMHDR nmhdr;
             public int msg;
             public IntPtr wParam;
             public IntPtr lParam;
             public Richedit.CHARRANGE chrg;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public class ENPROTECTED64
-        {
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 56)]
-            public byte[] contents = new byte[56];
         }
 
         public class ActiveX

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
@@ -85,11 +85,6 @@ namespace System.Windows.Forms
         /// </summary>
         public object? GetLParam(Type cls) => Marshal.PtrToStructure(LParamInternal, cls);
 
-        /// <summary>
-        ///  Gets the <see cref="LParam"/> value, and converts the value to an object of given type.
-        /// </summary>
-        public T? GetLParam<T>() => Marshal.PtrToStructure<T>(LParamInternal);
-
         internal static Message Create(IntPtr hWnd, User32.WM msg, nint wparam, nint lparam)
             => Create(hWnd, (int)msg, wparam, lparam);
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
@@ -85,6 +85,11 @@ namespace System.Windows.Forms
         /// </summary>
         public object? GetLParam(Type cls) => Marshal.PtrToStructure(LParamInternal, cls);
 
+        /// <summary>
+        ///  Gets the <see cref="LParam"/> value, and converts the value to an object of given type.
+        /// </summary>
+        public T? GetLParam<T>() => Marshal.PtrToStructure<T>(LParamInternal);
+
         internal static Message Create(IntPtr hWnd, User32.WM msg, nint wparam, nint lparam)
             => Create(hWnd, (int)msg, wparam, lparam);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3274,8 +3274,8 @@ namespace System.Windows.Forms
         /// </summary>
         private unsafe void EnLinkMsgHandler(ref Message m)
         {
-            NativeMethods.ENLINK enlink;
-            enlink = *(NativeMethods.ENLINK*)m.LParamInternal;
+            ENLINK enlink;
+            enlink = *(ENLINK*)m.LParamInternal;
 
             switch ((User32.WM)enlink.msg)
             {
@@ -3434,9 +3434,9 @@ namespace System.Windows.Forms
 
                     case EN.PROTECTED:
                         {
-                            NativeMethods.ENPROTECTED enprotected;
+                            ENPROTECTED enprotected;
 
-                            enprotected = *(NativeMethods.ENPROTECTED*)m.LParamInternal;
+                            enprotected = *(ENPROTECTED*)m.LParamInternal;
 
                             switch (enprotected.msg)
                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -3279,11 +3279,11 @@ namespace System.Windows.Forms
             //unfortunately does not respect IA64 struct alignment conventions.
             if (IntPtr.Size == 8)
             {
-                enlink = ConvertFromENLINK64((NativeMethods.ENLINK64)m.GetLParam(typeof(NativeMethods.ENLINK64)));
+                enlink = ConvertFromENLINK64(m.GetLParam<NativeMethods.ENLINK64>());
             }
             else
             {
-                enlink = (NativeMethods.ENLINK)m.GetLParam(typeof(NativeMethods.ENLINK));
+                enlink = m.GetLParam<NativeMethods.ENLINK>();
             }
 
             switch ((User32.WM)enlink.msg)
@@ -3449,11 +3449,11 @@ namespace System.Windows.Forms
                             //unfortunately does not respect IA64 struct alignment conventions.
                             if (IntPtr.Size == 8)
                             {
-                                enprotected = ConvertFromENPROTECTED64((NativeMethods.ENPROTECTED64)m.GetLParam(typeof(NativeMethods.ENPROTECTED64)));
+                                enprotected = ConvertFromENPROTECTED64(m.GetLParam<NativeMethods.ENPROTECTED64>());
                             }
                             else
                             {
-                                enprotected = (NativeMethods.ENPROTECTED)m.GetLParam(typeof(NativeMethods.ENPROTECTED));
+                                enprotected = m.GetLParam<NativeMethods.ENPROTECTED>();
                             }
 
                             switch (enprotected.msg)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -2052,7 +2052,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void WmWindowFromPoint(ref Message message)
         {
-            var point = (Point)message.GetLParam(typeof(Point));
+            var point = message.GetLParam<Point>();
             bool result = false;
             message.ResultInternal = GetWindowFromPoint(point, ref result);
         }
@@ -2304,7 +2304,7 @@ namespace System.Windows.Forms
             switch (message.Msg)
             {
                 case (int)(User32.WM.REFLECT_NOTIFY):
-                    User32.NMHDR nmhdr = (User32.NMHDR)message.GetLParam(typeof(User32.NMHDR));
+                    User32.NMHDR nmhdr = message.GetLParam<User32.NMHDR>();
                     if (nmhdr.code == (int)TTN.SHOW && !_trackPosition)
                     {
                         WmShow();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -2050,11 +2050,11 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Handles the WM_WINDOWFROMPOINT message.
         /// </summary>
-        private void WmWindowFromPoint(ref Message message)
+        private unsafe void WmWindowFromPoint(ref Message message)
         {
-            var point = message.GetLParam<Point>();
+            var lpPoint = (Point*)message.LParamInternal;
             bool result = false;
-            message.ResultInternal = GetWindowFromPoint(point, ref result);
+            message.ResultInternal = GetWindowFromPoint(*lpPoint, ref result);
         }
 
         /// <summary>
@@ -2299,17 +2299,17 @@ namespace System.Windows.Forms
             }
         }
 
-        private void WndProc(ref Message message)
+        private unsafe void WndProc(ref Message message)
         {
             switch (message.Msg)
             {
                 case (int)(User32.WM.REFLECT_NOTIFY):
-                    User32.NMHDR nmhdr = message.GetLParam<User32.NMHDR>();
-                    if (nmhdr.code == (int)TTN.SHOW && !_trackPosition)
+                    var nmhdr = (User32.NMHDR*)message.LParamInternal;
+                    if (nmhdr->code == (int)TTN.SHOW && !_trackPosition)
                     {
                         WmShow();
                     }
-                    else if (nmhdr.code == (int)TTN.POP)
+                    else if (nmhdr->code == (int)TTN.POP)
                     {
                         WmPop();
                         _window?.DefWndProc(ref message);

--- a/src/System.Windows.Forms/tests/InteropTests/NativeTests/CMakeLists.txt
+++ b/src/System.Windows.Forms/tests/InteropTests/NativeTests/CMakeLists.txt
@@ -32,11 +32,13 @@ add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:/we4055>) # 'conversion' : from 
 
 add_library(NativeTests SHARED
     AccessibleObjectTests.cpp
-    WebBrowserSiteBaseInteropTests.cpp
     DllGetClassObject.cpp
     DispatchImpl.cpp
-    StandardErrorInfoUsageTest.cpp
     RawErrorInfoUsageTest.cpp
+    RichTextBoxTests.cpp
+    StandardErrorInfoUsageTest.cpp
+    WebBrowserSiteBaseInteropTests.cpp
+
     Exports.def
     ${IDL_OUTPUT_DIRECTORY}/${IDL_NAME}_i.c
 )

--- a/src/System.Windows.Forms/tests/InteropTests/NativeTests/RichTextBoxTests.cpp
+++ b/src/System.Windows.Forms/tests/InteropTests/NativeTests/RichTextBoxTests.cpp
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "testhelpers.h"
+#include <cassert>
+#include <richedit.h>
+
+void WINAPI RichTextBox_Enlink(ENLINK* enlink)
+{
+    enlink->nmhdr.code = 132;
+    enlink->nmhdr.hwndFrom = (HWND)765;
+    enlink->nmhdr.idFrom = 432;
+    enlink->msg = 22;
+    enlink->wParam = 6578;
+    enlink->lParam = 54425;
+    enlink->chrg.cpMin = 109;
+    enlink->chrg.cpMax = 1577;
+}
+
+void WINAPI RichTextBox_Enprotected(ENPROTECTED* enprotected)
+{
+    enprotected->nmhdr.code = 132;
+    enprotected->nmhdr.hwndFrom = (HWND)765;
+    enprotected->nmhdr.idFrom = 432;
+    enprotected->msg = 22;
+    enprotected->wParam = 6578;
+    enprotected->lParam = 54425;
+    enprotected->chrg.cpMin = 109;
+    enprotected->chrg.cpMax = 1577;
+}

--- a/src/System.Windows.Forms/tests/InteropTests/NativeTests/RichTextBoxTests.cpp
+++ b/src/System.Windows.Forms/tests/InteropTests/NativeTests/RichTextBoxTests.cpp
@@ -6,26 +6,114 @@
 #include <cassert>
 #include <richedit.h>
 
-extern "C" __declspec(dllexport) void WINAPI RichTextBox_Enlink(ENLINK* enlink)
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_EnLink(ENLINK* value)
 {
-    enlink->nmhdr.code = 132;
-    enlink->nmhdr.hwndFrom = (HWND)765;
-    enlink->nmhdr.idFrom = 432;
-    enlink->msg = 22;
-    enlink->wParam = 6578;
-    enlink->lParam = 54425;
-    enlink->chrg.cpMin = 109;
-    enlink->chrg.cpMax = 1577;
+    value->nmhdr.code = 132;
+    value->nmhdr.hwndFrom = (HWND)765;
+    value->nmhdr.idFrom = 432;
+    value->msg = 22;
+    value->wParam = 6578;
+    value->lParam = 54425;
+    value->chrg.cpMin = 109;
+    value->chrg.cpMax = 1577;
 }
 
-extern "C" __declspec(dllexport) void WINAPI RichTextBox_Enprotected(ENPROTECTED* enprotected)
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_EnProtected(ENPROTECTED* value)
 {
-    enprotected->nmhdr.code = 132;
-    enprotected->nmhdr.hwndFrom = (HWND)765;
-    enprotected->nmhdr.idFrom = 432;
-    enprotected->msg = 22;
-    enprotected->wParam = 6578;
-    enprotected->lParam = 54425;
-    enprotected->chrg.cpMin = 109;
-    enprotected->chrg.cpMax = 1577;
+    value->nmhdr.code = 132;
+    value->nmhdr.hwndFrom = (HWND)765;
+    value->nmhdr.idFrom = 432;
+    value->msg = 22;
+    value->wParam = 6578;
+    value->lParam = 54425;
+    value->chrg.cpMin = 109;
+    value->chrg.cpMax = 1577;
+}
+
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_EnDropFiles(ENDROPFILES* value)
+{
+    value->nmhdr.code = 132;
+    value->nmhdr.hwndFrom = (HWND)765;
+    value->nmhdr.idFrom = 432;
+    value->hDrop = (HANDLE)22;
+    value->cp = 6578;
+    value->fProtected = TRUE;
+}
+
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_CharRange(CHARRANGE* value)
+{
+    value->cpMin = 109;
+    value->cpMax = 1577;
+}
+
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_EditStream(EDITSTREAM* value)
+{
+    value->dwCookie = 109;
+    value->dwError = 1577;
+    value->pfnCallback = (EDITSTREAMCALLBACK)6578;
+}
+
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_FindTextW(FINDTEXTW* value)
+{
+    value->lpstrText = L"Fine Text";
+    value->chrg.cpMin = 109;
+    value->chrg.cpMax = 1577;
+}
+
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_GetTextEx(GETTEXTEX* value)
+{
+    value->cb = 132;
+    value->flags = GT_RAWTEXT;
+    value->codepage = 432;
+    value->lpDefaultChar = (LPCSTR)22;
+    value->lpUsedDefChar = (LPBOOL)6578;
+}
+
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_GetTextLengthEx(GETTEXTLENGTHEX* value)
+{
+    value->flags = GTL_NUMBYTES;
+    value->codepage = 432;
+}
+
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_ParaFormat(PARAFORMAT* value)
+{
+    value->cbSize = 132;
+    value->dwMask = PFM_ALIGNMENT;
+    value->wNumbering = PFN_UCROMAN;
+    value->wReserved = 6578;
+    value->dxStartIndent = 109;
+    value->dxRightIndent = 432;
+    value->dxOffset = 54425;
+    value->wAlignment = PFA_JUSTIFY;
+    value->cTabCount = 6565;
+    value->rgxTabs[0] = 8989;
+    value->rgxTabs[31] = 812;
+}
+
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_ReqResize(REQRESIZE* value)
+{
+    value->nmhdr.code = 132;
+    value->nmhdr.hwndFrom = (HWND)765;
+    value->nmhdr.idFrom = 432;
+    value->rc.left = 6578;
+    value->rc.right = 109;
+    value->rc.top = 54425;
+    value->rc.bottom = 8989;
+}
+
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_SelChange(SELCHANGE* value)
+{
+    value->nmhdr.code = 132;
+    value->nmhdr.hwndFrom = (HWND)765;
+    value->nmhdr.idFrom = 432;
+    value->seltyp = SEL_MULTICHAR;
+    value->chrg.cpMin = 109;
+    value->chrg.cpMax = 1577;
+}
+
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_TextRange(TEXTRANGE* value)
+{
+    value->lpstrText = "Fine Text";
+    value->chrg.cpMin = 109;
+    value->chrg.cpMax = 1577;
 }

--- a/src/System.Windows.Forms/tests/InteropTests/NativeTests/RichTextBoxTests.cpp
+++ b/src/System.Windows.Forms/tests/InteropTests/NativeTests/RichTextBoxTests.cpp
@@ -6,7 +6,7 @@
 #include <cassert>
 #include <richedit.h>
 
-void WINAPI RichTextBox_Enlink(ENLINK* enlink)
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_Enlink(ENLINK* enlink)
 {
     enlink->nmhdr.code = 132;
     enlink->nmhdr.hwndFrom = (HWND)765;
@@ -18,7 +18,7 @@ void WINAPI RichTextBox_Enlink(ENLINK* enlink)
     enlink->chrg.cpMax = 1577;
 }
 
-void WINAPI RichTextBox_Enprotected(ENPROTECTED* enprotected)
+extern "C" __declspec(dllexport) void WINAPI RichTextBox_Enprotected(ENPROTECTED* enprotected)
 {
     enprotected->nmhdr.code = 132;
     enprotected->nmhdr.hwndFrom = (HWND)765;

--- a/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
@@ -9,6 +9,8 @@ using static Interop.Richedit;
 
 namespace System.Windows.Forms.Interop.Tests;
 
+// Magic numbrs in this file are coming from unmanaged part of the test
+// at https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/tests/InteropTests/NativeTests/RichTextBoxTests.cpp
 public class RichTextBoxTests
 {
     public const string NativeTests = "NativeTests";

--- a/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Xunit;
+using static System.Windows.Forms.NativeMethods;
+
+namespace System.Windows.Forms.Interop.Tests;
+
+public class RichTextBoxTests
+{
+    public const string NativeTests = "NativeTests";
+
+    [Fact]
+    public static void RichTextBox_Enlink_Test()
+    {
+        RichTextBox_Enlink(out var enlink);
+
+        Assert.Equal(132, enlink.nmhdr.code);
+        Assert.Equal((IntPtr)765, enlink.nmhdr.hwndFrom);
+        Assert.Equal((IntPtr)432, enlink.nmhdr.idFrom);
+        Assert.Equal(22, enlink.msg);
+        Assert.Equal((IntPtr)6578, enlink.wParam);
+        Assert.Equal((IntPtr)54425, enlink.lParam);
+        Assert.Equal(109, enlink.charrange.cpMin);
+        Assert.Equal(1577, enlink.charrange.cpMax);
+    }
+
+    [Fact]
+    public static void RichTextBox_Enprotected_Test()
+    {
+        RichTextBox_Enprotected(out var enprotected);
+
+        Assert.Equal(132, enprotected.nmhdr.code);
+        Assert.Equal((IntPtr)765, enprotected.nmhdr.hwndFrom);
+        Assert.Equal((IntPtr)432, enprotected.nmhdr.idFrom);
+        Assert.Equal(22, enprotected.msg);
+        Assert.Equal((IntPtr)6578, enprotected.wParam);
+        Assert.Equal((IntPtr)54425, enprotected.lParam);
+        Assert.Equal(109, enprotected.chrg.cpMin);
+        Assert.Equal(1577, enprotected.chrg.cpMax);
+    }
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_Enlink(out ENLINK enlink);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_Enprotected(out ENPROTECTED enprotected);
+}

--- a/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
@@ -4,7 +4,7 @@
 
 using System.Runtime.InteropServices;
 using Xunit;
-using static System.Windows.Forms.NativeMethods;
+using static Interop.Richedit;
 
 namespace System.Windows.Forms.Interop.Tests;
 
@@ -21,8 +21,8 @@ public class RichTextBoxTests
         Assert.Equal((IntPtr)765, enlink.nmhdr.hwndFrom);
         Assert.Equal((IntPtr)432, enlink.nmhdr.idFrom);
         Assert.Equal(22, enlink.msg);
-        Assert.Equal((IntPtr)6578, enlink.wParam);
-        Assert.Equal((IntPtr)54425, enlink.lParam);
+        Assert.Equal((nuint)6578, enlink.wParam);
+        Assert.Equal(54425, enlink.lParam);
         Assert.Equal(109, enlink.charrange.cpMin);
         Assert.Equal(1577, enlink.charrange.cpMax);
     }
@@ -36,8 +36,8 @@ public class RichTextBoxTests
         Assert.Equal((IntPtr)765, enprotected.nmhdr.hwndFrom);
         Assert.Equal((IntPtr)432, enprotected.nmhdr.idFrom);
         Assert.Equal(22, enprotected.msg);
-        Assert.Equal((IntPtr)6578, enprotected.wParam);
-        Assert.Equal((IntPtr)54425, enprotected.lParam);
+        Assert.Equal((nuint)6578, enprotected.wParam);
+        Assert.Equal(54425, enprotected.lParam);
         Assert.Equal(109, enprotected.chrg.cpMin);
         Assert.Equal(1577, enprotected.chrg.cpMax);
     }

--- a/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
@@ -111,7 +111,7 @@ public class RichTextBoxTests
     {
         RichTextBox_ParaFormat(out var value);
 
-        Assert.Equal(432u, value.cbSize);
+        Assert.Equal(132u, value.cbSize);
         Assert.Equal(PFM.ALIGNMENT, value.dwMask);
         Assert.Equal(PFN.UCROMAN, value.wNumbering);
         Assert.Equal(6578, value.wReserved);

--- a/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 using Xunit;
+using static Interop;
 using static Interop.Richedit;
 
 namespace System.Windows.Forms.Interop.Tests;
@@ -13,38 +14,186 @@ public class RichTextBoxTests
     public const string NativeTests = "NativeTests";
 
     [Fact]
-    public static void RichTextBox_Enlink_Test()
+    public static void RichTextBox_EnLink_Test()
     {
-        RichTextBox_Enlink(out var enlink);
+        RichTextBox_EnLink(out var value);
 
-        Assert.Equal(132, enlink.nmhdr.code);
-        Assert.Equal((IntPtr)765, enlink.nmhdr.hwndFrom);
-        Assert.Equal((IntPtr)432, enlink.nmhdr.idFrom);
-        Assert.Equal(22, enlink.msg);
-        Assert.Equal((nuint)6578, enlink.wParam);
-        Assert.Equal(54425, enlink.lParam);
-        Assert.Equal(109, enlink.charrange.cpMin);
-        Assert.Equal(1577, enlink.charrange.cpMax);
+        Assert.Equal(132, value.nmhdr.code);
+        Assert.Equal((IntPtr)765, value.nmhdr.hwndFrom);
+        Assert.Equal((IntPtr)432, value.nmhdr.idFrom);
+        Assert.Equal(22, value.msg);
+        Assert.Equal((nuint)6578, value.wParam);
+        Assert.Equal(54425, value.lParam);
+        Assert.Equal(109, value.charrange.cpMin);
+        Assert.Equal(1577, value.charrange.cpMax);
     }
 
     [Fact]
-    public static void RichTextBox_Enprotected_Test()
+    public static void RichTextBox_EnProtected_Test()
     {
-        RichTextBox_Enprotected(out var enprotected);
+        RichTextBox_EnProtected(out var value);
 
-        Assert.Equal(132, enprotected.nmhdr.code);
-        Assert.Equal((IntPtr)765, enprotected.nmhdr.hwndFrom);
-        Assert.Equal((IntPtr)432, enprotected.nmhdr.idFrom);
-        Assert.Equal(22, enprotected.msg);
-        Assert.Equal((nuint)6578, enprotected.wParam);
-        Assert.Equal(54425, enprotected.lParam);
-        Assert.Equal(109, enprotected.chrg.cpMin);
-        Assert.Equal(1577, enprotected.chrg.cpMax);
+        Assert.Equal(132, value.nmhdr.code);
+        Assert.Equal((IntPtr)765, value.nmhdr.hwndFrom);
+        Assert.Equal((IntPtr)432, value.nmhdr.idFrom);
+        Assert.Equal(22, value.msg);
+        Assert.Equal((nuint)6578, value.wParam);
+        Assert.Equal(54425, value.lParam);
+        Assert.Equal(109, value.chrg.cpMin);
+        Assert.Equal(1577, value.chrg.cpMax);
+    }
+
+    [Fact]
+    public static void RichTextBox_EnDropFiles_Test()
+    {
+        RichTextBox_EnDropFiles(out var value);
+
+        Assert.Equal(132, value.nmhdr.code);
+        Assert.Equal((IntPtr)765, value.nmhdr.hwndFrom);
+        Assert.Equal((IntPtr)432, value.nmhdr.idFrom);
+        Assert.Equal((IntPtr)22, value.hDrop);
+        Assert.Equal(6578, value.cp);
+        Assert.Equal(BOOL.TRUE, value.fProtected);
+    }
+
+    [Fact]
+    public static void RichTextBox_CharRange_Test()
+    {
+        RichTextBox_CharRange(out var value);
+
+        Assert.Equal(109, value.cpMin);
+        Assert.Equal(1577, value.cpMax);
+    }
+
+    [Fact]
+    public static void RichTextBox_EditStream_Test()
+    {
+        RichTextBox_EditStream(out var value);
+
+        Assert.Equal((UIntPtr)109, value.dwCookie);
+        Assert.Equal(1577u, value.dwError);
+        Assert.Equal((IntPtr)6578, value.pfnCallback);
+    }
+
+    [Fact]
+    public static unsafe void RichTextBox_FindTextW_Test()
+    {
+        RichTextBox_FindTextW(out var value);
+
+        Assert.Equal("Fine Text", Marshal.PtrToStringUni((IntPtr)value.lpstrText));
+        Assert.Equal(109, value.chrg.cpMin);
+        Assert.Equal(1577, value.chrg.cpMax);
+    }
+
+    [Fact]
+    public static unsafe void RichTextBox_GetTextEx_Test()
+    {
+        RichTextBox_GetTextEx(out var value);
+
+        Assert.Equal(132u, value.cb);
+        Assert.Equal(GT.RAWTEXT, value.flags);
+        Assert.Equal(432u, value.codepage);
+        Assert.Equal((IntPtr)22, value.lpDefaultChar);
+        Assert.Equal((IntPtr)6578, value.lpUsedDefChar);
+    }
+
+    [Fact]
+    public static unsafe void RichTextBox_GetTextLengthEx_Test()
+    {
+        RichTextBox_GetTextLengthEx(out var value);
+
+        Assert.Equal(GTL.NUMBYTES, value.flags);
+        Assert.Equal(432u, value.codepage);
+    }
+
+    [Fact]
+    public static unsafe void RichTextBox_ParaFormat_Test()
+    {
+        RichTextBox_ParaFormat(out var value);
+
+        Assert.Equal(432u, value.cbSize);
+        Assert.Equal(PFM.ALIGNMENT, value.dwMask);
+        Assert.Equal(PFN.UCROMAN, value.wNumbering);
+        Assert.Equal(6578, value.wReserved);
+        Assert.Equal(109, value.dxStartIndent);
+        Assert.Equal(432, value.dxRightIndent);
+        Assert.Equal(54425, value.dxOffset);
+        Assert.Equal(PFA.JUSTIFY, value.wAlignment);
+        Assert.Equal(6565, value.cTabCount);
+        Assert.Equal(8989, value.rgxTabs[0]);
+        Assert.Equal(812, value.rgxTabs[31]);
+    }
+
+    [Fact]
+    public static void RichTextBox_ReqResize_Test()
+    {
+        RichTextBox_ReqResize(out var value);
+
+        Assert.Equal(132, value.nmhdr.code);
+        Assert.Equal((IntPtr)765, value.nmhdr.hwndFrom);
+        Assert.Equal((IntPtr)432, value.nmhdr.idFrom);
+        Assert.Equal(6578, value.rc.left);
+        Assert.Equal(109, value.rc.right);
+        Assert.Equal(54425, value.rc.top);
+        Assert.Equal(8989, value.rc.bottom);
+    }
+
+    [Fact]
+    public static void RichTextBox_SelChange_Test()
+    {
+        RichTextBox_SelChange(out var value);
+
+        Assert.Equal(132, value.nmhdr.code);
+        Assert.Equal((IntPtr)765, value.nmhdr.hwndFrom);
+        Assert.Equal((IntPtr)432, value.nmhdr.idFrom);
+        Assert.Equal(SEL.MULTICHAR, value.seltyp);
+        Assert.Equal(109, value.chrg.cpMin);
+        Assert.Equal(1577, value.chrg.cpMax);
+    }
+
+    [Fact]
+    public static unsafe void RichTextBox_TextRange_Test()
+    {
+        RichTextBox_TextRange(out var value);
+
+        Assert.Equal("Fine Text", Marshal.PtrToStringAnsi(value.lpstrText));
+        Assert.Equal(109, value.chrg.cpMin);
+        Assert.Equal(1577, value.chrg.cpMax);
     }
 
     [DllImport(NativeTests, PreserveSig = true)]
-    private static extern void RichTextBox_Enlink(out ENLINK enlink);
+    private static extern void RichTextBox_EnLink(out ENLINK enlink);
 
     [DllImport(NativeTests, PreserveSig = true)]
-    private static extern void RichTextBox_Enprotected(out ENPROTECTED enprotected);
+    private static extern void RichTextBox_EnProtected(out ENPROTECTED enprotected);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_EnDropFiles(out ENDROPFILES value);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_CharRange(out CHARRANGE value);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_EditStream(out EDITSTREAM value);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_FindTextW(out FINDTEXTW value);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_GetTextEx(out GETTEXTEX value);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_GetTextLengthEx(out GETTEXTLENGTHEX value);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_ParaFormat(out PARAFORMAT value);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_ReqResize(out REQRESIZE value);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_SelChange(out SELCHANGE value);
+
+    [DllImport(NativeTests, PreserveSig = true)]
+    private static extern void RichTextBox_TextRange(out TEXTRANGE value);
 }

--- a/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/InteropTests/RichTextBoxTests.cs
@@ -10,7 +10,7 @@ using static Interop.Richedit;
 namespace System.Windows.Forms.Interop.Tests;
 
 // Magic numbrs in this file are coming from unmanaged part of the test
-// at https://github.com/dotnet/winforms/blob/main/src/System.Windows.Forms/tests/InteropTests/NativeTests/RichTextBoxTests.cpp
+// at src/System.Windows.Forms/tests/InteropTests/NativeTests/RichTextBoxTests.cpp
 public class RichTextBoxTests
 {
     public const string NativeTests = "NativeTests";

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MessageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MessageTests.cs
@@ -210,33 +210,6 @@ namespace System.Windows.Forms.Tests
             }
         }
 
-        [Fact]
-        public void Message_GetLParam_T_Invoke_ReturnsExpected()
-        {
-            IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf<TestStruct>());
-            try
-            {
-                var original = new TestStruct
-                {
-                    _field1 = 1,
-                    _field2 = 2
-                };
-                Marshal.StructureToPtr(original, ptr, fDeleteOld: false);
-
-                var message = new Message
-                {
-                    LParam = ptr
-                };
-                TestStruct lparam = message.GetLParam<TestStruct>();
-                Assert.Equal(1, lparam._field1);
-                Assert.Equal(2, lparam._field2);
-            }
-            finally
-            {
-                Marshal.FreeHGlobal(ptr);
-            }
-        }
-
         [StructLayout(LayoutKind.Sequential)]
         private struct TestStruct
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MessageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MessageTests.cs
@@ -210,6 +210,33 @@ namespace System.Windows.Forms.Tests
             }
         }
 
+        [Fact]
+        public void Message_GetLParam_T_Invoke_ReturnsExpected()
+        {
+            IntPtr ptr = Marshal.AllocHGlobal(Marshal.SizeOf<TestStruct>());
+            try
+            {
+                var original = new TestStruct
+                {
+                    _field1 = 1,
+                    _field2 = 2
+                };
+                Marshal.StructureToPtr(original, ptr, fDeleteOld: false);
+
+                var message = new Message
+                {
+                    LParam = ptr
+                };
+                TestStruct lparam = message.GetLParam<TestStruct>();
+                Assert.Equal(1, lparam._field1);
+                Assert.Equal(2, lparam._field2);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         private struct TestStruct
         {


### PR DESCRIPTION
That remove one warning from linker.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6962)