### PR TITLE
Enable nullability in DataGridViewRowAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -275,13 +275,13 @@
 ~override System.Windows.Forms.DataGridViewRow.Clone() -> object
 ~override System.Windows.Forms.DataGridViewRow.ContextMenuStrip.get -> System.Windows.Forms.ContextMenuStrip
 ~override System.Windows.Forms.DataGridViewRow.ContextMenuStrip.set -> void
-~override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.GetFocused() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.GetSelected() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Name.get -> string
-~override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Value.get -> string
+override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.GetChild(int index) -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.GetFocused() -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.GetSelected() -> System.Windows.Forms.AccessibleObject!
+override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Name.get -> string!
+override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Navigate(System.Windows.Forms.AccessibleNavigation navigationDirection) -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject?
+override System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Value.get -> string!
 ~override System.Windows.Forms.DataGridViewRow.DefaultCellStyle.get -> System.Windows.Forms.DataGridViewCellStyle
 ~override System.Windows.Forms.DataGridViewRow.DefaultCellStyle.set -> void
 ~override System.Windows.Forms.DataGridViewRow.InheritedStyle.get -> System.Windows.Forms.DataGridViewCellStyle
@@ -1232,9 +1232,9 @@
 ~System.Windows.Forms.DataGridViewRow.CreateCells(System.Windows.Forms.DataGridView dataGridView) -> void
 ~System.Windows.Forms.DataGridViewRow.CreateCells(System.Windows.Forms.DataGridView dataGridView, params object[] values) -> void
 ~System.Windows.Forms.DataGridViewRow.DataBoundItem.get -> object
