### PR TITLE
Refactoring AutomationId at the accessible object classes #6603

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AccessibleObject.cs
@@ -94,6 +94,8 @@ namespace System.Windows.Forms
             _systemWrapper = true;
         }
 
+        private protected virtual string? AutomationId => null;
+
         /// <summary>
         ///  Gets the bounds of the accessible object, in screen coordinates.
         /// </summary>
@@ -448,6 +450,7 @@ namespace System.Windows.Forms
                 UiaCore.UIA.IsPasswordPropertyId => false,
                 UiaCore.UIA.FrameworkIdPropertyId => NativeMethods.WinFormFrameworkId,
                 UiaCore.UIA.AccessKeyPropertyId => KeyboardShortcut ?? string.Empty,
+                UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                 _ => null
             };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Button.ButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Button.ButtonAccessibleObject.cs
@@ -17,8 +17,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UIA propertyID)
                 => propertyID switch
                 {
-                    UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UIA.ControlTypePropertyId
                         // If we don't set a default role for Button and ButtonBase accessible objects
                         // it will be retrieved from Windows.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.CheckBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBox.CheckBoxAccessibleObject.cs
@@ -70,8 +70,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         =>
                         // This is necessary for compatibility with MSAA proxy:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
@@ -33,6 +33,8 @@ namespace System.Windows.Forms
                 _textProvider = new ComboBoxUiaTextProvider(owner);
             }
 
+            private protected override string AutomationId => COMBO_BOX_EDIT_AUTOMATION_ID;
+
             /// <summary>
             ///  Returns the element in the specified direction.
             /// </summary>
@@ -88,8 +90,6 @@ namespace System.Windows.Forms
                         return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _owningComboBox.Enabled;
-                    case UiaCore.UIA.AutomationIdPropertyId:
-                        return COMBO_BOX_EDIT_AUTOMATION_ID;
                     case UiaCore.UIA.NativeWindowHandlePropertyId:
                         return _handle;
                     case UiaCore.UIA.IsOffscreenPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
@@ -27,6 +27,8 @@ namespace System.Windows.Forms
                 _childListControlhandle = childListControlhandle;
             }
 
+            private protected override string AutomationId => COMBO_BOX_LIST_AUTOMATION_ID;
+
             internal override Rectangle BoundingRectangle => User32.GetWindowRect(_owningComboBox.GetListNativeWindow());
 
             /// <summary>
@@ -144,8 +146,6 @@ namespace System.Windows.Forms
                         return (State & AccessibleStates.Focusable) == AccessibleStates.Focusable;
                     case UiaCore.UIA.IsEnabledPropertyId:
                         return _owningComboBox.Enabled;
-                    case UiaCore.UIA.AutomationIdPropertyId:
-                        return COMBO_BOX_LIST_AUTOMATION_ID;
                     case UiaCore.UIA.NativeWindowHandlePropertyId:
                         return _childListControlhandle;
                     case UiaCore.UIA.IsOffscreenPropertyId:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlAccessibleObject.cs
@@ -53,6 +53,8 @@ namespace System.Windows.Forms
                 }
             }
 
+            private protected override string AutomationId => Owner.Name;
+
             // If the control is used as an item of a ToolStrip via ToolStripControlHost,
             // its accessible object should provide info about the owning ToolStrip and items-siblings
             // to build a correct ToolStrip accessibility tree.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.DataGridViewCellAccessibleObject.cs
@@ -609,7 +609,7 @@ namespace System.Windows.Forms
                     GetHashCode()
                 };
 
