### PR TITLE
Enable nullability in OpenFileDialog

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1552,9 +1552,9 @@ System.Windows.Forms.NotifyIcon.Tag.get -> object?
 System.Windows.Forms.NotifyIcon.Tag.set -> void
 System.Windows.Forms.NotifyIcon.Text.get -> string!
 System.Windows.Forms.NotifyIcon.Text.set -> void
-~System.Windows.Forms.OpenFileDialog.OpenFile() -> System.IO.Stream
-~System.Windows.Forms.OpenFileDialog.SafeFileName.get -> string
-~System.Windows.Forms.OpenFileDialog.SafeFileNames.get -> string[]
+System.Windows.Forms.OpenFileDialog.OpenFile() -> System.IO.Stream!
+System.Windows.Forms.OpenFileDialog.SafeFileName.get -> string!
+System.Windows.Forms.OpenFileDialog.SafeFileNames.get -> string![]!
 ~System.Windows.Forms.PictureBox.ErrorImage.get -> System.Drawing.Image
 ~System.Windows.Forms.PictureBox.ErrorImage.set -> void
 ~System.Windows.Forms.PictureBox.Image.get -> System.Drawing.Image

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -153,7 +153,7 @@ namespace System.Windows.Forms
                 dialog.GetFileTypeIndex(out uint filterIndexTemp);
                 FilterIndex = unchecked((int)filterIndexTemp);
                 _fileNames = ProcessVistaFiles(dialog);
-                if (ProcessFileNames())
+                if (ProcessFileNames(_fileNames))
                 {
                     CancelEventArgs ceevent = new CancelEventArgs();
                     if (NativeWindow.WndProcShouldBeDebuggable)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -144,7 +144,7 @@ namespace System.Windows.Forms
         {
             int saveOptions = _options;
             int saveFilterIndex = FilterIndex;
-            string?[]? saveFileNames = _fileNames;
+            string[]? saveFileNames = _fileNames;
             bool ok = false;
 
             try

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -138,13 +138,13 @@ namespace System.Windows.Forms
             return ret;
         }
 
-        private protected abstract string[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog);
+        private protected abstract string?[] ProcessVistaFiles(WinFormsComWrappers.FileDialogWrapper dialog);
 
-        private bool HandleVistaFileOk(Interop.WinFormsComWrappers.FileDialogWrapper dialog)
+        private bool HandleVistaFileOk(WinFormsComWrappers.FileDialogWrapper dialog)
         {
             int saveOptions = _options;
             int saveFilterIndex = FilterIndex;
-            string[]? saveFileNames = _fileNames;
+            string?[]? saveFileNames = _fileNames;
             bool ok = false;
 
             try

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -138,7 +138,7 @@ namespace System.Windows.Forms
             return ret;
         }
 
-        private protected abstract string?[] ProcessVistaFiles(WinFormsComWrappers.FileDialogWrapper dialog);
+        private protected abstract string[] ProcessVistaFiles(WinFormsComWrappers.FileDialogWrapper dialog);
 
         private bool HandleVistaFileOk(WinFormsComWrappers.FileDialogWrapper dialog)
         {
@@ -250,11 +250,11 @@ namespace System.Windows.Forms
             return extensions.ToArray();
         }
 
-        private protected static string? GetFilePathFromShellItem(IShellItem item)
+        private protected static string GetFilePathFromShellItem(IShellItem item)
         {
             HRESULT hr = item.GetDisplayName(SIGDN.DESKTOPABSOLUTEPARSING, out string? filename);
             hr.ThrowIfFailed();
-            return filename;
+            return filename!;
         }
 
         private readonly FileDialogCustomPlacesCollection _customPlaces = new();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -804,10 +804,7 @@ namespace System.Windows.Forms
             try
             {
                 _charBuffer = new UnicodeCharBuffer(FileBufferSize);
-                if (_fileNames is not null)
-                {
-                    _charBuffer.PutString(_fileNames[0]!);
-                }
+                _charBuffer.PutString(FileName);
 
                 ofn.lStructSize = Marshal.SizeOf<NativeMethods.OPENFILENAME_I>();
                 ofn.hwndOwner = hWndOwner;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms
         private string? _title;
         private string? _initialDirectory;
         private string? _defaultExt;
-        private string[]? _fileNames;
+        private string?[]? _fileNames;
         private string? _filter;
         private bool _ignoreSecondFileOkNotification;
         private int _okNotificationCount;
@@ -176,7 +176,7 @@ namespace System.Windows.Forms
                     return string.Empty;
                 }
 
-                return _fileNames[0];
+                return _fileNames[0]!;
             }
             set => _fileNames = value is not null ? new string[] { value } : null;
         }
