### PR TITLE
Chores for test projects

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,6 +21,13 @@
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
+  <!-- Mark all projects located under **\tests\* folders as non-shipping -->
+  <PropertyGroup>
+    <_ProjectDirectoryRelativePath>$([MSBuild]::MakeRelative($(RepoRoot), $(MSBuildProjectDirectory)))</_ProjectDirectoryRelativePath>
+    <_IsUnderTestsFolder>$(_ProjectDirectoryRelativePath.Contains("\tests\"))</_IsUnderTestsFolder>
+    <IsShipping Condition="$(_IsUnderTestsFolder)">false</IsShipping>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' ">
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
     <Platform Condition="'$(Platform)' == 'AnyCPU' or '$(Platform)' == 'Any CPU'">$(TargetArchitecture)</Platform>

--- a/eng/CodeStyle.targets
+++ b/eng/CodeStyle.targets
@@ -5,12 +5,7 @@
     <EditorConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.src.globalconfig" />
   </ItemGroup>
 
-  <!--
-    Because some test projects such as System.Windows.Forms.TestUtilities and WinformsControlsTest do not satifsy the naming conditions in
-    https://github.com/dotnet/arcade/blob/e7ede87875f41a9b3df898ae08da5ebc96e24f56/src/Microsoft.DotNet.Arcade.Sdk/tools/Tests.props
-    we have to also test the presence of word Test as a workaround.
-  -->
-  <ItemGroup Condition="'$(IsTestProject)' == 'true' Or $(MSBuildProjectName.Contains('Test'))">
+  <ItemGroup Condition="'$(IsShipping)' == 'false'">
     <EditorConfigFiles Remove="$(MSBuildThisFileDirectory)CodeAnalysis.src.globalconfig" />
     <EditorConfigFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis.test.globalconfig" />
   </ItemGroup>

--- a/src/System.Windows.Forms/tests/InteropTests/NativeTests/NativeTests.proj
+++ b/src/System.Windows.Forms/tests/InteropTests/NativeTests/NativeTests.proj
@@ -1,6 +1,11 @@
 <Project Sdk="Microsoft.DotNet.CMake.Sdk">
-    <PropertyGroup>
-        <CMakeCompilerSearchScript>call &quot;$(RepoRoot)eng\init-vs-env.cmd&quot; $(TargetArchitecture)</CMakeCompilerSearchScript>
-        <CMakeLists>CMakeLists.txt</CMakeLists>
-    </PropertyGroup>
+  <PropertyGroup>
+    <CMakeCompilerSearchScript>call &quot;$(RepoRoot)eng\init-vs-env.cmd&quot; $(TargetArchitecture)</CMakeCompilerSearchScript>
+    <CMakeLists>CMakeLists.txt</CMakeLists>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CMakeArguments Include=" --log-level=WARNING" />
+    <CMakeNativeToolArguments Include=" -verbosity:quiet" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
* Reduce CMake verbosity
* Mark all projects under **\tests\* folders as non-shippable (relates to #7049 and #7065)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7083)