### PR TITLE
Ignore tooltip null-owners

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TTOOLINFOW.cs
@@ -29,35 +29,48 @@ internal static partial class Interop
             public TTOOLINFOW Info;
             public string? Text { get; set; }
             [MaybeNull]
-            private readonly T _handle;
+            private readonly T? _handle;
 
-            public unsafe ToolInfoWrapper(T handle, TTF flags = default, string? text = null)
+            public unsafe ToolInfoWrapper(T? handle, TTF flags = default, string? text = null)
             {
-                Info = new TTOOLINFOW
-                {
-                    hwnd = handle.Handle,
-                    uId = handle.Handle,
-                    uFlags = flags | TTF.IDISHWND
-                };
-                Text = text;
                 _handle = handle;
+                if (_handle is not null)
+                {
+                    Info = new TTOOLINFOW
+                    {
+                        hwnd = _handle.Handle,
+                        uId = _handle.Handle,
+                        uFlags = flags | TTF.IDISHWND
+                    };
+                }
+
+                Text = text;
             }
 
-            public unsafe ToolInfoWrapper(T handle, IntPtr id, TTF flags = default, string? text = null, RECT rect = default)
+            public unsafe ToolInfoWrapper(T? handle, IntPtr id, TTF flags = default, string? text = null, RECT rect = default)
             {
-                Info = new TTOOLINFOW
-                {
-                    hwnd = handle.Handle,
-                    uId = id,
-                    uFlags = flags,
-                    rect = rect
-                };
-                Text = text;
                 _handle = handle;
+                if (_handle is not null)
+                {
+                    Info = new TTOOLINFOW
+                    {
+                        hwnd = _handle.Handle,
+                        uId = id,
+                        uFlags = flags,
+                        rect = rect
+                    };
+                }
+
+                Text = text;
             }
 
             public unsafe nint SendMessage(IHandle sender, User32.WM message, BOOL state = BOOL.FALSE)
             {
+                if (_handle is null)
+                {
+                    return 0;
+                }
+
                 Info.cbSize = (uint)sizeof(TTOOLINFOW);
                 fixed (char* c = Text)
                 fixed (void* i = &Info)


### PR DESCRIPTION
Resolves #7262

In some circumstances it's plausible to have a race condition, and the control, for which a tooltip is being created, may have disappeared by the time the tooltip is about to be shown. This may lead to the following:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at System.Windows.Forms.Control.GetSafeHandle(IWin32Window window)
   at Interop.ComCtl32.ToolInfoWrapper`1..ctor(T handle, TTF flags, String text)
   at System.Windows.Forms.ToolTip.TryGetBubbleSize(IKeyboardToolTip tool, Rectangle toolRectangle, Size& bubbleSize)
   at System.Windows.Forms.ToolTip.ShowKeyboardToolTip(String text, IKeyboardToolTip tool, Int32 duration)
   at System.Windows.Forms.KeyboardToolTipStateMachine.ShowToolTip(IKeyboardToolTip tool, ToolTip toolTip)
```

Ignore such situations.

I tried to recreate the issue on W11 with the following tweak to [the existing test app](https://github.com/dotnet/winforms/blob/4223d0a6ff606335e064c378a302a05fa382f0e2/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DataGridViewInVirtualModeTest.cs) and had the mouse hover cells in the first column, but similar to [the customer's report](https://github.com/dotnet/winforms/issues/7262#issue-1262896269) was unable to do so. 

```cs
        private Timer _timer = new();
        private Random random = new((int)DateTime.Now.Ticks);

        public DataGridViewInVirtualModeTest()
        {
            InitializeComponent();
            dataGridView1.VirtualMode = false;
            DoubleBuffered = true;

            _timer.Interval = 100;
            _timer.Tick += (s, e) =>
            {
                _customers.Clear();

                // Add some sample entries to the data store
                for (int i = 0; i < random.Next(50, 100); i++)
                {
                    _customers.Add(new TestCustomer("Ann" + new string('0', random.Next(0, 50)), 23, true, "Female"));
                    _customers.Add(new TestCustomer("John" + new string('0', random.Next(0, 50)), 45, true, "Male"));
                    _customers.Add(new TestCustomer("Sarah" + new string('0', random.Next(0, 50)), 67, false, "Female"));
                }

                dataGridView1.DataSource = null;
                dataGridView1.DataSource = _customers;
            };
        }
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7269)