### PR TITLE
Enable nullability in AutoCompleteStringCollection

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -471,18 +471,18 @@ static System.Windows.Forms.ToolStrip.SetItemParent(System.Windows.Forms.ToolStr
 ~static System.Windows.Forms.ToolStripManager.SaveSettings(System.Windows.Forms.Form sourceForm) -> void
 ~static System.Windows.Forms.ToolStripManager.SaveSettings(System.Windows.Forms.Form sourceForm, string key) -> void
 ~static System.Windows.Forms.TreeNode.FromHandle(System.Windows.Forms.TreeView tree, nint handle) -> System.Windows.Forms.TreeNode
-~System.Windows.Forms.AutoCompleteStringCollection.Add(string value) -> int
-~System.Windows.Forms.AutoCompleteStringCollection.AddRange(string[] value) -> void
-~System.Windows.Forms.AutoCompleteStringCollection.Contains(string value) -> bool
-~System.Windows.Forms.AutoCompleteStringCollection.CopyTo(string[] array, int index) -> void
-~System.Windows.Forms.AutoCompleteStringCollection.GetEnumerator() -> System.Collections.IEnumerator
-~System.Windows.Forms.AutoCompleteStringCollection.IndexOf(string value) -> int
-~System.Windows.Forms.AutoCompleteStringCollection.Insert(int index, string value) -> void
-~System.Windows.Forms.AutoCompleteStringCollection.OnCollectionChanged(System.ComponentModel.CollectionChangeEventArgs e) -> void
-~System.Windows.Forms.AutoCompleteStringCollection.Remove(string value) -> void
-~System.Windows.Forms.AutoCompleteStringCollection.SyncRoot.get -> object
-~System.Windows.Forms.AutoCompleteStringCollection.this[int index].get -> string
-~System.Windows.Forms.AutoCompleteStringCollection.this[int index].set -> void
+System.Windows.Forms.AutoCompleteStringCollection.Add(string! value) -> int
+System.Windows.Forms.AutoCompleteStringCollection.AddRange(string![]! value) -> void
+System.Windows.Forms.AutoCompleteStringCollection.Contains(string! value) -> bool
+System.Windows.Forms.AutoCompleteStringCollection.CopyTo(string![]! array, int index) -> void
+System.Windows.Forms.AutoCompleteStringCollection.GetEnumerator() -> System.Collections.IEnumerator!
+System.Windows.Forms.AutoCompleteStringCollection.IndexOf(string! value) -> int
+System.Windows.Forms.AutoCompleteStringCollection.Insert(int index, string! value) -> void
+System.Windows.Forms.AutoCompleteStringCollection.OnCollectionChanged(System.ComponentModel.CollectionChangeEventArgs! e) -> void
+System.Windows.Forms.AutoCompleteStringCollection.Remove(string! value) -> void
+System.Windows.Forms.AutoCompleteStringCollection.SyncRoot.get -> object!
+System.Windows.Forms.AutoCompleteStringCollection.this[int index].get -> string!
+System.Windows.Forms.AutoCompleteStringCollection.this[int index].set -> void
 ~System.Windows.Forms.AxHost.AxHost(string clsid) -> void
 ~System.Windows.Forms.AxHost.AxHost(string clsid, int flags) -> void
 ~System.Windows.Forms.AxHost.ContainingControl.get -> System.Windows.Forms.ContainerControl
@@ -4647,7 +4647,7 @@ System.Windows.Forms.AutoCompleteSource.RecentlyUsedList = 4 -> System.Windows.F
 System.Windows.Forms.AutoCompleteStringCollection
 System.Windows.Forms.AutoCompleteStringCollection.AutoCompleteStringCollection() -> void
 System.Windows.Forms.AutoCompleteStringCollection.Clear() -> void
-System.Windows.Forms.AutoCompleteStringCollection.CollectionChanged -> System.ComponentModel.CollectionChangeEventHandler
+System.Windows.Forms.AutoCompleteStringCollection.CollectionChanged -> System.ComponentModel.CollectionChangeEventHandler?
 System.Windows.Forms.AutoCompleteStringCollection.Count.get -> int
 System.Windows.Forms.AutoCompleteStringCollection.IsReadOnly.get -> bool
 System.Windows.Forms.AutoCompleteStringCollection.IsSynchronized.get -> bool

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AutoCompleteStringCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.ComponentModel;
 
@@ -14,8 +12,8 @@ namespace System.Windows.Forms;
 /// </summary>
 public class AutoCompleteStringCollection : IList
 {
-    private CollectionChangeEventHandler onCollectionChanged;
-    private readonly List<string> data = new();
+    private CollectionChangeEventHandler? _onCollectionChanged;
+    private readonly List<string> _data = new();
 
     public AutoCompleteStringCollection()
     {
@@ -28,12 +26,12 @@ public class AutoCompleteStringCollection : IList
     {
         get
         {
-            return data[index];
+            return _data[index];
         }
         set
         {
-            OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Remove, data[index]));
-            data[index] = value;
+            OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Remove, _data[index]));
+            _data[index] = value;
             OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, value));
         }
     }
