### PR TITLE
Enable nullability in ToolStripSettings and ToolStripSettingsManager

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettings.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Configuration;
 using System.Drawing;
 
@@ -31,7 +29,7 @@ namespace System.Windows.Forms
         }
 
         [UserScopedSetting]
-        public string ItemOrder
+        public string? ItemOrder
         {
             get
             {
@@ -44,7 +42,7 @@ namespace System.Windows.Forms
         }
 
         [UserScopedSetting]
-        public string Name
+        public string? Name
         {
             get
             {
@@ -85,7 +83,7 @@ namespace System.Windows.Forms
         }
 
         [UserScopedSetting]
-        public string ToolStripPanelName
+        public string? ToolStripPanelName
         {
             get
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettingsManager.SettingsStub.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettingsManager.SettingsStub.cs
@@ -15,11 +15,11 @@ namespace System.Windows.Forms
         private struct SettingsStub
         {
             public bool Visible;
-            public string ToolStripPanelName;
+            public string? ToolStripPanelName;
             public Point Location;
             public Size Size;
-            public string ItemOrder;
-            public string Name;
+            public string? ItemOrder;
+            public string? Name;
 
             public SettingsStub(ToolStrip toolStrip)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettingsManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSettingsManager.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.Diagnostics;
 using System.Text;
@@ -108,7 +106,7 @@ namespace System.Windows.Forms
 
             foreach (SettingsStub toolStripSettings in toolStripSettingsToApply)
             {
-                object destinationPanel = !string.IsNullOrEmpty(toolStripSettings.ToolStripPanelName) ? toolStripSettings.ToolStripPanelName : null;
+                object? destinationPanel = !string.IsNullOrEmpty(toolStripSettings.ToolStripPanelName) ? toolStripSettings.ToolStripPanelName : null;
 
                 if (destinationPanel is null)
                 {
@@ -186,7 +184,7 @@ namespace System.Windows.Forms
                 toolStrip.Size = settings.Size;
 
                 // Apply the item order changes.
-                string itemNames = settings.ItemOrder;
+                string? itemNames = settings.ItemOrder;
                 if (!string.IsNullOrEmpty(itemNames))
                 {
                     string[] keys = itemNames.Split(',');


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripSettings and ToolStripSettingsManager.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7234)