### PR TITLE
Deprecate Permonitor mode intended only for Windows 8.1

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/HighDpiMode.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/HighDpiMode.cs
@@ -37,8 +37,9 @@ namespace System.Windows.Forms
         SystemAware,
 
         /// <summary>
-        ///  The window checks for DPI when it's created and adjusts scale factor when the DPI changes.
+        /// The window checks for DPI when it's created and adjusts scale factor when the DPI changes.
         /// </summary>
+        [Obsolete("Permonitor mode is applicable only on Windows 8.1. Winforms does not support this mode", true)]
         PerMonitor,
 
         /// <summary>


### PR DESCRIPTION
WinForms never fully supported this mode. Windows 10 and above versions use 'PermonitorV2' mode.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6972)