### PR TITLE
Reworking the base TextPattern implementation

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -66,9 +66,6 @@ namespace System.Windows.Forms
         // Indicates this object is being used ONLY to wrap a system IAccessible
         private readonly bool _systemWrapper;
 
-        private UiaTextProvider? _textProvider;
-        private UiaTextProvider2? _textProvider2;
-
         // The support for the UIA Notification event begins in RS3.
         // Assume the UIA Notification event is available until we learn otherwise.
         // If we learn that the UIA Notification event is not available,
@@ -555,28 +552,60 @@ namespace System.Windows.Forms
 
         internal virtual void Invoke() => DoDefaultAction();
 
-        internal virtual UiaCore.ITextRangeProvider? DocumentRangeInternal => _textProvider?.DocumentRange;
+        internal virtual UiaCore.ITextRangeProvider? DocumentRangeInternal
+        {
+            get
+            {
+                Debug.Fail("Not implemented. DocumentRangeInternal property should be overridden.");
+                return null;
+            }
+        }
 
-        internal virtual UiaCore.ITextRangeProvider[]? GetTextSelection() => _textProvider?.GetSelection();
+        internal virtual UiaCore.ITextRangeProvider[]? GetTextSelection()
+        {
+            Debug.Fail("Not implemented. GetTextSelection method should be overridden.");
+            return null;
+        }
 
-        internal virtual UiaCore.ITextRangeProvider[]? GetTextVisibleRanges() => _textProvider?.GetVisibleRanges();
+        internal virtual UiaCore.ITextRangeProvider[]? GetTextVisibleRanges()
+        {
+            Debug.Fail("Not implemented. GetTextVisibleRanges method should be overridden.");
+            return null;
+        }
 
         internal virtual UiaCore.ITextRangeProvider? GetTextRangeFromChild(UiaCore.IRawElementProviderSimple childElement)
-            => _textProvider?.RangeFromChild(childElement);
+        {
+            Debug.Fail("Not implemented. GetTextRangeFromChild method should be overridden.");
+            return null;
+        }
 
-        internal virtual UiaCore.ITextRangeProvider? GetTextRangeFromPoint(Point screenLocation) => _textProvider?.RangeFromPoint(screenLocation);
+        internal virtual UiaCore.ITextRangeProvider? GetTextRangeFromPoint(Point screenLocation)
+        {
+            Debug.Fail("Not implemented. GetTextRangeFromPoint method should be overridden.");
+            return null;
+        }
 
         internal virtual UiaCore.SupportedTextSelection SupportedTextSelectionInternal
-            => _textProvider?.SupportedTextSelection ?? UiaCore.SupportedTextSelection.None;
+        {
+            get
+            {
+                Debug.Fail("Not implemented. SupportedTextSelectionInternal property should be overridden.");
+                return UiaCore.SupportedTextSelection.None;
+            }
+        }
 
         internal virtual UiaCore.ITextRangeProvider? GetTextCaretRange(out BOOL isActive)
         {
             isActive = BOOL.FALSE;
-            return _textProvider2?.GetCaretRange(out isActive);
+            Debug.Fail("Not implemented. GetTextCaretRange method should be overridden.");
+            return null;
         }
 
-        internal virtual UiaCore.ITextRangeProvider? GetRangeFromAnnotation(UiaCore.IRawElementProviderSimple annotationElement) =>
-            _textProvider2?.RangeFromAnnotation(annotationElement);
+        internal virtual UiaCore.ITextRangeProvider? GetRangeFromAnnotation(UiaCore.IRawElementProviderSimple annotationElement)
+        {
+            Debug.Fail("Not implemented. GetRangeFromAnnotation method should be overridden.");
+            return null;
+        }
 
         internal virtual bool IsReadOnly => false;
 
@@ -1742,12 +1771,6 @@ namespace System.Windows.Forms
                 _systemIEnumVariant = (Oleaut32.IEnumVariant?)en;
                 _systemIOleWindow = (Ole32.IOleWindow?)acc;
             }