-            private string AutomationId
+            private protected override string AutomationId
             {
                 get
                 {
@@ -683,7 +683,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.DataItemControlTypeId,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused, // Announce the cell when focusing.
                     UiaCore.UIA.IsEnabledPropertyId => _owner?.DataGridView?.Enabled ?? false,
-                    UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.GridItemContainingGridPropertyId => _owner?.DataGridView?.AccessibilityObject,
                     _ => base.GetPropertyValue(propertyID),

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.GroupBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBox.GroupBoxAccessibleObject.cs
@@ -31,8 +31,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         => true,
                     _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.LabelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.LabelAccessibleObject.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using static Interop;
-
 namespace System.Windows.Forms
 {
     public partial class Label
@@ -31,13 +29,6 @@ namespace System.Windows.Forms
                     return AccessibleRole.StaticText;
                 }
             }
-
-            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
-                => propertyID switch
-                {
-                    UiaCore.UIA.AutomationIdPropertyId => _owningLabel.Name,
-                    _ => base.GetPropertyValue(propertyID)
-                };
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -207,7 +207,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId => _owningListView.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => false,
                     // If we don't set a default role for the accessible object

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms
                 _owningGroupIsDefault = owningGroupIsDefault;
             }
 
-            private string AutomationId
+            private protected override string AutomationId
                 => string.Format("{0}-{1}", typeof(ListViewGroup).Name, CurrentIndex);
 
             public override Rectangle Bounds
@@ -179,7 +179,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.GroupControlTypeId,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListView.Focused && Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -36,7 +36,7 @@ namespace System.Windows.Forms
                 ? _owningItem.Group ?? _owningListView.DefaultGroup
                 : null;
 
-            private string AutomationId
+            private protected override string AutomationId
                 => string.Format("{0}-{1}", typeof(ListViewItem).Name, CurrentIndex);
 
             public override Rectangle Bounds
@@ -166,7 +166,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ListItemControlTypeId,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => OwningListItemFocused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -128,7 +128,6 @@ namespace System.Windows.Forms
                         // object has the "text" control type, because it is just a container for the edit field.
                         UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TextControlTypeId,
                         UiaCore.UIA.ProcessIdPropertyId => Environment.ProcessId,
-                        UiaCore.UIA.AutomationIdPropertyId => AutomationId,
                         UiaCore.UIA.HasKeyboardFocusPropertyId => _owningListView.Focused && _owningListView.FocusedItem == _owningItem,
                         UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                         UiaCore.UIA.IsEnabledPropertyId => _owningListView.Enabled,
@@ -160,7 +159,7 @@ namespace System.Windows.Forms
                     return base.IsPatternSupported(patternId);
                 }
 
-                private string AutomationId
+                private protected override string AutomationId
                     => $"{typeof(ListViewItem.ListViewSubItem).Name}-{ParentInternal.GetChildIndex(this)}";
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Panel.PanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Panel.PanelAccessibleObject.cs
@@ -37,8 +37,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                => propertyID switch
                {
-                   UiaCore.UIA.AutomationIdPropertyId
-                       => Owner.Name,
                    UiaCore.UIA.IsKeyboardFocusablePropertyId
                        => false,
                    _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.PictureBoxAccessibleObject.cs
@@ -24,8 +24,6 @@ namespace System.Windows.Forms
                         => Owner.AccessibleRole == AccessibleRole.Default
                            ? UiaCore.UIA.PaneControlTypeId
                            : base.GetPropertyValue(propertyID),
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         => true,
                     _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.GridEntryAccessibleObject.cs
@@ -25,6 +25,8 @@ namespace System.Windows.Forms.PropertyGridInternal
                 _owningGridEntry = owner;
             }
 
+            private protected override string AutomationId => GetHashCode().ToString();
+
             public override Rectangle Bounds
             {
                 get => PropertyGridView is not null && PropertyGridView.IsHandleCreated
@@ -337,7 +339,6 @@ namespace System.Windows.Forms.PropertyGridInternal
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningGridEntry.HasFocus,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId => (State & AccessibleStates.Focusable) == AccessibleStates.Focusable,
                     UiaCore.UIA.IsEnabledPropertyId => true,
-                    UiaCore.UIA.AutomationIdPropertyId => GetHashCode().ToString(),
                     _ => base.GetPropertyValue(propertyID),
                 };
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.RadioButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButton.RadioButtonAccessibleObject.cs
@@ -50,8 +50,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:
                         // IsKeyboardFocusable = true regardless the control is enabled/disabled.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.ScrollBarAccessibleObject.cs
