### PR TITLE
Workaround for empty finalizers in DataGridView.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -34,10 +34,8 @@ namespace System.Windows.Forms
         {
         }
 
-        /// <summary>
-        /// Currently this finalizer is unneeded (empty). See https://github.com/dotnet/winforms/issues/6858.<br/>
-        /// All classes that are not need to be finalized contains in <see cref="DataGridViewElement.s_typesWithEmptyFinalizer"/> collection. Consider to modify it if needed.
-        /// </summary>
+        // NOTE: currently this finalizer is unneeded (empty). See https://github.com/dotnet/winforms/issues/6858.
+        // All classes that are not need to be finalized contains in DataGridViewElement.s_typesWithEmptyFinalizer collection. Consider to modify it if needed.
         ~DataGridViewBand() => Dispose(false);
 
         internal int CachedThickness { get; set; }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewBand.cs
@@ -34,6 +34,10 @@ namespace System.Windows.Forms
         {
         }
 
+        /// <summary>
+        /// Currently this finalizer is unneeded (empty). See https://github.com/dotnet/winforms/issues/6858.<br/>
+        /// All classes that are not need to be finalized contains in <see cref="DataGridViewElement.s_typesWithEmptyFinalizer"/> collection. Consider to modify it if needed.
+        /// </summary>
         ~DataGridViewBand() => Dispose(false);
 
         internal int CachedThickness { get; set; }
@@ -824,6 +828,9 @@ namespace System.Windows.Forms
                     contextMenuStrip.Disposed -= new EventHandler(DetachContextMenuStrip);
                 }
             }
+
+            // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type (and all of its subclasses) from DataGridViewElement.s_typesWithEmptyFinalizer!
+            // Also consider to modify ~DataGridViewBand() description.
         }
 
         internal void GetHeightInfo(int rowIndex, out int height, out int minimumHeight)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -84,10 +84,8 @@ namespace System.Windows.Forms
             _useDefaultToolTipText = true;
         }
 
-        /// <summary>
-        /// Currently this finalizer is unneeded (empty). See https://github.com/dotnet/winforms/issues/6858.<br/>
-        /// All classes that are not need to be finalized contains in <see cref="DataGridViewElement.s_typesWithEmptyFinalizer"/> collection. Consider to modify it if needed.
-        /// </summary>
+        // NOTE: currently this finalizer is unneeded (empty). See https://github.com/dotnet/winforms/issues/6858.
+        // All classes that are not need to be finalized contains in DataGridViewElement.s_typesWithEmptyFinalizer collection. Consider to modify it if needed.
         ~DataGridViewCell()
         {
             Dispose(false);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -84,6 +84,10 @@ namespace System.Windows.Forms
             _useDefaultToolTipText = true;
         }
 
+        /// <summary>
+        /// Currently this finalizer is unneeded (empty). See https://github.com/dotnet/winforms/issues/6858.<br/>
+        /// All classes that are not need to be finalized contains in <see cref="DataGridViewElement.s_typesWithEmptyFinalizer"/> collection. Consider to modify it if needed.
+        /// </summary>
         ~DataGridViewCell()
         {
             Dispose(false);
@@ -1320,6 +1324,9 @@ namespace System.Windows.Forms
                     contextMenuStrip.Disposed -= new EventHandler(DetachContextMenuStrip);
                 }
             }
