### PR TITLE
Fixing `TreeNode` accessible object status announcement by a screen reader

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
@@ -102,9 +102,7 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId
-                        => _owningTreeView.CheckBoxes
-                            ? UiaCore.UIA.CheckBoxControlTypeId
-                            : UiaCore.UIA.TreeItemControlTypeId,
+                        => UiaCore.UIA.TreeItemControlTypeId,
                     UiaCore.UIA.IsEnabledPropertyId
                         => _owningTreeView.Enabled,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
@@ -219,27 +219,18 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void TreeNodeAccessibleObject_GetPropertyValue_ControlType_IsCheckBox_IfNodesAreCheckBoxes()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TreeNodeAccessibleObject_GetPropertyValue_ControlType_IsTreeItem(bool checkBoxes)
         {
-            using TreeView control = new() { CheckBoxes = true };
-            TreeNode node = new(control);
-
-            UiaCore.UIA expected = UiaCore.UIA.CheckBoxControlTypeId;
-
-            Assert.Equal(expected, node.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
-            Assert.False(control.IsHandleCreated);
-        }
-
-        [WinFormsFact]
-        public void TreeNodeAccessibleObject_GetPropertyValue_ControlType_IsTreeItem_IfNodesAreNotCheckBoxes()
-        {
-            using TreeView control = new() { CheckBoxes = false };
+            using TreeView control = new() { CheckBoxes = checkBoxes };
             TreeNode node = new(control);
 
             UiaCore.UIA expected = UiaCore.UIA.TreeItemControlTypeId;
+            object actual = node.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId);
 
-            Assert.Equal(expected, node.AccessibilityObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+            Assert.Equal(expected, actual);
             Assert.False(control.IsHandleCreated);
         }
 


### PR DESCRIPTION
Fixes #6732
This allows a screen reader announce nodes states correctly (expand/collapse and checked/unchecked)
These changes don't affect any UIA properties, patterns and actions (except control type).
These changes affect the case when `CheckBoxes` is **true** only.
This fix is the reworked implementation of #6940.
See [comment](https://github.com/dotnet/winforms/pull/6940#issuecomment-1096780371)

## Proposed changes

- Change `TreeNode` accessible object control type to `tree item` despite CheckBoxes property

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user can hear correct and full info about nodes (affect the case when `CheckBoxes` is true)
- A user will hear `tree item` as tree node control type even it has a check box

## Regression? 

- No

## Risk

- Middle, the fix changes the familiar control type for nodes

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Main branch behavior when `CheckBoxes` is **false**

![image](https://user-images.githubusercontent.com/49272759/163799406-6f5618c9-5a5a-4cc5-ac98-2113871e8b30.png)


### Before
Narrator doesn't announce:
- "expand-collapse" state of a node
- "expanded"/"collapsed" action when you do it for a node
- position index inside the rest nodes like it does when `CheckBoxes` is **false**

![image](https://user-images.githubusercontent.com/49272759/163798999-289f70ec-9151-4cdf-b57c-cae27a45029e.png)


### After
Narrator announces correctly:
- "expand-collapse" state of a node
- "expanded"/"collapsed" action when you do it for a node
- position index inside the rest nodes like it does when `CheckBoxes` is **false**

![image](https://user-images.githubusercontent.com/49272759/163798058-ce2941f1-5c48-4092-8d12-e02e4193e35b.png)



## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manual testing
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Narrator, Inspect, AI tested cases:
      - `CheckBoxes` is true - Narrator should announce "expand-collapse" status and "checked-unchecked" status and position index inside the rest nodes.
      - `CheckBoxes` is false (the fix don't affect this case) - Narrator should announce "expand-collapse" status position index inside the rest nodes. It shouldn't announce "checked-unchecked state.
      - A node can't expand (leaf mode) - Narrator shouldn't announce "expand-collapse" state, known issue (#7043)
 
## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0
- Windows 11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7044)