### PR TITLE
VB fix title `MsgBox` and `InputBox` APIs

### DIFF
--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
@@ -317,10 +317,10 @@ Namespace Microsoft.VisualBasic
 
             'Tries to get the title using the AssemblyProduct attribute, which
             'can be controlled with the Product property in a project file.
-            Dim attribs = CallingAssembly.GetCustomAttributes(GetType(Reflection.AssemblyProductAttribute), False)
-            If attribs IsNot Nothing AndAlso attribs.Length > 0 Then
+            Dim attributes = CallingAssembly.GetCustomAttributes(GetType(Reflection.AssemblyProductAttribute), False)
+            If attributes IsNot Nothing AndAlso attributes.Length > 0 Then
 
-                Dim Title = DirectCast(attribs(0), Reflection.AssemblyProductAttribute).Product
+                Dim Title = DirectCast(attributes(0), Reflection.AssemblyProductAttribute).Product
 
                 '"Microsoft® .NET" is the default Product name when one is not
                 'explicitly specified, fall back to default case (use assembly name)

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
@@ -286,7 +286,7 @@ Namespace Microsoft.VisualBasic
                 ParentWindow = vbhost.GetParentWindow()
             End If
 
-            If Title Is Nothing Then
+            If String.IsNullOrEmpty(Title) Then
                 If vbhost Is Nothing Then
                     Title = GetTitleFromCallingAssembly()
                 Else

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Interaction.vb
@@ -369,8 +369,10 @@ Namespace Microsoft.VisualBasic
 
             Dim Title As String
 
-            'By reading the frames, we maintain the old behavior of using the title / name of the calling
-            'assembly (unless inlined), not necessarily the name of the application as a whole.
+            'By reading the frames, we maintain the old behavior of using the name of the calling
+            'assembly (unless inlined), not necessarily the name of the application as a whole. New
+            'behavior is that we try to use an assembly's product name if available, with a fallback
+            'of the dll name (dll name was the old behavior).
             For i As Integer = 0 To frames.Length - 1
                 Dim frame = frames(i)
                 If frame.HasMethod() Then


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3161


## Proposed changes

- Fix the regression of `MsgBox` and `InputBox` APIs specifying no title and getting `Microsoft.VisualBasic.Core` (or other assembly name based on inlining) as their title instead of the calling assembly

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes a regression

## Regression? 

- No

## Risk

- N/A

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<img width="215" alt="image" src="https://user-images.githubusercontent.com/25316035/169273892-70405285-4a7e-47ac-987f-ada5a0b9cca8.png">
<img width="474" alt="image" src="https://user-images.githubusercontent.com/25316035/169274398-46964e69-7ed9-4aeb-a174-429eb7178ca7.png">


### After

<img width="210" alt="image" src="https://user-images.githubusercontent.com/25316035/169273776-acde3a69-249d-4d32-aab5-50e31ebdfbac.png">
<img width="461" alt="image" src="https://user-images.githubusercontent.com/25316035/169274467-de85cc90-f3cf-4986-a5b3-69228e3567a1.png">



## Test methodology <!-- How did you ensure quality? -->

- I modified one of the projects in the solution to test it, I just removed the title parameter and gave it appropriate command-line arguments. Project name is in images above
- I also tested it with the product property set in the project file, and it worked

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

Not sure if I need to run this, please advise
 

## Test environment(s) <!-- Remove any that don't apply -->

 <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->

200% scaling
English

```
.NET SDK (reflecting any global.json):
 Version:   7.0.100-preview.3.22154.3
 Commit:    5fe093bc35

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.19044
 OS Platform: Windows
 RID:         win10-x64
 Base Path:   <redacted>\winforms\.dotnet\sdk\7.0.100-preview.3.22154.3\

global.json file:
  Not found

Host:
  Version:      7.0.0-preview.5.22267.11
  Architecture: x64
  Commit:       5b1fd50332

.NET SDKs installed:
  7.0.100-preview.3.22154.3 [<redacted>\winforms\.dotnet\sdk]

.NET runtimes installed:
  Microsoft.AspNetCore.App 7.0.0-preview.3.22152.6 [<redacted>\winforms\.dotnet\shared\Microsoft.AspNetCore.App]
  Microsoft.NETCore.App 7.0.0-preview.3.22151.6 [<redacted>\winforms\.dotnet\shared\Microsoft.NETCore.App]
  Microsoft.NETCore.App 7.0.0-preview.5.22267.11 [<redacted>\winforms\.dotnet\shared\Microsoft.NETCore.App]
  Microsoft.WindowsDesktop.App 7.0.0-preview.3.22128.8 [<redacted>\winforms\.dotnet\shared\Microsoft.WindowsDesktop.App]

Download .NET:
  https://aka.ms/dotnet-download

Learn about .NET Runtimes and SDKs:
  https://aka.ms/dotnet/runtimes-sdk-info
```


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7194)