### PR TITLE
Use generic list in MonitorEnumCallback

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Screen.MonitorEnumCallback.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Screen.MonitorEnumCallback.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using static Interop;
 
 namespace System.Windows.Forms
@@ -11,7 +10,7 @@ namespace System.Windows.Forms
     {
         private class MonitorEnumCallback
         {
-            public ArrayList screens = new ArrayList();
+            public List<Screen> screens = new();
 
             public virtual BOOL Callback(IntPtr monitor, Gdi32.HDC hdc, IntPtr lprcMonitor, IntPtr lparam)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Screen.cs
@@ -114,9 +114,7 @@ namespace System.Windows.Forms
 
                         if (closure.screens.Count > 0)
                         {
-                            Screen[] temp = new Screen[closure.screens.Count];
-                            closure.screens.CopyTo(temp, 0);
-                            s_screens = temp;
+                            s_screens = closure.screens.ToArray();
                         }
                         else
                         {


### PR DESCRIPTION
## Proposed changes

- Use generic list in MonitorEnumCallback.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7041)