### PR TITLE
Disable nuget warning NU 1505 until https://github.com/dotnet/sdk/issues/24747 is fixed.

### DIFF
--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/VisualBasicRuntimeTest.csproj
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/VisualBasicRuntimeTest.csproj
@@ -2,8 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- NU1505 reports duplicate package download for Microsoft.NETCore.App.Host.win-x64.
+         Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
+    <NoWarn>$(NoWarn);NU1505</NoWarn>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.VisualBasic.Facade.csproj" />
   </ItemGroup>

--- a/src/System.Windows.Forms/tests/AccessibilityTests/AccessibilityTests.csproj
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/AccessibilityTests.csproj
@@ -6,11 +6,13 @@
     <AssemblyName>AccessibilityTests</AssemblyName>
     <!--<TargetFrameworks>net472;net6.0-windows</TargetFrameworks>-->
     <ApplicationManifest>app1.manifest</ApplicationManifest>
-
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
+    <!-- NU1505 reports duplicate package download for Microsoft.NETCore.App.Host.win-x64.
+         Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
+    <NoWarn>$(NoWarn);NU1505</NoWarn>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Windows.Forms.csproj" />
   </ItemGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/DemoConsole.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/DemoConsole.csproj
@@ -8,14 +8,14 @@
     <StartupObject />
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
-
-    <NoWarn>$(NoWarn),SA1633,CS8002</NoWarn>
+    <!-- NU1505 reports duplicate package download for Microsoft.NETCore.App.Host.win-x64.
+         Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
+    <NoWarn>$(NoWarn);SA1633;CS8002;NU1505</NoWarn>
     <Copyright>Copyright © Paolo Foti 2008</Copyright>
     <Company />
     <Authors>Paolo Foti</Authors>
     <PackageLicenseExpression>CPOL</PackageLicenseExpression>
     <PackageProjectUrl>https://www.codeproject.com/Articles/24385/Have-a-Great-DesignTime-Experience-with-a-Powerful</PackageProjectUrl>
-
     <SuppressLicenseValidation>true</SuppressLicenseValidation>
   </PropertyGroup>
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/NativeHost.ManagedControl/NativeHost.ManagedControl.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/NativeHost.ManagedControl/NativeHost.ManagedControl.csproj
@@ -4,11 +4,13 @@
     <AssemblyName>NativeHost.ManagedControl</AssemblyName>
     <Platforms>x86;x64</Platforms>
     <EnableComHosting>true</EnableComHosting>
-
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
+    <!-- NU1505 reports duplicate package download for Microsoft.NETCore.App.Host.win-x64.
+         Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
+    <NoWarn>$(NoWarn);NU1505</NoWarn>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\System.Windows.Forms.Primitives\src\System.Windows.Forms.Primitives.csproj" />
     <ProjectReference Include="..\..\..\src\System.Windows.Forms.csproj" />

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
@@ -13,7 +13,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn),WFDEV001</NoWarn>
+    <!-- NU1505 reports duplicate package download for Microsoft.NETCore.App.Host.win-x64.
+         Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
+    <NoWarn>$(NoWarn),WFDEV001;NU1505</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Error window in Visual Studio displays the following

```
Warning	NU1505	Duplicate 'PackageDownload' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageDownload' items are: 

Microsoft.NETCore.App.Host.win-x64 [7.0.0-preview.4.22214.7], 
Microsoft.NETCore.App.Host.win-x64 [7.0.0-preview.4.22214.7],
Microsoft.NETCore.App.Host.win-x64 [7.0.0-preview.4.22214.7],
Microsoft.NETCore.App.Host.win-x64 [7.0.0-preview.4.22214.7].

AccessibilityTests	D:\winforms\src\System.Windows.Forms\tests\AccessibilityTests\AccessibilityTests.csproj
```

The warning is supposed to report downloads of the same package with different versions - https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1505

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7024)