### PR TITLE
Fix empty DataGridView HasKeyboardFocus property being always true

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -244,7 +244,7 @@ namespace System.Windows.Forms
                     case UiaCore.UIA.HasKeyboardFocusPropertyId:
                         // If no inner cell entire DGV should be announced as focused by Narrator.
                         // Else only inner cell should be announced as focused by Narrator but not entire DGV.
-                        return RowCount == 0;
+                        return _ownerDataGridView.Focused;
                     case UiaCore.UIA.IsKeyboardFocusablePropertyId:
                         return _ownerDataGridView.CanFocus;
                     case UiaCore.UIA.IsControlElementPropertyId:

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAccessibleObjectTests.cs
@@ -509,49 +509,87 @@ namespace System.Windows.Forms.Tests
             Assert.False(dataGridView.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForEmptyDGV()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForEmptyDGV(bool focused)
         {
-            using DataGridView dataGridView = new();
+            using DataGridView dataGridView = new FakeFocusDataGridView(focused);
 
-            Assert.True((bool)dataGridView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+            bool actual = (bool)dataGridView.AccessibilityObject
+                .GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId);
+
+            Assert.Equal(focused, dataGridView.Focused);
+            Assert.Equal(0, dataGridView.RowCount); // DGV is empty
+            Assert.Equal(focused, actual);
             Assert.False(dataGridView.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForNotEmptyDGV()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForNotEmptyDGV(bool focused)
         {
-            using DataGridView dataGridView = new();
-
+            using DataGridView dataGridView = new FakeFocusDataGridView(focused);
             dataGridView.Columns.Add(new DataGridViewButtonColumn());
 
-            Assert.False((bool)dataGridView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+            bool actual = (bool)dataGridView.AccessibilityObject
+                .GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId);
+
+            Assert.Equal(focused, dataGridView.Focused);
+            Assert.Equal(1, dataGridView.RowCount); // One new row for editing, it will be in focus instead of whole DGV
+            Assert.Equal(focused, actual);
             Assert.False(dataGridView.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForGridWithHiddenRow()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForGridWithHiddenRow(bool focused)
         {
-            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+            using DataGridView dataGridView = new FakeFocusDataGridView(focused) { AllowUserToAddRows = false };
             dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
             dataGridView.Rows.Add("Test");
             dataGridView.Rows[0].Visible = false;
 
-            Assert.True((bool)dataGridView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+            bool actual = (bool)dataGridView.AccessibilityObject
+                .GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId);
+
+            Assert.Equal(focused, dataGridView.Focused);
+            Assert.Equal(focused, actual);
             Assert.False(dataGridView.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForNonEditableDGV()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForNonEditableDGV(bool focused)
         {
-            using DataGridView dataGridView = new()
+            using DataGridView dataGridView = new FakeFocusDataGridView(focused)
             {
                 ReadOnly = true,
                 AllowUserToAddRows = false
             };
 
-            Assert.True((bool)dataGridView.AccessibilityObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+            bool actual = (bool)dataGridView.AccessibilityObject
+                .GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId);
+
+            Assert.Equal(focused, dataGridView.Focused);
+            Assert.Equal(focused, actual);
             Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        private class FakeFocusDataGridView : DataGridView
+        {
+            private readonly bool _focused;
+
+            public FakeFocusDataGridView(bool focused)
+            {
+                _focused = focused;
+            }
+
+            // Emulate the focus state to avoid creation of a form and the control's Handle
+            public override bool Focused => _focused;
         }
 
         [WinFormsFact]


### PR DESCRIPTION
Property value was ignoring whether DGV was focused or not.
Now for empty DGV  `HasKeyboardFocusProperty` will have the same value as owner's Focused property. For non-empty DGV it will remain always false as focus will be acquired by inner cells.
Fixes #7026

<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- Change empty `DataGridView`'s `HasKeyboardFocus` property calculation to reflect DGV focused state.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- `HasKeyboardFocus` will have correct value for empty `DataGridView`.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Without focus - `HasKeyboardFocus` is true:
![before_unfocused_true](https://user-images.githubusercontent.com/102954094/163999280-e0bbda84-4fc2-4b81-8b4a-11893f3ecac5.png)

With focus (note the dotted line on DGV) - `HasKeyboardFocus` is true:
![before_focused_true](https://user-images.githubusercontent.com/102954094/163998692-1350dab6-057f-4245-b198-6a5c6b7dc839.png)

### After

Without focus - `HasKeyboardFocus` is false:
![after_notfocused_false](https://user-images.githubusercontent.com/102954094/163998722-53848269-7bfb-4389-af95-b6dd3e540134.png)

With focus (note the dotted line on DGV) - `HasKeyboardFocus` is true:
![after_focused_true](https://user-images.githubusercontent.com/102954094/163998715-f4be876a-26fe-4ae4-bd38-22a0f171d287.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual (with Inspect tool)
- Unit
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

Tested following cases with Inspect tool:
- Have an empty DataGridView without focus on it - `HasKeyboardFocus` should be false
- Set focus on empty DataGridView - `HasKeyboardFocus` should be true

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0
- Windows 10


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7052)