### PR TITLE
Fix disabling a focused TextBox draws TextBox wrong

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -3,3 +3,4 @@ System.Windows.Forms.LinkArea.Equals(System.Windows.Forms.LinkArea other) -> boo
 System.Windows.Forms.TableLayoutPanelCellPosition.Equals(System.Windows.Forms.TableLayoutPanelCellPosition other) -> bool
 override System.Windows.Forms.Form.OnGotFocus(System.EventArgs! e) -> void
 ~override System.Windows.Forms.ToolStripDropDownMenu.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
+override System.Windows.Forms.TextBox.OnEnabledChanged(System.EventArgs! e) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -648,10 +648,7 @@ namespace System.Windows.Forms
             // There is a bug in the underlying Win32 control which prevents it from correctly redrawing its borders when switching between enabled and disabled state.
             // The border color is never updated when switching state, so the control will always paint using the color set when the handle was created (either enabled or disabled).
             // The only way to force the control to update its border color is to force a handle creation.
-            if (IsHandleCreated && Application.RenderWithVisualStyles)
-            {
-                RecreateHandle();
-            }
+            RecreateHandle();
         }
 
         protected override void OnKeyUp(KeyEventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBox.cs
@@ -641,6 +641,19 @@ namespace System.Windows.Forms
             base.OnHandleDestroyed(e);
         }
 
+        protected override void OnEnabledChanged(EventArgs e)
+        {
+            base.OnEnabledChanged(e);
+
+            // There is a bug in the underlying Win32 control which prevents it from correctly redrawing its borders when switching between enabled and disabled state.
+            // The border color is never updated when switching state, so the control will always paint using the color set when the handle was created (either enabled or disabled).
+            // The only way to force the control to update its border color is to force a handle creation.
+            if (IsHandleCreated && Application.RenderWithVisualStyles)
+            {
+                RecreateHandle();
+            }
+        }
+
         protected override void OnKeyUp(KeyEventArgs e)
         {
             base.OnKeyUp(e);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4856


## Proposed changes

- override OnEnabledChanged() and force RecreateHandle

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- RecreateHandle might be unexpected

## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7146)