### PR TITLE
Fixing ShowInTaskbar=false doesn't work in some cases (#6421)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -6361,10 +6361,7 @@ namespace System.Windows.Forms
 
             if (Modal && _dialogResult == DialogResult.None)
             {
-                if (GetState(States.Recreate) == false)
-                {
-                    DialogResult = DialogResult.Cancel;
-                }
+                DialogResult = DialogResult.Cancel;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -6361,7 +6361,10 @@ namespace System.Windows.Forms
 
             if (Modal && _dialogResult == DialogResult.None)
             {
-                DialogResult = DialogResult.Cancel;
+                if (GetState(States.Recreate) == false)
+                {
+                    DialogResult = DialogResult.Cancel;
+                }
             }
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/System.Windows.Forms.IntegrationTests.Common/MainFormControlsTabOrder.cs
@@ -28,6 +28,7 @@ namespace System.Windows.Forms.IntegrationTests.Common
         RichTextBoxesButton,
         PictureBoxesButton,
         FormBorderStylesButton,
+        FormShowInTaskbarButton,
         ToggleIconButton,
         ErrorProviderButton,
         TaskDialogButton,

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/FormShowInTaskbar.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/FormShowInTaskbar.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -30,8 +29,6 @@ namespace WinformsControlsTest
 
         private void BtnTest_Click(object sender, EventArgs e)
         {
-            bool expectedIsHandleCreated = true;
-
             using var form = new Form()
             {
                 Width = 680,

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/FormShowInTaskbar.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/FormShowInTaskbar.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace WinformsControlsTest
+{
+    public class FormShowInTaskbar : Form
+    {
+        public FormShowInTaskbar()
+        {
+            Width = 600;
+            Height = 460;
+            StartPosition = FormStartPosition.CenterScreen;
+
+            var btnTest = new Button()
+            {
+                Text = "Click here to open new Form",
+                Location = new Point(10, 10),
+                Height = 60,
+                AutoSize = true,
+            };
+
+            btnTest.Click += BtnTest_Click;
+            Controls.Add(btnTest);
+        }
+
+        private void BtnTest_Click(object sender, EventArgs e)
+        {
+            bool expectedIsHandleCreated = true;
+
+            using var form = new Form()
+            {
+                Width = 680,
+                Height = 400,
+                StartPosition = FormStartPosition.CenterScreen,
+            };
+
+            var btnTest = new Button()
+            {
+                Text = $"Click here to test ShowInTaskbar.{Environment.NewLine}If the test result is failed, this dialog will automatically close, or it will throw an exception.",
+                Location = new Point(10, 10),
+                Height = 60,
+                AutoSize = true,
+            };
+
+            btnTest.Click += (object sender, EventArgs e) =>
+            {
+                IntPtr formHandle = form.Handle;
+                form.ShowInTaskbar = !form.ShowInTaskbar;
+
+                if (form.IsHandleCreated == false)
+                    throw new Exception();
+
+                if (formHandle == form.Handle)
+                    throw new Exception();
+            };
+
+            form.Controls.Add(btnTest);
+            form.ShowDialog(this);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MainForm.cs
@@ -144,6 +144,10 @@ namespace WinformsControlsTest
                 new InitInfo("FormBorderStyles", (obj, e) => new FormBorderStyles().Show(this))
             },
             {
+                MainFormControlsTabOrder.FormShowInTaskbarButton,
+                new InitInfo("FormShowInTaskbar", (obj, e) => new FormShowInTaskbar().Show(this))
+            },
+            {
                 MainFormControlsTabOrder.ToggleIconButton,
                 new InitInfo("ToggleFormIcon", (obj, e) => ShowIcon = !ShowIcon)
             },

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -1820,6 +1820,32 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/6421")]
+        [WinFormsFact]
+        public void Form_ShowInTaskBar_SetFalse_GetReturnsExpected()
+        {
+            using var control = new Form
+            {
+                ShowInTaskbar = true,
+            };
+
+            var prefValue = DialogResult.OK;
+
+            control.Load += (object sender, EventArgs e) =>
+            {
+                control.ShowInTaskbar = false;
+            };
+
+            control.Shown += (object sender, EventArgs e) =>
+            {
+                control.DialogResult = prefValue;
+            };
+
+            control.ShowDialog();
+
+            Assert.Equal(prefValue, control.DialogResult);
+        }
+
         public static IEnumerable<object[]> Visible_Set_TestData()
         {
             foreach (DialogResult dialogResult in Enum.GetValues(typeof(DialogResult)))

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -1820,30 +1820,35 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, createdCallCount);
         }
 
-        [ActiveIssue("https://github.com/dotnet/winforms/issues/6421")]
         [WinFormsFact]
-        public void Form_ShowInTaskBar_SetFalse_GetReturnsExpected()
+        public void Form_ShowInTaskbar_SetFalse_GetReturnsExpected()
         {
-            using var control = new Form
+            // Regression test for https://github.com/dotnet/winforms/issues/6421
+
+            using var form = new Form
             {
                 ShowInTaskbar = true,
             };
 
-            var prefValue = DialogResult.OK;
+            bool expectedIsHandleCreated = true;
+            DialogResult expectedDialogResult = DialogResult.OK;
 
-            control.Load += (object sender, EventArgs e) =>
+            form.Load += (object sender, EventArgs e) =>
             {
-                control.ShowInTaskbar = false;
+                IntPtr formHandle = form.Handle;
+                form.ShowInTaskbar = false;
+
+                Assert.Equal(expectedIsHandleCreated, form.IsHandleCreated);
+                Assert.NotEqual(formHandle, form.Handle);
             };
 
-            control.Shown += (object sender, EventArgs e) =>
+            form.Shown += (object sender, EventArgs e) =>
             {
-                control.DialogResult = prefValue;
+                form.DialogResult = expectedDialogResult;
             };
 
-            control.ShowDialog();
-
-            Assert.Equal(prefValue, control.DialogResult);
+            Assert.Equal(expectedDialogResult, form.ShowDialog());
+            Assert.Equal(expectedDialogResult, form.DialogResult);
         }
 
         public static IEnumerable<object[]> Visible_Set_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FormTests.cs
@@ -1830,7 +1830,6 @@ namespace System.Windows.Forms.Tests
                 ShowInTaskbar = true,
             };
 
-            bool expectedIsHandleCreated = true;
             DialogResult expectedDialogResult = DialogResult.OK;
 
             form.Load += (object sender, EventArgs e) =>
@@ -1838,7 +1837,7 @@ namespace System.Windows.Forms.Tests
                 IntPtr formHandle = form.Handle;
                 form.ShowInTaskbar = false;
 
-                Assert.Equal(expectedIsHandleCreated, form.IsHandleCreated);
+                Assert.True(form.IsHandleCreated);
                 Assert.NotEqual(formHandle, form.Handle);
             };
 


### PR DESCRIPTION
Fixes  https://github.com/dotnet/winforms/issues/6421.

If you set ShowInTaskbar=false, the winforms will recreate the Handle. It will call RecreateHandleCore() from Control.cs.

In method WmNCDestroy(ref Message m) from class Form.cs, The program needs to confirm whether the handle is being recreated before setting the value of the DialogResult.

If the program is in the process of recreating the handle, setting DialogResult = DialogResult.Cancel will cause the Form to be automatically closed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6989)