### PR TITLE
Optimizing virtual mode checking when user uses keyboard to change checkbox state

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6699,7 +6699,7 @@ namespace System.Windows.Forms
                         }
                     }
 
-                    if (CheckBoxes)
+                    if (CheckBoxes && !VirtualMode)
                     {
                         NMLVKEYDOWN* lvkd = (NMLVKEYDOWN*)m.LParamInternal;
                         if (lvkd->wVKey == (short)Keys.Space)
@@ -6708,14 +6708,11 @@ namespace System.Windows.Forms
                             if (focusedItem is not null)
                             {
                                 bool check = !focusedItem.Checked;
-                                if (!VirtualMode)
+                                foreach (ListViewItem item in SelectedItems)
                                 {
-                                    foreach (ListViewItem item in SelectedItems)
+                                    if (item != focusedItem)
                                     {
-                                        if (item != focusedItem)
-                                        {
-                                            item.Checked = check;
-                                        }
+                                        item.Checked = check;
                                     }
                                 }
                             }


### PR DESCRIPTION
Fixes #6096

## Proposed changes

Optimizing virtual mode checking when user uses keyboard to change checkbox state.
Changed ListView.cs at line 6702:
if (CheckBoxes) 
to 
if (CheckBoxes && !VirtualMode)
Existing unit test:
ListView_WmReflectNotify_LVN_KEYDOWN_SpaceKey_HasCheckBoxes_WithoutGroups_CheckedExpected

## Customer Impact
Optimized algorithm enhances performance and is easy to support. 

## Regression? 
No

## Risk
Minimal

## Test methodology
Unit tests

## Test environment(s)
Microsoft Windows [Version 120.2212.4170.0]
.NET Core SDK: 7.0.100-preview.3.22179.4


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7158)