### PR TITLE
Enable nullability in BindingContext and HashKey

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -632,7 +632,7 @@ static System.Resources.ResXResourceReader.FromFileContents(string! fileContents
 ~static System.Windows.Forms.AxHost.GetIPictureFromPicture(System.Drawing.Image image) -> object
 ~static System.Windows.Forms.AxHost.GetPictureFromIPicture(object picture) -> System.Drawing.Image
 ~static System.Windows.Forms.AxHost.GetPictureFromIPictureDisp(object picture) -> System.Drawing.Image
-~static System.Windows.Forms.BindingContext.UpdateBinding(System.Windows.Forms.BindingContext newBindingContext, System.Windows.Forms.Binding binding) -> void
+static System.Windows.Forms.BindingContext.UpdateBinding(System.Windows.Forms.BindingContext? newBindingContext, System.Windows.Forms.Binding! binding) -> void
 ~static System.Windows.Forms.Control.FromChildHandle(nint handle) -> System.Windows.Forms.Control
 ~static System.Windows.Forms.Control.FromHandle(nint handle) -> System.Windows.Forms.Control
 ~static System.Windows.Forms.DataGridViewCell.MeasureTextHeight(System.Drawing.Graphics graphics, string text, System.Drawing.Font font, int maxWidth, System.Windows.Forms.TextFormatFlags flags) -> int
@@ -796,12 +796,12 @@ System.Resources.ResXResourceWriter.ResXResourceWriter(System.IO.TextWriter! tex
 ~System.Windows.Forms.Binding.NullValue.get -> object
 ~System.Windows.Forms.Binding.NullValue.set -> void
 ~System.Windows.Forms.Binding.PropertyName.get -> string
-~System.Windows.Forms.BindingContext.Add(object dataSource, System.Windows.Forms.BindingManagerBase listManager) -> void
-~System.Windows.Forms.BindingContext.Contains(object dataSource) -> bool
-~System.Windows.Forms.BindingContext.Contains(object dataSource, string dataMember) -> bool
-~System.Windows.Forms.BindingContext.Remove(object dataSource) -> void
-~System.Windows.Forms.BindingContext.this[object dataSource, string dataMember].get -> System.Windows.Forms.BindingManagerBase
-~System.Windows.Forms.BindingContext.this[object dataSource].get -> System.Windows.Forms.BindingManagerBase
+System.Windows.Forms.BindingContext.Add(object! dataSource, System.Windows.Forms.BindingManagerBase! listManager) -> void
+System.Windows.Forms.BindingContext.Contains(object! dataSource) -> bool
+System.Windows.Forms.BindingContext.Contains(object! dataSource, string? dataMember) -> bool
+System.Windows.Forms.BindingContext.Remove(object! dataSource) -> void
+System.Windows.Forms.BindingContext.this[object! dataSource, string? dataMember].get -> System.Windows.Forms.BindingManagerBase!
+System.Windows.Forms.BindingContext.this[object! dataSource].get -> System.Windows.Forms.BindingManagerBase!
 System.Windows.Forms.BindingMemberInfo.BindingField.get -> string!
 System.Windows.Forms.BindingMemberInfo.BindingMember.get -> string!
 System.Windows.Forms.BindingMemberInfo.BindingMemberInfo(string? dataMember) -> void
@@ -1664,9 +1664,9 @@ virtual System.Resources.ResXResourceWriter.AddAlias(string? aliasName, System.R
 ~virtual System.Windows.Forms.Binding.OnBindingComplete(System.Windows.Forms.BindingCompleteEventArgs e) -> void
 ~virtual System.Windows.Forms.Binding.OnFormat(System.Windows.Forms.ConvertEventArgs cevent) -> void
 ~virtual System.Windows.Forms.Binding.OnParse(System.Windows.Forms.ConvertEventArgs cevent) -> void
-~virtual System.Windows.Forms.BindingContext.AddCore(object dataSource, System.Windows.Forms.BindingManagerBase listManager) -> void
-~virtual System.Windows.Forms.BindingContext.OnCollectionChanged(System.ComponentModel.CollectionChangeEventArgs ccevent) -> void
-~virtual System.Windows.Forms.BindingContext.RemoveCore(object dataSource) -> void
+virtual System.Windows.Forms.BindingContext.AddCore(object! dataSource, System.Windows.Forms.BindingManagerBase! listManager) -> void
+virtual System.Windows.Forms.BindingContext.OnCollectionChanged(System.ComponentModel.CollectionChangeEventArgs! ccevent) -> void
+virtual System.Windows.Forms.BindingContext.RemoveCore(object! dataSource) -> void
 ~virtual System.Windows.Forms.BindingSource.Add(object value) -> int
 ~virtual System.Windows.Forms.BindingSource.AddNew() -> object
 ~virtual System.Windows.Forms.BindingSource.ApplySort(System.ComponentModel.ListSortDescriptionCollection sorts) -> void
@@ -5275,7 +5275,7 @@ System.Windows.Forms.BindingCompleteState.Success = 0 -> System.Windows.Forms.Bi
 System.Windows.Forms.BindingContext
 System.Windows.Forms.BindingContext.BindingContext() -> void
 System.Windows.Forms.BindingContext.Clear() -> void
-System.Windows.Forms.BindingContext.CollectionChanged -> System.ComponentModel.CollectionChangeEventHandler
+System.Windows.Forms.BindingContext.CollectionChanged -> System.ComponentModel.CollectionChangeEventHandler?
 System.Windows.Forms.BindingContext.IsReadOnly.get -> bool
 System.Windows.Forms.BindingManagerBase
 System.Windows.Forms.BindingManagerBase.BindingComplete -> System.Windows.Forms.BindingCompleteEventHandler!

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.HashKey.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.HashKey.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Globalization;
+
+namespace System.Windows.Forms
+{
+    public partial class BindingContext
+    {
+        private class HashKey
+        {
+            private readonly WeakReference _wRef;
+            private readonly int _dataSourceHashCode;
+            private readonly string _dataMember;
+
+            internal HashKey(object dataSource, string dataMember)
+            {
+                ArgumentNullException.ThrowIfNull(dataSource);
+                dataMember ??= string.Empty;
+
+                // The dataMember should be case insensitive, so convert the
+                // dataMember to lower case
+                _wRef = new WeakReference(dataSource, false);
+                _dataSourceHashCode = dataSource.GetHashCode();
+                _dataMember = dataMember.ToLower(CultureInfo.InvariantCulture);
+            }
+
+            public override int GetHashCode() => HashCode.Combine(_dataSourceHashCode, _dataMember);
+
+            public override bool Equals(object target)
+            {
+                if (!(target is HashKey keyTarget))
+                {
+                    return false;
+                }
+
+                return _wRef.Target == keyTarget._wRef.Target && _dataMember == keyTarget._dataMember;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.HashKey.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.HashKey.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Globalization;
 
 namespace System.Windows.Forms
@@ -16,7 +14,7 @@ namespace System.Windows.Forms
             private readonly int _dataSourceHashCode;
             private readonly string _dataMember;
 
-            internal HashKey(object dataSource, string dataMember)
+            internal HashKey(object dataSource, string? dataMember)
             {
                 ArgumentNullException.ThrowIfNull(dataSource);
                 dataMember ??= string.Empty;
@@ -30,9 +28,9 @@ namespace System.Windows.Forms
 
             public override int GetHashCode() => HashCode.Combine(_dataSourceHashCode, _dataMember);
 
-            public override bool Equals(object target)
+            public override bool Equals(object? target)
             {
-                if (!(target is HashKey keyTarget))
+                if (target is not HashKey keyTarget)
                 {
                     return false;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -83,7 +81,7 @@ namespace System.Windows.Forms
         ///  Gets the System.Windows.Forms.BindingManagerBase associated with the specified
         ///  data source and data member.
         /// </summary>
-        public BindingManagerBase this[object dataSource, string dataMember]
+        public BindingManagerBase this[object dataSource, string? dataMember]
         {
             get => EnsureListManager(dataSource, dataMember);
         }
@@ -124,7 +122,7 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.collectionChangedEventDescr))]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Browsable(false)]
-        public event CollectionChangeEventHandler CollectionChanged
+        public event CollectionChangeEventHandler? CollectionChanged
         {
             add
             {
@@ -166,12 +164,12 @@ namespace System.Windows.Forms
         ///  Gets a value indicating whether the System.Windows.Forms.BindingContext
         ///  contains the specified data source and data member.
         /// </summary>
-        public bool Contains(object dataSource, string dataMember)
+        public bool Contains(object dataSource, string? dataMember)
         {
             return _listManagers.ContainsKey(GetKey(dataSource, dataMember));
         }
 
-        private static HashKey GetKey(object dataSource, string dataMember)
+        private static HashKey GetKey(object dataSource, string? dataMember)
         {
             return new HashKey(dataSource, dataMember);
         }
@@ -214,9 +212,9 @@ namespace System.Windows.Forms
         ///  - If the data source is an ICurrencyManagerProvider, just delegate to the data
         ///  source.
         /// </summary>
-        private BindingManagerBase EnsureListManager(object dataSource, string dataMember)
+        private BindingManagerBase EnsureListManager(object dataSource, string? dataMember)
         {
-            BindingManagerBase bindingManagerBase = null;
+            BindingManagerBase? bindingManagerBase = null;
 
             dataMember ??= string.Empty;
 
@@ -233,10 +231,10 @@ namespace System.Windows.Forms
 
             // Check for previously created binding manager
             HashKey key = GetKey(dataSource, dataMember);
-            WeakReference wRef = _listManagers[key] as WeakReference;
+            WeakReference? wRef = _listManagers[key] as WeakReference;
             if (wRef is not null)
             {
-                bindingManagerBase = (BindingManagerBase)wRef.Target;
+                bindingManagerBase = (BindingManagerBase?)wRef.Target;
             }
 
             if (bindingManagerBase is not null)
@@ -267,7 +265,7 @@ namespace System.Windows.Forms
 
                 BindingManagerBase formerManager = EnsureListManager(dataSource, dataPath);
 
-                PropertyDescriptor prop = formerManager.GetItemProperties().Find(dataField, true);
+                PropertyDescriptor? prop = formerManager.GetItemProperties().Find(dataField, true);
                 if (prop is null)
                 {
                     throw new ArgumentException(string.Format(SR.RelatedListManagerChild, dataField));
@@ -329,10 +327,10 @@ namespace System.Windows.Forms
 
         private void ScrubWeakRefs()
         {
-            ArrayList cleanupList = null;
+            ArrayList? cleanupList = null;
             foreach (DictionaryEntry de in _listManagers)
             {
-                WeakReference wRef = (WeakReference)de.Value;
+                WeakReference wRef = (WeakReference)de.Value!;
                 if (wRef.Target is null)
                 {
                     cleanupList ??= new ArrayList();
@@ -355,7 +353,7 @@ namespace System.Windows.Forms
         ///  that support IBindableComponent, to update their Bindings when the value of
         ///  IBindableComponent.BindingContext is changed.
         /// </summary>
-        public static void UpdateBinding(BindingContext newBindingContext, Binding binding)
+        public static void UpdateBinding(BindingContext? newBindingContext, Binding binding)
         {
             ArgumentNullException.ThrowIfNull(binding);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
@@ -7,7 +7,6 @@
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Globalization;
 
 namespace System.Windows.Forms
 {
@@ -16,7 +15,7 @@ namespace System.Windows.Forms
     ///  objects for a Win Form.
     /// </summary>
     [DefaultEvent(nameof(CollectionChanged))]
-    public class BindingContext : ICollection
+    public partial class BindingContext : ICollection
     {
         private readonly Hashtable _listManagers;
 
@@ -175,37 +174,6 @@ namespace System.Windows.Forms
         private static HashKey GetKey(object dataSource, string dataMember)
         {
             return new HashKey(dataSource, dataMember);
-        }
-
-        private class HashKey
-        {
-            private readonly WeakReference _wRef;
-            private readonly int _dataSourceHashCode;
-            private readonly string _dataMember;
-
-            internal HashKey(object dataSource, string dataMember)
-            {
-                ArgumentNullException.ThrowIfNull(dataSource);
-                dataMember ??= string.Empty;
-
-                // The dataMember should be case insensitive, so convert the
-                // dataMember to lower case
-                _wRef = new WeakReference(dataSource, false);
-                _dataSourceHashCode = dataSource.GetHashCode();
-                _dataMember = dataMember.ToLower(CultureInfo.InvariantCulture);
-            }
-
-            public override int GetHashCode() => HashCode.Combine(_dataSourceHashCode, _dataMember);
-
-            public override bool Equals(object target)
-            {
-                if (!(target is HashKey keyTarget))
-                {
-                    return false;
-                }
-
-                return _wRef.Target == keyTarget._wRef.Target && _dataMember == keyTarget._dataMember;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed changes

- Enable nullability in BindingContext and HashKey.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7108)