### PR TITLE
Use different paths for faster inner loop

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -33,7 +33,7 @@ Add references to the binary(-ies) to your project ported to .NET. For example, 
 ```xml
 <ItemGroup>
     <Reference Include="[Drive]:[Path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\net7.0\System.Windows.Forms.dll" />
-    <Reference Include="[Drive]:[Path-to-repo]\winforms\artifacts\bin\System.Windows.Forms\Debug\net7.0\System.Windows.Forms.Primitives.dll" />
+    <Reference Include="[Drive]:[Path-to-repo]\winforms\artifacts\bin\System.Windows.Forms.Primitives\Debug\net7.0\System.Windows.Forms.Primitives.dll" />
 </ItemGroup>
 ```
 


### PR DESCRIPTION
That change allow build just `System.Windows.Forms.Primitives` for example, and then pickup changes without need for building `System.Windows.Forms`.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7088)