-        }
-
-        internal void UseTextProviders(UiaTextProvider textProvider, UiaTextProvider2 textProvider2)
-        {
-            _textProvider = textProvider.OrThrowIfNull();
-            _textProvider2 = textProvider2.OrThrowIfNull();
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
@@ -11,21 +11,15 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Defines the DataGridView TextBox EditingControl accessible object.
         /// </summary>
-        internal class DataGridViewTextBoxEditingControlAccessibleObject : ControlAccessibleObject
+        internal class DataGridViewTextBoxEditingControlAccessibleObject : TextBoxBaseAccessibleObject
         {
             /// <summary>
             ///  The parent is changed when the editing control is attached to another editing cell.
             /// </summary>
             private AccessibleObject? _parentAccessibleObject;
-            private readonly TextBoxBase _owningDataGridViewTextBoxEditingControl;
-            private readonly TextBoxBaseUiaTextProvider _textProvider;
 
             public DataGridViewTextBoxEditingControlAccessibleObject(DataGridViewTextBoxEditingControl ownerControl) : base(ownerControl)
-            {
-                _owningDataGridViewTextBoxEditingControl = ownerControl;
-                _textProvider = new TextBoxBaseUiaTextProvider(ownerControl);
-                UseTextProviders(_textProvider, _textProvider);
-            }
+            { }
 
             public override AccessibleObject? Parent => _parentAccessibleObject;
 
@@ -72,12 +66,8 @@ namespace System.Windows.Forms
                 => patternId switch
                 {
                     UiaCore.UIA.ValuePatternId => true,
-                    UiaCore.UIA.TextPatternId => true,
-                    UiaCore.UIA.TextPattern2Id => true,
                     _ => base.IsPatternSupported(patternId)
                 };
-
-            internal override bool IsReadOnly => _owningDataGridViewTextBoxEditingControl.ReadOnly;
 
             /// <summary>
             ///  Sets the parent accessible object for the node which can be added or removed to/from hierarchy nodes.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridViewTextBox.GridViewTextBoxAccessibleObject.cs
@@ -11,16 +11,13 @@ namespace System.Windows.Forms.PropertyGridInternal
     {
         private partial class GridViewTextBox
         {
-            private class GridViewTextBoxAccessibleObject : ControlAccessibleObject
+            private class GridViewTextBoxAccessibleObject : TextBoxBaseAccessibleObject
             {
                 private readonly PropertyGridView _owningPropertyGridView;
-                private readonly TextBoxBaseUiaTextProvider _textProvider;
 
                 public GridViewTextBoxAccessibleObject(GridViewTextBox owner) : base(owner)
                 {
                     _owningPropertyGridView = owner.PropertyGridView;
-                    _textProvider = new TextBoxBaseUiaTextProvider(owner);
-                    UseTextProviders(_textProvider, _textProvider);
                 }
 
                 public override AccessibleStates State
@@ -40,8 +37,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                         return states;
                     }
                 }
-
-                internal override bool IsIAccessibleExSupported() => true;
 
                 /// <summary>
                 ///  Returns the element in the specified direction.
@@ -83,8 +78,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                 internal override bool IsPatternSupported(UiaCore.UIA patternId) => patternId switch
                 {
                     UiaCore.UIA.ValuePatternId => true,
-                    UiaCore.UIA.TextPatternId => true,
-                    UiaCore.UIA.TextPattern2Id => true,
                     _ => base.IsPatternSupported(patternId)
                 };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using static Interop;
+using static Interop.UiaCore;
 
 namespace System.Windows.Forms
 {
@@ -10,28 +12,49 @@ namespace System.Windows.Forms
     {
         internal class TextBoxBaseAccessibleObject : ControlAccessibleObject
         {
-            private readonly TextBoxBase _owningTextBoxBase;
             private readonly TextBoxBaseUiaTextProvider _textProvider;
 
             public TextBoxBaseAccessibleObject(TextBoxBase owner) : base(owner)
             {
-                _owningTextBoxBase = owner;
                 _textProvider = new TextBoxBaseUiaTextProvider(owner);
-
-                UseTextProviders(_textProvider, _textProvider);
             }
 
             internal override bool IsIAccessibleExSupported() => true;
 
-            internal override bool IsPatternSupported(UiaCore.UIA patternId) =>
-                patternId switch
+            internal override bool IsPatternSupported(UIA patternId)
+                => patternId switch
                 {
-                    UiaCore.UIA.TextPatternId => true,
-                    UiaCore.UIA.TextPattern2Id => true,
+                    UIA.TextPatternId => true,
+                    UIA.TextPattern2Id => true,
                     _ => base.IsPatternSupported(patternId)
                 };
 
-            internal override bool IsReadOnly => _owningTextBoxBase.ReadOnly;
+            internal override bool IsReadOnly
+                => Owner is TextBoxBase textBoxBase && textBoxBase.ReadOnly;
+
+            internal override ITextRangeProvider DocumentRangeInternal
+                => _textProvider.DocumentRange;
+
+            internal override ITextRangeProvider[]? GetTextSelection()
+                => _textProvider.GetSelection();
+
+            internal override ITextRangeProvider[]? GetTextVisibleRanges()
+                => _textProvider.GetVisibleRanges();
+
+            internal override ITextRangeProvider? GetTextRangeFromChild(IRawElementProviderSimple childElement)
+                => _textProvider.RangeFromChild(childElement);
+
+            internal override ITextRangeProvider? GetTextRangeFromPoint(Point screenLocation)
+                => _textProvider.RangeFromPoint(screenLocation);
+
+            internal override SupportedTextSelection SupportedTextSelectionInternal
+                => _textProvider.SupportedTextSelection;
+
+            internal override ITextRangeProvider? GetTextCaretRange(out BOOL isActive)
+                => _textProvider.GetCaretRange(out isActive);
+
+            internal override ITextRangeProvider GetRangeFromAnnotation(IRawElementProviderSimple annotationElement)
+                => _textProvider.RangeFromAnnotation(annotationElement);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
@@ -218,9 +218,7 @@ namespace System.Windows.Forms
             }
 
             protected override AccessibleObject CreateAccessibilityInstance()
-            {
-                return new ToolStripTextBoxControlAccessibleObject(this, Owner);
-            }
+                => new ToolStripTextBoxControlAccessibleObject(this);
 
             protected override void Dispose(bool disposing)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownEdit.UpDownEditAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownEdit.UpDownEditAccessibleObject.cs
@@ -2,29 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using static Interop;
-
 namespace System.Windows.Forms
 {
     public abstract partial class UpDownBase
     {
         internal partial class UpDownEdit
         {
-            internal class UpDownEditAccessibleObject : ControlAccessibleObject
+            internal class UpDownEditAccessibleObject : TextBoxBaseAccessibleObject
             {
-                private readonly UpDownEdit _owningUpDownEdit;
-                private readonly TextBoxBaseUiaTextProvider _textProvider;
                 private readonly UpDownBase _parent;
 
                 public UpDownEditAccessibleObject(UpDownEdit owner, UpDownBase parent) : base(owner)
                 {
                     _parent = parent.OrThrowIfNull();
-                    _owningUpDownEdit = owner;
-                    _textProvider = new TextBoxBaseUiaTextProvider(owner);
-                    UseTextProviders(_textProvider, _textProvider);
                 }
-
-                internal override bool IsIAccessibleExSupported() => true;
 
                 public override string? Name
                 {
@@ -39,16 +30,6 @@ namespace System.Windows.Forms
                 }
 
                 public override string? KeyboardShortcut => _parent.AccessibilityObject.KeyboardShortcut;
-
-                internal override bool IsPatternSupported(UiaCore.UIA patternId)
-                    => patternId switch
-                    {
-                        UiaCore.UIA.TextPatternId => true,
-                        UiaCore.UIA.TextPattern2Id => true,
-                        _ => base.IsPatternSupported(patternId)
-                    };
-
-                internal override bool IsReadOnly => _owningUpDownEdit.ReadOnly;
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControlAccessibleObjectTests.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms.Tests
             TextBox textBox = toolStripTextBox.TextBox;
             Type type = toolStripTextBox.GetType().GetNestedType("ToolStripTextBoxControlAccessibleObject", BindingFlags.NonPublic);
             Assert.NotNull(type);
-            ControlAccessibleObject accessibleObject = (ControlAccessibleObject)Activator.CreateInstance(type, textBox, toolStripTextBox);
+            ControlAccessibleObject accessibleObject = (ControlAccessibleObject)Activator.CreateInstance(type, textBox);
             Assert.Equal(textBox, accessibleObject.Owner);
         }
 
@@ -29,7 +29,7 @@ namespace System.Windows.Forms.Tests
             TextBox textBox = toolStripTextBox.TextBox;
             Type type = toolStripTextBox.GetType().GetNestedType("ToolStripTextBoxControlAccessibleObject", BindingFlags.NonPublic);
             Assert.NotNull(type);
-            Assert.Throws<TargetInvocationException>(() => Activator.CreateInstance(type, (Control)null, toolStripTextBox));
+            Assert.Throws<TargetInvocationException>(() => Activator.CreateInstance(type, (Control)null));
         }
 
         [WinFormsTheory]


### PR DESCRIPTION
Fixes #7080

## Proposed changes

- Move the real implementation into derived types (`TextBoxBaseAccessibleObject` and `ComboBoxChildEditUiaProvider`) like we did for the rest patterns in `AccessibleObject.cs` (eg. ExpandCollapse pattern)
- Reduce the logic of edit fields that have TextPattern behavior, inherit them from TextBoxBaseAccessibleObject, thereby taking many members from it and reducing the size of the types, making them simpler.

The main reason for this change - ~95% of accessible objects don't implement TextPattern and they don't know about this pattern and shouldn't keep text providers that are not used. The decision is based on discussions of CF #377144 (Bug 1043396)

PS. `ToolStripTextBoxControlAccessibleObject` doesn't need to inherit `FragmentNavigate` and `FragmentRoot` from `ToolStripHostedControlAccessibleObject` because the base `ControlAccessibleObject` class do it for any ControlHost items.

## Customer Impact

- No

## Regression? 

- No

## Risk

- TextPattern may be broken

## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manual testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using Narrator, Inspect and AI. Checked how TextPattern works for all edit controls

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0
- Windows 11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7081)