### PR TITLE
Fixed Narrator announcement of an empty form or its inner controls when opening

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 System.Windows.Forms.BindingMemberInfo.Equals(System.Windows.Forms.BindingMemberInfo other) -> bool
 System.Windows.Forms.LinkArea.Equals(System.Windows.Forms.LinkArea other) -> bool
 System.Windows.Forms.TableLayoutPanelCellPosition.Equals(System.Windows.Forms.TableLayoutPanelCellPosition other) -> bool
+override System.Windows.Forms.Form.OnGotFocus(System.EventArgs! e) -> void

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Form.FormAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Form.FormAccessibleObjectTests.cs
@@ -74,5 +74,84 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AccessibleRole.Client, actual);
             Assert.False(form.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData("null")] // The form is empty
+        [InlineData("invisible")]  // The form has invisible control (looks empty)
+        [InlineData("disabled")] // The form has disabled control
+        public void FormAccessibleObject_RaiseFocusEvent_WhenFormGetsFocus_WithoutActiveControl(string controlCase)
+        {
+            using Form form = new FocusEventsCounterForm();
+            using Control control = controlCase switch
+            {
+                "null" => null,
+                "invisible" => new Button() { Visible = false },
+                "disabled" => new Button() { Enabled = false },
+                _ => null
+            };
+            form.Controls.Add(control);
+            form.CreateControl(true);
+            var accessibleObject = (FocusEventsCounterFormAccessibleObject)form.AccessibilityObject;
+
+            Assert.NotNull(accessibleObject);
+            Assert.Equal(0, accessibleObject.RaiseAutomationFocusEventCallsCount);
+            Assert.True(form.IsHandleCreated);
+
+            form.Visible = true;
+            form.Focus();
+
+            Assert.Null(form.ActiveControl);
+            Assert.Equal(1, accessibleObject.RaiseAutomationFocusEventCallsCount);
+        }
+
+        [WinFormsFact]
+        public void FormAccessibleObject_RaiseFocusEvent_WhenFormGetsFocus_WithActiveControl()
+        {
+            using Form form = new FocusEventsCounterForm();
+            using Button control = new();
+            form.Controls.Add(control);
+            form.CreateControl(true);
+            var accessibleObject = (FocusEventsCounterFormAccessibleObject)form.AccessibilityObject;
+
+            Assert.NotNull(accessibleObject);
+            Assert.Equal(0, accessibleObject.RaiseAutomationFocusEventCallsCount);
+            Assert.True(form.IsHandleCreated);
+
+            form.Visible = true;
+            control.Visible = true;
+            form.Focus();
+
+            Assert.NotNull(form.ActiveControl);
+
+            // The child control gets the focus changed event instead of the form.
+            // Native control does it itself, so a screen reader should focus on the inner control.
+            Assert.Equal(0, accessibleObject.RaiseAutomationFocusEventCallsCount);
+        }
+
+        private class FocusEventsCounterForm : Form
+        {
+            protected override AccessibleObject CreateAccessibilityInstance()
+                => new FocusEventsCounterFormAccessibleObject(this);
+        }
+
+        private class FocusEventsCounterFormAccessibleObject : FormAccessibleObject
+        {
+            public FocusEventsCounterFormAccessibleObject(Form owner) : base(owner)
+            {
+                RaiseAutomationFocusEventCallsCount = 0;
+            }
+
+            public int RaiseAutomationFocusEventCallsCount { get; private set; }
+
+            internal override bool RaiseAutomationEvent(UiaCore.UIA eventId)
+            {
+                if (eventId == UiaCore.UIA.AutomationFocusChangedEventId)
+                {
+                    RaiseAutomationFocusEventCallsCount++;
+                }
+
+                return base.RaiseAutomationEvent(eventId);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #6896
This is a regression from .NET 3.1 after #2096. (.NET Core 3.0 and .NET Framework work well)

## Proposed changes

- Raise the focus event for a form or its active control, when the form is opening. Thereby a screen reader will focus on the form and announce its title.
**We can't raise the UIA focus event in `OnGotFocus`, `OnShown`, `OnLoad` event handlers, because when they work AccessibleObject is not created yet and we can't be sure that a UIA tool (eg. Narrator) is working. It's a Form control issue only, when it's showing and if the form is empty. So we have to use `OnAccessibleObjectCreated` and check a focus state there.
If the form has enabled and visible controls, we need to do nothing.**

## Customer Impact

- Now a user can know from Narrator that a form has been opened

## Regression? 

- Yes (from #2096)

## Risk

- Minimal

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before - todo

<!-- TODO -->

### After - todo

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- CTI

## Accessibility testing 
- Using Narrator, AI, and Inspect.
   Tested the following cases:
     - Open an empty form - Narrator should focus on the form and announce its title
     - Open a form with one control - Narrator should focus on this control and announce the form title and then the control info. Also checked, if a control, that overrides `OnGotFocus`, doesn't conflict with this fix raising focus event:
        - ListBox
        - DateTimePicker
        - ListView
        - MonthCalendar
        - TabControl
     - Open a form with several controls - Narrator should focus on an active control (usually, that has a minimal TabIndex) and announce the form title and then the active control info.
     - Open a form with one disabled or invisible control (so we can't focus on it) - Narrator should focus on the form and announce its title
    


## Test environment(s) <!-- Remove any that don't apply -->

- Windows 11
- .NET 7.0.0-preview.4.22179.1


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6974)