### PR TITLE
Fixing TreeView TreeNode accessible object supports Expand-Collapse pattern even if the node can't expand.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.TreeNodeAccessibleObject.cs
@@ -120,7 +120,7 @@ namespace System.Windows.Forms
             internal override bool IsPatternSupported(UiaCore.UIA patternId)
                 => patternId switch
                 {
-                    UiaCore.UIA.ExpandCollapsePatternId => true,
+                    UiaCore.UIA.ExpandCollapsePatternId => _owningTreeNode.childCount > 0,
                     UiaCore.UIA.LegacyIAccessiblePatternId => true,
                     UiaCore.UIA.ScrollItemPatternId => true,
                     UiaCore.UIA.SelectionItemPatternId => true,

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
@@ -235,46 +235,46 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId)]
-        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
-        [InlineData((int)UiaCore.UIA.ScrollItemPatternId)]
-        [InlineData((int)UiaCore.UIA.SelectionItemPatternId)]
-        public void TreeNodeAccessibleObject_IsPatternSupported_IfCommonNodes(int patternId)
+        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId, false)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId, true)]
+        [InlineData((int)UiaCore.UIA.ScrollItemPatternId, true)]
+        [InlineData((int)UiaCore.UIA.SelectionItemPatternId, true)]
+        public void TreeNodeAccessibleObject_IsPatternSupported_IfCommonNodes(int patternId, bool expected)
         {
             using TreeView control = new();
             TreeNode node = new(control);
 
-            Assert.True(node.AccessibilityObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.Equal(node.AccessibilityObject.IsPatternSupported((UiaCore.UIA)patternId), expected);
             Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
-        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId)]
-        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
-        [InlineData((int)UiaCore.UIA.ScrollItemPatternId)]
-        [InlineData((int)UiaCore.UIA.SelectionItemPatternId)]
-        [InlineData((int)UiaCore.UIA.TogglePatternId)]
-        public void TreeNodeAccessibleObject_IsPatternSupported_IfNodesAreCheckBoxes(int patternId)
+        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId, false)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId, true)]
+        [InlineData((int)UiaCore.UIA.ScrollItemPatternId, true)]
+        [InlineData((int)UiaCore.UIA.SelectionItemPatternId, true)]
+        [InlineData((int)UiaCore.UIA.TogglePatternId, true)]
+        public void TreeNodeAccessibleObject_IsPatternSupported_IfNodesAreCheckBoxes(int patternId, bool expected)
         {
             using TreeView control = new() { CheckBoxes = true };
             TreeNode node = new(control);
 
-            Assert.True(node.AccessibilityObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.Equal(node.AccessibilityObject.IsPatternSupported((UiaCore.UIA)patternId), expected);
             Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]
-        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId)]
-        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
-        [InlineData((int)UiaCore.UIA.ScrollItemPatternId)]
-        [InlineData((int)UiaCore.UIA.SelectionItemPatternId)]
-        [InlineData((int)UiaCore.UIA.ValuePatternId)]
-        public void TreeNodeAccessibleObject_IsPatternSupported_IfNodesAreEditable(int patternId)
+        [InlineData((int)UiaCore.UIA.ExpandCollapsePatternId, false)]
+        [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId, true)]
+        [InlineData((int)UiaCore.UIA.ScrollItemPatternId, true)]
+        [InlineData((int)UiaCore.UIA.SelectionItemPatternId, true)]
+        [InlineData((int)UiaCore.UIA.ValuePatternId, true)]
+        public void TreeNodeAccessibleObject_IsPatternSupported_IfNodesAreEditable(int patternId, bool expected)
         {
             using TreeView control = new() { LabelEdit = true };
             TreeNode node = new(control);
 
-            Assert.True(node.AccessibilityObject.IsPatternSupported((UiaCore.UIA)patternId));
+            Assert.Equal(node.AccessibilityObject.IsPatternSupported((UiaCore.UIA)patternId), expected);
             Assert.False(control.IsHandleCreated);
         }
 
@@ -474,6 +474,18 @@ namespace System.Windows.Forms.Tests
             TreeNode node = new(control) { Text = testText };
 
             Assert.Equal(testText, node.AccessibilityObject.Value);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_HasChildren_ExpandCollapsePatternAvailable()
+        {
+            using TreeView control = new();
+            TreeNode node = new(control);
+            node.Nodes.Add("ChildNode");
+
+            Assert.True(node.AccessibilityObject.IsPatternSupported(UiaCore.UIA.ExpandCollapsePatternId));
+            Assert.True(node.childCount > 0);
             Assert.False(control.IsHandleCreated);
         }
     }


### PR DESCRIPTION
Fixes #7043


## Proposed changes

TreeView TreeNode accessible object supports Expand-Collapse pattern even if the node can't expand.
Changed TreeNode.TreeNodeAccessibleObject.cs at line 123:
UiaCore.UIA.ExpandCollapsePatternId => _owningTreeNode.childCount > 0

**Added unit tests:**
TreeNodeAccessibleObject_HasChildren_ExpandCollapsePatternAvailable

changed test TreeNodeAccessibleObject_IsPatternSupported_IfNodesAreEditable

## Customer Impact

User has no wrong options to expand or collapse a node which can't expand.

## Regression? 

No

## Risk

Minimal


## Screenshots

### Before
TreeView TreeNode accessible object supports Expand-Collapse pattern even if the node can't expand.
![image](https://user-images.githubusercontent.com/102961955/166303373-d01382bd-66e0-48a1-9891-2373f02cedd4.png)

### After
TreeView TreeNode accessible object doesn't support Expand-Collapse pattern if the node can't expand.
![image](https://user-images.githubusercontent.com/102961955/166304012-293bba19-1df2-46de-b936-5e15694f5091.png)


## Test methodology

Manual testing
Unit tests
CTI

## Accessibility testing

Inspect


 

## Test environment(s)

Microsoft Windows [Version 120.2212.4170.0]
.NET Core SDK: 7.0.100-preview.3.22179.4


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7125)