### PR TITLE
Removing an extra NotSortedAccessibleStatus for an empty DataGridView by adding check for empty DVG

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -276,7 +276,12 @@ namespace System.Windows.Forms
                             }
                         }
 
-                        return SR.NotSortedAccessibleStatus;
+                        if (ColumnCount > 0 && RowCount > 0)
+                        {
+                            return SR.NotSortedAccessibleStatus;
+                        }
+
+                        break;
                 }
 
                 return base.GetPropertyValue(propertyID);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAccessibleObjectTests.cs
@@ -1629,5 +1629,35 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(0, dataGridView.AccessibilityObject.RowCount);
             Assert.False(dataGridView.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_ItemStatusProperty_IsExpected_ForNonSortedDGV()
+        {
+            using DataGridView dataGridView = new();
+            using DataGridViewTextBoxColumn column = new();
+            dataGridView.Columns.Add(column);
+
+            object actual = dataGridView.AccessibilityObject
+                .GetPropertyValue(UiaCore.UIA.ItemStatusPropertyId);
+
+            Assert.Equal(1, dataGridView.RowCount);
+            Assert.Equal(1, dataGridView.ColumnCount);
+            Assert.Equal(SR.NotSortedAccessibleStatus, actual);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewAccessibleObject_ItemStatusProperty_IsNull_ForEmptyDGV()
+        {
+            using DataGridView dataGridView = new() { AllowUserToAddRows = false };
+
+            object actual = dataGridView.AccessibilityObject
+                .GetPropertyValue(UiaCore.UIA.ItemStatusPropertyId);
+
+            Assert.Equal(0, dataGridView.RowCount);
+            Assert.Equal(0, dataGridView.ColumnCount);
+            Assert.Null(actual);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
     }
 }


### PR DESCRIPTION
Fixes #7079

## Proposed changes
Empty DataGridView has unexpected NotSortedAccessibleStatus item status.
Added additional check for empty DataGridView in DataGridViewAccessibleObject.GetPropertyValue() (DataGridView.AccessibleObject.cs- line 279).

Added unit tests:
DataGridViewAccessibleObject_ItemStatusProperty_IsExpected_ForNonSortedDGV
DataGridViewAccessibleObject_ItemStatusProperty_IsNull_ForEmptyDGV

## Customer Impact
User has correct UI properties.

## Regression? 
Yes. Regression from https://github.com/dotnet/winforms/pull/6498

## Risk
Minimal


## Screenshots
### Before
Empty DataGridView has unexpected NotSortedAccessibleStatus item status:
![image](https://user-images.githubusercontent.com/102961955/166195975-6b67a64f-2db2-4d36-a2b6-1601e1b16370.png)

### After
Empty DataGridView has no item status:
![image](https://user-images.githubusercontent.com/102961955/166196859-488c112b-df13-414a-8557-3625e13d770b.png)
![111_2](https://user-images.githubusercontent.com/102961955/166200226-234d4cba-32be-4ec2-a4a3-99e2a983b490.png)


## Test methodology
Manual testing
Unit tests
CTI

## Accessibility testing
Inspect
 

## Test environment(s)
Microsoft Windows [Version 120.2212.4170.0]
.NET Core SDK: 7.0.100-preview.3.22179.4


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7117)