### PR TITLE
fix Exception on accessing accessible object after control is disposed

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/LisstView.DisposingContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LisstView.DisposingContext.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    public partial class ListView
+    {
+        private class DisposingContext : IDisposable
+        {
+            private readonly ListView _owner;
+
+            public DisposingContext(ListView owner)
+            {
+                _owner = owner;
+                _owner.ClearingInnerListOnDispose = true;
+            }
+
+            public void Dispose()
+            {
+                _owner.ClearingInnerListOnDispose = false;
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewItemCollection.cs
@@ -125,14 +125,9 @@ namespace System.Windows.Forms
                 }
                 set
                 {
-                    if (value is ListViewItem)
-                    {
-                        this[index] = (ListViewItem)value;
-                    }
-                    else if (value is not null)
-                    {
-                        this[index] = new ListViewItem(value.ToString(), -1);
-                    }
+                    this[index] = value is ListViewItem item
+                        ? item
+                        : new ListViewItem(value.ToString(), -1);
                 }
             }
 
@@ -155,10 +150,8 @@ namespace System.Windows.Forms
                     {
                         return this[index];
                     }
-                    else
-                    {
-                        return null;
-                    }
+
+                    return null;
                 }
             }
 
@@ -174,13 +167,14 @@ namespace System.Windows.Forms
 
             int IList.Add(object item)
             {
-                if (item is ListViewItem)
+                if (item is ListViewItem listViewItem)
                 {
-                    return IndexOf(Add((ListViewItem)item));
+                    return IndexOf(Add(listViewItem));
                 }
-                else if (item is not null)
+
+                if (item is {} obj)
                 {
-                    return IndexOf(Add(item.ToString()));
+                    return IndexOf(Add(obj.ToString()));
                 }
 
                 return -1;
@@ -193,9 +187,9 @@ namespace System.Windows.Forms
             /// </summary>
             public virtual ListViewItem Add(string text, int imageIndex)
             {
-                ListViewItem li = new ListViewItem(text, imageIndex);
-                Add(li);
-                return li;
+                ListViewItem item = new(text, imageIndex);
+                Add(item);
+                return item;
             }
 
             /// <summary>
@@ -218,9 +212,9 @@ namespace System.Windows.Forms
             /// </summary>
             public virtual ListViewItem Add(string text, string imageKey)
             {
-                ListViewItem li = new ListViewItem(text, imageKey);
-                Add(li);
-                return li;
+                ListViewItem item = new(text, imageKey);
+                Add(item);
+                return item;
             }
 
             /// <summary>
@@ -230,12 +224,12 @@ namespace System.Windows.Forms
             /// </summary>
             public virtual ListViewItem Add(string key, string text, string imageKey)
             {
-                ListViewItem li = new ListViewItem(text, imageKey)
+                ListViewItem item = new(text, imageKey)
                 {
                     Name = key
                 };
-                Add(li);
-                return li;
+                Add(item);
+                return item;
             }
 
             /// <summary>
@@ -245,12 +239,12 @@ namespace System.Windows.Forms
             /// </summary>
             public virtual ListViewItem Add(string key, string text, int imageIndex)
             {
-                ListViewItem li = new ListViewItem(text, imageIndex)
+                ListViewItem item = new(text, imageIndex)
                 {
                     Name = key
                 };
-                Add(li);
-                return li;
+                Add(item);
+                return item;
             }
 
             // END - NEW ADD OVERLOADS IN WHIDBEY  -->
@@ -266,7 +260,7 @@ namespace System.Windows.Forms
             {
                 ArgumentNullException.ThrowIfNull(items);
 
-                ListViewItem[] itemArray = new ListViewItem[items.Count];
+                var itemArray = new ListViewItem[items.Count];
                 items.CopyTo(itemArray, 0);
                 InnerList.AddRange(itemArray);
             }
@@ -285,16 +279,7 @@ namespace System.Windows.Forms
             }
 
             bool IList.Contains(object item)
-            {
-                if (item is ListViewItem)
-                {
-                    return Contains((ListViewItem)item);
-                }
-                else
-                {
-                    return false;
-                }
-            }
+                => item is ListViewItem listViewItem && Contains(listViewItem);
 
             /// <summary>
             ///  Returns true if the collection contains an item with the specified key, false otherwise.
@@ -378,16 +363,7 @@ namespace System.Windows.Forms
             }
 
             int IList.IndexOf(object item)
