### PR TITLE
Enable nullability in SaveFileDialog

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1613,7 +1613,7 @@ System.Windows.Forms.OpenFileDialog.SafeFileNames.get -> string![]!
 ~System.Windows.Forms.RichTextBox.SelectionTabs.get -> int[]
 ~System.Windows.Forms.RichTextBox.SelectionTabs.set -> void
 ~System.Windows.Forms.RichTextBox.UndoActionName.get -> string
-~System.Windows.Forms.SaveFileDialog.OpenFile() -> System.IO.Stream
+System.Windows.Forms.SaveFileDialog.OpenFile() -> System.IO.Stream!
 ~System.Windows.Forms.TabControl.ControlCollection.ControlCollection(System.Windows.Forms.TabControl owner) -> void
 ~System.Windows.Forms.TabControl.DeselectTab(string tabPageName) -> void
 ~System.Windows.Forms.TabControl.DeselectTab(System.Windows.Forms.TabPage tabPage) -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -684,7 +684,7 @@ namespace System.Windows.Forms
                             Debug.Assert(currentExtension.Length == 0 || currentExtension.StartsWith("."),
                                          "File.GetExtension should return something that starts with '.'");
 
-                            string s = fileName!.Substring(0, fileName.Length - currentExtension.Length);
+                            string s = fileName.Substring(0, fileName.Length - currentExtension.Length);
 
                             // we don't want to append the extension if it contains wild cards
                             if (extensions[j].IndexOfAny(new char[] { '*', '?' }) == -1)
@@ -736,7 +736,7 @@ namespace System.Windows.Forms
         ///  Prompts the user with a <see cref="MessageBox"/> when a
         ///  file does not exist.
         /// </summary>
-        private void PromptFileNotFound(string? fileName)
+        private void PromptFileNotFound(string fileName)
         {
             MessageBoxWithFocusRestore(string.Format(SR.FileDialogFileNotFound, fileName), DialogCaption,
                     MessageBoxButtons.OK, MessageBoxIcon.Warning);
@@ -746,7 +746,7 @@ namespace System.Windows.Forms
         /// If it's necessary to throw up a "This file exists, are you sure?" kind of MessageBox,
         /// here's where we do it. Return value is whether or not the user hit "okay".
         /// </summary>
-        private protected virtual bool PromptUserIfAppropriate(string? fileName)
+        private protected virtual bool PromptUserIfAppropriate(string fileName)
         {
             if ((_options & (int)Comdlg32.OFN.FILEMUSTEXIST) != 0)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SaveFileDialog.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using static Interop;
@@ -164,10 +162,14 @@ namespace System.Windows.Forms
             return result;
         }
 
-        private protected override string[] ProcessVistaFiles(Interop.WinFormsComWrappers.FileDialogWrapper dialog)
+        private protected override string[] ProcessVistaFiles(WinFormsComWrappers.FileDialogWrapper dialog)
         {
-            var saveDialog = (Interop.WinFormsComWrappers.FileSaveDialogWrapper)dialog;
-            dialog.GetResult(out IShellItem item);
+            dialog.GetResult(out IShellItem? item);
+            if (item is null)
+            {
+                return Array.Empty<string>();
+            }
+
             return new string[] { GetFilePathFromShellItem(item) };
         }
 
@@ -186,7 +188,7 @@ namespace System.Windows.Forms
 
             var obj = WinFormsComWrappers.Instance
                 .GetOrCreateObjectForComInstance(lpDialogUnknownPtr, CreateObjectFlags.None);
-            return (Interop.WinFormsComWrappers.FileDialogWrapper)obj;
+            return (WinFormsComWrappers.FileDialogWrapper)obj;
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in SaveFileDialog.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7167)