@@ -42,19 +40,19 @@ public class AutoCompleteStringCollection : IList
     ///  Gets the number of strings in the
     ///  <see cref="AutoCompleteStringCollection"/> .
     /// </summary>
-    public int Count => data.Count;
+    public int Count => _data.Count;
 
-    bool IList.IsReadOnly => ((IList)data).IsReadOnly;
+    bool IList.IsReadOnly => ((IList)_data).IsReadOnly;
 
-    bool IList.IsFixedSize => ((IList)data).IsFixedSize;
+    bool IList.IsFixedSize => ((IList)_data).IsFixedSize;
 
-    public event CollectionChangeEventHandler CollectionChanged
+    public event CollectionChangeEventHandler? CollectionChanged
     {
-        add => onCollectionChanged += value;
-        remove => onCollectionChanged -= value;
+        add => _onCollectionChanged += value;
+        remove => _onCollectionChanged -= value;
     }
 
-    protected void OnCollectionChanged(CollectionChangeEventArgs e) => onCollectionChanged?.Invoke(this, e);
+    protected void OnCollectionChanged(CollectionChangeEventArgs e) => _onCollectionChanged?.Invoke(this, e);
 
     /// <summary>
     ///  Adds a string with the specified value to the
@@ -62,7 +60,7 @@ public class AutoCompleteStringCollection : IList
     /// </summary>
     public int Add(string value)
     {
-        int index = ((IList)data).Add(value);
+        int index = ((IList)_data).Add(value);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, value));
         return index;
     }
@@ -74,7 +72,7 @@ public class AutoCompleteStringCollection : IList
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        data.AddRange(value);
+        _data.AddRange(value);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Refresh, null));
     }
 
@@ -84,7 +82,7 @@ public class AutoCompleteStringCollection : IList
     /// </summary>
     public void Clear()
     {
-        data.Clear();
+        _data.Clear();
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Refresh, null));
     }
 
@@ -93,19 +91,19 @@ public class AutoCompleteStringCollection : IList
     ///  <see cref="AutoCompleteStringCollection"/> contains a string with the specified
     ///  value.
     /// </summary>
-    public bool Contains(string value) => data.Contains(value);
+    public bool Contains(string value) => _data.Contains(value);
 
     /// <summary>
     ///  Copies the <see cref="AutoCompleteStringCollection"/> values to a one-dimensional <see cref="Array"/> instance at the
     ///  specified index.
     /// </summary>
-    public void CopyTo(string[] array, int index) => data.CopyTo(array, index);
+    public void CopyTo(string[] array, int index) => _data.CopyTo(array, index);
 
     /// <summary>
     ///  Returns the index of the first occurrence of a string in
     ///  the <see cref="AutoCompleteStringCollection"/> .
     /// </summary>
-    public int IndexOf(string value) => data.IndexOf(value);
+    public int IndexOf(string value) => _data.IndexOf(value);
 
     /// <summary>
     ///  Inserts a string into the <see cref="AutoCompleteStringCollection"/> at the specified
@@ -113,27 +111,27 @@ public class AutoCompleteStringCollection : IList
     /// </summary>
     public void Insert(int index, string value)
     {
-        data.Insert(index, value);
+        _data.Insert(index, value);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Add, value));
     }
 
     /// <summary>
     ///  Gets a value indicating whether the <see cref="AutoCompleteStringCollection"/> is read-only.
     /// </summary>
-    public bool IsReadOnly => ((IList)data).IsReadOnly;
+    public bool IsReadOnly => ((IList)_data).IsReadOnly;
 
     /// <summary>
     ///  Gets a value indicating whether access to the <see cref="AutoCompleteStringCollection"/>
     ///  is synchronized (thread-safe).
     /// </summary>
-    public bool IsSynchronized => ((IList)data).IsSynchronized;
+    public bool IsSynchronized => ((IList)_data).IsSynchronized;
 
     /// <summary>
     ///  Removes a specific string from the <see cref="AutoCompleteStringCollection"/> .
     /// </summary>
     public void Remove(string value)
     {
-        data.Remove(value);
+        _data.Remove(value);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Remove, value));
     }
 
