### PR TITLE
Fix nested/User control scaling.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -637,18 +637,6 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Recursively enables required scaling from the given control
-        /// </summary>
-        private void EnableRequiredScaling(Control start, bool enable)
-        {
-            start.RequiredScalingEnabled = enable;
-            foreach (Control c in start.Controls)
-            {
-                EnableRequiredScaling(c, enable);
-            }
-        }
-
-        /// <summary>
         ///  Assigns focus to the activeControl. If there is no activeControl then focus is given to
         ///  the form. package scope for Form
         /// </summary>
@@ -788,7 +776,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void LayoutScalingNeeded()
         {
-            EnableRequiredScaling(this, true);
+            EnableRequiredScaling(true);
             _state[s_stateScalingNeededOnLayout] = true;
 
             // If layout is not currently suspended, then perform a layout now,
@@ -1023,7 +1011,7 @@ namespace System.Windows.Forms
                 if (includedBounds)
                 {
                     _state[s_stateScalingNeededOnLayout] = false;
-                    EnableRequiredScaling(this, enable: false);
+                    EnableRequiredScaling(enable: false);
                 }
 
                 _state[s_stateParentChanged] = false;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -4587,16 +4587,29 @@ namespace System.Windows.Forms
             ActiveXInstance.UpdateBounds(ref x, ref y, ref width, ref height, flags);
         }
 
+
         /// <summary>
-        ///  Assigns a new parent control. Sends out the appropriate property change
-        ///  notifications for properties that are affected by the change of parent.
+        ///  Recursively enables required scaling from the given control
+        /// </summary>
+        internal void EnableRequiredScaling(bool enable)
+        {
+            RequiredScalingEnabled = enable;
+            foreach (Control control in Controls)
+            {
+                control.EnableRequiredScaling(enable);
+            }
+        }
+
+        /// <summary>
+        /// Assigns a new parent control. Sends out the appropriate property change
+        /// notifications for properties that are affected by the change of parent.
         /// </summary>
         internal virtual void AssignParent(Control value)
         {
             // Adopt the parent's required scaling bits
             if (value is not null)
             {
-                RequiredScalingEnabled = value.RequiredScalingEnabled;
+                EnableRequiredScaling(value.RequiredScalingEnabled);
             }
 
             if (CanAccessProperties)
@@ -6278,6 +6291,15 @@ namespace System.Windows.Forms
         private void InitScaling(BoundsSpecified specified)
         {
             _requiredScaling |= (byte)((int)specified & RequiredScalingMask);
+
+            // Initscaling on children of container control.
+            if (specified == BoundsSpecified.Size)
+            {
+                foreach (Control control in Controls)
+                {
+                    control.InitScaling(specified);
+                }
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -4587,7 +4587,6 @@ namespace System.Windows.Forms
             ActiveXInstance.UpdateBounds(ref x, ref y, ref width, ref height, flags);
         }
 
-
         /// <summary>
         ///  Recursively enables required scaling from the given control
         /// </summary>


### PR DESCRIPTION
Fixes #6381.

Nested controls are disabled for scaling once their parent layout is finished.
However, Parent might be reparented and could go through a new layout based on
 its parent's scale dimensions.

We are maintaining multiple flags around scaling here and can be cleaned but require full testing. Making a scoped fix here to limit the risk.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6971)