### PR TITLE
Use OrThrowIfNull in CheckedIndexCollection constructor

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedIndexCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.CheckedIndexCollection.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms
 
             internal CheckedIndexCollection(CheckedListBox owner)
             {
-                _owner = owner;
+                _owner = owner.OrThrowIfNull();
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.CheckedIndexCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.CheckedIndexCollection.cs
@@ -17,7 +17,7 @@ namespace System.Windows.Forms
             /* C#r: protected */
             public CheckedIndexCollection(ListView owner)
             {
-                _owner = owner;
+                _owner = owner.OrThrowIfNull();
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckedListBox.CheckedIndexCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckedListBox.CheckedIndexCollectionTests.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class CheckedListBox_CheckedIndexCollectionTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void CheckedIndexCollection_Ctor_OwnerIsNull_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("owner", () => { new CheckedListBox.CheckedIndexCollection(null); });
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListView.CheckedIndexCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListView.CheckedIndexCollectionTests.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ListView_CheckedIndexCollectionTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void CheckedIndexCollection_Ctor_OwnerIsNull_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>("owner", () => { new ListView.CheckedIndexCollection(null); });
+        }
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/dotnet/winforms/pull/7018/files#r856669700

## Proposed changes

- Use OrThrowIfNull in CheckedIndexCollection constructor. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7091)