### PR TITLE
Enable nullability in DataGridViewHitTestTypeInternal and DataGridViewValidateCellInternal

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewHitTestTypeInternal.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewHitTestTypeInternal.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class DataGridView

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewValidateCellInternal.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataGridViewValidateCellInternal.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class DataGridView


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewHitTestTypeInternal and DataGridViewValidateCellInternal.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7235)