### PR TITLE
Fix TreeView overflow exception

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -3095,7 +3095,7 @@ namespace System.Windows.Forms
                             else
                             {
                                 treeViewState[TREEVIEWSTATE_showTreeViewContextMenu] = true;
-                                User32.SendMessageW(this, User32.WM.CONTEXTMENU, Handle, (IntPtr)User32.GetMessagePos());
+                                User32.SendMessageW(this, User32.WM.CONTEXTMENU, Handle, (IntPtr)(int)User32.GetMessagePos());
                             }
 
                             m.Result = (IntPtr)1;


### PR DESCRIPTION
Fixing an overflow exception in `TreeView` control in 32 bit process due to incorrect cast from `uint -> IntPtr`.

Fixes #7098 


## Proposed changes

- Cast return value (`nint`) of `GetMessagePos()` in the `TreeView `control to `int` before casting it to `IntPtr`


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customer should be able to use `TreeView `control in a 32-bit process.

## Regression? 

- Regressed from .NET 3.1

## Risk

- Low. Similar change is in .NET 7.0 since Preview 1

<!-- end TELL-MODE -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7183)