### PR TITLE
Enable nullability in ToolStripHighContrastRenderer

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -14,29 +14,29 @@ namespace System.Windows.Forms
     {
         private const int GRIP_PADDING = 4;
 
-        BitVector32 options;
-        private static readonly int optionsDottedBorder = BitVector32.CreateMask();
-        private static readonly int optionsDottedGrip = BitVector32.CreateMask(optionsDottedBorder);
-        private static readonly int optionsFillWhenSelected = BitVector32.CreateMask(optionsDottedGrip);
+        private BitVector32 _options;
+        private static readonly int s_optionsDottedBorder = BitVector32.CreateMask();
+        private static readonly int s_optionsDottedGrip = BitVector32.CreateMask(s_optionsDottedBorder);
+        private static readonly int s_optionsFillWhenSelected = BitVector32.CreateMask(s_optionsDottedGrip);
 
         public ToolStripHighContrastRenderer(bool systemRenderMode)
         {
-            options[optionsDottedBorder | optionsDottedGrip | optionsFillWhenSelected] = !systemRenderMode;
+            _options[s_optionsDottedBorder | s_optionsDottedGrip | s_optionsFillWhenSelected] = !systemRenderMode;
         }
 
         public bool DottedBorder
         {
-            get { return options[optionsDottedBorder]; }
+            get { return _options[s_optionsDottedBorder]; }
         }
 
         public bool DottedGrip
         {
-            get { return options[optionsDottedGrip]; }
+            get { return _options[s_optionsDottedGrip]; }
         }
 
         public bool FillWhenSelected
         {
-            get { return options[optionsFillWhenSelected]; }
+            get { return _options[s_optionsFillWhenSelected]; }
         }
 
         // this is a renderer override, so return null so we don't get into an infinite loop.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -2,16 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-#region Using directives
-
 using System.Collections.Specialized;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
-
-#endregion
 
 namespace System.Windows.Forms
 {
@@ -46,7 +40,7 @@ namespace System.Windows.Forms
         }
 
         // this is a renderer override, so return null so we don't get into an infinite loop.
-        internal override ToolStripRenderer RendererOverride
+        internal override ToolStripRenderer? RendererOverride
         {
             get { return null; }
         }
@@ -381,7 +375,7 @@ namespace System.Windows.Forms
 
         protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
         {
-            Image image = e.Image;
+            Image? image = e.Image;
             if (image is not null)
             {
                 if (Image.GetPixelFormatSize(image.PixelFormat) > 16)


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripHighContrastRenderer.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7179)