@@ -142,33 +140,33 @@ public class AutoCompleteStringCollection : IList
     /// </summary>
     public void RemoveAt(int index)
     {
-        string value = data[index];
-        data.RemoveAt(index);
+        string value = _data[index];
+        _data.RemoveAt(index);
         OnCollectionChanged(new CollectionChangeEventArgs(CollectionChangeAction.Remove, value));
     }
 
     /// <summary>
     ///  Gets an object that can be used to synchronize access to the <see cref="AutoCompleteStringCollection"/>.
     /// </summary>
-    public object SyncRoot => ((IList)data).SyncRoot;
+    public object SyncRoot => ((IList)_data).SyncRoot;
 
-    object IList.this[int index]
+    object? IList.this[int index]
     {
         get => this[index];
-        set => this[index] = (string)value;
+        set => this[index] = (string)value!;
     }
 
-    int IList.Add(object value) => Add((string)value);
+    int IList.Add(object? value) => Add((string)value!);
 
-    bool IList.Contains(object value) => Contains((string)value);
+    bool IList.Contains(object? value) => Contains((string)value!);
 
-    int IList.IndexOf(object value) => IndexOf((string)value);
+    int IList.IndexOf(object? value) => IndexOf((string)value!);
 
-    void IList.Insert(int index, object value) => Insert(index, (string)value);
+    void IList.Insert(int index, object? value) => Insert(index, (string)value!);
 
-    void IList.Remove(object value) => Remove((string)value);
+    void IList.Remove(object? value) => Remove((string)value!);
 
-    void ICollection.CopyTo(Array array, int index) => ((ICollection)data).CopyTo(array, index);
+    void ICollection.CopyTo(Array array, int index) => ((ICollection)_data).CopyTo(array, index);
 
