### PR TITLE
Prevent exceptions to pops up from CCW

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IDropSourceVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IDropSourceVtbl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -26,15 +27,31 @@ internal partial class Interop
             [UnmanagedCallersOnly]
             private static HRESULT QueryContinueDrag(IntPtr thisPtr, BOOL fEscapePressed, User32.MK grfKeyState)
             {
-                var inst = ComInterfaceDispatch.GetInstance<Ole32.IDropSource>((ComInterfaceDispatch*)thisPtr);
-                return inst.QueryContinueDrag(fEscapePressed, grfKeyState);
+                try
+                {
+                    var instance = ComInterfaceDispatch.GetInstance<Ole32.IDropSource>((ComInterfaceDispatch*)thisPtr);
+                    return instance.QueryContinueDrag(fEscapePressed, grfKeyState);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                    return (HRESULT)ex.HResult;
+                }
             }
 
             [UnmanagedCallersOnly]
             private static HRESULT GiveFeedback(IntPtr thisPtr, Ole32.DROPEFFECT dwEffect)
             {
-                var inst = ComInterfaceDispatch.GetInstance<Ole32.IDropSource>((ComInterfaceDispatch*)thisPtr);
-                return inst.GiveFeedback(dwEffect);
+                try
+                {
+                    var instance = ComInterfaceDispatch.GetInstance<Ole32.IDropSource>((ComInterfaceDispatch*)thisPtr);
+                    return instance.GiveFeedback(dwEffect);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                    return (HRESULT)ex.HResult;
+                }
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IDropTargetVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IDropTargetVtbl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Drawing;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -29,31 +30,63 @@ internal partial class Interop
             [UnmanagedCallersOnly]
             private static int DragEnter(IntPtr thisPtr, IntPtr pDataObj, uint grfKeyState, Point pt, uint* pdwEffect)
             {
-                Ole32.IDropTarget inst = ComInterfaceDispatch.GetInstance<Ole32.IDropTarget>((ComInterfaceDispatch*)thisPtr);
-                var dataObject = WinFormsComWrappers.Instance.GetOrCreateObjectForComInstance(pDataObj, CreateObjectFlags.Unwrap);
-                return (int)inst.DragEnter(dataObject, grfKeyState, pt, ref *pdwEffect);
+                try
+                {
+                    Ole32.IDropTarget instance = ComInterfaceDispatch.GetInstance<Ole32.IDropTarget>((ComInterfaceDispatch*)thisPtr);
+                    var dataObject = WinFormsComWrappers.Instance.GetOrCreateObjectForComInstance(pDataObj, CreateObjectFlags.Unwrap);
+                    return (int)instance.DragEnter(dataObject, grfKeyState, pt, ref *pdwEffect);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                    return ex.HResult;
+                }
             }
 
             [UnmanagedCallersOnly]
             private static int DragOver(IntPtr thisPtr, uint grfKeyState, Point pt, uint* pdwEffect)
             {
-                Ole32.IDropTarget inst = ComInterfaceDispatch.GetInstance<Ole32.IDropTarget>((ComInterfaceDispatch*)thisPtr);
-                return (int)inst.DragOver(grfKeyState, pt, ref *pdwEffect);
+                try
+                {
+                    Ole32.IDropTarget instance = ComInterfaceDispatch.GetInstance<Ole32.IDropTarget>((ComInterfaceDispatch*)thisPtr);
+                    return (int)instance.DragOver(grfKeyState, pt, ref *pdwEffect);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                    return ex.HResult;
+                }
             }
 
             [UnmanagedCallersOnly]
             private static int DragLeave(IntPtr thisPtr)
             {
-                Ole32.IDropTarget inst = ComInterfaceDispatch.GetInstance<Ole32.IDropTarget>((ComInterfaceDispatch*)thisPtr);
-                return (int)inst.DragLeave();
+                try
+                {
+                    Ole32.IDropTarget instance = ComInterfaceDispatch.GetInstance<Ole32.IDropTarget>((ComInterfaceDispatch*)thisPtr);
+                    return (int)instance.DragLeave();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                    return ex.HResult;
+                }
             }
 
             [UnmanagedCallersOnly]
             private static int Drop(IntPtr thisPtr, IntPtr pDataObj, uint grfKeyState, Point pt, uint* pdwEffect)
             {
-                Ole32.IDropTarget inst = ComInterfaceDispatch.GetInstance<Ole32.IDropTarget>((ComInterfaceDispatch*)thisPtr);
-                var dataObject = WinFormsComWrappers.Instance.GetOrCreateObjectForComInstance(pDataObj, CreateObjectFlags.Unwrap);
-                return (int)inst.Drop(dataObject, grfKeyState, pt, ref *pdwEffect);
+                try
+                {
+                    Ole32.IDropTarget instance = ComInterfaceDispatch.GetInstance<Ole32.IDropTarget>((ComInterfaceDispatch*)thisPtr);
+                    var dataObject = WinFormsComWrappers.Instance.GetOrCreateObjectForComInstance(pDataObj, CreateObjectFlags.Unwrap);
+                    return (int)instance.Drop(dataObject, grfKeyState, pt, ref *pdwEffect);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                    return ex.HResult;
+                }
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumFORMATETCVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumFORMATETCVtbl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
@@ -52,6 +53,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -66,6 +68,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -81,6 +84,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -97,6 +101,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumStringVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumStringVtbl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
@@ -29,22 +30,38 @@ internal partial class Interop
             [UnmanagedCallersOnly]
             private static int Next(IntPtr thisPtr, int celt, IntPtr* rgelt, int* pceltFetched)
             {
-                IEnumString inst = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
-                string[] elt = new string[celt];
-                var result = inst.Next(celt, elt, (IntPtr)pceltFetched);
-                for (var i = 0; i < *pceltFetched; i++)
+                try
                 {
-                    rgelt[i] = Marshal.StringToCoTaskMemUni(elt[i]);
-                }
+                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
+                    string[] elt = new string[celt];
+                    var result = instance.Next(celt, elt, (IntPtr)pceltFetched);
+                    for (var i = 0; i < *pceltFetched; i++)
+                    {
+                        rgelt[i] = Marshal.StringToCoTaskMemUni(elt[i]);
+                    }
 
-                return result;
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                    return ex.HResult;
+                }
             }
 
             [UnmanagedCallersOnly]
             private static int Skip(IntPtr thisPtr, int celt)
             {
-                IEnumString inst = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
-                return inst.Skip(celt);
+                try
+                {
+                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
+                    return instance.Skip(celt);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                    return ex.HResult;
+                }
             }
 
             [UnmanagedCallersOnly]
@@ -52,15 +69,15 @@ internal partial class Interop
             {
                 try
                 {
-                    IEnumString inst = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
-                    inst.Reset();
+                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
+                    instance.Reset();
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
 
             [UnmanagedCallersOnly]
@@ -68,16 +85,15 @@ internal partial class Interop
             {
                 try
                 {
-                    IEnumString inst = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
-                    inst.Clone(out var cloned);
+                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
+                    instance.Clone(out var cloned);
                     *ppenum = WinFormsComWrappers.Instance.GetOrCreateComInterfaceForObject(cloned, CreateComInterfaceFlags.None);
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumStringVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumStringVtbl.cs
@@ -92,6 +92,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IFileDialogEventsVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IFileDialogEventsVtbl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -39,6 +40,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -55,6 +57,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -70,6 +73,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -85,6 +89,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -101,6 +106,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -116,6 +122,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -132,6 +139,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IFileDialogEventsVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IFileDialogEventsVtbl.cs
@@ -33,9 +33,9 @@ internal partial class Interop
             {
                 try
                 {
-                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
                     Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    return (int)inst.OnFileOk(fd);
+                    return (int)instance.OnFileOk(fd);
                 }
                 catch (Exception ex)
                 {
@@ -48,10 +48,10 @@ internal partial class Interop
             {
                 try
                 {
-                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
                     Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
                     Shell32.IShellItem siFolder = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance(psiFolder, CreateObjectFlags.Unwrap);
-                    return (int)inst.OnFolderChanging(fd, siFolder);
+                    return (int)instance.OnFolderChanging(fd, siFolder);
                 }
                 catch (Exception ex)
                 {
@@ -64,9 +64,9 @@ internal partial class Interop
             {
                 try
                 {
-                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
                     Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    return (int)inst.OnFolderChange(fd);
+                    return (int)instance.OnFolderChange(fd);
                 }
                 catch (Exception ex)
                 {
@@ -79,9 +79,9 @@ internal partial class Interop
             {
                 try
                 {
-                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
                     Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    return (int)inst.OnSelectionChange(fd);
+                    return (int)instance.OnSelectionChange(fd);
                 }
                 catch (Exception ex)
                 {
@@ -94,10 +94,10 @@ internal partial class Interop
             {
                 try
                 {
-                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
                     Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
                     Shell32.IShellItem si = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance(psi, CreateObjectFlags.Unwrap);
-                    return (int)inst.OnShareViolation(fd, si, pResponse);
+                    return (int)instance.OnShareViolation(fd, si, pResponse);
                 }
                 catch (Exception ex)
                 {
@@ -110,9 +110,9 @@ internal partial class Interop
             {
                 try
                 {
-                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
                     Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    return (int)inst.OnTypeChange(fd);
+                    return (int)instance.OnTypeChange(fd);
                 }
                 catch (Exception ex)
                 {
@@ -125,10 +125,10 @@ internal partial class Interop
             {
                 try
                 {
-                    Shell32.IFileDialogEvents inst = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
                     Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
                     Shell32.IShellItem si = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance(psi, CreateObjectFlags.Unwrap);
-                    return (int)inst.OnOverwrite(fd, si, pResponse);
+                    return (int)instance.OnOverwrite(fd, si, pResponse);
                 }
                 catch (Exception ex)
                 {

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IStreamVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IStreamVtbl.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -37,15 +37,14 @@ internal partial class Interop
             {
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    inst.Read(pv, cb, pcbRead);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    instance.Read(pv, cb, pcbRead);
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
 
             [UnmanagedCallersOnly]
@@ -53,15 +52,14 @@ internal partial class Interop
             {
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    inst.Write(pv, cb, pcbWritten);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    instance.Write(pv, cb, pcbWritten);
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
 
             [UnmanagedCallersOnly]
@@ -69,15 +67,14 @@ internal partial class Interop
             {
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    inst.Seek(dlibMove, dwOrigin, plibNewPosition);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    instance.Seek(dlibMove, dwOrigin, plibNewPosition);
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
 
             [UnmanagedCallersOnly]
@@ -85,15 +82,14 @@ internal partial class Interop
             {
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    inst.SetSize(libNewSize);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    instance.SetSize(libNewSize);
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
 
             [UnmanagedCallersOnly]
@@ -101,17 +97,16 @@ internal partial class Interop
             {
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
                     Interop.Ole32.IStream pstmStream = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)pstm);
 
-                    inst.CopyTo(pstmStream, cb, pcbRead, pcbWritten);
+                    instance.CopyTo(pstmStream, cb, pcbRead, pcbWritten);
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
 
             [UnmanagedCallersOnly]
@@ -119,15 +114,14 @@ internal partial class Interop
             {
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    inst.Commit((Interop.Ole32.STGC)grfCommitFlags);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    instance.Commit((Interop.Ole32.STGC)grfCommitFlags);
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
 
             [UnmanagedCallersOnly]
@@ -135,15 +129,14 @@ internal partial class Interop
             {
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    inst.Revert();
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    instance.Revert();
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
 
             [UnmanagedCallersOnly]
@@ -151,8 +144,8 @@ internal partial class Interop
             {
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    return (int)inst.LockRegion(libOffset, cb, dwLockType);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    return (int)instance.LockRegion(libOffset, cb, dwLockType);
                 }
                 catch (Exception ex)
                 {
@@ -165,8 +158,8 @@ internal partial class Interop
             {
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    return (int)inst.UnlockRegion(libOffset, cb, dwLockType);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    return (int)instance.UnlockRegion(libOffset, cb, dwLockType);
                 }
                 catch (Exception ex)
                 {
@@ -179,15 +172,14 @@ internal partial class Interop
             {
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    inst.Stat(out *pstatstg, grfStatFlag);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    instance.Stat(out *pstatstg, grfStatFlag);
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
 
             [UnmanagedCallersOnly]
@@ -200,16 +192,15 @@ internal partial class Interop
 
                 try
                 {
-                    Interop.Ole32.IStream inst = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
 
-                    *ppstm = Instance.GetOrCreateComInterfaceForObject(inst.Clone(), CreateComInterfaceFlags.None);
+                    *ppstm = Instance.GetOrCreateComInterfaceForObject(instance.Clone(), CreateComInterfaceFlags.None);
+                    return S_OK;
                 }
                 catch (Exception ex)
                 {
                     return ex.HResult;
                 }
-
-                return S_OK;
             }
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IStreamVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IStreamVtbl.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -43,6 +44,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -58,6 +60,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -73,6 +76,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -88,6 +92,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -105,6 +110,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -120,6 +126,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -135,6 +142,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -149,6 +157,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -163,6 +172,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -178,6 +188,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }
@@ -199,6 +210,7 @@ internal partial class Interop
                 }
                 catch (Exception ex)
                 {
+                    Debug.WriteLine(ex);
                     return ex.HResult;
                 }
             }


### PR DESCRIPTION
This PR ensures that methods marked as `UnmanagedCallersOnly` wrapped in the try/catch.
Also rename `inst` to `instance` to conform to code style

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7180)