### PR TITLE
Enable nullability in classes that inherit from Com2ExtendedUITypeEditor

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/VSSDK/Interop.IProvidePropertyBuilder.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/VSSDK/Interop.IProvidePropertyBuilder.cs
@@ -24,9 +24,9 @@ internal partial class Interop
             HRESULT ExecuteBuilder(
                 Ole32.DispatchID dispid,
                 [MarshalAs(UnmanagedType.BStr)] string bstrGuidBldr,
-                [MarshalAs(UnmanagedType.Interface)] object pdispApp,
+                [MarshalAs(UnmanagedType.Interface)] object? pdispApp,
                 IntPtr hwndBldrOwner,
-                [In, Out, MarshalAs(UnmanagedType.Struct)] ref object pvarValue,
+                [In, Out, MarshalAs(UnmanagedType.Struct)] ref object? pvarValue,
                 BOOL* actionCommitted);
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IProvidePropertyBuilderHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IProvidePropertyBuilderHandler.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Design;
 using static Interop;
 
@@ -13,7 +14,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
     {
         public override Type Interface => typeof(VSSDK.IProvidePropertyBuilder);
 
-        private unsafe bool GetBuilderGuidString(VSSDK.IProvidePropertyBuilder target, Ole32.DispatchID dispid, ref string? strGuidBldr, VSSDK.CTLBLDTYPE* bldrType)
+        private unsafe bool GetBuilderGuidString(VSSDK.IProvidePropertyBuilder target, Ole32.DispatchID dispid, [NotNullWhen(true)] ref string? strGuidBldr, VSSDK.CTLBLDTYPE* bldrType)
         {
             BOOL valid = BOOL.FALSE;
             var pGuidBldr = new string[1];

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing.Design;
@@ -34,11 +32,11 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  the user to modify the value.  Host assistance in presenting UI to the user
         ///  can be found through the valueAccess.getService function.
         /// </summary>
-        public unsafe override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        public unsafe override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
         {
-            IntPtr parentHandle = (IntPtr)User32.GetFocus();
+            IntPtr parentHandle = User32.GetFocus();
 
-            IUIService uiSvc = (IUIService)provider.GetService(typeof(IUIService));
+            IUIService? uiSvc = (IUIService?)provider.GetService(typeof(IUIService));
             if (uiSvc is not null)
             {
                 IWin32Window parent = uiSvc.GetDialogOwnerWindow();
@@ -49,14 +47,14 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
 
             BOOL useValue = BOOL.FALSE;
-            object pValue = value;
+            object? pValue = value;
 
             try
             {
-                object obj = propDesc.TargetObject;
-                if (obj is ICustomTypeDescriptor)
+                object? obj = propDesc.TargetObject;
+                if (obj is ICustomTypeDescriptor customTypeDescriptor)
                 {
-                    obj = ((ICustomTypeDescriptor)obj).GetPropertyOwner(propDesc);
+                    obj = customTypeDescriptor.GetPropertyOwner(propDesc);
                 }
 
                 Debug.Assert(obj is VSSDK.IProvidePropertyBuilder, "object is not IProvidePropertyBuilder");
@@ -90,7 +88,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  Retrieves the editing style of the Edit method.  If the method
         ///  is not supported, this will return None.
         /// </summary>
-        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context)
         {
             return UITypeEditorEditStyle.Modal;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
@@ -14,15 +14,15 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     internal class Com2PropertyBuilderUITypeEditor : Com2ExtendedUITypeEditor
     {
-        private readonly Com2PropertyDescriptor propDesc;
-        private readonly string guidString;
-        private readonly VSSDK.CTLBLDTYPE bldrType;
+        private readonly Com2PropertyDescriptor _propDesc;
+        private readonly string _guidString;
+        private readonly VSSDK.CTLBLDTYPE _bldrType;
 
         public Com2PropertyBuilderUITypeEditor(Com2PropertyDescriptor pd, string guidString, VSSDK.CTLBLDTYPE type, UITypeEditor baseEditor) : base(baseEditor)
         {
-            propDesc = pd;
-            this.guidString = guidString;
-            bldrType = type;
+            _propDesc = pd;
+            _guidString = guidString;
+            _bldrType = type;
         }
 
         /// <summary>
@@ -51,18 +51,18 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             try
             {
-                object? obj = propDesc.TargetObject;
+                object? obj = _propDesc.TargetObject;
                 if (obj is ICustomTypeDescriptor customTypeDescriptor)
                 {
-                    obj = customTypeDescriptor.GetPropertyOwner(propDesc);
+                    obj = customTypeDescriptor.GetPropertyOwner(_propDesc);
                 }
 
                 Debug.Assert(obj is VSSDK.IProvidePropertyBuilder, "object is not IProvidePropertyBuilder");
                 VSSDK.IProvidePropertyBuilder propBuilder = (VSSDK.IProvidePropertyBuilder)obj;
 
                 if (!propBuilder.ExecuteBuilder(
-                    propDesc.DISPID,
-                    guidString,
+                    _propDesc.DISPID,
+                    _guidString,
                     null,
                     parentHandle,
                     ref pValue,
@@ -76,7 +76,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 Debug.Fail("Failed to show property frame: " + ex.ErrorCode.ToString(CultureInfo.InvariantCulture));
             }
 
-            if (useValue.IsTrue() && (bldrType & VSSDK.CTLBLDTYPE.FEDITSOBJIDRECTLY) == 0)
+            if (useValue.IsTrue() && (_bldrType & VSSDK.CTLBLDTYPE.FEDITSOBJIDRECTLY) == 0)
             {
                 return pValue;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing.Design;
 using System.Runtime.InteropServices;
@@ -30,40 +28,40 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  the user to modify the value.  Host assistance in presenting UI to the user
         ///  can be found through the valueAccess.getService function.
         /// </summary>
-        public override object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+        public override object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
         {
             IntPtr hWndParent = User32.GetFocus(); // Windows.GetForegroundWindow
 
             try
             {
-                ICom2PropertyPageDisplayService propPageSvc = (ICom2PropertyPageDisplayService)provider.GetService(typeof(ICom2PropertyPageDisplayService));
+                ICom2PropertyPageDisplayService? propPageSvc = (ICom2PropertyPageDisplayService?)provider.GetService(typeof(ICom2PropertyPageDisplayService));
 
                 if (propPageSvc is null)
                 {
                     propPageSvc = this;
                 }
 
-                object instance = context.Instance;
+                object? instance = context?.Instance;
 
-                if (!instance.GetType().IsArray)
+                if (instance is not null && !instance.GetType().IsArray)
                 {
                     instance = propDesc.TargetObject;
-                    if (instance is ICustomTypeDescriptor)
+                    if (instance is ICustomTypeDescriptor customTypeDescriptor)
                     {
-                        instance = ((ICustomTypeDescriptor)instance).GetPropertyOwner(propDesc);
+                        instance = customTypeDescriptor.GetPropertyOwner(propDesc);
                     }
                 }
 
                 propPageSvc.ShowPropertyPage(propDesc.Name, instance, (int)propDesc.DISPID, guid, hWndParent);
             }
-            catch (Exception ex1)
+            catch (Exception ex)
             {
                 if (provider is not null)
                 {
-                    IUIService uiSvc = (IUIService)provider.GetService(typeof(IUIService));
+                    IUIService? uiSvc = (IUIService?)provider.GetService(typeof(IUIService));
                     if (uiSvc is not null)
                     {
-                        uiSvc.ShowError(ex1, SR.ErrorTypeConverterFailed);
+                        uiSvc.ShowError(ex, SR.ErrorTypeConverterFailed);
                     }
                 }
             }
@@ -75,7 +73,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  Retrieves the editing style of the Edit method.  If the method
         ///  is not supported, this will return None.
         /// </summary>
-        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
+        public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context)
         {
             return UITypeEditorEditStyle.Modal;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
@@ -12,13 +12,13 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     internal class Com2PropertyPageUITypeEditor : Com2ExtendedUITypeEditor, ICom2PropertyPageDisplayService
     {
-        private readonly Com2PropertyDescriptor propDesc;
-        private Guid guid;
+        private readonly Com2PropertyDescriptor _propDesc;
+        private readonly Guid _guid;
 
         public Com2PropertyPageUITypeEditor(Com2PropertyDescriptor pd, Guid guid, UITypeEditor baseEditor) : base(baseEditor)
         {
-            propDesc = pd;
-            this.guid = guid;
+            _propDesc = pd;
+            _guid = guid;
         }
 
         /// <summary>
@@ -45,14 +45,14 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                 if (instance is not null && !instance.GetType().IsArray)
                 {
-                    instance = propDesc.TargetObject;
+                    instance = _propDesc.TargetObject;
                     if (instance is ICustomTypeDescriptor customTypeDescriptor)
                     {
-                        instance = customTypeDescriptor.GetPropertyOwner(propDesc);
+                        instance = customTypeDescriptor.GetPropertyOwner(_propDesc);
                     }
                 }
 
-                propPageSvc.ShowPropertyPage(propDesc.Name, instance, (int)propDesc.DISPID, guid, hWndParent);
+                propPageSvc.ShowPropertyPage(_propDesc.Name, instance, (int)_propDesc.DISPID, _guid, hWndParent);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in classes that inherit from Com2ExtendedUITypeEditor.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7036)