+
+            // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type (and all of its subclasses) from DataGridViewElement.s_typesWithEmptyFinalizer!
+            // Also consider to modify ~DataGridViewCell() description.
         }
 
         protected virtual bool DoubleClickUnsharesRow(DataGridViewCellEventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
@@ -936,13 +936,15 @@ namespace System.Windows.Forms
             {
                 if (disposing)
                 {
-                    //
                     lock (this)
                     {
                         Site?.Container?.Remove(this);
                         _disposed?.Invoke(this, EventArgs.Empty);
                     }
                 }
+
+                // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type (and all of its subclasses) from DataGridViewElement.s_typesWithEmptyFinalizer!
+                // Also consider to modify ~DataGridViewBand() description.
             }
             finally
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElement.cs
@@ -18,6 +18,9 @@ namespace System.Windows.Forms
         /// </summary>
         public DataGridViewElement()
         {
+            if (NeedSuppressFinalize(GetType()))
+                GC.SuppressFinalize(this);
+
             State = DataGridViewElementStates.Visible;
         }
 
@@ -88,6 +91,21 @@ namespace System.Windows.Forms
         protected void RaiseMouseWheel(MouseEventArgs e)
         {
             _dataGridView?.OnMouseWheelInternal(e);
+        }
+
+        /// <summary>
+        /// Determines whether <see cref="GC.SuppressFinalize(object)" /> should be called in the constructor for the given <paramref name="type"/>.<br/>
+        /// <see cref="GC.SuppressFinalize(object)" /> must be called on known internal subclasses of <see cref="DataGridViewBand" /> / <see cref="DataGridViewCell" /> which don't need a finalizer.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns><see langword="true"/> if need to call <see cref="GC.SuppressFinalize(object)" />, <see langword="false"/> otherwise.</returns>
+        private static bool NeedSuppressFinalize(Type type)
+        {
+            return type == typeof(DataGridViewBand) || type == typeof(DataGridViewColumn) || type == typeof(DataGridViewButtonColumn) || type == typeof(DataGridViewCheckBoxColumn) ||
+                type == typeof(DataGridViewComboBoxColumn) || type == typeof(DataGridViewImageColumn) || type == typeof(DataGridViewLinkColumn) || type == typeof(DataGridViewTextBoxColumn) ||
+                type == typeof(DataGridViewRow) || type == typeof(DataGridViewCell) || type == typeof(DataGridViewButtonCell) || type == typeof(DataGridViewCheckBoxCell) ||
+                type == typeof(DataGridViewComboBoxCell) || type == typeof(DataGridViewHeaderCell) || type == typeof(DataGridViewColumnHeaderCell) || type == typeof(DataGridViewTopLeftHeaderCell) ||
+                type == typeof(DataGridViewRowHeaderCell) || type == typeof(DataGridViewImageCell) || type == typeof(DataGridViewLinkCell) || type == typeof(DataGridViewTextBoxCell);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElement.cs
@@ -12,7 +12,7 @@ namespace System.Windows.Forms
     public class DataGridViewElement
     {
         /// <summary>
-        /// These are subclasses of the <see cref="DataGridViewElement"/> for which you don't need to call the finalizer, because it's empty.
+        /// These are subclasses of the <see cref="DataGridViewElement"/> for which we don't need to call the finalizer, because it's empty.
         /// See https://github.com/dotnet/winforms/issues/6858.
         /// </summary>
         private static readonly HashSet<Type> s_typesWithEmptyFinalizer = new()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewElement.cs
@@ -11,6 +11,34 @@ namespace System.Windows.Forms
     /// </summary>
     public class DataGridViewElement
     {
+        /// <summary>
+        /// These are subclasses of the <see cref="DataGridViewElement"/> for which you don't need to call the finalizer, because it's empty.
+        /// See https://github.com/dotnet/winforms/issues/6858.
+        /// </summary>
+        private static readonly HashSet<Type> s_typesWithEmptyFinalizer = new()
+        {
+            typeof(DataGridViewBand),
+            typeof(DataGridViewColumn),
+            typeof(DataGridViewButtonColumn),
+            typeof(DataGridViewCheckBoxColumn),
+            typeof(DataGridViewComboBoxColumn),
+            typeof(DataGridViewImageColumn),
+            typeof(DataGridViewLinkColumn),
+            typeof(DataGridViewTextBoxColumn),
+            typeof(DataGridViewRow),
+            typeof(DataGridViewCell),
+            typeof(DataGridViewButtonCell),
+            typeof(DataGridViewCheckBoxCell),
+            typeof(DataGridViewComboBoxCell),
+            typeof(DataGridViewHeaderCell),
+            typeof(DataGridViewColumnHeaderCell),
+            typeof(DataGridViewTopLeftHeaderCell),
+            typeof(DataGridViewRowHeaderCell),
+            typeof(DataGridViewImageCell),
+            typeof(DataGridViewLinkCell),
+            typeof(DataGridViewTextBoxCell)
+        };
+
         private DataGridView? _dataGridView;
 
         /// <summary>
@@ -18,7 +46,7 @@ namespace System.Windows.Forms
         /// </summary>
         public DataGridViewElement()
         {
-            if (NeedSuppressFinalize(GetType()))
+            if (s_typesWithEmptyFinalizer.Contains(GetType()))
                 GC.SuppressFinalize(this);
 
             State = DataGridViewElementStates.Visible;
@@ -91,21 +119,6 @@ namespace System.Windows.Forms
         protected void RaiseMouseWheel(MouseEventArgs e)
         {
             _dataGridView?.OnMouseWheelInternal(e);
-        }
-
-        /// <summary>
-        /// Determines whether <see cref="GC.SuppressFinalize(object)" /> should be called in the constructor for the given <paramref name="type"/>.<br/>
-        /// <see cref="GC.SuppressFinalize(object)" /> must be called on known internal subclasses of <see cref="DataGridViewBand" /> / <see cref="DataGridViewCell" /> which don't need a finalizer.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns><see langword="true"/> if need to call <see cref="GC.SuppressFinalize(object)" />, <see langword="false"/> otherwise.</returns>
-        private static bool NeedSuppressFinalize(Type type)
-        {
-            return type == typeof(DataGridViewBand) || type == typeof(DataGridViewColumn) || type == typeof(DataGridViewButtonColumn) || type == typeof(DataGridViewCheckBoxColumn) ||
-                type == typeof(DataGridViewComboBoxColumn) || type == typeof(DataGridViewImageColumn) || type == typeof(DataGridViewLinkColumn) || type == typeof(DataGridViewTextBoxColumn) ||
-                type == typeof(DataGridViewRow) || type == typeof(DataGridViewCell) || type == typeof(DataGridViewButtonCell) || type == typeof(DataGridViewCheckBoxCell) ||
-                type == typeof(DataGridViewComboBoxCell) || type == typeof(DataGridViewHeaderCell) || type == typeof(DataGridViewColumnHeaderCell) || type == typeof(DataGridViewTopLeftHeaderCell) ||
-                type == typeof(DataGridViewRowHeaderCell) || type == typeof(DataGridViewImageCell) || type == typeof(DataGridViewLinkCell) || type == typeof(DataGridViewTextBoxCell);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewHeaderCell.cs
@@ -63,6 +63,9 @@ namespace System.Windows.Forms
                 FlipXPThemesBitmap.Dispose();
             }
 
+            // If you are adding releasing unmanaged resources code here (disposing == false), you need to remove this class type (and all of its subclasses) from DataGridViewElement.s_typesWithEmptyFinalizer!
+            // Also consider to modify ~DataGridViewCell() description.
+
             base.Dispose(disposing);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewElementTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewElementTests.cs
@@ -355,12 +355,12 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewElement_Subclasses_SuppressFinalizeCall()
         {
             TestAccessor<DataGridViewElement> testAccessor = new(null);
-            var needSuppressFinalize = testAccessor.CreateDelegate<Func<Type, bool>>("NeedSuppressFinalize");
+            var typesWithEmptyFinalizer = testAccessor.Dynamic.s_typesWithEmptyFinalizer as HashSet<Type>;
 
             foreach (var type in typeof(DataGridViewElement).Assembly.GetTypes().Where(type => type == typeof(DataGridViewBand) || type == typeof(DataGridViewCell) ||
                 type.IsSubclassOf(typeof(DataGridViewBand)) || type.IsSubclassOf(typeof(DataGridViewCell))))
             {
-                Assert.True(needSuppressFinalize(type), $"Type {type} is not present in the DataGridViewElement.NeedSuppressFinalize() method. " +
+                Assert.True(typesWithEmptyFinalizer.Contains(type), $"Type {type} is not present in the DataGridViewElement.s_typesWithEmptyFinalizer collection. " +
                     $"Consider adding it or add exclusion to this test (if a new class really needs a finalizer).");
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewElementTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewElementTests.cs
@@ -351,6 +351,20 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(1, callCount);
         }
 
+        [WinFormsFact]
+        public void DataGridViewElement_Subclasses_SuppressFinalizeCall()
+        {
+            TestAccessor<DataGridViewElement> testAccessor = new(null);
+            var needSuppressFinalize = testAccessor.CreateDelegate<Func<Type, bool>>("NeedSuppressFinalize");
+
+            foreach (var type in typeof(DataGridViewElement).Assembly.GetTypes().Where(type => type == typeof(DataGridViewBand) || type == typeof(DataGridViewCell) ||
+                type.IsSubclassOf(typeof(DataGridViewBand)) || type.IsSubclassOf(typeof(DataGridViewCell))))
+            {
+                Assert.True(needSuppressFinalize(type), $"Type {type} is not present in the DataGridViewElement.NeedSuppressFinalize() method. " +
+                    $"Consider adding it or add exclusion to this test (if a new class really needs a finalizer).");
+            }
+        }
+
         private class SubDataGridViewCell : DataGridViewCell
         {
             public new void RaiseCellClick(DataGridViewCellEventArgs e) => base.RaiseCellClick(e);


### PR DESCRIPTION
Contribute to #6858.
This is continuation of https://github.com/dotnet/winforms/pull/6878 based on discussion.
Documentation for calling `GC.SuppressFinalize` on users subclasses also need to be updated some how...

## Test methodology

- Existing UT.
- New UT for all subclasses coverage.
- Manual.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6978)