@@ -134,7 +134,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId => _owningScrollBar.Name,
                     // If we don't set a default role for the accessible object
                     // it will be retrieved from Windows.
                     // And we don't have a 100% guarantee it will be correct, hence set it ourselves.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitterAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Splitter.SplitterAccessibleObject.cs
@@ -17,8 +17,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.ControlTypePropertyId
                         // If we don't set a default role for the accessible object
                         // it will be retrieved from Windows.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabControlAccessibleObject.cs
@@ -135,7 +135,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UIA propertyID)
                 => propertyID switch
                 {
-                    UIA.AutomationIdPropertyId => _owningTabControl.Name,
                     UIA.HasKeyboardFocusPropertyId => _owningTabControl.Focused,
                     UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
@@ -12,14 +12,14 @@ namespace System.Windows.Forms
     {
         internal class TabAccessibleObject : AccessibleObject
         {
-            private TabControl? OwningTabControl => _owningTabPage.ParentInternal as TabControl;
-
             private readonly TabPage _owningTabPage;
 
             public TabAccessibleObject(TabPage owningTabPage)
             {
                 _owningTabPage = owningTabPage.OrThrowIfNull();
             }
+
+            private protected override string AutomationId => _owningTabPage.Name;
 
             public override Rectangle Bounds
             {
@@ -47,6 +47,8 @@ namespace System.Windows.Forms
             public override string? DefaultAction => SystemIAccessibleInternal?.get_accDefaultAction(GetChildId());
 
             public override string? Name => _owningTabPage.Text;
+
+            private TabControl? OwningTabControl => _owningTabPage.ParentInternal as TabControl;
 
             public override AccessibleRole Role
                 => SystemIAccessibleInternal?.get_accRole(GetChildId()) is object accRole
@@ -116,7 +118,6 @@ namespace System.Windows.Forms
                 => propertyID switch
                 {
                     UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.TabItemControlTypeId,
-                    UiaCore.UIA.AutomationIdPropertyId => _owningTabPage.Name,
                     UiaCore.UIA.IsEnabledPropertyId => OwningTabControl?.Enabled ?? false,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => (State & AccessibleStates.Focused) == AccessibleStates.Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabPageAccessibleObject.cs
@@ -83,7 +83,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId => _owningTabPage.Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTabPage.Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripContainer.ToolStripContainerAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripContainer.ToolStripContainerAccessibleObject.cs
@@ -17,8 +17,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                => propertyID switch
                {
-                   UiaCore.UIA.AutomationIdPropertyId
-                       => Owner.Name,
                    UiaCore.UIA.HasKeyboardFocusPropertyId
                        => Owner.Focused,
                    UiaCore.UIA.IsKeyboardFocusablePropertyId

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.TrackBarAccessibleObject.cs
@@ -156,7 +156,6 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => _owningTrackBar.AccessibleRole == AccessibleRole.Default
                                                             ? UiaCore.UIA.SliderControlTypeId
                                                             : base.GetPropertyValue(propertyID),
-                    UiaCore.UIA.AutomationIdPropertyId => _owningTrackBar.Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId => _owningTrackBar.Focused,
                     UiaCore.UIA.IsKeyboardFocusablePropertyId
                         // This is necessary for compatibility with MSAA proxy:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.WebBrowserAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.WebBrowserAccessibleObject.cs
@@ -16,8 +16,6 @@ namespace System.Windows.Forms
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch
                 {
-                    UiaCore.UIA.AutomationIdPropertyId
-                        => Owner.Name,
                     UiaCore.UIA.HasKeyboardFocusPropertyId
                         => Owner.Focused,
                     _ => base.GetPropertyValue(propertyID)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AccessibleObjectTests.cs
@@ -2568,12 +2568,14 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(7, parent.accChildCount);
         }
 
-        [WinFormsFact]
-        public void AccessibleObject_GetPropertyValue_ControlTypeProperty_ReturnsNull()
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.ControlTypePropertyId)]
+        [InlineData((int)UiaCore.UIA.AutomationIdPropertyId)]
+        public void AccessibleObject_GetPropertyValue_ReturnsNull_IfExpected(int propertyId)
         {
             AccessibleObject accessibleObject = new AccessibleObject();
 
-            Assert.Null(accessibleObject.GetPropertyValue(Interop.UiaCore.UIA.ControlTypePropertyId));
+            Assert.Null(accessibleObject.GetPropertyValue((UiaCore.UIA)propertyId));
         }
 
         public static IEnumerable<object[]> AccessibleObject_RuntimeId_IsOverriden_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBase.ButtonBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBase.ButtonBaseAccessibleObjectTests.cs
@@ -235,6 +235,17 @@ namespace System.Windows.Forms.Tests
             Assert.False(buttonBase.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ButtonBaseAccessibleObject_GetPropertyValue_AutomationId_ReturnsExpected()
+        {
+            using SubButtonBase ownerControl = new() { Name = "test name" };
+            string expected = ownerControl.Name;
+            object actual = ownerControl.AccessibilityObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId);
+
+            Assert.Equal(expected, actual);
+            Assert.False(ownerControl.IsHandleCreated);
+        }
+
         private class SubButtonBase : ButtonBase
         {
             public Action PerformClickAction { get; set; }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -1568,6 +1568,17 @@ namespace System.Windows.Forms.Tests
             Assert.True(toolStrip.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ControlAccessibleObject_GetPropertyValue_AutomationId_ReturnsExpected()
+        {
+            using Control ownerControl = new() { Name = "test name" };
+            string expected = ownerControl.Name;
+            object actual = ownerControl.AccessibilityObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId);
+
+            Assert.Equal(expected, actual);
+            Assert.False(ownerControl.IsHandleCreated);
+        }
+
         // ContextMenuStrip, From, ToolStripDropDown, ToolStripDropDownMenu
         // are Top level controls that can't be added to a ToolStrip.
         // A TabPage can be added to a TabControl only (see TabPage.AssignParent method).

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
@@ -995,6 +995,24 @@ namespace System.Windows.Forms.Tests
             Assert.False(dataGridView.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_GetPropertyValue_AutomationId_ReturnsExpected()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            dataGridView.Rows.Add(new DataGridViewRow());
+
+            DataGridViewCellAccessibleObject dataGridViewCellAccessibleObject = new(dataGridView.Rows[0].Cells[0]);
+            string expected = string.Empty;
+            foreach (int runtimeIdPart in dataGridViewCellAccessibleObject.RuntimeId)
+            {
+                expected += runtimeIdPart.ToString();
+            }
+
+            Assert.Equal(expected, dataGridViewCellAccessibleObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
         private class SubDataGridViewCell : DataGridViewCell
         {
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxAccessibleObjectTests.cs
@@ -119,5 +119,16 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(groupBox.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void GroupBoxAccessibleObject_GetPropertyValue_AutomationId_ReturnsExpected()
+        {
+            using GroupBox ownerControl = new() { Name = "test name" };
+            string expected = ownerControl.Name;
+            object actual = ownerControl.AccessibilityObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId);
+
+            Assert.Equal(expected, actual);
+            Assert.False(ownerControl.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelAccessibleObjectTests.cs
@@ -9,20 +9,23 @@ namespace System.Windows.Forms.Tests
 {
     public class LabelAccessibleObjectTests
     {
-        [WinFormsFact]
-        public void LabelAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.NamePropertyId, "Address")]
+        [InlineData((int)UiaCore.UIA.AutomationIdPropertyId, "Label1")]
+        public void LabelAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
         {
-            string testAccName = "Address";
-            using var label = new Label();
-            label.Text = "Some test label text";
-            label.Name = "Label1";
-            label.AccessibleName = testAccName;
-            AccessibleObject labelAccessibleObject = label.AccessibilityObject;
+            using Label label = new()
+            {
+                Text = "Some test label text",
+                Name = "Label1",
+                AccessibleName = "Address"
+            };
 
+            Label.LabelAccessibleObject accessibilityObject = (Label.LabelAccessibleObject)label.AccessibilityObject;
+
+            object value = accessibilityObject.GetPropertyValue((UiaCore.UIA)propertyID);
+            Assert.Equal(expected, value);
             Assert.False(label.IsHandleCreated);
-
-            var accessibleName = labelAccessibleObject.GetPropertyValue(Interop.UiaCore.UIA.NamePropertyId);
-            Assert.Equal(testAccName, accessibleName);
         }
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
@@ -336,5 +336,18 @@ namespace System.Windows.Forms.Tests
             Assert.Equal((UiaCore.ToggleState)expected, accessibleObject.ToggleState);
             Assert.False(control.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_GetPropertyValue_AutomationId_ReturnsExpected()
+        {
+            using ListView listView = new();
+            ListViewItem item = new();
+            listView.Items.Add(item);
+            var accessibleObject = (ListViewItemBaseAccessibleObject)item.AccessibilityObject;
+
+            var expected = string.Format("{0}-{1}", typeof(ListViewItem).Name, accessibleObject.CurrentIndex);
+            Assert.Equal(expected, accessibleObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
+            Assert.False(listView.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBox.PictureBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBox.PictureBoxAccessibleObjectTests.cs
@@ -102,8 +102,7 @@ namespace System.Windows.Forms.Tests
                 AccessibleName = "TestName"
             };
 
-            Assert.False(pictureBox.IsHandleCreated);
-            var pictureBoxAccessibleObject = new PictureBox.PictureBoxAccessibleObject(pictureBox);
+            PictureBox.PictureBoxAccessibleObject pictureBoxAccessibleObject = new(pictureBox);
             object value = pictureBoxAccessibleObject.GetPropertyValue((UIA)propertyID);
 
             Assert.Equal(expected, value);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabControlAccessibleObjectTests.cs
@@ -744,18 +744,20 @@ namespace System.Windows.Forms.Tests
             Assert.False(tabControl.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void TabControlAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData((int)UIA.NamePropertyId, "TestName")]
+        [InlineData((int)UIA.AutomationIdPropertyId, "TabControl1")]
+        public void TabControlAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
         {
-            const string name = "Test name";
             using TabControl tabControl = new()
             {
-                AccessibleName = name
+                Name = "TabControl1",
+                AccessibleName = "TestName"
             };
 
-            object actual = tabControl.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+            object actual = tabControl.AccessibilityObject.GetPropertyValue((UIA)propertyID);
 
-            Assert.Equal(name, actual);
+            Assert.Equal(expected, actual);
             Assert.False(tabControl.IsHandleCreated);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabPageAccessibleObjectTests.cs
@@ -479,18 +479,20 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(createControl, tabPage.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void TabPageAccessibleObject_GetPropertyValue_Name_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData((int)UIA.NamePropertyId, "TestName")]
+        [InlineData((int)UIA.AutomationIdPropertyId, "TabPage1")]
+        public void TabPageAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
         {
-            const string name = "Test name";
             using TabPage tabPage = new()
             {
-                AccessibleName = name
+                Name = "TabPage1",
+                AccessibleName = "TestName"
             };
 
-            object actual = tabPage.AccessibilityObject.GetPropertyValue(UIA.NamePropertyId);
+            object actual = tabPage.AccessibilityObject.GetPropertyValue((UIA)propertyID);
 
-            Assert.Equal(name, actual);
+            Assert.Equal(expected, actual);
             Assert.False(tabPage.IsHandleCreated);
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TrackBar.TrackBarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TrackBar.TrackBarAccessibleObjectTests.cs
@@ -413,17 +413,21 @@ namespace System.Windows.Forms.Tests
             Assert.False(trackBar.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void TrackBarAccessibilityObject_GetPropertyValue_Name_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData((int)UiaCore.UIA.NamePropertyId, "TestAccessibleName")]
+        [InlineData((int)UiaCore.UIA.AutomationIdPropertyId, "TestControlName")]
+        public void TrackBarAccessibilityObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
         {
-            const string name = "Test name";
             using TrackBar trackBar = new()
             {
-                AccessibleName = name
+                Name = expected.ToString(),
+                AccessibleName = expected.ToString()
             };
-            object actual = trackBar.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
 
-            Assert.Equal(name, actual);
+            TrackBar.TrackBarAccessibleObject accessibilityObject = (TrackBar.TrackBarAccessibleObject)trackBar.AccessibilityObject;
+
+            object value = accessibilityObject.GetPropertyValue((UiaCore.UIA)propertyID);
+            Assert.Equal(expected, value);
             Assert.False(trackBar.IsHandleCreated);
         }
 


### PR DESCRIPTION
Fixes #6603
This PR finishes https://github.com/dotnet/winforms/pull/6641 (adds unit tests)

## Proposed changes

- The AutomationId property is moved to the AccessibleObject base class
- This property returns null at AccessibleObject
- It is returned at the GetPropertyValue method of AccessibleObject for the case AutomationIdPropertyId
- The current implementations in the 4 classes derived from AO are kept the same way, but they are marked as overrides
- Returning of the Owner.Name is moved to the ControlAccessibleObjectObject class to make it universal for all its descendants
- All duplicate code with the same logic is cleaned out in the derived classes
- Initial discussion on this topic is here: https://github.com/dotnet/winforms/pull/6429#issuecomment-1009286397

Unit tests:

1) AccessibleObject - AccessibleObject_GetPropertyValue_ReturnsNull (two unit tests combined)
2) DataGridViewCellAccessibleObject - DataGridViewCellAccessibleObject_GetPropertyValue_AutomationId_ReturnsExpected (new)
3) ListViewItemBaseAccessibleObject - ListViewItemBaseAccessibleObject_GetPropertyValue_AutomationId_ReturnsExpected (new)
4) ListViewSubItemAccessibleObject - ListViewSubItemAccessibleObject_GetPropertyValue_returns_correct_values (existing)
5) ControlAccessibleObject - ControlAccessibleObject_GetPropertyValue_AutomationId_ReturnsExpected (new)
6) ButtonBaseAccessibleObject - ButtonBaseAccessibleObject_GetPropertyValue_AutomationId_ReturnsExpected (new)
7) CheckBoxAccessibleObject - CheckBoxAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected (existing)
8) GroupBoxAccessibleObject - GroupBoxAccessibleObject_GetPropertyValue_AutomationId_ReturnsExpected (new)
9) LabelAccessibleObject - LabelAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected (two unit tests combined)
10) ListViewAccessibleObject - ListViewAccessibleObject_GetPropertyValue_returns_correct_values (existing)
11) PanelAccessibleObject - PanelAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected (existing)
12) PictureBoxAccessibleObject - PictureBoxAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected (existing)
13) RadioButtonAccessibleObject - RadioButtonAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected (existing)
14) ScrollBarAccessibleObject - ScrollBarAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected (existing)
15) SplitterAccessibleObject - SplitterAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected (existing)
16) TabControlAccessibleObject - TabControlAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected (two unit tests combined)
17) TabPageAccessibleObject - TabPageAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected (two unit tests combined)
18) TrackBarAccessibleObject - TrackBarAccessibilityObject_GetPropertyValue_Invoke_ReturnsExpected (two unit tests combined)

Combined existed NamePropertyId tests and new AutomationIdPropertyId tests:
{
		TrackBarAccessibilityObject_GetPropertyValue_Invoke_ReturnsExpected
		TabPageAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected
		TabControlAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected
		LabelAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected
}
just like existing:
{
		CheckBoxAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected
		PanelAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected
		PictureBoxAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected
                ListViewSubItemAccessibleObject_GetPropertyValue_returns_correct_values
		ListViewAccessibleObject_GetPropertyValue_returns_correct_values
}
<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Tests based on the old implementation of AutomationId could become obsolete.


## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- CTI testing

## Test environment(s) <!-- Remove any that don't apply -->

Microsoft Windows [Version 120.2212.4170.0]
.NET Core SDK: 7.0.100-preview.3.22179.4


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7206)