-~System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.DataGridViewRowAccessibleObject(System.Windows.Forms.DataGridViewRow owner) -> void
-~System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Owner.get -> System.Windows.Forms.DataGridViewRow
-~System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Owner.set -> void
+System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.DataGridViewRowAccessibleObject(System.Windows.Forms.DataGridViewRow! owner) -> void
+System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Owner.get -> System.Windows.Forms.DataGridViewRow?
+System.Windows.Forms.DataGridViewRow.DataGridViewRowAccessibleObject.Owner.set -> void
 ~System.Windows.Forms.DataGridViewRow.ErrorText.get -> string
 ~System.Windows.Forms.DataGridViewRow.ErrorText.set -> void
 ~System.Windows.Forms.DataGridViewRow.GetContextMenuStrip(int rowIndex) -> System.Windows.Forms.ContextMenuStrip

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -14,9 +14,9 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewRowAccessibleObject : AccessibleObject
         {
-            private int[]? runtimeId;
-            private DataGridViewRow? owner;
-            private DataGridViewSelectedRowCellsAccessibleObject? selectedCellsAccessibilityObject;
+            private int[]? _runtimeId;
+            private DataGridViewRow? _owner;
+            private DataGridViewSelectedRowCellsAccessibleObject? _selectedCellsAccessibilityObject;
 
             public DataGridViewRowAccessibleObject()
             {
@@ -24,53 +24,53 @@ namespace System.Windows.Forms
 
             public DataGridViewRowAccessibleObject(DataGridViewRow owner)
             {
-                this.owner = owner.OrThrowIfNull();
+                _owner = owner.OrThrowIfNull();
             }
 
             /// <summary>
             ///  Returns the index of the row, taking into account the invisibility of other rows.
             /// </summary>
             private int VisibleIndex
-                => owner?.DataGridView is not null
-                    ? owner.DataGridView.ColumnHeadersVisible
-                        ? owner.DataGridView.Rows.GetVisibleIndex(owner) + 1
-                        : owner.DataGridView.Rows.GetVisibleIndex(owner)
+                => _owner?.DataGridView is not null
+                    ? _owner.DataGridView.ColumnHeadersVisible
+                        ? _owner.DataGridView.Rows.GetVisibleIndex(_owner) + 1
+                        : _owner.DataGridView.Rows.GetVisibleIndex(_owner)
                     : -1;
 
             public override Rectangle Bounds
             {
                 get
                 {
-                    if (owner is null)
+                    if (_owner is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    if (owner.DataGridView is null || !owner.DataGridView.IsHandleCreated)
+                    if (_owner.DataGridView is null || !_owner.DataGridView.IsHandleCreated)
                     {
                         return Rectangle.Empty;
                     }
 
-                    Rectangle rowRect = owner.DataGridView.RectangleToScreen(owner.DataGridView.GetRowDisplayRectangle(owner.Index, false /*cutOverflow*/));
+                    Rectangle rowRect = _owner.DataGridView.RectangleToScreen(_owner.DataGridView.GetRowDisplayRectangle(_owner.Index, false /*cutOverflow*/));
 
                     int horizontalScrollBarHeight = 0;
-                    if (owner.DataGridView.HorizontalScrollBarVisible)
+                    if (_owner.DataGridView.HorizontalScrollBarVisible)
                     {
-                        horizontalScrollBarHeight = owner.DataGridView.HorizontalScrollBarHeight;
+                        horizontalScrollBarHeight = _owner.DataGridView.HorizontalScrollBarHeight;
                     }
 
                     Rectangle dataGridViewRect = ParentPrivate!.Bounds;
 
                     int columnHeadersHeight = 0;
-                    if (owner.DataGridView.ColumnHeadersVisible)
+                    if (_owner.DataGridView.ColumnHeadersVisible)
                     {
-                        columnHeadersHeight = owner.DataGridView.ColumnHeadersHeight;
+                        columnHeadersHeight = _owner.DataGridView.ColumnHeadersHeight;
                     }
 
                     int rowRectBottom = rowRect.Bottom;
                     if ((dataGridViewRect.Bottom - horizontalScrollBarHeight) < rowRectBottom)
                     {
-                        rowRectBottom = dataGridViewRect.Bottom - owner.DataGridView.BorderWidth - horizontalScrollBarHeight;
+                        rowRectBottom = dataGridViewRect.Bottom - _owner.DataGridView.BorderWidth - horizontalScrollBarHeight;
                     }
 
                     if ((dataGridViewRect.Top + columnHeadersHeight) > rowRect.Top)
@@ -90,13 +90,13 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (owner is null)
+                    if (_owner is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    int index = owner is { Visible: true, DataGridView: { } }
-                            ? owner.DataGridView.Rows.GetVisibleIndex(owner)
+                    int index = _owner is { Visible: true, DataGridView: { } }
+                            ? _owner.DataGridView.Rows.GetVisibleIndex(_owner)
                             : -1;
 
                     return string.Format(SR.DataGridView_AccRowName, index.ToString(CultureInfo.CurrentCulture));
@@ -105,15 +105,15 @@ namespace System.Windows.Forms
 
             public DataGridViewRow? Owner
             {
-                get => owner;
+                get => _owner;
                 set
                 {
-                    if (owner is not null)
+                    if (_owner is not null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerAlreadySet);
                     }
 
-                    owner = value;
+                    _owner = value;
                 }
             }
 
@@ -123,19 +123,19 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (owner is null)
+                    if (_owner is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    return owner.DataGridView?.AccessibilityObject;
+                    return _owner.DataGridView?.AccessibilityObject;
                 }
             }
 
             public override AccessibleRole Role => AccessibleRole.Row;
 
             internal override int[] RuntimeId
-                => runtimeId ??= new int[]
+                => _runtimeId ??= new int[]
                 {
                     RuntimeIDFirstItem, // first item is static - 0x2a
                     Parent?.GetHashCode() ?? 0,
@@ -146,17 +146,17 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (owner is null)
+                    if (_owner is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    if (selectedCellsAccessibilityObject is null)
+                    if (_selectedCellsAccessibilityObject is null)
                     {
-                        selectedCellsAccessibilityObject = new DataGridViewSelectedRowCellsAccessibleObject(owner);
+                        _selectedCellsAccessibilityObject = new DataGridViewSelectedRowCellsAccessibleObject(_owner);
                     }
 
-                    return selectedCellsAccessibilityObject;
+                    return _selectedCellsAccessibilityObject;
                 }
             }
 
@@ -164,7 +164,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (owner is null)
+                    if (_owner is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
@@ -172,15 +172,15 @@ namespace System.Windows.Forms
                     AccessibleStates accState = AccessibleStates.Selectable;
 
                     bool allCellsAreSelected = true;
-                    if (owner.Selected)
+                    if (_owner.Selected)
                     {
                         allCellsAreSelected = true;
                     }
                     else
                     {
-                        for (int i = 0; i < owner.Cells.Count; i++)
+                        for (int i = 0; i < _owner.Cells.Count; i++)
                         {
-                            if (!owner.Cells[i].Selected)
+                            if (!_owner.Cells[i].Selected)
                             {
                                 allCellsAreSelected = false;
                                 break;
@@ -193,10 +193,10 @@ namespace System.Windows.Forms
                         accState |= AccessibleStates.Selected;
                     }
 
-                    if (owner.DataGridView is not null && owner.DataGridView.IsHandleCreated)
+                    if (_owner.DataGridView is not null && _owner.DataGridView.IsHandleCreated)
                     {
-                        Rectangle rowBounds = owner.DataGridView.GetRowDisplayRectangle(owner.Index, true /*cutOverflow*/);
-                        if (!rowBounds.IntersectsWith(owner.DataGridView.ClientRectangle))
+                        Rectangle rowBounds = _owner.DataGridView.GetRowDisplayRectangle(_owner.Index, true /*cutOverflow*/);
+                        if (!rowBounds.IntersectsWith(_owner.DataGridView.ClientRectangle))
                         {
                             accState |= AccessibleStates.Offscreen;
                         }
@@ -210,12 +210,12 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (owner is null)
+                    if (_owner is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    if (owner.DataGridView is not null && owner.DataGridView.AllowUserToAddRows && owner.Index == owner.DataGridView.NewRowIndex)
+                    if (_owner.DataGridView is not null && _owner.DataGridView.AllowUserToAddRows && _owner.Index == _owner.DataGridView.NewRowIndex)
                     {
                         return SR.DataGridView_AccRowCreateNew;
                     }
@@ -225,7 +225,7 @@ namespace System.Windows.Forms
                     int childCount = GetChildCount();
 
                     // filter out the row header acc object even when DataGridView::RowHeadersVisible is turned on
-                    int startIndex = owner.DataGridView is not null && owner.DataGridView.RowHeadersVisible ? 1 : 0;
+                    int startIndex = _owner.DataGridView is not null && _owner.DataGridView.RowHeadersVisible ? 1 : 0;
 
                     for (int i = startIndex; i < childCount; i++)
                     {
@@ -252,48 +252,48 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
 
-                if (owner is null)
+                if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                if (owner.DataGridView is null || index > GetChildCount() - 1)
+                if (_owner.DataGridView is null || index > GetChildCount() - 1)
                 {
                     return null;
                 }
 
-                if (index == 0 && owner.DataGridView.RowHeadersVisible)
+                if (index == 0 && _owner.DataGridView.RowHeadersVisible)
                 {
-                    return owner.HeaderCell.AccessibilityObject;
+                    return _owner.HeaderCell.AccessibilityObject;
                 }
                 else
                 {
                     // decrement the index because the first child is the RowHeaderCell AccessibilityObject
-                    if (owner.DataGridView.RowHeadersVisible)
+                    if (_owner.DataGridView.RowHeadersVisible)
                     {
                         index--;
                     }
 
                     Debug.Assert(index >= 0);
-                    int columnIndex = owner.DataGridView.Columns.ActualDisplayIndexToColumnIndex(index, DataGridViewElementStates.Visible);
-                    return owner.Cells[columnIndex].AccessibilityObject;
+                    int columnIndex = _owner.DataGridView.Columns.ActualDisplayIndexToColumnIndex(index, DataGridViewElementStates.Visible);
+                    return _owner.Cells[columnIndex].AccessibilityObject;
                 }
             }
 
             public override int GetChildCount()
             {
-                if (owner is null)
+                if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                if (owner.DataGridView is null)
+                if (_owner.DataGridView is null)
                 {
                     return 0;
                 }
 
-                int result = owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible);
-                if (owner.DataGridView.RowHeadersVisible)
+                int result = _owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible);
+                if (_owner.DataGridView.RowHeadersVisible)
                 {
                     // + 1 comes from the row header cell accessibility object
                     result++;
@@ -306,17 +306,17 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetFocused()
             {
-                if (owner is null)
+                if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                if (owner.DataGridView is not null &&
-                    owner.DataGridView.Focused &&
-                    owner.DataGridView.CurrentCell is not null &&
-                    owner.DataGridView.CurrentCell.RowIndex == owner.Index)
+                if (_owner.DataGridView is not null &&
+                    _owner.DataGridView.Focused &&
+                    _owner.DataGridView.CurrentCell is not null &&
+                    _owner.DataGridView.CurrentCell.RowIndex == _owner.Index)
                 {
-                    return owner.DataGridView.CurrentCell.AccessibilityObject;
+                    return _owner.DataGridView.CurrentCell.AccessibilityObject;
                 }
                 else
                 {
@@ -326,12 +326,12 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? Navigate(AccessibleNavigation navigationDirection)
             {
-                if (owner is null)
+                if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                if (owner.DataGridView is null)
+                if (_owner.DataGridView is null)
                 {
                     return null;
                 }
@@ -340,12 +340,12 @@ namespace System.Windows.Forms
                 {
                     case AccessibleNavigation.Down:
                     case AccessibleNavigation.Next:
-                        if (owner.Index != owner.DataGridView.Rows.GetLastRow(DataGridViewElementStates.Visible))
+                        if (_owner.Index != _owner.DataGridView.Rows.GetLastRow(DataGridViewElementStates.Visible))
                         {
                             int visibleIndex = VisibleIndex;
                             return visibleIndex < 0
                                 ? null
-                                : owner.DataGridView.AccessibilityObject.GetChild(visibleIndex + 1);
+                                : _owner.DataGridView.AccessibilityObject.GetChild(visibleIndex + 1);
                         }
                         else
                         {
@@ -354,11 +354,11 @@ namespace System.Windows.Forms
 
                     case AccessibleNavigation.Up:
                     case AccessibleNavigation.Previous:
-                        if (owner.Index != owner.DataGridView.Rows.GetFirstRow(DataGridViewElementStates.Visible))
+                        if (_owner.Index != _owner.DataGridView.Rows.GetFirstRow(DataGridViewElementStates.Visible))
                         {
-                            return owner.DataGridView.AccessibilityObject.GetChild(VisibleIndex - 1);
+                            return _owner.DataGridView.AccessibilityObject.GetChild(VisibleIndex - 1);
                         }
-                        else if (owner.DataGridView.ColumnHeadersVisible)
+                        else if (_owner.DataGridView.ColumnHeadersVisible)
                         {
                             // return the top row header acc obj
                             return ParentPrivate?.GetChild(0);
@@ -397,12 +397,12 @@ namespace System.Windows.Forms
 
             public override void Select(AccessibleSelection flags)
             {
-                if (owner is null)
+                if (_owner is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                DataGridView? dataGridView = owner.DataGridView;
+                DataGridView? dataGridView = _owner.DataGridView;
 
                 if (dataGridView is null || !dataGridView.IsHandleCreated)
                 {
@@ -416,18 +416,18 @@ namespace System.Windows.Forms
 
                 if ((flags & AccessibleSelection.TakeSelection) == AccessibleSelection.TakeSelection)
                 {
-                    if (owner.Cells.Count > 0)
+                    if (_owner.Cells.Count > 0)
                     {
                         if (dataGridView.CurrentCell is not null && dataGridView.CurrentCell.OwningColumn is not null)
                         {
-                            dataGridView.CurrentCell = owner.Cells[dataGridView.CurrentCell.OwningColumn.Index]; // Do not change old selection
+                            dataGridView.CurrentCell = _owner.Cells[dataGridView.CurrentCell.OwningColumn.Index]; // Do not change old selection
                         }
                         else
                         {
                             int firstVisibleCell = dataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible).Index;
                             if (firstVisibleCell > -1)
                             {
-                                dataGridView.CurrentCell = owner.Cells[firstVisibleCell]; // Do not change old selection
+                                dataGridView.CurrentCell = _owner.Cells[firstVisibleCell]; // Do not change old selection
                             }
                         }
                     }
@@ -437,14 +437,14 @@ namespace System.Windows.Forms
                 {
                     if (dataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect || dataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect)
                     {
-                        owner.Selected = true;
+                        _owner.Selected = true;
                     }
                 }
 
                 if ((flags & AccessibleSelection.RemoveSelection) == AccessibleSelection.RemoveSelection &&
                     (flags & (AccessibleSelection.AddSelection | AccessibleSelection.TakeSelection)) == 0)
                 {
-                    owner.Selected = false;
+                    _owner.Selected = false;
                 }
             }
 
@@ -487,7 +487,7 @@ namespace System.Windows.Forms
                 return patternId.Equals(UiaCore.UIA.LegacyIAccessiblePatternId);
             }
 
-            internal override bool IsReadOnly => owner?.ReadOnly ?? false;
+            internal override bool IsReadOnly => _owner?.ReadOnly ?? false;
 
             internal override object? GetPropertyValue(UiaCore.UIA propertyId)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Drawing;
 using System.Globalization;
@@ -16,9 +14,9 @@ namespace System.Windows.Forms
     {
         protected class DataGridViewRowAccessibleObject : AccessibleObject
         {
-            private int[] runtimeId;
-            private DataGridViewRow owner;
-            private DataGridViewSelectedRowCellsAccessibleObject selectedCellsAccessibilityObject;
+            private int[]? runtimeId;
+            private DataGridViewRow? owner;
+            private DataGridViewSelectedRowCellsAccessibleObject? selectedCellsAccessibilityObject;
 
             public DataGridViewRowAccessibleObject()
             {
@@ -26,7 +24,7 @@ namespace System.Windows.Forms
 
             public DataGridViewRowAccessibleObject(DataGridViewRow owner)
             {
-                this.owner = owner;
+                this.owner = owner.OrThrowIfNull();
             }
 
             /// <summary>
@@ -61,7 +59,7 @@ namespace System.Windows.Forms
                         horizontalScrollBarHeight = owner.DataGridView.HorizontalScrollBarHeight;
                     }
 
-                    Rectangle dataGridViewRect = ParentPrivate.Bounds;
+                    Rectangle dataGridViewRect = ParentPrivate!.Bounds;
 
                     int columnHeadersHeight = 0;
                     if (owner.DataGridView.ColumnHeadersVisible)
@@ -105,7 +103,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            public DataGridViewRow Owner
+            public DataGridViewRow? Owner
             {
                 get => owner;
                 set
@@ -119,9 +117,9 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override AccessibleObject Parent => ParentPrivate;
+            public override AccessibleObject? Parent => ParentPrivate;
 
-            private AccessibleObject ParentPrivate
+            private AccessibleObject? ParentPrivate
             {
                 get
                 {
@@ -140,7 +138,7 @@ namespace System.Windows.Forms
                 => runtimeId ??= new int[]
                 {
                     RuntimeIDFirstItem, // first item is static - 0x2a
-                    Parent.GetHashCode(),
+                    Parent?.GetHashCode() ?? 0,
                     GetHashCode()
                 };
 
@@ -231,7 +229,7 @@ namespace System.Windows.Forms
 
                     for (int i = startIndex; i < childCount; i++)
                     {
-                        AccessibleObject cellAccObj = GetChild(i);
+                        AccessibleObject? cellAccObj = GetChild(i);
                         if (cellAccObj is not null)
                         {
                             sb.Append(cellAccObj.Value);
@@ -247,7 +245,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override AccessibleObject GetChild(int index)
+            public override AccessibleObject? GetChild(int index)
             {
                 if (index < 0)
                 {
@@ -306,7 +304,7 @@ namespace System.Windows.Forms
 
             public override AccessibleObject GetSelected() => SelectedCellsAccessibilityObject;
 
-            public override AccessibleObject GetFocused()
+            public override AccessibleObject? GetFocused()
             {
                 if (owner is null)
                 {
@@ -326,7 +324,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            public override AccessibleObject Navigate(AccessibleNavigation navigationDirection)
+            public override AccessibleObject? Navigate(AccessibleNavigation navigationDirection)
             {
                 if (owner is null)
                 {
@@ -363,7 +361,7 @@ namespace System.Windows.Forms
                         else if (owner.DataGridView.ColumnHeadersVisible)
                         {
                             // return the top row header acc obj
-                            return ParentPrivate.GetChild(0);
+                            return ParentPrivate?.GetChild(0);
                         }
                         else
                         {
@@ -404,7 +402,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                DataGridView dataGridView = owner.DataGridView;
+                DataGridView? dataGridView = owner.DataGridView;
 
                 if (dataGridView is null || !dataGridView.IsHandleCreated)
                 {
@@ -450,7 +448,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal override UiaCore.IRawElementProviderFragment FragmentNavigate(UiaCore.NavigateDirection direction)
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
                 {
                     if (Owner is null)
@@ -476,7 +474,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
+            internal override UiaCore.IRawElementProviderFragmentRoot? FragmentRoot
             {
                 get
                 {
@@ -489,9 +487,9 @@ namespace System.Windows.Forms
                 return patternId.Equals(UiaCore.UIA.LegacyIAccessiblePatternId);
             }
 
-            internal override bool IsReadOnly => owner.ReadOnly;
+            internal override bool IsReadOnly => owner?.ReadOnly ?? false;
 
-            internal override object GetPropertyValue(UiaCore.UIA propertyId)
+            internal override object? GetPropertyValue(UiaCore.UIA propertyId)
             {
                 switch (propertyId)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -31,10 +31,10 @@ namespace System.Windows.Forms
             ///  Returns the index of the row, taking into account the invisibility of other rows.
             /// </summary>
             private int VisibleIndex
-                => _owningDataGridViewRow?.DataGridView is not null
-                    ? _owningDataGridViewRow.DataGridView.ColumnHeadersVisible
-                        ? _owningDataGridViewRow.DataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow) + 1
-                        : _owningDataGridViewRow.DataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow)
+                => _owningDataGridViewRow?.DataGridView is DataGridView dataGridView
+                    ? dataGridView.ColumnHeadersVisible
+                        ? dataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow) + 1
+                        : dataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow)
                     : -1;
 
             public override Rectangle Bounds
@@ -311,10 +311,10 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owningDataGridViewRow.DataGridView is not null &&
-                    _owningDataGridViewRow.DataGridView.Focused &&
-                    _owningDataGridViewRow.DataGridView.CurrentCell is not null &&
-                    _owningDataGridViewRow.DataGridView.CurrentCell.RowIndex == _owningDataGridViewRow.Index)
+                if (_owningDataGridViewRow.DataGridView is DataGridView dataGridView &&
+                    dataGridView.Focused &&
+                    dataGridView.CurrentCell is not null &&
+                    dataGridView.CurrentCell.RowIndex == _owningDataGridViewRow.Index)
                 {
                     return _owningDataGridViewRow.DataGridView.CurrentCell.AccessibilityObject;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -24,7 +24,7 @@ namespace System.Windows.Forms
 
             public DataGridViewRowAccessibleObject(DataGridViewRow owner)
             {
-                _owner = owner.OrThrowIfNull();
+                _owner = owner;
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.DataGridViewRowAccessibleObject.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms
         protected class DataGridViewRowAccessibleObject : AccessibleObject
         {
             private int[]? _runtimeId;
-            private DataGridViewRow? _owner;
+            private DataGridViewRow? _owningDataGridViewRow;
             private DataGridViewSelectedRowCellsAccessibleObject? _selectedCellsAccessibilityObject;
 
             public DataGridViewRowAccessibleObject()
@@ -24,53 +24,53 @@ namespace System.Windows.Forms
 
             public DataGridViewRowAccessibleObject(DataGridViewRow owner)
             {
-                _owner = owner;
+                _owningDataGridViewRow = owner;
             }
 
             /// <summary>
             ///  Returns the index of the row, taking into account the invisibility of other rows.
             /// </summary>
             private int VisibleIndex
-                => _owner?.DataGridView is not null
-                    ? _owner.DataGridView.ColumnHeadersVisible
-                        ? _owner.DataGridView.Rows.GetVisibleIndex(_owner) + 1
-                        : _owner.DataGridView.Rows.GetVisibleIndex(_owner)
+                => _owningDataGridViewRow?.DataGridView is not null
+                    ? _owningDataGridViewRow.DataGridView.ColumnHeadersVisible
+                        ? _owningDataGridViewRow.DataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow) + 1
+                        : _owningDataGridViewRow.DataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow)
                     : -1;
 
             public override Rectangle Bounds
             {
                 get
                 {
-                    if (_owner is null)
+                    if (_owningDataGridViewRow is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    if (_owner.DataGridView is null || !_owner.DataGridView.IsHandleCreated)
+                    if (_owningDataGridViewRow.DataGridView is null || !_owningDataGridViewRow.DataGridView.IsHandleCreated)
                     {
                         return Rectangle.Empty;
                     }
 
-                    Rectangle rowRect = _owner.DataGridView.RectangleToScreen(_owner.DataGridView.GetRowDisplayRectangle(_owner.Index, false /*cutOverflow*/));
+                    Rectangle rowRect = _owningDataGridViewRow.DataGridView.RectangleToScreen(_owningDataGridViewRow.DataGridView.GetRowDisplayRectangle(_owningDataGridViewRow.Index, false /*cutOverflow*/));
 
                     int horizontalScrollBarHeight = 0;
-                    if (_owner.DataGridView.HorizontalScrollBarVisible)
+                    if (_owningDataGridViewRow.DataGridView.HorizontalScrollBarVisible)
                     {
-                        horizontalScrollBarHeight = _owner.DataGridView.HorizontalScrollBarHeight;
+                        horizontalScrollBarHeight = _owningDataGridViewRow.DataGridView.HorizontalScrollBarHeight;
                     }
 
                     Rectangle dataGridViewRect = ParentPrivate!.Bounds;
 
                     int columnHeadersHeight = 0;
-                    if (_owner.DataGridView.ColumnHeadersVisible)
+                    if (_owningDataGridViewRow.DataGridView.ColumnHeadersVisible)
                     {
-                        columnHeadersHeight = _owner.DataGridView.ColumnHeadersHeight;
+                        columnHeadersHeight = _owningDataGridViewRow.DataGridView.ColumnHeadersHeight;
                     }
 
                     int rowRectBottom = rowRect.Bottom;
                     if ((dataGridViewRect.Bottom - horizontalScrollBarHeight) < rowRectBottom)
                     {
-                        rowRectBottom = dataGridViewRect.Bottom - _owner.DataGridView.BorderWidth - horizontalScrollBarHeight;
+                        rowRectBottom = dataGridViewRect.Bottom - _owningDataGridViewRow.DataGridView.BorderWidth - horizontalScrollBarHeight;
                     }
 
                     if ((dataGridViewRect.Top + columnHeadersHeight) > rowRect.Top)
@@ -90,13 +90,13 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (_owner is null)
+                    if (_owningDataGridViewRow is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    int index = _owner is { Visible: true, DataGridView: { } }
-                            ? _owner.DataGridView.Rows.GetVisibleIndex(_owner)
+                    int index = _owningDataGridViewRow is { Visible: true, DataGridView: { } }
+                            ? _owningDataGridViewRow.DataGridView.Rows.GetVisibleIndex(_owningDataGridViewRow)
                             : -1;
 
                     return string.Format(SR.DataGridView_AccRowName, index.ToString(CultureInfo.CurrentCulture));
@@ -105,15 +105,15 @@ namespace System.Windows.Forms
 
             public DataGridViewRow? Owner
             {
-                get => _owner;
+                get => _owningDataGridViewRow;
                 set
                 {
-                    if (_owner is not null)
+                    if (_owningDataGridViewRow is not null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerAlreadySet);
                     }
 
-                    _owner = value;
+                    _owningDataGridViewRow = value;
                 }
             }
 
@@ -123,12 +123,12 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (_owner is null)
+                    if (_owningDataGridViewRow is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    return _owner.DataGridView?.AccessibilityObject;
+                    return _owningDataGridViewRow.DataGridView?.AccessibilityObject;
                 }
             }
 
@@ -146,14 +146,14 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (_owner is null)
+                    if (_owningDataGridViewRow is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
                     if (_selectedCellsAccessibilityObject is null)
                     {
-                        _selectedCellsAccessibilityObject = new DataGridViewSelectedRowCellsAccessibleObject(_owner);
+                        _selectedCellsAccessibilityObject = new DataGridViewSelectedRowCellsAccessibleObject(_owningDataGridViewRow);
                     }
 
                     return _selectedCellsAccessibilityObject;
@@ -164,7 +164,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (_owner is null)
+                    if (_owningDataGridViewRow is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
@@ -172,15 +172,15 @@ namespace System.Windows.Forms
                     AccessibleStates accState = AccessibleStates.Selectable;
 
                     bool allCellsAreSelected = true;
-                    if (_owner.Selected)
+                    if (_owningDataGridViewRow.Selected)
                     {
                         allCellsAreSelected = true;
                     }
                     else
                     {
-                        for (int i = 0; i < _owner.Cells.Count; i++)
+                        for (int i = 0; i < _owningDataGridViewRow.Cells.Count; i++)
                         {
-                            if (!_owner.Cells[i].Selected)
+                            if (!_owningDataGridViewRow.Cells[i].Selected)
                             {
                                 allCellsAreSelected = false;
                                 break;
@@ -193,10 +193,10 @@ namespace System.Windows.Forms
                         accState |= AccessibleStates.Selected;
                     }
 
-                    if (_owner.DataGridView is not null && _owner.DataGridView.IsHandleCreated)
+                    if (_owningDataGridViewRow.DataGridView is not null && _owningDataGridViewRow.DataGridView.IsHandleCreated)
                     {
-                        Rectangle rowBounds = _owner.DataGridView.GetRowDisplayRectangle(_owner.Index, true /*cutOverflow*/);
-                        if (!rowBounds.IntersectsWith(_owner.DataGridView.ClientRectangle))
+                        Rectangle rowBounds = _owningDataGridViewRow.DataGridView.GetRowDisplayRectangle(_owningDataGridViewRow.Index, true /*cutOverflow*/);
+                        if (!rowBounds.IntersectsWith(_owningDataGridViewRow.DataGridView.ClientRectangle))
                         {
                             accState |= AccessibleStates.Offscreen;
                         }
@@ -210,12 +210,12 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (_owner is null)
+                    if (_owningDataGridViewRow is null)
                     {
                         throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                     }
 
-                    if (_owner.DataGridView is not null && _owner.DataGridView.AllowUserToAddRows && _owner.Index == _owner.DataGridView.NewRowIndex)
+                    if (_owningDataGridViewRow.DataGridView is not null && _owningDataGridViewRow.DataGridView.AllowUserToAddRows && _owningDataGridViewRow.Index == _owningDataGridViewRow.DataGridView.NewRowIndex)
                     {
                         return SR.DataGridView_AccRowCreateNew;
                     }
@@ -225,7 +225,7 @@ namespace System.Windows.Forms
                     int childCount = GetChildCount();
 
                     // filter out the row header acc object even when DataGridView::RowHeadersVisible is turned on
-                    int startIndex = _owner.DataGridView is not null && _owner.DataGridView.RowHeadersVisible ? 1 : 0;
+                    int startIndex = _owningDataGridViewRow.DataGridView is not null && _owningDataGridViewRow.DataGridView.RowHeadersVisible ? 1 : 0;
 
                     for (int i = startIndex; i < childCount; i++)
                     {
@@ -252,48 +252,48 @@ namespace System.Windows.Forms
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
 
-                if (_owner is null)
+                if (_owningDataGridViewRow is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.DataGridView is null || index > GetChildCount() - 1)
+                if (_owningDataGridViewRow.DataGridView is null || index > GetChildCount() - 1)
                 {
                     return null;
                 }
 
-                if (index == 0 && _owner.DataGridView.RowHeadersVisible)
+                if (index == 0 && _owningDataGridViewRow.DataGridView.RowHeadersVisible)
                 {
-                    return _owner.HeaderCell.AccessibilityObject;
+                    return _owningDataGridViewRow.HeaderCell.AccessibilityObject;
                 }
                 else
                 {
                     // decrement the index because the first child is the RowHeaderCell AccessibilityObject
-                    if (_owner.DataGridView.RowHeadersVisible)
+                    if (_owningDataGridViewRow.DataGridView.RowHeadersVisible)
                     {
                         index--;
                     }
 
                     Debug.Assert(index >= 0);
-                    int columnIndex = _owner.DataGridView.Columns.ActualDisplayIndexToColumnIndex(index, DataGridViewElementStates.Visible);
-                    return _owner.Cells[columnIndex].AccessibilityObject;
+                    int columnIndex = _owningDataGridViewRow.DataGridView.Columns.ActualDisplayIndexToColumnIndex(index, DataGridViewElementStates.Visible);
+                    return _owningDataGridViewRow.Cells[columnIndex].AccessibilityObject;
                 }
             }
 
             public override int GetChildCount()
             {
-                if (_owner is null)
+                if (_owningDataGridViewRow is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.DataGridView is null)
+                if (_owningDataGridViewRow.DataGridView is null)
                 {
                     return 0;
                 }
 
-                int result = _owner.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible);
-                if (_owner.DataGridView.RowHeadersVisible)
+                int result = _owningDataGridViewRow.DataGridView.Columns.GetColumnCount(DataGridViewElementStates.Visible);
+                if (_owningDataGridViewRow.DataGridView.RowHeadersVisible)
                 {
                     // + 1 comes from the row header cell accessibility object
                     result++;
@@ -306,17 +306,17 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetFocused()
             {
-                if (_owner is null)
+                if (_owningDataGridViewRow is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.DataGridView is not null &&
-                    _owner.DataGridView.Focused &&
-                    _owner.DataGridView.CurrentCell is not null &&
-                    _owner.DataGridView.CurrentCell.RowIndex == _owner.Index)
+                if (_owningDataGridViewRow.DataGridView is not null &&
+                    _owningDataGridViewRow.DataGridView.Focused &&
+                    _owningDataGridViewRow.DataGridView.CurrentCell is not null &&
+                    _owningDataGridViewRow.DataGridView.CurrentCell.RowIndex == _owningDataGridViewRow.Index)
                 {
-                    return _owner.DataGridView.CurrentCell.AccessibilityObject;
+                    return _owningDataGridViewRow.DataGridView.CurrentCell.AccessibilityObject;
                 }
                 else
                 {
@@ -326,12 +326,12 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? Navigate(AccessibleNavigation navigationDirection)
             {
-                if (_owner is null)
+                if (_owningDataGridViewRow is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                if (_owner.DataGridView is null)
+                if (_owningDataGridViewRow.DataGridView is null)
                 {
                     return null;
                 }
@@ -340,12 +340,12 @@ namespace System.Windows.Forms
                 {
                     case AccessibleNavigation.Down:
                     case AccessibleNavigation.Next:
-                        if (_owner.Index != _owner.DataGridView.Rows.GetLastRow(DataGridViewElementStates.Visible))
+                        if (_owningDataGridViewRow.Index != _owningDataGridViewRow.DataGridView.Rows.GetLastRow(DataGridViewElementStates.Visible))
                         {
                             int visibleIndex = VisibleIndex;
                             return visibleIndex < 0
                                 ? null
-                                : _owner.DataGridView.AccessibilityObject.GetChild(visibleIndex + 1);
+                                : _owningDataGridViewRow.DataGridView.AccessibilityObject.GetChild(visibleIndex + 1);
                         }
                         else
                         {
@@ -354,11 +354,11 @@ namespace System.Windows.Forms
 
                     case AccessibleNavigation.Up:
                     case AccessibleNavigation.Previous:
-                        if (_owner.Index != _owner.DataGridView.Rows.GetFirstRow(DataGridViewElementStates.Visible))
+                        if (_owningDataGridViewRow.Index != _owningDataGridViewRow.DataGridView.Rows.GetFirstRow(DataGridViewElementStates.Visible))
                         {
-                            return _owner.DataGridView.AccessibilityObject.GetChild(VisibleIndex - 1);
+                            return _owningDataGridViewRow.DataGridView.AccessibilityObject.GetChild(VisibleIndex - 1);
                         }
-                        else if (_owner.DataGridView.ColumnHeadersVisible)
+                        else if (_owningDataGridViewRow.DataGridView.ColumnHeadersVisible)
                         {
                             // return the top row header acc obj
                             return ParentPrivate?.GetChild(0);
@@ -397,12 +397,12 @@ namespace System.Windows.Forms
 
             public override void Select(AccessibleSelection flags)
             {
-                if (_owner is null)
+                if (_owningDataGridViewRow is null)
                 {
                     throw new InvalidOperationException(SR.DataGridViewRowAccessibleObject_OwnerNotSet);
                 }
 
-                DataGridView? dataGridView = _owner.DataGridView;
+                DataGridView? dataGridView = _owningDataGridViewRow.DataGridView;
 
                 if (dataGridView is null || !dataGridView.IsHandleCreated)
                 {
@@ -416,18 +416,18 @@ namespace System.Windows.Forms
 
                 if ((flags & AccessibleSelection.TakeSelection) == AccessibleSelection.TakeSelection)
                 {
-                    if (_owner.Cells.Count > 0)
+                    if (_owningDataGridViewRow.Cells.Count > 0)
                     {
                         if (dataGridView.CurrentCell is not null && dataGridView.CurrentCell.OwningColumn is not null)
                         {
-                            dataGridView.CurrentCell = _owner.Cells[dataGridView.CurrentCell.OwningColumn.Index]; // Do not change old selection
+                            dataGridView.CurrentCell = _owningDataGridViewRow.Cells[dataGridView.CurrentCell.OwningColumn.Index]; // Do not change old selection
                         }
                         else
                         {
                             int firstVisibleCell = dataGridView.Columns.GetFirstColumn(DataGridViewElementStates.Visible).Index;
                             if (firstVisibleCell > -1)
                             {
-                                dataGridView.CurrentCell = _owner.Cells[firstVisibleCell]; // Do not change old selection
+                                dataGridView.CurrentCell = _owningDataGridViewRow.Cells[firstVisibleCell]; // Do not change old selection
                             }
                         }
                     }
@@ -437,14 +437,14 @@ namespace System.Windows.Forms
                 {
                     if (dataGridView.SelectionMode == DataGridViewSelectionMode.FullRowSelect || dataGridView.SelectionMode == DataGridViewSelectionMode.RowHeaderSelect)
                     {
-                        _owner.Selected = true;
+                        _owningDataGridViewRow.Selected = true;
                     }
                 }
 
                 if ((flags & AccessibleSelection.RemoveSelection) == AccessibleSelection.RemoveSelection &&
                     (flags & (AccessibleSelection.AddSelection | AccessibleSelection.TakeSelection)) == 0)
                 {
-                    _owner.Selected = false;
+                    _owningDataGridViewRow.Selected = false;
                 }
             }
 
@@ -487,7 +487,7 @@ namespace System.Windows.Forms
                 return patternId.Equals(UiaCore.UIA.LegacyIAccessiblePatternId);
             }
 
-            internal override bool IsReadOnly => _owner?.ReadOnly ?? false;
+            internal override bool IsReadOnly => _owningDataGridViewRow?.ReadOnly ?? false;
 
             internal override object? GetPropertyValue(UiaCore.UIA propertyId)
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
@@ -22,19 +22,19 @@ namespace System.Windows.Forms.Tests
             Assert.Null(accessibleObject.Help);
         }
 
-        public static IEnumerable<object[]> Ctor_DataGridViewRow_TestData()
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Ctor_OwningDataGridViewRowIsNull_RaiseException()
         {
-            yield return new object[] { null };
-            yield return new object[] { new DataGridViewRow() };
+            Assert.Throws<ArgumentNullException>(() => { new DataGridViewRowAccessibleObject(null); });
         }
 
-        [Theory]
-        [MemberData(nameof(Ctor_DataGridViewRow_TestData))]
-        public void DataGridViewRowAccessibleObject_Ctor_DataGridViewRow(DataGridViewRow owner)
+        [WinFormsFact]
+        public void DataGridViewRowAccessibleObject_Ctor_DataGridViewRow()
         {
-            var accessibleObject = new DataGridViewRowAccessibleObject(owner);
+            using var dataGridViewRow = new DataGridViewRow();
+            var accessibleObject = new DataGridViewRowAccessibleObject(dataGridViewRow);
 
-            Assert.Equal(owner, accessibleObject.Owner);
+            Assert.Equal(dataGridViewRow, accessibleObject.Owner);
             Assert.Equal(AccessibleRole.Row, accessibleObject.Role);
             Assert.Null(accessibleObject.DefaultAction);
             Assert.Null(accessibleObject.Help);
@@ -52,16 +52,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, accessibleObject.Bounds);
         }
 
-        public static IEnumerable<object[]> NoOwner_TestData()
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Bounds_GetNoOwner_ThrowsInvalidOperationException()
         {
-            yield return new object[] { new DataGridViewRowAccessibleObject() };
-            yield return new object[] { new DataGridViewRowAccessibleObject(null) };
-        }
-
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_Bounds_GetNoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
-        {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Bounds);
         }
 
@@ -152,10 +146,10 @@ namespace System.Windows.Forms.Tests
             Assert.False(dataGridView.IsHandleCreated);
         }
 
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_Name_GetNoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Name_GetNoOwner_ThrowsInvalidOperationException()
         {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Name);
         }
 
@@ -190,10 +184,10 @@ namespace System.Windows.Forms.Tests
             Assert.Same(expected, accessibleObject.Parent);
         }
 
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_Parent_GetNoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Parent_GetNoOwner_ThrowsInvalidOperationException()
         {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Parent);
         }
 
@@ -209,10 +203,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, accessibleObject.State);
         }
 
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_State_GetNoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_State_GetNoOwner_ThrowsInvalidOperationException()
         {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.State);
         }
 
@@ -228,10 +222,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, accessibleObject.Value);
         }
 
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_Value_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Value_NoOwner_ThrowsInvalidOperationException()
         {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Value);
         }
 
@@ -242,10 +236,10 @@ namespace System.Windows.Forms.Tests
             accessibleObject.DoDefaultAction();
         }
 
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_GetChild_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_GetChild_NoOwner_ThrowsInvalidOperationException()
         {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.GetChild(0));
         }
 
@@ -269,10 +263,10 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentOutOfRangeException>("index", () => accessibleObject.GetChild(index));
         }
 
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_GetChildCount_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_GetChildCount_NoOwner_ThrowsInvalidOperationException()
         {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.GetChildCount());
         }
 
@@ -285,10 +279,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, accessibleObject.GetChildCount());
         }
 
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_GetFocused_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_GetFocused_NoOwner_ThrowsInvalidOperationException()
         {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.GetFocused());
         }
 
@@ -316,10 +310,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("Selected Row Cells", selectedAccessibleObject.Value);
         }
 
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_GetSelected_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_GetSelected_NoOwner_ThrowsInvalidOperationException()
         {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.GetSelected());
         }
 
@@ -338,10 +332,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, accessibleObject.Navigate(navigationDirection));
         }
 
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_Navigate_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Navigate_NoOwner_ThrowsInvalidOperationException()
         {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Navigate(AccessibleNavigation.Right));
         }
 
@@ -376,10 +370,10 @@ namespace System.Windows.Forms.Tests
             accessibleObject.Select(flags);
         }
 
-        [Theory]
-        [MemberData(nameof(NoOwner_TestData))]
-        public void DataGridViewRowAccessibleObject_Select_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        [Fact]
+        public void DataGridViewRowAccessibleObject_Select_NoOwner_ThrowsInvalidOperationException()
         {
+            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Select(AccessibleSelection.None));
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowAccessibleObjectTests.cs
@@ -22,19 +22,19 @@ namespace System.Windows.Forms.Tests
             Assert.Null(accessibleObject.Help);
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_Ctor_OwningDataGridViewRowIsNull_RaiseException()
+        public static IEnumerable<object[]> Ctor_DataGridViewRow_TestData()
         {
-            Assert.Throws<ArgumentNullException>(() => { new DataGridViewRowAccessibleObject(null); });
+            yield return new object[] { null };
+            yield return new object[] { new DataGridViewRow() };
         }
 
-        [WinFormsFact]
-        public void DataGridViewRowAccessibleObject_Ctor_DataGridViewRow()
+        [Theory]
+        [MemberData(nameof(Ctor_DataGridViewRow_TestData))]
+        public void DataGridViewRowAccessibleObject_Ctor_DataGridViewRow(DataGridViewRow owner)
         {
-            using var dataGridViewRow = new DataGridViewRow();
-            var accessibleObject = new DataGridViewRowAccessibleObject(dataGridViewRow);
+            var accessibleObject = new DataGridViewRowAccessibleObject(owner);
 
-            Assert.Equal(dataGridViewRow, accessibleObject.Owner);
+            Assert.Equal(owner, accessibleObject.Owner);
             Assert.Equal(AccessibleRole.Row, accessibleObject.Role);
             Assert.Null(accessibleObject.DefaultAction);
             Assert.Null(accessibleObject.Help);
@@ -52,10 +52,16 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, accessibleObject.Bounds);
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_Bounds_GetNoOwner_ThrowsInvalidOperationException()
+        public static IEnumerable<object[]> NoOwner_TestData()
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
+            yield return new object[] { new DataGridViewRowAccessibleObject() };
+            yield return new object[] { new DataGridViewRowAccessibleObject(null) };
+        }
+
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_Bounds_GetNoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
+        {
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Bounds);
         }
 
@@ -146,10 +152,10 @@ namespace System.Windows.Forms.Tests
             Assert.False(dataGridView.IsHandleCreated);
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_Name_GetNoOwner_ThrowsInvalidOperationException()
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_Name_GetNoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Name);
         }
 
@@ -184,10 +190,10 @@ namespace System.Windows.Forms.Tests
             Assert.Same(expected, accessibleObject.Parent);
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_Parent_GetNoOwner_ThrowsInvalidOperationException()
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_Parent_GetNoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Parent);
         }
 
@@ -203,10 +209,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, accessibleObject.State);
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_State_GetNoOwner_ThrowsInvalidOperationException()
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_State_GetNoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.State);
         }
 
@@ -222,10 +228,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, accessibleObject.Value);
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_Value_NoOwner_ThrowsInvalidOperationException()
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_Value_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Value);
         }
 
@@ -236,10 +242,10 @@ namespace System.Windows.Forms.Tests
             accessibleObject.DoDefaultAction();
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_GetChild_NoOwner_ThrowsInvalidOperationException()
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_GetChild_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.GetChild(0));
         }
 
@@ -263,10 +269,10 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentOutOfRangeException>("index", () => accessibleObject.GetChild(index));
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_GetChildCount_NoOwner_ThrowsInvalidOperationException()
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_GetChildCount_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.GetChildCount());
         }
 
@@ -279,10 +285,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, accessibleObject.GetChildCount());
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_GetFocused_NoOwner_ThrowsInvalidOperationException()
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_GetFocused_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.GetFocused());
         }
 
@@ -310,10 +316,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal("Selected Row Cells", selectedAccessibleObject.Value);
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_GetSelected_NoOwner_ThrowsInvalidOperationException()
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_GetSelected_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.GetSelected());
         }
 
@@ -332,10 +338,10 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, accessibleObject.Navigate(navigationDirection));
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_Navigate_NoOwner_ThrowsInvalidOperationException()
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_Navigate_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Navigate(AccessibleNavigation.Right));
         }
 
@@ -370,10 +376,10 @@ namespace System.Windows.Forms.Tests
             accessibleObject.Select(flags);
         }
 
-        [Fact]
-        public void DataGridViewRowAccessibleObject_Select_NoOwner_ThrowsInvalidOperationException()
+        [Theory]
+        [MemberData(nameof(NoOwner_TestData))]
+        public void DataGridViewRowAccessibleObject_Select_NoOwner_ThrowsInvalidOperationException(AccessibleObject accessibleObject)
         {
-            DataGridViewRowAccessibleObject accessibleObject = new();
             Assert.Throws<InvalidOperationException>(() => accessibleObject.Select(AccessibleSelection.None));
         }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewRowAccessibleObject.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7069)