### PR TITLE
Reverse resetting the Anchorinfo when size chnages.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -3427,17 +3427,7 @@ namespace System.Windows.Forms
         public Size Size
         {
             get => new Size(_width, _height);
-            set
-            {
-                if (CommonProperties.GetNeedsAnchorLayout(this))
-                {
-                    // Reset AnchorInfo that may have been calculated based on default Size of the control or
-                    // with the previous size of the control.  Especially in the designer scenario.                  .
-                    DefaultLayout.SetAnchorInfo(element: this, value: null);
-                }
-
-                SetBounds(_x, _y, value.Width, value.Height, BoundsSpecified.Size);
-            }
+            set => SetBounds(_x, _y, value.Width, value.Height, BoundsSpecified.Size);
         }
 
         [SRCategory(nameof(SR.CatPropertyChanged))]


### PR DESCRIPTION
This is a regression caused by #6778 that was helping optimize anchor info calculation.
However, in certain scenarios, we access `AnchorInfo` by assuming it was initialized at the time of handle creation and resetting it to null with `size change` is causing null reference exception in those scenarios.  Given regression was introduced in the current preview, taking this revert while we are investigating on how to get anchor layout working for higher DPI machines.

Fixes #7159 and #7090


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7170)