### PR TITLE
Move SplitData and SplitterMessageFilter to separate files

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitData.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitData.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    public partial class Splitter
+    {
+        /// <summary>
+        ///  Return value holder...
+        /// </summary>
+        private class SplitData
+        {
+            public int dockWidth = -1;
+            public int dockHeight = -1;
+            internal Control? target;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitterMessageFilter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitterMessageFilter.cs
@@ -10,11 +10,11 @@ namespace System.Windows.Forms
     {
         private class SplitterMessageFilter : IMessageFilter
         {
-            private readonly Splitter owner;
+            private readonly Splitter _owner;
 
             public SplitterMessageFilter(Splitter splitter)
             {
-                owner = splitter;
+                _owner = splitter;
             }
 
             /// <summary>
@@ -25,7 +25,7 @@ namespace System.Windows.Forms
                 {
                     if (m.MsgInternal == User32.WM.KEYDOWN && (Keys)m.WParamInternal == Keys.Escape)
                     {
-                        owner.SplitEnd(false);
+                        _owner.SplitEnd(false);
                     }
 
                     return true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitterMessageFilter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitterMessageFilter.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class Splitter
+    {
+        private class SplitterMessageFilter : IMessageFilter
+        {
+            private readonly Splitter owner;
+
+            public SplitterMessageFilter(Splitter splitter)
+            {
+                owner = splitter;
+            }
+
+            /// <summary>
+            /// </summary>
+            public bool PreFilterMessage(ref Message m)
+            {
+                if (m.MsgInternal >= User32.WM.KEYFIRST && m.MsgInternal <= User32.WM.KEYLAST)
+                {
+                    if (m.MsgInternal == User32.WM.KEYDOWN && (Keys)m.WParamInternal == Keys.Escape)
+                    {
+                        owner.SplitEnd(false);
+                    }
+
+                    return true;
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.cs
@@ -982,42 +982,5 @@ namespace System.Windows.Forms
             string s = base.ToString();
             return s + ", MinExtra: " + MinExtra.ToString(CultureInfo.CurrentCulture) + ", MinSize: " + MinSize.ToString(CultureInfo.CurrentCulture);
         }
-
-        /// <summary>
-        ///  Return value holder...
-        /// </summary>
-        private class SplitData
-        {
-            public int dockWidth = -1;
-            public int dockHeight = -1;
-            internal Control? target;
-        }
-
-        private class SplitterMessageFilter : IMessageFilter
-        {
-            private readonly Splitter owner;
-
-            public SplitterMessageFilter(Splitter splitter)
-            {
-                owner = splitter;
-            }
-
-            /// <summary>
-            /// </summary>
-            public bool PreFilterMessage(ref Message m)
-            {
-                if (m.MsgInternal >= User32.WM.KEYFIRST && m.MsgInternal <= User32.WM.KEYLAST)
-                {
-                    if (m.MsgInternal == User32.WM.KEYDOWN && (Keys)m.WParamInternal == Keys.Escape)
-                    {
-                        owner.SplitEnd(false);
-                    }
-
-                    return true;
-                }
-
-                return false;
-            }
-        }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Move SplitData and SplitterMessageFilter to separate files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/6999)