### PR TITLE
Cut working incorrectly in ToolStripTextBox

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
@@ -506,7 +506,7 @@ namespace System.Windows.Forms
         public void Clear() { TextBox.Clear(); }
         public void ClearUndo() { TextBox.ClearUndo(); }
         public void Copy() { TextBox.Copy(); }
-        public void Cut() { TextBox.Copy(); }
+        public void Cut() { TextBox.Cut(); }
         public void DeselectAll() { TextBox.DeselectAll(); }
         public char GetCharFromPosition(Point pt) { return TextBox.GetCharFromPosition(pt); }
         public int GetCharIndexFromPosition(Point pt) { return TextBox.GetCharIndexFromPosition(pt); }


### PR DESCRIPTION
I assume that this is a bug which we all living with .NET 2.0
Highly unlikely this is ever would be fixed, but would like to discuss possible options.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6986)