### PR TITLE
Test that numeric up-down successfully focused

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
@@ -17,16 +17,15 @@ namespace System.Windows.Forms.UITests
         [WinFormsFact]
         public async Task NumericUpDownAccessibleObject_Focused_ReturnsCorrectValueAsync()
         {
-            await RunSingleControlTestAsync<NumericUpDown>((form, control) =>
+            await RunSingleControlTestAsync<NumericUpDown>(async (form, control) =>
             {
                 var accessibleObject = control.AccessibilityObject;
+                await MoveMouseToControlAsync(control);
                 form.Activate();
                 control.Focus();
 
                 var focused = accessibleObject.GetFocused();
                 Assert.NotNull(focused);
-
-                return Task.CompletedTask;
             });
         }
     }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Windows.Forms.UITests
+{
+    public class NumericUpDownTests : ControlTestBase
+    {
+        public NumericUpDownTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+        }
+
+        [WinFormsFact]
+        public async Task NumericUpDownAccessibleObject_Focused_ReturnsCorrectValueAsync()
+        {
+            await RunSingleControlTestAsync<NumericUpDown>((form, control) =>
+            {
+                control.Focus();
+
+                var isFocused = control.Focused;
+                AccessibleObject accessibleObject = control.AccessibilityObject;
+                var focused = accessibleObject.GetFocused();
+                Assert.NotNull(focused);
+
+                return Task.CompletedTask;
+            });
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
@@ -4,7 +4,6 @@
 
 using Xunit;
 using Xunit.Abstractions;
-using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms.UITests
 {

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Drawing;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using Xunit.Abstractions;
+using System.Runtime.InteropServices;
 
 namespace System.Windows.Forms.UITests
 {
@@ -20,14 +21,9 @@ namespace System.Windows.Forms.UITests
             await RunSingleControlTestAsync<NumericUpDown>((form, control) =>
             {
                 var accessibleObject = control.AccessibilityObject;
-                form.BringToFront();
+                form.Activate();
                 control.Focus();
 
-                Assert.True(control.Focused, "NumericUpDown should be focused");
-                this.TestOutputHelper.WriteLine($"Textbox state: {accessibleObject.GetChild(0)!.State}");
-                Assert.True(
-                    AccessibleStates.Focused == (accessibleObject.GetChild(0)!.State & AccessibleStates.Focused),
-                    "NumericUpDown's text box accessbile object state should be focused");
                 var focused = accessibleObject.GetFocused();
                 Assert.NotNull(focused);
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/NumericUpDownTests.cs
@@ -19,10 +19,15 @@ namespace System.Windows.Forms.UITests
         {
             await RunSingleControlTestAsync<NumericUpDown>((form, control) =>
             {
+                var accessibleObject = control.AccessibilityObject;
+                form.BringToFront();
                 control.Focus();
 
-                var isFocused = control.Focused;
-                AccessibleObject accessibleObject = control.AccessibilityObject;
+                Assert.True(control.Focused, "NumericUpDown should be focused");
+                this.TestOutputHelper.WriteLine($"Textbox state: {accessibleObject.GetChild(0)!.State}");
+                Assert.True(
+                    AccessibleStates.Focused == (accessibleObject.GetChild(0)!.State & AccessibleStates.Focused),
+                    "NumericUpDown's text box accessbile object state should be focused");
                 var focused = accessibleObject.GetFocused();
                 Assert.NotNull(focused);
 


### PR DESCRIPTION
This is successfully catches bug in the https://github.com/dotnet/winforms/pull/7145 implementation
I need just call to `GetFocused`, but if some additional check can be made, I can add them.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7191)