-            {
-                if (item is ListViewItem)
-                {
-                    return IndexOf((ListViewItem)item);
-                }
-                else
-                {
-                    return -1;
-                }
-            }
+                => item is ListViewItem listViewItem ? IndexOf(listViewItem) : -1;
 
             /// <summary>
             ///  The zero-based index of the first occurrence of value within the entire CollectionBase, if found; otherwise, -1.
@@ -429,7 +405,7 @@ namespace System.Windows.Forms
             /// </summary>
             private bool IsValidIndex(int index)
             {
-                return (index >= 0) && (index < Count);
+                return index >= 0 && index < Count;
             }
 
             public ListViewItem Insert(int index, ListViewItem item)
@@ -455,40 +431,32 @@ namespace System.Windows.Forms
 
             void IList.Insert(int index, object item)
             {
-                if (item is ListViewItem)
+                if (item is ListViewItem listViewItem)
                 {
-                    Insert(index, (ListViewItem)item);
+                    Insert(index, listViewItem);
                 }
-                else if (item is not null)
+                else if (item is {} obj)
                 {
-                    Insert(index, item.ToString());
+                    Insert(index, obj.ToString());
                 }
             }
 
             // <-- NEW INSERT OVERLOADS IN WHIDBEY
 
             public ListViewItem Insert(int index, string text, string imageKey)
-            {
-                return Insert(index, new ListViewItem(text, imageKey));
-            }
+                => Insert(index, new ListViewItem(text, imageKey));
 
             public virtual ListViewItem Insert(int index, string key, string text, string imageKey)
-            {
-                ListViewItem li = new ListViewItem(text, imageKey)
-                {
-                    Name = key
-                };
-                return Insert(index, li);
-            }
+                => Insert(index, new ListViewItem(text, imageKey)
+                    {
+                        Name = key
+                    });
 
             public virtual ListViewItem Insert(int index, string key, string text, int imageIndex)
-            {
-                ListViewItem li = new ListViewItem(text, imageIndex)
-                {
-                    Name = key
-                };
-                return Insert(index, li);
-            }
+                => Insert(index, new ListViewItem(text, imageIndex)
+                    {
+                        Name = key
+                    });
 
             // END - NEW INSERT OVERLOADS IN WHIDBEY -->
 
@@ -527,12 +495,10 @@ namespace System.Windows.Forms
 
             void IList.Remove(object item)
             {
-                if (item is null || !(item is ListViewItem))
+                if (item is ListViewItem listViewItem)
                 {
-                    return;
+                    Remove(listViewItem);
                 }
-
-                Remove((ListViewItem)item);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
@@ -266,7 +266,7 @@ namespace System.Windows.Forms
 
                     User32.SendMessageW(_owner, (User32.WM)LVM.DELETEALLITEMS);
 
-                    // There's a problem in the list view that if it's in small icon, it won't pick upo the small icon
+                    // There's a problem in the list view that if it's in small icon, it won't pick up the small icon
                     // sizes until it changes from large icon, so we flip it twice here...
                     if (_owner.View == View.SmallIcon)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -4744,10 +4744,9 @@ namespace System.Windows.Forms
                 }
 
                 Debug.Assert(_listViewItems is null, "listItemsArray not null, even though handle created");
-                ListViewItem[]? items = null;
                 ListViewItemCollection tempItems = Items;
 
-                items = new ListViewItem[tempItems.Count];
+                ListViewItem[] items = new ListViewItem[tempItems.Count];
                 tempItems.CopyTo(items, 0);
 
                 _listViewItems = new List<ListViewItem>(items.Length);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -92,6 +92,7 @@ namespace System.Windows.Forms
         private const int LISTVIEWSTATE1_disposingImageLists = 0x00000004;
         private const int LISTVIEWSTATE1_useCompatibleStateImageBehavior = 0x00000008;
         private const int LISTVIEWSTATE1_selectedIndexChangedSkipped = 0x00000010;
+        private const int LISTVIEWSTATE1_clearingInnerListOnDispose = 0x00000020;
 
         private const int LVLABELEDITTIMER = 0x2A;
         private const int LVTOOLTIPTRACKING = 0x30;
@@ -3143,8 +3144,11 @@ namespace System.Windows.Forms
                     Unhook();
                 }
 