-    public IEnumerator GetEnumerator() => data.GetEnumerator();
+    public IEnumerator GetEnumerator() => _data.GetEnumerator();
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AutoCompleteStringCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AutoCompleteStringCollectionTests.cs
@@ -1,0 +1,344 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+
+namespace System.Windows.Forms.Tests;
+
+public class AutoCompleteStringCollectionTests
+{
+    [Fact]
+    public void Ctor_Default()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        Assert.Equal(0, collection.Count);
+        Assert.False(collection.IsReadOnly);
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_AddRange_Invoke_Success()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        string[] values = new string[] { "1", "2", "3" };
+        collection.AddRange(values);
+
+        foreach (string s in values)
+        {
+            Assert.True(collection.Contains(s));
+        }
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_AddRange_NullValue_ThrowsArgumentNullException()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        Assert.Throws<ArgumentNullException>("value", () => collection.AddRange(null));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_Contains_Invoke_ReturnsExpected()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        string s = "value";
+        collection.Add(s);
+
+        Assert.True(collection.Contains(s));
+        Assert.False(collection.Contains("anotherValue"));
+        Assert.False(collection.Contains(null));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_Contains_Empty_ReturnsFalse()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+
+        Assert.False(collection.Contains("value"));
+        Assert.False(collection.Contains(null));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListContains_Invoke_ReturnsExpected()
+    {
+        IList collection = new AutoCompleteStringCollection();
+        string s = "value";
+        collection.Add(s);
+
+        Assert.True(collection.Contains(s));
+        Assert.False(collection.Contains("anotherValue"));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListContains_Empty_ReturnsFalse()
+    {
+        IList collection = new AutoCompleteStringCollection();
+
+        Assert.False(collection.Contains("value"));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IndexOf_Invoke_ReturnsExpected()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        string s = "value";
+        collection.Add(s);
+
+        Assert.Equal(0, collection.IndexOf(s));
+        Assert.Equal(-1, collection.IndexOf("anotherValue"));
+        Assert.Equal(-1, collection.IndexOf(null));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IndexOf_Empty_ReturnsFalse()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+
+        Assert.Equal(-1, collection.IndexOf("value"));
+        Assert.Equal(-1, collection.IndexOf(null));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListIndexOf_Invoke_ReturnsExpected()
+    {
+        IList collection = new AutoCompleteStringCollection();
+        string s = "value";
+        collection.Add(s);
+
+        Assert.Equal(0, collection.IndexOf(s));
+        Assert.Equal(-1, collection.IndexOf("anotherValue"));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListIndexOf_Empty_ReturnsMinusOne()
+    {
+        IList collection = new AutoCompleteStringCollection();
+
+        Assert.Equal(-1, collection.IndexOf("value"));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_Insert_String_Success()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        string s = "value1";
+        collection.Add("value2");
+        collection.Insert(1, s);
+        Assert.Equal(2, collection.Count);
+        Assert.Same(s, collection[1]);
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_Insert_AlreadyInOtherCollection_GetReturnsExpected()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        collection.Add("value1");
+
+        AutoCompleteStringCollection otherCollection = new AutoCompleteStringCollection();
+
+        string s = "value2";
+        otherCollection.Add(s);
+
+        // The string appears to belong to two collections.
+        collection.Insert(0, s);
+        Assert.Same(s, collection[0]);
+        Assert.Equal(s, collection[0]);
+        Assert.Equal(s, Assert.Single(otherCollection));
+    }
+
+    [WinFormsTheory]
+    [InlineData(-1)]
+    [InlineData(1)]
+    public void AutoCompleteStringCollection_Insert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, "value"));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListInsert_String_Success()
+    {
+        IList collection = new AutoCompleteStringCollection();
+        string s = "value1";
+        collection.Add("value2");
+        collection.Insert(1, s);
+        Assert.Equal(2, collection.Count);
+        Assert.Same(s, collection[1]);
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListInsert_NullItem_ThrowsArgumentOutOfRangeException()
+    {
+        IList collection = new AutoCompleteStringCollection();
+        Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(-1, null));
+        Assert.Empty(collection);
+    }
+
+    [WinFormsTheory]
+    [InlineData(-1)]
+    [InlineData(1)]
+    public void AutoCompleteStringCollection_IListInsert_InvalidIndex_ThrowsArgumentOutOfRangeException(int index)
+    {
+        IList collection = new AutoCompleteStringCollection();
+        Assert.Throws<ArgumentOutOfRangeException>("index", () => collection.Insert(index, "value"));
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_Remove_String_Success()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        collection.Add("value");
+
+        // Remove null.
+        collection.Remove(null);
+        Assert.Same("value", Assert.Single(collection));
+
+        collection.Remove("value");
+        Assert.Empty(collection);
+
+        // Remove again.
+        collection.Remove("value");
+        Assert.Empty(collection);
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListRemove_String_Success()
+    {
+        IList collection = new AutoCompleteStringCollection();
+        collection.Add("value");
+
+        collection.Remove("value");
+        Assert.Empty(collection);
+
+        // Remove again.
+        collection.Remove("value");
+        Assert.Empty(collection);
+    }
+
+    [WinFormsTheory]
+    [InlineData(null)]
+    [InlineData("text")]
+    public void AutoCompleteStringCollection_IListRemove_InvalidItem_Nop(object value)
+    {
+        IList collection = new AutoCompleteStringCollection();
+        collection.Add(value);
+
+        collection.Remove(value);
+        Assert.Empty(collection);
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_CopyTo_NonEmpty_Success()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        collection.Add("value");
+
+        var array = new string[] { "1", "2", "3" };
+        collection.CopyTo(array, 1);
+        Assert.Equal(new string[] { "1", "value", "3" }, array);
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_CopyTo_Empty_Nop()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        var array = new string[] { "1", "2", "3" };
+        collection.CopyTo(array, 0);
+        Assert.Equal(new string[] { "1", "2", "3" }, array);
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_GetEnumerator_InvokeEmpty_ReturnsExpected()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+
+        IEnumerator enumerator = collection.GetEnumerator();
+        for (int i = 0; i < 2; i++)
+        {
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            // Move again.
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            // Reset.
+            enumerator.Reset();
+        }
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_GetEnumerator_InvokeNotEmpty_ReturnsExpected()
+    {
+        AutoCompleteStringCollection collection = new AutoCompleteStringCollection();
+        collection.Add("2");
+
+        IEnumerator enumerator = collection.GetEnumerator();
+        for (int i = 0; i < 2; i++)
+        {
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("2", enumerator.Current);
+
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            // Move again.
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            // Reset.
+            enumerator.Reset();
+        }
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListGetEnumerator_InvokeEmpty_ReturnsExpected()
+    {
+        IList collection = new AutoCompleteStringCollection();
+
+        IEnumerator enumerator = collection.GetEnumerator();
+        for (int i = 0; i < 2; i++)
+        {
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            // Move again.
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            // Reset.
+            enumerator.Reset();
+        }
+    }
+
+    [WinFormsFact]
+    public void AutoCompleteStringCollection_IListGetEnumerator_InvokeNotEmpty_ReturnsExpected()
+    {
+        IList collection = new AutoCompleteStringCollection();
+        collection.Add("2");
+
+        IEnumerator enumerator = collection.GetEnumerator();
+        for (int i = 0; i < 2; i++)
+        {
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal("2", enumerator.Current);
+
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            // Move again.
+            Assert.False(enumerator.MoveNext());
+            Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+
+            // Reset.
+            enumerator.Reset();
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Enable nullability in AutoCompleteStringCollection.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7047)