### PR TITLE
Enable CA2014 warnings for src files

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -409,7 +409,7 @@ dotnet_diagnostic.CA2012.severity = warning
 dotnet_diagnostic.CA2013.severity = warning
 
 # Do not use stackalloc in loops
-dotnet_diagnostic.CA2014.severity = none # TODO: warning
+dotnet_diagnostic.CA2014.severity = warning
 
 # Do not define finalizers for types derived from MemoryManager<T>
 dotnet_diagnostic.CA2015.severity = warning


### PR DESCRIPTION
## Proposed changes

- Enable CA2014 warnings for src files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7094)