### PR TITLE
Enable nullability in TreeViewImageIndexConverter

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -664,9 +664,9 @@
 ~override System.Windows.Forms.TreeView.Text.get -> string
 ~override System.Windows.Forms.TreeView.Text.set -> void
 ~override System.Windows.Forms.TreeView.ToString() -> string
-~override System.Windows.Forms.TreeViewImageIndexConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) -> object
-~override System.Windows.Forms.TreeViewImageIndexConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) -> object
-~override System.Windows.Forms.TreeViewImageIndexConverter.GetStandardValues(System.ComponentModel.ITypeDescriptorContext context) -> System.ComponentModel.TypeConverter.StandardValuesCollection
+override System.Windows.Forms.TreeViewImageIndexConverter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
+override System.Windows.Forms.TreeViewImageIndexConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+override System.Windows.Forms.TreeViewImageIndexConverter.GetStandardValues(System.ComponentModel.ITypeDescriptorContext? context) -> System.ComponentModel.TypeConverter.StandardValuesCollection!
 ~override System.Windows.Forms.TreeViewImageKeyConverter.ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) -> object
 ~override System.Windows.Forms.UpDownBase.BackgroundImage.get -> System.Drawing.Image
 ~override System.Windows.Forms.UpDownBase.BackgroundImage.set -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageIndexConverter.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     using System.ComponentModel;
@@ -26,7 +24,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Converts the given value object to a 32-bit signed integer object.
         /// </summary>
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
         {
             if (value is string strValue)
             {
@@ -50,7 +48,7 @@ namespace System.Windows.Forms
         ///  type is string.  If this cannot convert to the destination type, this will
         ///  throw a NotSupportedException.
         /// </summary>
-        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destinationType)
         {
             ArgumentNullException.ThrowIfNull(destinationType);
 
@@ -75,13 +73,13 @@ namespace System.Windows.Forms
         ///  will return null if the data type does not support a
         ///  standard set of values.
         /// </summary>
-        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext? context)
         {
             if (context is not null && context.Instance is not null)
             {
-                object instance = context.Instance;
+                object? instance = context.Instance;
 
-                PropertyDescriptor imageListProp = ImageListUtils.GetImageListProperty(context.PropertyDescriptor, ref instance);
+                PropertyDescriptor? imageListProp = ImageListUtils.GetImageListProperty(context.PropertyDescriptor, ref instance);
 
                 while (instance is not null && imageListProp is null)
                 {
@@ -100,7 +98,7 @@ namespace System.Windows.Forms
                     {
                         // We didn't find the image list in this component.  See if the
                         // component has a "parent" property.  If so, walk the tree...
-                        PropertyDescriptor parentProp = props[ParentImageListProperty];
+                        PropertyDescriptor? parentProp = props[ParentImageListProperty];
                         if (parentProp is not null)
                         {
                             instance = parentProp.GetValue(instance);
@@ -115,15 +113,13 @@ namespace System.Windows.Forms
 
                 if (imageListProp is not null)
                 {
-                    ImageList imageList = (ImageList)imageListProp.GetValue(instance);
+                    ImageList? imageList = (ImageList?)imageListProp.GetValue(instance);
 
                     if (imageList is not null)
                     {
                         // Create array to contain standard values
-                        //
-                        object[] values;
                         int nImages = imageList.Images.Count + 2;
-                        values = new object[nImages];
+                        object[] values = new object[nImages];
                         values[nImages - 2] = ImageList.Indexer.DefaultIndex;
                         values[nImages - 1] = -2;
 
@@ -138,11 +134,12 @@ namespace System.Windows.Forms
                 }
             }
 
-            return new StandardValuesCollection(new object[]
-                                                {
-                                                    ImageList.Indexer.DefaultIndex,
-                                                    ImageList.Indexer.NoneIndex
-                                                });
+            return new StandardValuesCollection(
+                new object[]
+                {
+                    ImageList.Indexer.DefaultIndex,
+                    ImageList.Indexer.NoneIndex
+                });
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in TreeViewImageIndexConverter.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7095)