### PR TITLE
Replace hashtable with generic dictionary in TreeView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -1969,7 +1969,7 @@ namespace System.Windows.Forms
                 }
 
                 _handle = User32.SendMessageW(tv, (User32.WM)TVM.INSERTITEMW, 0, ref tvis);
-                tv._nodeTable[_handle] = this;
+                tv._nodesByHandle[_handle] = this;
 
                 // Lets update the Lparam to the Handle.
                 UpdateNode(TVIF.PARAM);
@@ -2068,7 +2068,7 @@ namespace System.Windows.Forms
                     User32.SendMessageW(tv, (User32.WM)TVM.DELETEITEM, 0, _handle);
                 }
 
-                treeView._nodeTable.Remove(_handle);
+                treeView._nodesByHandle.Remove(_handle);
                 _handle = IntPtr.Zero;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -73,19 +73,19 @@ namespace System.Windows.Forms
                     throw new ArgumentException(string.Format(SR.TreeNodeBoundToAnotherTreeView), nameof(value));
                 }
 
-                if (tv._nodeTable.ContainsKey(value.Handle) && value.index != index)
+                if (tv._nodesByHandle.ContainsKey(value.Handle) && value.index != index)
                 {
                     throw new ArgumentException(string.Format(SR.OnlyOneControl, value.Text), nameof(value));
                 }
 
-                if (tv._nodeTable.ContainsKey(value.Handle)
+                if (tv._nodesByHandle.ContainsKey(value.Handle)
                     && value.Handle == actual.Handle
                     && value.index == index)
                 {
                     return;
                 }
 
-                tv._nodeTable.Remove(actual._handle);
+                tv._nodesByHandle.Remove(actual._handle);
                 value.parent = owner;
                 value.index = index;
                 owner.children[index] = value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -138,7 +138,7 @@ namespace System.Windows.Forms
         internal TreeNodeCollection nodes;
         internal TreeNode editNode;
         internal TreeNode root;
-        internal Dictionary<IntPtr, TreeNode> _nodeTable = new();
+        internal Dictionary<IntPtr, TreeNode> _nodesByHandle = new();
         internal bool nodesCollectionClear; //this is set when the treeNodeCollection is getting cleared and used by TreeView
         private MouseButtons downButton;
         private TreeViewDrawMode drawMode = TreeViewDrawMode.Normal;
@@ -1934,7 +1934,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal TreeNode NodeFromHandle(IntPtr handle)
         {
-            _nodeTable.TryGetValue(handle, out TreeNode treeNode);
+            _nodesByHandle.TryGetValue(handle, out TreeNode treeNode);
             return treeNode;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -138,7 +138,7 @@ namespace System.Windows.Forms
         internal TreeNodeCollection nodes;
         internal TreeNode editNode;
         internal TreeNode root;
-        internal Hashtable _nodeTable = new();
+        internal Dictionary<IntPtr, TreeNode> _nodeTable = new();
         internal bool nodesCollectionClear; //this is set when the treeNodeCollection is getting cleared and used by TreeView
         private MouseButtons downButton;
         private TreeViewDrawMode drawMode = TreeViewDrawMode.Normal;
@@ -1932,7 +1932,11 @@ namespace System.Windows.Forms
         ///  Note this can be null - particularly if any windows messages get generated during
         ///  the insertion of a tree node (TVM_INSERTITEM)
         /// </summary>
-        internal TreeNode NodeFromHandle(IntPtr handle) => (TreeNode)_nodeTable[handle];
+        internal TreeNode NodeFromHandle(IntPtr handle)
+        {
+            _nodeTable.TryGetValue(handle, out TreeNode treeNode);
+            return treeNode;
+        }
 
         /// <summary>
         ///  Fires the DrawNode event.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNodeCollectionTests.cs
@@ -132,7 +132,7 @@ namespace System.Windows.Forms.Tests
             TreeNodeCollection collection = treeView.Nodes;
             collection.Add("Node 1");
             collection[0] = new TreeNode("New node 1");
-            Assert.Equal(1, treeView._nodeTable.Count);
+            Assert.Equal(1, treeView._nodesByHandle.Count);
             Assert.Equal(1, collection.Count);
         }
 


### PR DESCRIPTION
## Proposed changes

- Replace hashtable with generic list in TreeView.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7040)