### PR TITLE
Remove unused Message m parameters

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -6034,7 +6034,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  WM_ENTERSIZEMOVE handler, so that user can hook up OnResizeBegin event.
         /// </summary>
-        private void WmEnterSizeMove(ref Message m)
+        private void WmEnterSizeMove()
         {
             _formStateEx[FormStateExInModalSizingLoop] = 1;
             OnResizeBegin(EventArgs.Empty);
@@ -6043,7 +6043,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  WM_EXITSIZEMOVE handler, so that user can hook up OnResizeEnd event.
         /// </summary>
-        private void WmExitSizeMove(ref Message m)
+        private void WmExitSizeMove()
         {
             _formStateEx[FormStateExInModalSizingLoop] = 0;
             OnResizeEnd(EventArgs.Empty);
@@ -6565,11 +6565,11 @@ namespace System.Windows.Forms
                     WmClose(ref m);
                     break;
                 case User32.WM.ENTERSIZEMOVE:
-                    WmEnterSizeMove(ref m);
+                    WmEnterSizeMove();
                     DefWndProc(ref m);
                     break;
                 case User32.WM.EXITSIZEMOVE:
-                    WmExitSizeMove(ref m);
+                    WmExitSizeMove();
                     DefWndProc(ref m);
                     break;
                 case User32.WM.CREATE:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5847,7 +5847,7 @@ namespace System.Windows.Forms
             Debug.Assert(retval != 0, "LVM_SETTILEVIEWINFO failed");
         }
 
-        private void WmNmClick(ref Message m)
+        private void WmNmClick()
         {
             // If we're checked, hittest to see if we're
             // on the check mark
@@ -5889,7 +5889,7 @@ namespace System.Windows.Forms
             }
         }
 
-        private void WmNmDblClick(ref Message m)
+        private void WmNmDblClick()
         {
             // If we're checked, hittest to see if we're
             // on the item
@@ -6627,7 +6627,7 @@ namespace System.Windows.Forms
                     }
 
                 case (int)NM.CLICK:
-                    WmNmClick(ref m);
+                    WmNmClick();
                     // FALL THROUGH //
                     goto case (int)NM.RCLICK;
 
@@ -6653,7 +6653,7 @@ namespace System.Windows.Forms
                     break;
 
                 case (int)NM.DBLCLK:
-                    WmNmDblClick(ref m);
+                    WmNmDblClick();
                     // FALL THROUGH //
                     goto case (int)NM.RDBLCLK;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NotifyIcon.cs
@@ -693,7 +693,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Handles the mouse-down event
         /// </summary>
-        private void WmMouseDown(ref Message m, MouseButtons button, int clicks)
+        private void WmMouseDown(MouseButtons button, int clicks)
         {
             if (clicks == 2)
             {
@@ -708,7 +708,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Handles the mouse-move event
         /// </summary>
-        private void WmMouseMove(ref Message m)
+        private void WmMouseMove()
         {
             OnMouseMove(new MouseEventArgs(Control.MouseButtons, 0, 0, 0, 0));
         }
@@ -716,7 +716,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Handles the mouse-up event
         /// </summary>
-        private void WmMouseUp(ref Message m, MouseButtons button)
+        private void WmMouseUp(MouseButtons button)
         {
             OnMouseUp(new MouseEventArgs(button, 0, 0, 0, 0));
             //subhag
@@ -729,7 +729,7 @@ namespace System.Windows.Forms
             doubleClick = false;
         }
 
-        private void WmTaskbarCreated(ref Message m)
+        private void WmTaskbarCreated()
         {
             added = false;
             UpdateIcon(visible);
@@ -743,31 +743,31 @@ namespace System.Windows.Forms
                     switch ((User32.WM)msg.LParamInternal)
                     {
                         case User32.WM.LBUTTONDBLCLK:
-                            WmMouseDown(ref msg, MouseButtons.Left, 2);
+                            WmMouseDown(MouseButtons.Left, 2);
                             break;
                         case User32.WM.LBUTTONDOWN:
-                            WmMouseDown(ref msg, MouseButtons.Left, 1);
+                            WmMouseDown(MouseButtons.Left, 1);
                             break;
                         case User32.WM.LBUTTONUP:
-                            WmMouseUp(ref msg, MouseButtons.Left);
+                            WmMouseUp(MouseButtons.Left);
                             break;
                         case User32.WM.MBUTTONDBLCLK:
-                            WmMouseDown(ref msg, MouseButtons.Middle, 2);
+                            WmMouseDown(MouseButtons.Middle, 2);
                             break;
                         case User32.WM.MBUTTONDOWN:
-                            WmMouseDown(ref msg, MouseButtons.Middle, 1);
+                            WmMouseDown(MouseButtons.Middle, 1);
                             break;
                         case User32.WM.MBUTTONUP:
-                            WmMouseUp(ref msg, MouseButtons.Middle);
+                            WmMouseUp(MouseButtons.Middle);
                             break;
                         case User32.WM.MOUSEMOVE:
-                            WmMouseMove(ref msg);
+                            WmMouseMove();
                             break;
                         case User32.WM.RBUTTONDBLCLK:
-                            WmMouseDown(ref msg, MouseButtons.Right, 2);
+                            WmMouseDown(MouseButtons.Right, 2);
                             break;
                         case User32.WM.RBUTTONDOWN:
-                            WmMouseDown(ref msg, MouseButtons.Right, 1);
+                            WmMouseDown(MouseButtons.Right, 1);
                             break;
                         case User32.WM.RBUTTONUP:
                             if (contextMenuStrip is not null)
@@ -775,7 +775,7 @@ namespace System.Windows.Forms
                                 ShowContextMenu();
                             }
 
-                            WmMouseUp(ref msg, MouseButtons.Right);
+                            WmMouseUp(MouseButtons.Right);
                             break;
                         case (User32.WM)NIN.BALLOONSHOW:
                             OnBalloonTipShown();
@@ -816,7 +816,7 @@ namespace System.Windows.Forms
                 default:
                     if (msg.Msg == (int)WM_TASKBARCREATED)
                     {
-                        WmTaskbarCreated(ref msg);
+                        WmTaskbarCreated();
                     }
 
                     window.DefWndProc(ref msg);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -2068,7 +2068,7 @@ namespace System.Windows.Forms
             return tcc.Cancel;
         }
 
-        private void WmTabBaseReLayout(ref Message m)
+        private void WmTabBaseReLayout()
         {
             BeginUpdate();
             _cachedDisplayRect = Rectangle.Empty;
@@ -2158,7 +2158,7 @@ namespace System.Windows.Forms
 
             if (m.MsgInternal == _tabBaseReLayoutMessage)
             {
-                WmTabBaseReLayout(ref m);
+                WmTabBaseReLayout();
                 return;
             }
 


### PR DESCRIPTION
Some private methods have unused `Message m` parameters, so we can remove them.

## Proposed changes

- Remove unused m parameters

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7101)