### PR TITLE
Fix condition in skipAppModel to use UseWindowsDesktopSDK

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-VisualBasic/.template.config/template.json
@@ -89,7 +89,7 @@
     },
     "skipAppModel": {
       "type": "computed",
-      "value": "(hostIsCli && !UseAppFramework)"
+      "value": "(UseWindowsDesktopSdk || (hostIsCli && !UseAppFramework))"
     }
     },
     "primaryOutputs": [


### PR DESCRIPTION
Fixes #7267

## Proposed changes
- Update skipAppModel condition to consider UseWindowsDesktopSDK which to properly create template targeting netcoreapp3.1 when created from Visual Studio


## Customer Impact

- Without change, customer cannot create a netcoreapp3.1 Winforms app successfully in Visual Studio

## Regression? 

- No, this appears to have been an issue for quite some time.

## Risk

- Low

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

-  Installed template locally with changes, verified both CLI and Visual Studio was successful when targeting 3.1
-  Verified no regressions for other TFMs