-                // Remove any items we have
-                Items.Clear();
+                using (DisposingContext context = new(this))
+                {
+                    // Remove any items we have
+                    Items.Clear();
+                }
 
                 if (_odCacheFontHandleWrapper is not null)
                 {
@@ -3205,6 +3209,12 @@ namespace System.Windows.Forms
             }
 
             base.Dispose(disposing);
+        }
+
+        private bool ClearingInnerListOnDispose
+        {
+            get => _listViewState1 [LISTVIEWSTATE1_clearingInnerListOnDispose];
+            set => _listViewState1 [LISTVIEWSTATE1_clearingInnerListOnDispose] = value;
         }
 
         /// <summary>
@@ -4746,7 +4756,7 @@ namespace System.Windows.Forms
                 Debug.Assert(_listViewItems is null, "listItemsArray not null, even though handle created");
                 ListViewItemCollection tempItems = Items;
 
-                ListViewItem[] items = new ListViewItem[tempItems.Count];
+                var items = new ListViewItem[tempItems.Count];
                 tempItems.CopyTo(items, 0);
 
                 _listViewItems = new List<ListViewItem>(items.Length);
@@ -4760,6 +4770,11 @@ namespace System.Windows.Forms
 
         protected override void OnGotFocus(EventArgs e)
         {
+            if (ClearingInnerListOnDispose)
+            {
+                return;
+            }
+
             base.OnGotFocus(e);
 
             if (ShowItemToolTips && Items.Count > 0 && (FocusedItem ?? Items[0]) is ListViewItem focusedItem)
@@ -4767,7 +4782,9 @@ namespace System.Windows.Forms
                 NotifyAboutGotFocus(focusedItem);
             }
 
-            if (IsHandleCreated && IsAccessibilityObjectCreated && AccessibilityObject.GetFocus() is AccessibleObject focusedAccessibleObject)
+            if (IsHandleCreated &&
+                IsAccessibilityObjectCreated &&
+                AccessibilityObject.GetFocus() is AccessibleObject focusedAccessibleObject)
             {
                 focusedAccessibleObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -1125,13 +1125,13 @@ namespace System.Windows.Forms
         {
             UpdateStateFromListView(displayIndex, checkSelection);
 
-            if (listView is not null && (listView.Site is null || !listView.Site.DesignMode) && group is not null)
-            {
-                group.Items.Remove(this);
-            }
-
             if (listView is not null)
             {
+                if ((listView.Site is null || !listView.Site.DesignMode) && group is not null)
+                {
+                    group.Items.Remove(this);
+                }
+
                 KeyboardToolTipStateMachine.Instance.Unhook(this, listView.KeyboardToolTip);
             }
 


### PR DESCRIPTION
When `ListView` is disposed, we first "un-host" all managed items by setting `ListView` field to null, then send message to the native control to delete all items.
If edit box is open, native control closes it, as edit box closes, it moves focus to the `ListView`. As a result, when edit box is open and `ListView` control is disposed, `ListView` gets `OnGotFocus` event which results in an attempt to re-create accessible object which leads to an exception. When edit box is closed while the `ListView` is disposed, the focus message is not sent by the native control. Thus, the test is fixed by closing the edit box before the `ListView` control is going out of focus. The real live scenario is fixed by ignoring the focus move if we know that the `ListView` control is being disposed.

```
System.Windows.Forms.ListViewItem.AccessibilityObject.get   << exception here due to nulled-out owner ListView
System.Windows.Forms.ListView.ListViewAccessibleObject.GetFocus
System.Windows.Forms.ListView.OnGotFocus
System.Windows.Forms.Control.InvokeGotFocus
System.Windows.Forms.Control.WmSetFocus
System.Windows.Forms.Control.WndProc
System.Windows.Forms.ListView.WndProc
System.Windows.Forms.Control.ControlNativeWindow.OnMessage
System.Windows.Forms.Control.ControlNativeWindow.WndProc
System.Windows.Forms.NativeWindow.Callback
<snip>
Interop.User32.SendMessageW   <<<<  here - https://github.com/dotnet/winforms/blob/33cbab32f3646ad820be6d76bbbb831c8094c270/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs#L269
ListView sends LVM_DELETEALLITEMS

System.Windows.Forms.ListView.ListViewNativeItemCollection.Clear
System.Windows.Forms.ListView.ListViewItemCollection.Clear
System.Windows.Forms.ListView.Dispose

```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7221)