### PR TITLE
Enable nullability in Com2IDispatchConverter

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IDispatchConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IDispatchConverter.cs
@@ -12,20 +12,20 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  What we return textually for null.
         /// </summary>
-        protected static readonly string none = SR.toStringNone;
+        protected static readonly string s_none = SR.toStringNone;
 
-        private readonly bool allowExpand;
+        private readonly bool _allowExpand;
 
         public Com2IDispatchConverter(bool allowExpand, TypeConverter baseConverter)
             : base(baseConverter)
         {
-            this.allowExpand = allowExpand;
+            _allowExpand = allowExpand;
         }
 
         public Com2IDispatchConverter(Com2PropertyDescriptor propDesc, bool allowExpand)
             : base(propDesc.PropertyType)
         {
-            this.allowExpand = allowExpand;
+            _allowExpand = allowExpand;
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             {
                 if (value is null)
                 {
-                    return none;
+                    return s_none;
                 }
 
                 string text = ComNativeDescriptor.Instance.GetName(value);
@@ -91,7 +91,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         public override bool GetPropertiesSupported(ITypeDescriptorContext? context)
         {
-            return allowExpand;
+            return _allowExpand;
         }
 
         // no dropdown, please!

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IDispatchConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IDispatchConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Globalization;
 
@@ -34,7 +32,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  Determines if this converter can convert an object in the given source
         ///  type to the native type of the converter.
         /// </summary>
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
         {
             return false;
         }
@@ -43,7 +41,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  Determines if this converter can convert an object to the given destination
         ///  type.
         /// </summary>
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        public override bool CanConvertTo(ITypeDescriptorContext? context, Type? destinationType)
         {
             return destinationType == typeof(string);
         }
@@ -55,7 +53,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  type is string.  If this cannot convert to the destination type, this will
         ///  throw a NotSupportedException.
         /// </summary>
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
         {
             if (destinationType == typeof(string))
             {
@@ -82,7 +80,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             return base.ConvertTo(context, culture, value, destinationType);
         }
 
-        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext context, object value, Attribute[] attributes)
+        public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes)
         {
             return TypeDescriptor.GetProperties(value, attributes);
         }
@@ -91,14 +89,13 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  Determines if this object supports properties.  By default, this
         ///  is false.
         /// </summary>
-        public override bool GetPropertiesSupported(ITypeDescriptorContext context)
+        public override bool GetPropertiesSupported(ITypeDescriptorContext? context)
         {
             return allowExpand;
         }
 
         // no dropdown, please!
-        //
-        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext? context)
         {
             return false;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IDispatchConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IDispatchConverter.cs
@@ -11,8 +11,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     internal class Com2IDispatchConverter : Com2ExtendedTypeConverter
     {
-        readonly Com2PropertyDescriptor propDesc;
-
         /// <summary>
         ///  What we return textually for null.
         /// </summary>
@@ -20,15 +18,15 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
         private readonly bool allowExpand;
 
-        public Com2IDispatchConverter(Com2PropertyDescriptor propDesc, bool allowExpand, TypeConverter baseConverter) : base(baseConverter)
+        public Com2IDispatchConverter(bool allowExpand, TypeConverter baseConverter)
+            : base(baseConverter)
         {
-            this.propDesc = propDesc;
             this.allowExpand = allowExpand;
         }
 
-        public Com2IDispatchConverter(Com2PropertyDescriptor propDesc, bool allowExpand) : base(propDesc.PropertyType)
+        public Com2IDispatchConverter(Com2PropertyDescriptor propDesc, bool allowExpand)
+            : base(propDesc.PropertyType)
         {
-            this.propDesc = propDesc;
             this.allowExpand = allowExpand;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IVsPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IVsPerPropertyBrowsingHandler.cs
@@ -193,11 +193,11 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     HRESULT hr = vsObj.DisplayChildProperties(sender.DISPID, &pfResult);
                     if (gveevent.TypeConverter is Com2IDispatchConverter)
                     {
-                        gveevent.TypeConverter = new Com2IDispatchConverter(sender, (hr == HRESULT.S_OK && pfResult.IsTrue()));
+                        gveevent.TypeConverter = new Com2IDispatchConverter(sender, hr == HRESULT.S_OK && pfResult.IsTrue());
                     }
                     else
                     {
-                        gveevent.TypeConverter = new Com2IDispatchConverter(sender, (hr == HRESULT.S_OK && pfResult.IsTrue()), gveevent.TypeConverter);
+                        gveevent.TypeConverter = new Com2IDispatchConverter(hr == HRESULT.S_OK && pfResult.IsTrue(), gveevent.TypeConverter);
                     }
                 }
             }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in Com2IDispatchConverter.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7060)