### PR TITLE
Improve roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,51 +2,19 @@
 
 This roadmap communicates priorities for evolving and extending the scope of Windows Forms. For general information regarding .NET plans, see [.NET roadmap](https://github.com/dotnet/core/blob/master/roadmap.md).
 
-* [Past](#past)
-* [Present](#present)
 * [Future](#future)
+* [Present](#present)
 
 This repository is a community effort and we welcome community feedback on our plans. The best way to give your feedback is to open an issue in this repo.
 We also invite contributions. The [up-for-grabs issues](https://github.com/dotnet/winforms/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs) on GitHub are a good place to start.
 
-## Past 
-
-### Windows Forms runtime
-
-* **.NET Core 3.x**<br/>
-    The primary goal of .NET Core 3.x release was to achieve parity with .NET Framework.
-
-* **.NET 5.0**
-    - We aimed to optimize our implementations, reduce our memory footprints, increase performance, and update implementations to deliver all aspects of modern Windows UI, including missing properties or actions, and new UI controls.
-    - Added [Task Dialog](https://docs.microsoft.com/dotnet/api/system.windows.forms.taskdialog) control, and added missing functionality to [ListView](https://docs.microsoft.com/dotnet/api/system.windows.forms.listview) control.
-    - We have also further increased our accessibility support, e.g. by adding [Text Pattern support](https://docs.microsoft.com/windows/win32/winauto/uiauto-implementingtextandtextrange).
-    - Reinstated Visual Basic support.
-    - Enabled ARM64 support.
-
-
-### Windows Forms Designer
-
-Our main effort was focused on enabling full experience for Windows Forms designer for .NET projects. 
-
-## Present
-
-### Windows Forms runtime
-
-**Under considerations**.<br/>A number of aspects are being considered including (but not limited to) layout engine and high DPI support, theming, new controls and components.
-
-### Windows Forms Designer
-
-We continue the work on the designer to to achieve the parity with the .NET Framework designer.
-This involves adding the remaining controls and features and improving stability and performance for the designer.
-
 ## Future
 
-Besides the designer work, here is the list of improvements we are planning to work on in the future.
+Here is the list of improvements we are planning to work on in the future.
 
 ### Accessibility improvements
 
 Including support for standard [WCAG2.1]( https://www.w3.org/TR/WCAG21/), such as enabling tooltips for controls on `Tab` ([#2726](https://github.com/dotnet/winforms/issues/2726)), etc.
-
 
 ### High DPI improvements
 
@@ -74,3 +42,13 @@ Such as Ribbon Control, Balloons, SearchBox, improvements around ListView, etc.
 
 Enable dark theme, etc.
 
+## Present
+
+### Windows Forms runtime
+
+**Under considerations**.<br/>A number of aspects are being considered including (but not limited to) layout engine and high DPI support, theming, new controls and components.
+
+### Windows Forms Designer
+
+We continue the work on the designer to to achieve the parity with the .NET Framework designer.
+This involves adding the remaining controls and features and improving stability and performance for the designer.


### PR DESCRIPTION
I find this document via announcement to .NET 7 Preview 3
and I think it give bad vibes, and not adequately show efforts which is made in this repository.

So I take liberty and slice and dice this document with explanation how I think it should be improved and why.

- Removed *Past* section, since this is roadmap. WinForms deliver past achievements and even if it was glorious past, it may outshine Future goals. Also since it is on first place, it outshines even present
- Move *Present* to backyard. Technically that section is fine, but `Windows Forms runtime` is so bland and gives impression that there no goals for WinForms. Everybody who is familiar with corporate speak may think that "we consider everything, but do not commit to anything". I do not know how to rephrase, but want to point to the wording, which give not enough appreciation of work which happens in this repo. 
- My impression that Future and the Present is really the same, because you actively fixing bugs in Accessibility and work in High DPI support all the time. Because this project is stable, and really everything sounds like ongoing work, but maybe there some way how to present information which will have more *commitment*, if that's possible within your operational limitations. Maybe something like https://github.com/microsoft/microsoft-ui-xaml/blob/main/docs/roadmap.md#features-by-release where would be concrete goals tied to controls/features like Dark Theme support for example.

Please treat this is open critique. If you have better ideas how to improve roadmap then mine please just discard this changes.