@@ -413,7 +413,7 @@ namespace System.Windows.Forms
             NativeMethods.OPENFILENAME_I ofn = Marshal.PtrToStructure<NativeMethods.OPENFILENAME_I>(lpOFN)!;
             int saveOptions = _options;
             int saveFilterIndex = FilterIndex;
-            string[]? saveFileNames = _fileNames;
+            string?[]? saveFileNames = _fileNames;
             bool ok = false;
             try
             {
@@ -470,7 +470,7 @@ namespace System.Windows.Forms
             return ok;
         }
 
-        private protected static bool FileExists(string fileName)
+        private protected static bool FileExists(string? fileName)
         {
             try
             {
@@ -670,21 +670,21 @@ namespace System.Windows.Forms
                 string[] extensions = FilterExtensions;
                 for (int i = 0; i < _fileNames!.Length; i++)
                 {
-                    string fileName = _fileNames[i];
+                    string? fileName = _fileNames[i];
                     if ((_options & AddExtensionOption) != 0 && !Path.HasExtension(fileName))
                     {
                         bool fileMustExist = (_options & (int)Comdlg32.OFN.FILEMUSTEXIST) != 0;
 
                         for (int j = 0; j < extensions.Length; j++)
                         {
-                            string currentExtension = Path.GetExtension(fileName);
+                            string currentExtension = Path.GetExtension(fileName)!;
 
                             Debug.Assert(!extensions[j].StartsWith("."),
                                          "FileDialog.FilterExtensions should not return things starting with '.'");
                             Debug.Assert(currentExtension.Length == 0 || currentExtension.StartsWith("."),
                                          "File.GetExtension should return something that starts with '.'");
 
-                            string s = fileName.Substring(0, fileName.Length - currentExtension.Length);
+                            string s = fileName!.Substring(0, fileName.Length - currentExtension.Length);
 
                             // we don't want to append the extension if it contains wild cards
                             if (extensions[j].IndexOfAny(new char[] { '*', '?' }) == -1)
@@ -736,7 +736,7 @@ namespace System.Windows.Forms
         ///  Prompts the user with a <see cref="MessageBox"/> when a
         ///  file does not exist.
         /// </summary>
-        private void PromptFileNotFound(string fileName)
+        private void PromptFileNotFound(string? fileName)
         {
             MessageBoxWithFocusRestore(string.Format(SR.FileDialogFileNotFound, fileName), DialogCaption,
                     MessageBoxButtons.OK, MessageBoxIcon.Warning);
@@ -746,7 +746,7 @@ namespace System.Windows.Forms
         /// If it's necessary to throw up a "This file exists, are you sure?" kind of MessageBox,
         /// here's where we do it. Return value is whether or not the user hit "okay".
         /// </summary>
-        private protected virtual bool PromptUserIfAppropriate(string fileName)
+        private protected virtual bool PromptUserIfAppropriate(string? fileName)
         {
             if ((_options & (int)Comdlg32.OFN.FILEMUSTEXIST) != 0)
             {
@@ -804,9 +804,9 @@ namespace System.Windows.Forms
             try
             {
                 _charBuffer = new UnicodeCharBuffer(FileBufferSize);
-                if (_fileNames is not null)
+                if (_fileNames is not null && _fileNames[0] is not null)
                 {
-                    _charBuffer.PutString(_fileNames[0]);
+                    _charBuffer.PutString(_fileNames[0]!);
                 }
 
                 ofn.lStructSize = Marshal.SizeOf<NativeMethods.OPENFILENAME_I>();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -433,7 +433,7 @@ namespace System.Windows.Forms
                     _fileNames = GetMultiselectFiles(_charBuffer);
                 }
 
-                if (ProcessFileNames())
+                if (ProcessFileNames(_fileNames))
                 {
                     CancelEventArgs ceevent = new CancelEventArgs();
                     if (NativeWindow.WndProcShouldBeDebuggable)
@@ -663,14 +663,14 @@ namespace System.Windows.Forms
         ///  of the "addExtension", "checkFileExists", "createPrompt", and
         ///  "overwritePrompt" properties.
         /// </summary>
-        private bool ProcessFileNames()
+        private bool ProcessFileNames(string[] fileNames)
         {
             if ((_options & (int)Comdlg32.OFN.NOVALIDATE) == 0)
             {
                 string[] extensions = FilterExtensions;
-                for (int i = 0; i < _fileNames!.Length; i++)
+                for (int i = 0; i < fileNames.Length; i++)
                 {
-                    string? fileName = _fileNames[i];
+                    string fileName = fileNames[i];
                     if ((_options & AddExtensionOption) != 0 && !Path.HasExtension(fileName))
                     {
                         bool fileMustExist = (_options & (int)Comdlg32.OFN.FILEMUSTEXIST) != 0;
@@ -699,7 +699,7 @@ namespace System.Windows.Forms
                             }
                         }
 
-                        _fileNames[i] = fileName;
+                        fileNames[i] = fileName;
                     }
 
                     if (!PromptUserIfAppropriate(fileName))

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms
         private string? _title;
         private string? _initialDirectory;
         private string? _defaultExt;
-        private string?[]? _fileNames;
+        private string[]? _fileNames;
         private string? _filter;
         private bool _ignoreSecondFileOkNotification;
         private int _okNotificationCount;
@@ -171,12 +171,12 @@ namespace System.Windows.Forms
         {
             get
             {
-                if (_fileNames is null || string.IsNullOrEmpty(_fileNames[0]))
+                if (_fileNames is null)
                 {
                     return string.Empty;
                 }
 
-                return _fileNames[0]!;
+                return _fileNames[0];
             }
             set => _fileNames = value is not null ? new string[] { value } : null;
         }
@@ -413,7 +413,7 @@ namespace System.Windows.Forms
             NativeMethods.OPENFILENAME_I ofn = Marshal.PtrToStructure<NativeMethods.OPENFILENAME_I>(lpOFN)!;
             int saveOptions = _options;
             int saveFilterIndex = FilterIndex;
-            string?[]? saveFileNames = _fileNames;
+            string[]? saveFileNames = _fileNames;
             bool ok = false;
             try
             {
@@ -804,7 +804,7 @@ namespace System.Windows.Forms
             try
             {
                 _charBuffer = new UnicodeCharBuffer(FileBufferSize);
-                if (_fileNames is not null && _fileNames[0] is not null)
+                if (_fileNames is not null)
                 {
                     _charBuffer.PutString(_fileNames[0]!);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using static Interop;
@@ -139,10 +137,15 @@ namespace System.Windows.Forms
 
         private protected override string[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog)
         {
-            var openDialog = (Interop.WinFormsComWrappers.FileOpenDialogWrapper)dialog;
+            var openDialog = (WinFormsComWrappers.FileOpenDialogWrapper)dialog;
             if (Multiselect)
             {
-                openDialog.GetResults(out Interop.WinFormsComWrappers.ShellItemArrayWrapper results);
+                openDialog.GetResults(out WinFormsComWrappers.ShellItemArrayWrapper? results);
+                if (results is null)
+                {
+                    return Array.Empty<string>();
+                }
+
                 try
                 {
                     results.GetCount(out uint count);
@@ -150,7 +153,7 @@ namespace System.Windows.Forms
                     for (uint i = 0; i < count; ++i)
                     {
                         results.GetItemAt(i, out IShellItem item);
-                        files[unchecked((int)i)] = GetFilePathFromShellItem(item);
+                        files[unchecked((int)i)] = GetFilePathFromShellItem(item) ?? string.Empty;
                     }
 
                     return files;
@@ -162,12 +165,17 @@ namespace System.Windows.Forms
             }
             else
             {
-                openDialog.GetResult(out IShellItem item);
-                return new string[] { GetFilePathFromShellItem(item) };
+                openDialog.GetResult(out IShellItem? item);
+                if (item is null)
+                {
+                    return Array.Empty<string>();
+                }
+
+                return new string[] { GetFilePathFromShellItem(item) ?? string.Empty };
             }
         }
 
-        private protected override Interop.WinFormsComWrappers.FileDialogWrapper CreateVistaDialog()
+        private protected override WinFormsComWrappers.FileDialogWrapper CreateVistaDialog()
         {
             HRESULT hr = Ole32.CoCreateInstance(
                 in CLSID.FileOpenDialog,
@@ -182,7 +190,7 @@ namespace System.Windows.Forms
 
             var obj = WinFormsComWrappers.Instance
                 .GetOrCreateObjectForComInstance(lpDialogUnknownPtr, CreateObjectFlags.None);
-            return (Interop.WinFormsComWrappers.FileDialogWrapper)obj;
+            return (WinFormsComWrappers.FileDialogWrapper)obj;
         }
 
         [Browsable(false)]
@@ -194,17 +202,16 @@ namespace System.Windows.Forms
                 string fullPath = FileName;
                 if (string.IsNullOrEmpty(fullPath))
                 {
-                    return "";
+                    return string.Empty;
                 }
 
-                string safePath = RemoveSensitivePathInformation(fullPath);
-                return safePath;
+                return RemoveSensitivePathInformation(fullPath);
             }
         }
 
         private static string RemoveSensitivePathInformation(string fullPath)
         {
-            return System.IO.Path.GetFileName(fullPath);
+            return Path.GetFileName(fullPath);
         }
 
         [Browsable(false)]
@@ -215,7 +222,10 @@ namespace System.Windows.Forms
             {
                 string[] fullPaths = FileNames;
                 if (fullPaths is null || 0 == fullPaths.Length)
-                { return Array.Empty<string>(); }
+                {
+                    return Array.Empty<string>();
+                }
+
                 string[] safePaths = new string[fullPaths.Length];
                 for (int i = 0; i < safePaths.Length; ++i)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -135,7 +135,7 @@ namespace System.Windows.Forms
             return result;
         }
 
-        private protected override string?[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog)
+        private protected override string[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog)
         {
             var openDialog = (WinFormsComWrappers.FileOpenDialogWrapper)dialog;
             if (Multiselect)
@@ -149,7 +149,7 @@ namespace System.Windows.Forms
                 try
                 {
                     results.GetCount(out uint count);
-                    string?[] files = new string?[count];
+                    string[] files = new string[count];
                     for (uint i = 0; i < count; ++i)
                     {
                         results.GetItemAt(i, out IShellItem item);
@@ -168,10 +168,10 @@ namespace System.Windows.Forms
                 openDialog.GetResult(out IShellItem? item);
                 if (item is null)
                 {
-                    return Array.Empty<string?>();
+                    return Array.Empty<string>();
                 }
 
-                return new string?[] { GetFilePathFromShellItem(item) };
+                return new string[] { GetFilePathFromShellItem(item) };
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/OpenFileDialog.cs
@@ -135,7 +135,7 @@ namespace System.Windows.Forms
             return result;
         }
 
-        private protected override string[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog)
+        private protected override string?[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog)
         {
             var openDialog = (WinFormsComWrappers.FileOpenDialogWrapper)dialog;
             if (Multiselect)
@@ -149,11 +149,11 @@ namespace System.Windows.Forms
                 try
                 {
                     results.GetCount(out uint count);
-                    string[] files = new string[count];
+                    string?[] files = new string?[count];
                     for (uint i = 0; i < count; ++i)
                     {
                         results.GetItemAt(i, out IShellItem item);
-                        files[unchecked((int)i)] = GetFilePathFromShellItem(item) ?? string.Empty;
+                        files[unchecked((int)i)] = GetFilePathFromShellItem(item);
                     }
 
                     return files;
@@ -168,10 +168,10 @@ namespace System.Windows.Forms
                 openDialog.GetResult(out IShellItem? item);
                 if (item is null)
                 {
-                    return Array.Empty<string>();
+                    return Array.Empty<string?>();
                 }
 
-                return new string[] { GetFilePathFromShellItem(item) ?? string.Empty };
+                return new string?[] { GetFilePathFromShellItem(item) };
             }
         }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in OpenFileDialog.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6997)