### PR TITLE
revert Exception on accessing accessible object after control is disposed

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6907,7 +6907,4 @@ Stack trace where the illegal operation occurred was:
   <data name="EditDefaultAccessibleName" xml:space="preserve">
     <value>Spinner</value>
   </data>
-  <data name="ListViewItemAccessibilityObjectRequiresListView" xml:space="preserve">
-    <value>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</value>
-  </data>
 </root>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -6571,11 +6571,6 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Aktuální objekt přístupnosti je určený jenom pro ovládací prvek ListView v zobrazení {0}, {1} nebo {2}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Událost aktivovaná v případě změny zaškrtnuté vlastnosti položky ListView</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -6571,11 +6571,6 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Das aktuelle Objekt für Barrierefreiheit gilt nur für ListView in der Ansicht "{0}", "{1}" oder "{2}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Das ausgelöste Ereignis, wenn sich die aktivierte Eigenschaft für ein ListView-Element ändert.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -6571,11 +6571,6 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">El objeto de accesibilidad actual solo es para la vista ListView en {0}, {1} o {2} Vista</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Evento que se desencadena cuando cambia la propiedad checked de un elemento ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -6571,11 +6571,6 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">L’objet d’accessibilité actuel est uniquement destiné à ListView dans l’affichage {0}, {1} ou {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Événement déclenché lorsque la propriété Checked d'un élément ListView est modifiée.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -6571,11 +6571,6 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">L'oggetto accessibilità corrente viene usato solo per il controllo ListView nella visualizzazione {0}, {1} o {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Evento generato quando la proprietà checked di un elemento di ListView cambia.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -6571,11 +6571,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">現在のアクセシビリティ オブジェクトは {0}、{1} または {2} ビューの ListView にのみ使用できます</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView アイテムのチェックされたプロパティが変更するときに発生するイベントです。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -6571,11 +6571,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">현재 접근성 개체는 {0}, {1} 또는 {2} 보기의 ListView에만 해당됩니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView 항목의 Checked 속성이 변경되면 이벤트가 발생합니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -6571,11 +6571,6 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Bieżący obiekt ułatwień dostępu jest przeznaczony tylko dla elementu ListView w widoku {0}, {1} lub {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Zdarzenie wywoływane, gdy zostanie zmieniona zaznaczona właściwość elementu ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -6571,11 +6571,6 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">O objeto de acessibilidade atual é apenas para ListView no modo de exibição {0}, {1} ou {2}</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Evento gerado quando a propriedade de ativação de um item ListView é alterada.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -6572,11 +6572,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Текущий объект специальных возможностей предназначен только для ListView в представлениях {0}, {1} или {2}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">Событие возникает при изменении отмеченного свойства элемента ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -6571,11 +6571,6 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Geçerli erişilebilirlik nesnesi yalnızca {0}, {1} veya {2} görünümündeki ListView içindir</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView öğesinin Checked özelliği değiştiğinde harekete geçirilen olay.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -6571,11 +6571,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">当前的可访问性对象仅适用于 {0}、{1} 或 {2} 视图中的 ListView</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">当 ListView 项的 Checked 属性更改时引发的事件。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -6571,11 +6571,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">目前的協助工具物件僅適用於 {0}、 {1} 或 {2} 檢視中的 ListView</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
-        <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
-        <target state="new">Cannot get accessiblity object when ListViewItem is not attached to a ListView.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemCheckedDescr">
         <source>Event raised when the checked property of a ListView item changes.</source>
         <target state="translated">ListView 項目的核取屬性變更時引發的事件。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -227,8 +227,12 @@ namespace System.Windows.Forms
         {
             get
             {
-                ListView owningListView = listView ?? Group?.ListView
-                    ?? throw new InvalidOperationException(SR.ListViewItemAccessibilityObjectRequiresListView);
+                ListView owningListView = listView ?? Group?.ListView;
+                if (owningListView is null)
+                {
+                    _accessibilityObject = null;
+                    return _accessibilityObject;
+                }
 
                 if (_accessibilityObject is null || owningListView.View != _accessibilityObjectView)
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItemTests.cs
@@ -1071,11 +1071,11 @@ namespace System.Windows.Forms.Tests
         }
 
         [Fact]
-        public void ListViewItem_AccessibilityObject_ThrowsInvalidOperationException_IfListViewNotExists()
+        public void ListViewItem_AccessibilityObject_ReturnsNull_IfListViewNotExists()
         {
             ListViewItem item = new();
 
-            Assert.Throws<InvalidOperationException>(() => item.AccessibilityObject);
+            Assert.Null(item.AccessibilityObject);
         }
 
         [WinFormsFact]
@@ -1099,7 +1099,7 @@ namespace System.Windows.Forms.Tests
 
             listView.Items.RemoveAt(0);
 
-            Assert.Throws<InvalidOperationException>(() => item.AccessibilityObject);
+            Assert.Null(item.AccessibilityObject);
         }
 
         [WinFormsFact]
@@ -1113,7 +1113,7 @@ namespace System.Windows.Forms.Tests
 
             listView.Items.Clear();
 
-            Assert.Throws<InvalidOperationException>(() => item.AccessibilityObject);
+            Assert.Null(item.AccessibilityObject);
         }
     }
 }


### PR DESCRIPTION
This prevents exception in control disposal

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7223)