### PR TITLE
DataGridView flaky tests.

### DIFF
--- a/src/System.Windows.Forms/tests/TestUtilities/ThreadExceptionFixture.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/ThreadExceptionFixture.cs
@@ -13,12 +13,16 @@ namespace System
         {
             Application.EnableVisualStyles();
 
+            // This is done to avoid the effect of the mouse cursor on some tests with invalidates count: https://github.com/dotnet/winforms/pull/7031
+            Cursor.Position = new Drawing.Point(Screen.PrimaryScreen.WorkingArea.Width, Screen.PrimaryScreen.WorkingArea.Height);
+
             Application.ThreadException += OnThreadException;
         }
 
         public virtual void Dispose()
         {
             Application.ThreadException -= OnThreadException;
+            //Xunit.Assert.Equal(new Drawing.Point(Screen.PrimaryScreen.WorkingArea.Width, Screen.PrimaryScreen.WorkingArea.Height), Cursor.Position);
         }
 
         private void OnThreadException(object sender, ThreadExceptionEventArgs e)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTests.cs
@@ -1109,7 +1109,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6739")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6739")]
+        [WinFormsTheory]
         [MemberData(nameof(RowHeadersWidth_SetWithHandle_TestData))]
         public void DataGridView_RowHeadersWidth_SetWithHandle_GetReturnsExpected(DataGridViewRowHeadersWidthSizeMode rowHeadersWidthSizeMode, bool rowHeadersVisible, bool autoSize, int value, int expectedValue, int expectedInvalidatedCallCount)
         {
@@ -1121,7 +1121,12 @@ namespace System.Windows.Forms.Tests
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
             int invalidatedCallCount = 0;
-            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            control.Invalidated += (sender, e) =>
+            {
+                Assert.True(++invalidatedCallCount <= expectedInvalidatedCallCount,
+                    $"Extra ({invalidatedCallCount}) invalidate, must be <= {expectedInvalidatedCallCount}.");
+            };
+
             int styleChangedCallCount = 0;
             control.StyleChanged += (sender, e) => styleChangedCallCount++;
             int createdCallCount = 0;
@@ -1973,7 +1978,7 @@ namespace System.Windows.Forms.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/winforms/issues/6926")]
-        [WinFormsTheory(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/6926")]
+        [WinFormsTheory]
         [MemberData(nameof(OnColumnHeadersHeightChanged_TestData))]
         public void DataGridView_OnColumnHeadersHeightChanged_InvokeWithHandle_CallsColumnHeadersHeightChanged(DataGridViewColumnHeadersHeightSizeMode columnHeadersWidthSizeMode, bool columnHeadersVisible, EventArgs eventArgs)
         {
@@ -1983,8 +1988,11 @@ namespace System.Windows.Forms.Tests
                 ColumnHeadersVisible = columnHeadersVisible
             };
             Assert.NotEqual(IntPtr.Zero, control.Handle);
-            int invalidatedCallCount = 0;
-            control.Invalidated += (sender, e) => invalidatedCallCount++;
+            control.Invalidated += (sender, e) =>
+            {
+                throw new Xunit.Sdk.XunitException("Invalidated event occurred.");
+            };
+
             int styleChangedCallCount = 0;
             control.StyleChanged += (sender, e) => styleChangedCallCount++;
             int createdCallCount = 0;
@@ -2002,7 +2010,6 @@ namespace System.Windows.Forms.Tests
             control.OnColumnHeadersHeightChanged(eventArgs);
             Assert.Equal(1, callCount);
             Assert.True(control.IsHandleCreated);
-            Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
 
@@ -2011,7 +2018,6 @@ namespace System.Windows.Forms.Tests
             control.OnColumnHeadersHeightChanged(eventArgs);
             Assert.Equal(1, callCount);
             Assert.True(control.IsHandleCreated);
-            Assert.Equal(0, invalidatedCallCount);
             Assert.Equal(0, styleChangedCallCount);
             Assert.Equal(0, createdCallCount);
         }


### PR DESCRIPTION
Attempt to investigate DGV flaky tests. https://github.com/dotnet/winforms/issues/6926 https://github.com/dotnet/winforms/issues/6739

Both tests fail due to extra invalidate. To investigate further we need to understand 2 things:

- [x] [Couse of invalidate - call stack](https://github.com/dotnet/winforms/pull/7031#issuecomment-1101339968).
- [x] Input parameters pattern: `rowHeadersVisible: True` / `columnHeadersVisible: True`

Fails by run №:

11: [Windows_x86-xunit
System.Windows.Forms.Tests.ToolStripItemTests.ToolStripItem_ImageKey_ShouldSerializeValueWithOwnerWithImageList_Success](https://dev.azure.com/dnceng/public/_build/results?buildId=1722813&view=ms.vss-test-web.build-test-results-tab&runId=46748528&resultId=110931&paneView=debug)
27: [Windows_arm64-xunit
System.Windows.Forms.Tests.DataGridViewTests.DataGridView_DefaultCellStyles_Rendering](https://dev.azure.com/dnceng/public/_build/results?buildId=1723543&view=ms.vss-test-web.build-test-results-tab&runId=46761178&resultId=106555&paneView=debug)
**29**: [Windows_x64-xunit
System.Windows.Forms.Tests.DataGridViewTests.DataGridView_RowHeadersWidth_SetWithHandle_GetReturnsExpected](https://dev.azure.com/dnceng/public/_build/results?buildId=1723590&view=ms.vss-test-web.build-test-results-tab&runId=46762248&resultId=104683&paneView=debug). Got it!


The problem is in [random cursor position](https://github.com/dotnet/winforms/pull/7031#issuecomment-1101339968) during tests.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7031)