### PR TITLE
Use LibraryImport in some Interop User32

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.100-preview.3.22154.3",
+    "dotnet": "7.0.100-preview.5.22228.6",
     "runtimes": {
       "dotnet/x64": [
         "$(VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion)"
@@ -11,7 +11,7 @@
     }
   },
   "sdk": {
-    "version": "7.0.100-preview.3.22154.3"
+    "version": "7.0.100-preview.5.22228.6"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22301.2",

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ActivateKeyboardLayout.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ActivateKeyboardLayout.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr ActivateKeyboardLayout(IntPtr hkl, uint Flags);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr ActivateKeyboardLayout(IntPtr hkl, uint Flags);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.AreDpiAwarenessContextsEqual.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.AreDpiAwarenessContextsEqual.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, EntryPoint = "AreDpiAwarenessContextsEqual", SetLastError = true)]
-        private static extern BOOL AreDpiAwarenessContextsEqualInternal(IntPtr dpiContextA, IntPtr dpiContextB);
+        [LibraryImport(Libraries.User32, EntryPoint = "AreDpiAwarenessContextsEqual", SetLastError = true)]
+        private static partial BOOL AreDpiAwarenessContextsEqualInternal(IntPtr dpiContextA, IntPtr dpiContextB);
 
         /// <summary>
         ///  Tries to compare two DPIawareness context values. Return true if they were equal.

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.BlockInput.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.BlockInput.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL BlockInput(BOOL fBlockIt);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL BlockInput(BOOL fBlockIt);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CallNextHookEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CallNextHookEx.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern nint CallNextHookEx(IntPtr hhook, User32.HC nCode, nint wparam, nint lparam);
+        [LibraryImport(Libraries.User32)]
+        public static partial nint CallNextHookEx(IntPtr hhook, User32.HC nCode, nint wparam, nint lparam);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CallWindowProcW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CallWindowProcW.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr CallWindowProcW(
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr CallWindowProcW(
             IntPtr wndProc,
             IntPtr hWnd,
             WM msg,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ClipCursor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ClipCursor.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static unsafe extern BOOL ClipCursor(RECT* rcClip);
+        [LibraryImport(Libraries.User32)]
+        public static unsafe partial BOOL ClipCursor(RECT* rcClip);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CloseDesktop.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CloseDesktop.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern BOOL CloseDesktop(IntPtr hDesktop);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial BOOL CloseDesktop(IntPtr hDesktop);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CopyImage.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CopyImage.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr CopyImage(IntPtr hImage, IMAGE type, int cx, int cy, LR flags);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr CopyImage(IntPtr hImage, IMAGE type, int cx, int cy, LR flags);
 
         public static IntPtr CopyImage(IHandle hImage, IMAGE type, int cx, int cy, LR flags)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CreateAcceleratorTableW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CreateAcceleratorTableW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public unsafe static extern IntPtr CreateAcceleratorTableW(ACCEL* paccel, int cAccel);
+        [LibraryImport(Libraries.User32)]
+        public unsafe static partial IntPtr CreateAcceleratorTableW(ACCEL* paccel, int cAccel);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CreateMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CreateMenu.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr CreateMenu();
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr CreateMenu();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CreatePopupMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CreatePopupMenu.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr CreatePopupMenu();
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr CreatePopupMenu();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DefFrameProcW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DefFrameProcW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr DefFrameProcW(IntPtr hWnd, IntPtr hWndClient, WM msg, IntPtr wParam, IntPtr lParam);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr DefFrameProcW(IntPtr hWnd, IntPtr hWndClient, WM msg, IntPtr wParam, IntPtr lParam);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DefMDIChildProcW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DefMDIChildProcW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr DefMDIChildProcW(IntPtr hWnd, WM msg, IntPtr wParam, IntPtr lParam);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr DefMDIChildProcW(IntPtr hWnd, WM msg, IntPtr wParam, IntPtr lParam);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DefWindowProcW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DefWindowProcW.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr DefWindowProcW(
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr DefWindowProcW(
             IntPtr hWnd,
             WM msg,
             IntPtr wParam,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyAcceleratorTable.cs.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyAcceleratorTable.cs.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL DestroyAcceleratorTable(IntPtr hAccel);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL DestroyAcceleratorTable(IntPtr hAccel);
 
         public static BOOL DestroyAcceleratorTable(HandleRef hAccel)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyCursor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyCursor.cs
@@ -8,8 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-
-        public static extern BOOL DestroyCursor(IntPtr hCurs);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL DestroyCursor(IntPtr hCurs);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyIcon.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyIcon.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public extern static BOOL DestroyIcon(IntPtr handle);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial BOOL DestroyIcon(IntPtr handle);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyMenu.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL DestroyMenu(IntPtr hMenu);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL DestroyMenu(IntPtr hMenu);
 
         public static BOOL DestroyMenu(HandleRef hMenu)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DestroyWindow.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL DestroyWindow(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL DestroyWindow(IntPtr hWnd);
 
         public static BOOL DestroyWindow(IHandle hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DrawIcon.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DrawIcon.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL DrawIcon(IntPtr hDC, int x, int y, IntPtr hIcon);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL DrawIcon(IntPtr hDC, int x, int y, IntPtr hIcon);
 
         public static BOOL DrawIcon(IntPtr hDC, int x, int y, IHandle hIcon)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DrawIconEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DrawIconEx.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL DrawIconEx(
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL DrawIconEx(
             Gdi32.HDC hDC,
             int xLeft,
             int yTop,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DrawMenuBar.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.DrawMenuBar.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        private static extern BOOL DrawMenuBar(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        private static partial BOOL DrawMenuBar(IntPtr hWnd);
 
         public static BOOL DrawMenuBar(IHandle hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnableMenuItem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnableMenuItem.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL EnableMenuItem(IntPtr hMenu, SC uIDEnableItem, MF uEnable);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL EnableMenuItem(IntPtr hMenu, SC uIDEnableItem, MF uEnable);
 
         public static BOOL EnableMenuItem(HandleRef hMenu, SC uIDEnableItem, MF uEnable)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnableScrollBar.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnableScrollBar.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern BOOL EnableScrollBar(IntPtr hWnd, SB wSBflags, ESB wArrows);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial BOOL EnableScrollBar(IntPtr hWnd, SB wSBflags, ESB wArrows);
 
         public static BOOL EnableScrollBar(IHandle hWnd, SB wSBflags, ESB wArrows)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnableWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EnableWindow.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL EnableWindow(IntPtr hWnd, BOOL bEnable);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL EnableWindow(IntPtr hWnd, BOOL bEnable);
 
         public static BOOL EnableWindow(HandleRef hWnd, BOOL bEnable)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EndDialog.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EndDialog.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL EndDialog(IntPtr hDlg, IntPtr nResult);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL EndDialog(IntPtr hDlg, IntPtr nResult);
 
         public static BOOL EndDialog(HandleRef hDlg, IntPtr nResult)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EndPaint.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.EndPaint.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public unsafe static extern BOOL EndPaint(IntPtr hWnd, PAINTSTRUCT* lpPaint);
+        [LibraryImport(Libraries.User32)]
+        public unsafe static partial BOOL EndPaint(IntPtr hWnd, PAINTSTRUCT* lpPaint);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetActiveWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetActiveWindow.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetActiveWindow();
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetActiveWindow();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetAncestor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetAncestor.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetAncestor(IntPtr hwnd, GA flags);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetAncestor(IntPtr hwnd, GA flags);
 
         public static IntPtr GetAncestor(IHandle hwnd, GA flags)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetAsyncKeyState.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetAsyncKeyState.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern short GetAsyncKeyState(int vkey);
+        [LibraryImport(Libraries.User32)]
+        public static partial short GetAsyncKeyState(int vkey);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetCapture.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetCapture.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetCapture();
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetCapture();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetCaretBlinkTime.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetCaretBlinkTime.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern uint GetCaretBlinkTime();
+        [LibraryImport(Libraries.User32)]
+        public static partial uint GetCaretBlinkTime();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetClipboardFormatNameW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetClipboardFormatNameW.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        private static unsafe extern int GetClipboardFormatNameW(uint format, char* lpszFormatName, int cchMaxCount);
+        [LibraryImport(Libraries.User32)]
+        private static unsafe partial int GetClipboardFormatNameW(uint format, char* lpszFormatName, int cchMaxCount);
 
         public static unsafe string? GetClipboardFormatNameW(uint format)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetCursor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetCursor.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetCursor();
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetCursor();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDesktopWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDesktopWindow.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetDesktopWindow();
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetDesktopWindow();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDlgItem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDlgItem.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetDlgItem(IntPtr hWnd, DialogItemID nIDDlgItem);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetDlgItem(IntPtr hWnd, DialogItemID nIDDlgItem);
 
         public static IntPtr GetDlgItem(IHandle hWnd, DialogItemID nIDDlgItem)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDoubleClickTime.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDoubleClickTime.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern uint GetDoubleClickTime();
+        [LibraryImport(Libraries.User32)]
+        public static partial uint GetDoubleClickTime();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDpiForSystem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDpiForSystem.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
     internal static partial class User32
     {
         // This is only available on Windows 1607 and later. Avoids needing a DC to get the DPI.
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern uint GetDpiForSystem();
+        [LibraryImport(Libraries.User32)]
+        public static partial uint GetDpiForSystem();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDpiForWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetDpiForWindow.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern uint GetDpiForWindow(IntPtr hwnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial uint GetDpiForWindow(IntPtr hwnd);
 
         public static uint GetDpiForWindow(IHandle hwnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetFocus.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetFocus.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetFocus();
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetFocus();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetForegroundWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetForegroundWindow.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetForegroundWindow();
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetForegroundWindow();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetGuiResources.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetGuiResources.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern uint GetGuiResources(IntPtr hProcess, GR uiFlags);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial uint GetGuiResources(IntPtr hProcess, GR uiFlags);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetKeyState.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetKeyState.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern short GetKeyState(int keyCode);
+        [LibraryImport(Libraries.User32)]
+        public static partial short GetKeyState(int keyCode);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetKeyboardLayout.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetKeyboardLayout.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetKeyboardLayout(uint idThread);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetKeyboardLayout(uint idThread);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetKeyboardLayoutList.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetKeyboardLayoutList.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public unsafe static extern int GetKeyboardLayoutList(int nBuff, IntPtr* lpList);
+        [LibraryImport(Libraries.User32)]
+        public unsafe static partial int GetKeyboardLayoutList(int nBuff, IntPtr* lpList);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetKeyboardState.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetKeyboardState.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public unsafe static extern BOOL GetKeyboardState(byte* lpKeyState);
+        [LibraryImport(Libraries.User32)]
+        public unsafe static partial BOOL GetKeyboardState(byte* lpKeyState);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetMenu.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetMenu(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetMenu(IntPtr hWnd);
 
         public static IntPtr GetMenu(IHandle hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetMenuItemCount.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetMenuItemCount.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern int GetMenuItemCount(IntPtr hMenu);
+        [LibraryImport(Libraries.User32)]
+        public static partial int GetMenuItemCount(IntPtr hMenu);
 
         public static int GetMenuItemCount(HandleRef hMenu)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetMenuItemID.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetMenuItemID.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern int GetMenuItemID(IntPtr hMenu, int nPos);
+        [LibraryImport(Libraries.User32)]
+        public static partial int GetMenuItemID(IntPtr hMenu, int nPos);
 
         public static int GetMenuItemID(HandleRef hMenu, int nPos)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetMessageTime.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetMessageTime.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern int GetMessageTime();
+        [LibraryImport(Libraries.User32)]
+        public static partial int GetMessageTime();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetParent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetParent.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetParent(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetParent(IntPtr hWnd);
 
         public static IntPtr GetParent(IHandle hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetProcessWindowStation.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetProcessWindowStation.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetProcessWindowStation();
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetProcessWindowStation();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetSubMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetSubMenu.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetSubMenu(IntPtr hMenu, int nPos);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetSubMenu(IntPtr hMenu, int nPos);
 
         public static IntPtr GetSubMenu(HandleRef hMenu, int nPos)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetSystemMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetSystemMenu.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetSystemMenu(IntPtr hWnd, BOOL bRevert);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetSystemMenu(IntPtr hWnd, BOOL bRevert);
 
         public static IntPtr GetSystemMenu(HandleRef hWnd, BOOL bRevert)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetSystemMetrics.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetSystemMetrics.cs
@@ -90,11 +90,11 @@ internal static partial class Interop
             SM_CYSIZEFRAME = SM_CYFRAME
         }
 
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern int GetSystemMetrics(SystemMetric nIndex);
+        [LibraryImport(Libraries.User32)]
+        public static partial int GetSystemMetrics(SystemMetric nIndex);
 
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        private static extern int GetSystemMetricsForDpi(SystemMetric nIndex, uint dpi);
+        [LibraryImport(Libraries.User32)]
+        private static partial int GetSystemMetricsForDpi(SystemMetric nIndex, uint dpi);
 
         /// <summary>
         ///  Tries to get system metrics for the dpi. dpi is ignored if "GetSystemMetricsForDpi" is not available on the OS that this application is running.

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindow.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr GetWindow(IntPtr hWnd, GW uCmd);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr GetWindow(IntPtr hWnd, GW uCmd);
 
         public static IntPtr GetWindow(IHandle hWnd, GW uCmd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowLong.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowLong.cs
@@ -9,11 +9,11 @@ internal static partial class Interop
     internal static partial class User32
     {
         // We only ever call this on 32 bit so IntPtr is correct
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        private static extern nint GetWindowLongW(IntPtr hWnd, GWL nIndex);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        private static partial nint GetWindowLongW(IntPtr hWnd, GWL nIndex);
 
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern nint GetWindowLongPtrW(IntPtr hWnd, GWL nIndex);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial nint GetWindowLongPtrW(IntPtr hWnd, GWL nIndex);
 
         public static nint GetWindowLong(IntPtr hWnd, GWL nIndex)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowText.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowText.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern int GetWindowTextLengthW(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial int GetWindowTextLengthW(IntPtr hWnd);
 
         public static int GetWindowTextLengthW(HandleRef hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowThreadProcessId.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.GetWindowThreadProcessId.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+        [LibraryImport(Libraries.User32)]
+        public static partial uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
 
         public static uint GetWindowThreadProcessId(IHandle hWnd, out uint lpdwProcessId)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.HideCaret.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.HideCaret.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL HideCaret(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL HideCaret(IntPtr hWnd);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.InvalidateRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.InvalidateRect.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public unsafe static extern BOOL InvalidateRect(IntPtr hWnd, RECT* lpRect, BOOL bErase);
+        [LibraryImport(Libraries.User32)]
+        public unsafe static partial BOOL InvalidateRect(IntPtr hWnd, RECT* lpRect, BOOL bErase);
 
         public unsafe static BOOL InvalidateRect(HandleRef hWnd, RECT* lpRect, BOOL bErase)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsChild.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsChild.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL IsChild(IntPtr hWndParent, IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL IsChild(IntPtr hWndParent, IntPtr hWnd);
 
         public static BOOL IsChild(IntPtr hWndParent, HandleRef hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsProcessDPIAware.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsProcessDPIAware.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL IsProcessDPIAware();
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL IsProcessDPIAware();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsValidDpiAwarenessContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsValidDpiAwarenessContext.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL IsValidDpiAwarenessContext(IntPtr value);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL IsValidDpiAwarenessContext(IntPtr value);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsWindow.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL IsWindow(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL IsWindow(IntPtr hWnd);
 
         public static BOOL IsWindow(HandleRef hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsWindowEnabled.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsWindowEnabled.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL IsWindowEnabled(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL IsWindowEnabled(IntPtr hWnd);
 
         public static BOOL IsWindowEnabled(IHandle hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsWindowUnicode.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsWindowUnicode.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL IsWindowUnicode(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL IsWindowUnicode(IntPtr hWnd);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsWindowVisible.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsWindowVisible.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL IsWindowVisible(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL IsWindowVisible(IntPtr hWnd);
 
         public static BOOL IsWindowVisible(IHandle hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsZoomed.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.IsZoomed.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL IsZoomed(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL IsZoomed(IntPtr hWnd);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.KillTimer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.KillTimer.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL KillTimer(IntPtr hWnd, IntPtr uIDEvent);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL KillTimer(IntPtr hWnd, IntPtr uIDEvent);
 
         public static BOOL KillTimer(HandleRef hWnd, IntPtr uIDEvent)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.LoadCursorW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.LoadCursorW.cs
@@ -31,7 +31,7 @@ internal static partial class Interop
             public const int IDC_HELP = 32651;
         }
 
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr LoadCursorW(IntPtr hInstance, IntPtr lpCursorName);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr LoadCursorW(IntPtr hInstance, IntPtr lpCursorName);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MapWindowPoints.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MapWindowPoints.cs
@@ -9,8 +9,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public unsafe static extern int MapWindowPoints(IntPtr hWndFrom, IntPtr hWndTo, Point* lpPoints, uint cPoints);
+        [LibraryImport(Libraries.User32)]
+        public unsafe static partial int MapWindowPoints(IntPtr hWndFrom, IntPtr hWndTo, Point* lpPoints, uint cPoints);
 
         public unsafe static int MapWindowPoint(IHandle hWndFrom, IHandle hWndTo, ref Point lpPoints)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MessageBeep.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MessageBeep.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, SetLastError = true, ExactSpelling = true)]
-        public static extern BOOL MessageBeep(MB type);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial BOOL MessageBeep(MB type);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MonitorFromWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MonitorFromWindow.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr MonitorFromWindow(IntPtr hwnd, MONITOR dwFlags);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr MonitorFromWindow(IntPtr hwnd, MONITOR dwFlags);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MsgWaitForMultipleObjectsEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.MsgWaitForMultipleObjectsEx.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern uint MsgWaitForMultipleObjectsEx(uint nCount, IntPtr pHandles, uint dwMilliseconds, QS dwWakeMask, MWMO dwFlags);
+        [LibraryImport(Libraries.User32)]
+        public static partial uint MsgWaitForMultipleObjectsEx(uint nCount, IntPtr pHandles, uint dwMilliseconds, QS dwWakeMask, MWMO dwFlags);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.OemKeyScan.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.OemKeyScan.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern uint OemKeyScan(ushort wAsciiVal);
+        [LibraryImport(Libraries.User32)]
+        public static partial uint OemKeyScan(ushort wAsciiVal);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.OpenInputDesktop.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.OpenInputDesktop.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr OpenInputDesktop(DF dwFlags, BOOL fInherit, DESKTOP dwDesiredAccess);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial IntPtr OpenInputDesktop(DF dwFlags, BOOL fInherit, DESKTOP dwDesiredAccess);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.PostMessageW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.PostMessageW.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL PostMessageW(
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL PostMessageW(
             IntPtr hWnd,
             WM Msg,
             nint wParam = default,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.PostQuitMessage.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.PostQuitMessage.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern void PostQuitMessage(int nExitCode);
+        [LibraryImport(Libraries.User32)]
+        public static partial void PostQuitMessage(int nExitCode);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.PostThreadMessageW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.PostThreadMessageW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern int PostThreadMessageW(uint id, WM msg, IntPtr wparam, IntPtr lparam);
+        [LibraryImport(Libraries.User32)]
+        public static partial int PostThreadMessageW(uint id, WM msg, IntPtr wparam, IntPtr lparam);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ReleaseCapture.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ReleaseCapture.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL ReleaseCapture();
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL ReleaseCapture();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.RemoveMenuItem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.RemoveMenuItem.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL RemoveMenu(IntPtr hMenu, uint uPosition, MF uFlags);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL RemoveMenu(IntPtr hMenu, uint uPosition, MF uFlags);
 
         public static BOOL RemoveMenu(HandleRef hMenu, uint uPosition, MF uFlags)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ScrollWindowEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ScrollWindowEx.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public unsafe static extern int ScrollWindowEx(
+        [LibraryImport(Libraries.User32)]
+        public unsafe static partial int ScrollWindowEx(
             IntPtr hWnd,
             int dx,
             int dy,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendDlgItemMessageW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendDlgItemMessageW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr SendDlgItemMessageW(IntPtr hDlg, DialogItemID nIDDlgItem, WM Msg, IntPtr wParam = default, IntPtr lParam = default);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr SendDlgItemMessageW(IntPtr hDlg, DialogItemID nIDDlgItem, WM Msg, IntPtr wParam = default, IntPtr lParam = default);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendInput.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendInput.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public unsafe static extern uint SendInput(uint cInputs, INPUT* pInputs, int cbSize);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public unsafe static partial uint SendInput(uint cInputs, INPUT* pInputs, int cbSize);
 
         public unsafe static uint SendInput(uint cInputs, Span<INPUT> pInputs, int cbSize)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendMessageTimeoutW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendMessageTimeoutW.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr SendMessageTimeoutW(
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr SendMessageTimeoutW(
             IntPtr hWnd,
             WM Msg,
             IntPtr wParam,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendMessageW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SendMessageW.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern nint SendMessageW(
+        [LibraryImport(Libraries.User32)]
+        public static partial nint SendMessageW(
             IntPtr hWnd,
             WM Msg,
             nint wParam = default,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetActiveWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetActiveWindow.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr SetActiveWindow(IntPtr hWnd);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial IntPtr SetActiveWindow(IntPtr hWnd);
 
         public static IntPtr SetActiveWindow(HandleRef hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetCapture.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetCapture.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr SetCapture(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr SetCapture(IntPtr hWnd);
 
         public static IntPtr SetCapture(IHandle handle)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetClassLong.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetClassLong.cs
@@ -9,11 +9,11 @@ internal static partial class Interop
     internal static partial class User32
     {
         // We only ever call this on 32 bit so IntPtr is correct
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        private static extern IntPtr SetClassLongW(IntPtr hwnd, GCL nIndex, IntPtr dwNewLong);
+        [LibraryImport(Libraries.User32)]
+        private static partial IntPtr SetClassLongW(IntPtr hwnd, GCL nIndex, IntPtr dwNewLong);
 
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        private static extern IntPtr SetClassLongPtrW(IntPtr hwnd, GCL nIndex, IntPtr dwNewLong);
+        [LibraryImport(Libraries.User32)]
+        private static partial IntPtr SetClassLongPtrW(IntPtr hwnd, GCL nIndex, IntPtr dwNewLong);
 
         public static IntPtr SetClassLong(IntPtr hWnd, GCL nIndex, IntPtr dwNewLong)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetCursor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetCursor.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        private static extern IntPtr SetCursor(IntPtr hCursor);
+        [LibraryImport(Libraries.User32)]
+        private static partial IntPtr SetCursor(IntPtr hCursor);
 
         public static IntPtr SetCursor(IHandle? hCursor)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetCursorPos.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetCursorPos.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL SetCursorPos(int x, int y);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL SetCursorPos(int x, int y);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetFocus.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetFocus.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr SetFocus(IntPtr hWnd);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial IntPtr SetFocus(IntPtr hWnd);
 
         public static IntPtr SetFocus(HandleRef hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetForegroundWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetForegroundWindow.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL SetForegroundWindow(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL SetForegroundWindow(IntPtr hWnd);
 
         public static BOOL SetForegroundWindow(IHandle hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetKeyboardState.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetKeyboardState.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public unsafe static extern BOOL SetKeyboardState(byte* lpKeyState);
+        [LibraryImport(Libraries.User32)]
+        public unsafe static partial BOOL SetKeyboardState(byte* lpKeyState);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetLayeredWindowAttributes.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetLayeredWindowAttributes.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern BOOL SetLayeredWindowAttributes(IntPtr hwnd, int crKey, byte bAlpha, LWA dwFlags);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial BOOL SetLayeredWindowAttributes(IntPtr hwnd, int crKey, byte bAlpha, LWA dwFlags);
 
         public static BOOL SetLayeredWindowAttributes(IHandle hwnd, int crKey, byte bAlpha, LWA dwFlags)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetMenu.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public extern static BOOL SetMenu(IntPtr hWnd, IntPtr hMenu);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL SetMenu(IntPtr hWnd, IntPtr hMenu);
 
         public static BOOL SetMenu(IHandle hWnd, IntPtr hMenu)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetMenuDefaultItem.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetMenuDefaultItem.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL SetMenuDefaultItem(IntPtr hwnd, int uItem, BOOL fByPos);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL SetMenuDefaultItem(IntPtr hwnd, int uItem, BOOL fByPos);
 
         public static BOOL SetMenuDefaultItem(HandleRef hwnd, int uItem, BOOL fByPos)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetParent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetParent.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr SetParent(IntPtr hWndChild, IntPtr hWndChildNewParent);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial IntPtr SetParent(IntPtr hWndChild, IntPtr hWndChildNewParent);
 
         public static IntPtr SetParent(IntPtr hWndChild, HandleRef hWndChildNewParent)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetProcessDPIAware.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetProcessDPIAware.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL SetProcessDPIAware();
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL SetProcessDPIAware();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetProcessDpiAwarenessContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetProcessDpiAwarenessContext.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL SetProcessDpiAwarenessContext(IntPtr value);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL SetProcessDpiAwarenessContext(IntPtr value);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetScrollPos.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetScrollPos.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern int SetScrollPos(IntPtr hWnd, SB nBar, int nPos, BOOL bRedraw);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial int SetScrollPos(IntPtr hWnd, SB nBar, int nPos, BOOL bRedraw);
 
         public static int SetScrollPos(IHandle hWnd, SB nBar, int nPos, BOOL bRedraw)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetTimer.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetTimer.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern IntPtr SetTimer(IntPtr hWnd, IntPtr nIDEvent, uint uElapse, IntPtr lpTimerFunc);
+        [LibraryImport(Libraries.User32)]
+        public static partial IntPtr SetTimer(IntPtr hWnd, IntPtr nIDEvent, uint uElapse, IntPtr lpTimerFunc);
 
         public static IntPtr SetTimer(IHandle hWnd, IntPtr nIDEvent, uint uElapse, IntPtr lpTimerFunc)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowLong.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowLong.cs
@@ -9,11 +9,11 @@ internal static partial class Interop
     internal static partial class User32
     {
         // We only ever call this on 32 bit so IntPtr is correct
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        private static extern IntPtr SetWindowLongW(IntPtr hWnd, GWL nIndex, nint dwNewLong);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        private static partial IntPtr SetWindowLongW(IntPtr hWnd, GWL nIndex, nint dwNewLong);
 
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr SetWindowLongPtrW(IntPtr hWnd, GWL nIndex, nint dwNewLong);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial IntPtr SetWindowLongPtrW(IntPtr hWnd, GWL nIndex, nint dwNewLong);
 
         public static IntPtr SetWindowLong(IntPtr hWnd, GWL nIndex, nint dwNewLong)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowPos.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowPos.cs
@@ -14,8 +14,8 @@ internal static partial class Interop
         public static IntPtr HWND_NOTOPMOST = (IntPtr)(-2);
         public static IntPtr HWND_MESSAGE = (IntPtr)(-3);
 
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL SetWindowPos(
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL SetWindowPos(
             IntPtr hWnd,
             IntPtr hWndInsertAfter,
             int x = 0,

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowRgn.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowRgn.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        private static extern int SetWindowRgn(IntPtr hwnd, IntPtr hrgn, BOOL fRedraw);
+        [LibraryImport(Libraries.User32)]
+        private static partial int SetWindowRgn(IntPtr hwnd, IntPtr hrgn, BOOL fRedraw);
 
         public static int SetWindowRgn(IHandle hwnd, Gdi32.HRGN hrgn, BOOL fRedraw)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowsHookExW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.SetWindowsHookExW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr SetWindowsHookExW(WH idHook, HOOKPROC lpfn, IntPtr hmod, uint dwThreadId);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial IntPtr SetWindowsHookExW(WH idHook, HOOKPROC lpfn, IntPtr hmod, uint dwThreadId);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ShowCaret.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ShowCaret.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL ShowCaret(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL ShowCaret(IntPtr hWnd);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ShowCursor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ShowCursor.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public extern static int ShowCursor(BOOL bShow);
+        [LibraryImport(Libraries.User32)]
+        public static partial int ShowCursor(BOOL bShow);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ShowWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ShowWindow.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL ShowWindow(IntPtr hWnd, SW nCmdShow);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL ShowWindow(IntPtr hWnd, SW nCmdShow);
 
         public static BOOL ShowWindow(IHandle hWnd, SW nCmdShow)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.UnhookWindowsHookEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.UnhookWindowsHookEx.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true, SetLastError = true)]
-        public static extern BOOL UnhookWindowsHookEx(IntPtr hhk);
+        [LibraryImport(Libraries.User32, SetLastError = true)]
+        public static partial BOOL UnhookWindowsHookEx(IntPtr hhk);
 
         public static BOOL UnhookWindowsHookEx(HandleRef hhk)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.UpdateWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.UpdateWindow.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL UpdateWindow(IntPtr hWnd);
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL UpdateWindow(IntPtr hWnd);
 
         public static BOOL UpdateWindow(IHandle hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ValidateRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.ValidateRect.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public unsafe static extern BOOL ValidateRect(IntPtr hWnd, RECT* lpRect);
+        [LibraryImport(Libraries.User32)]
+        public unsafe static partial BOOL ValidateRect(IntPtr hWnd, RECT* lpRect);
 
         public unsafe static BOOL ValidateRect(IHandle hWnd, RECT* lpRect)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WaitMessage.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.WaitMessage.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, ExactSpelling = true)]
-        public static extern BOOL WaitMessage();
+        [LibraryImport(Libraries.User32)]
+        public static partial BOOL WaitMessage();
     }
 }


### PR DESCRIPTION
Now that https://github.com/dotnet/runtime/issues/60595 is closed, perhaps we could start using LibraryImport instead of DllImport.

## Proposed changes

- Use LibraryImport in some Interop User32.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7172)