### PR TITLE
Enable nullability in Com2ExtendedUITypeEditor

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedUITypeEditor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 
 namespace System.Drawing.Design
@@ -13,7 +11,7 @@ namespace System.Drawing.Design
     /// </summary>
     internal class Com2ExtendedUITypeEditor : UITypeEditor
     {
-        private readonly UITypeEditor innerEditor;
+        private readonly UITypeEditor? innerEditor;
 
         public Com2ExtendedUITypeEditor(UITypeEditor baseTypeEditor)
         {
@@ -22,10 +20,10 @@ namespace System.Drawing.Design
 
         public Com2ExtendedUITypeEditor(Type baseType)
         {
-            innerEditor = (UITypeEditor)TypeDescriptor.GetEditor(baseType, typeof(UITypeEditor));
+            innerEditor = (UITypeEditor?)TypeDescriptor.GetEditor(baseType, typeof(UITypeEditor));
         }
 
-        public UITypeEditor InnerEditor
+        public UITypeEditor? InnerEditor
         {
             get
             {
@@ -33,7 +31,7 @@ namespace System.Drawing.Design
             }
         }
 
-        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
         {
             if (innerEditor is not null)
             {
@@ -49,7 +47,7 @@ namespace System.Drawing.Design
         ///  Determines if this editor supports the painting of a representation
         ///  of an object's value.
         /// </summary>
-        public override bool GetPaintValueSupported(ITypeDescriptorContext context)
+        public override bool GetPaintValueSupported(ITypeDescriptorContext? context)
         {
             if (innerEditor is not null)
             {
@@ -63,7 +61,7 @@ namespace System.Drawing.Design
         ///  Retrieves the editing style of the Edit method.  If the method
         ///  is not supported, this will return None.
         /// </summary>
-        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context)
         {
             if (innerEditor is not null)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedUITypeEditor.cs
@@ -11,31 +11,31 @@ namespace System.Drawing.Design
     /// </summary>
     internal class Com2ExtendedUITypeEditor : UITypeEditor
     {
-        private readonly UITypeEditor? innerEditor;
+        private readonly UITypeEditor? _innerEditor;
 
         public Com2ExtendedUITypeEditor(UITypeEditor baseTypeEditor)
         {
-            innerEditor = baseTypeEditor;
+            _innerEditor = baseTypeEditor;
         }
 
         public Com2ExtendedUITypeEditor(Type baseType)
         {
-            innerEditor = (UITypeEditor?)TypeDescriptor.GetEditor(baseType, typeof(UITypeEditor));
+            _innerEditor = (UITypeEditor?)TypeDescriptor.GetEditor(baseType, typeof(UITypeEditor));
         }
 
         public UITypeEditor? InnerEditor
         {
             get
             {
-                return innerEditor;
+                return _innerEditor;
             }
         }
 
         public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
         {
-            if (innerEditor is not null)
+            if (_innerEditor is not null)
             {
-                return innerEditor.EditValue(context, provider, value);
+                return _innerEditor.EditValue(context, provider, value);
             }
             else
             {
@@ -49,9 +49,9 @@ namespace System.Drawing.Design
         /// </summary>
         public override bool GetPaintValueSupported(ITypeDescriptorContext? context)
         {
-            if (innerEditor is not null)
+            if (_innerEditor is not null)
             {
-                return innerEditor.GetPaintValueSupported(context);
+                return _innerEditor.GetPaintValueSupported(context);
             }
 
             return base.GetPaintValueSupported(context);
@@ -63,9 +63,9 @@ namespace System.Drawing.Design
         /// </summary>
         public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context)
         {
-            if (innerEditor is not null)
+            if (_innerEditor is not null)
             {
-                return innerEditor.GetEditStyle(context);
+                return _innerEditor.GetEditStyle(context);
             }
 
             return base.GetEditStyle(context);
@@ -78,9 +78,9 @@ namespace System.Drawing.Design
         /// </summary>
         public override void PaintValue(PaintValueEventArgs e)
         {
-            if (innerEditor is not null)
+            if (_innerEditor is not null)
             {
-                innerEditor.PaintValue(e);
+                _innerEditor.PaintValue(e);
             }
 
             base.PaintValue(e);


### PR DESCRIPTION
## Proposed changes

- Enable nullability in Com2ExtendedUITypeEditor.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6994)