### PR TITLE
Use LibraryImport in some Interop Kernel32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.ActivateActCtx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.ActivateActCtx.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public extern static BOOL ActivateActCtx(IntPtr hActCtx, out IntPtr lpCookie);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial BOOL ActivateActCtx(IntPtr hActCtx, out IntPtr lpCookie);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.CloseHandle.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.CloseHandle.cs
@@ -8,8 +8,8 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern BOOL CloseHandle(IntPtr handle);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial BOOL CloseHandle(IntPtr handle);
 
         public static BOOL CloseHandle(HandleRef handle)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.CreateActCtxW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.CreateActCtxW.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public unsafe extern static IntPtr CreateActCtxW(ref ACTCTXW pActCtx);
+        [LibraryImport(Libraries.Kernel32)]
+        public static unsafe partial IntPtr CreateActCtxW(ref ACTCTXW pActCtx);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.DeactivateActCtx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.DeactivateActCtx.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public extern static BOOL DeactivateActCtx(uint dwFlags, IntPtr ulCookie);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial BOOL DeactivateActCtx(uint dwFlags, IntPtr ulCookie);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.DuplicateHandle.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.DuplicateHandle.cs
@@ -8,8 +8,8 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern IntPtr DuplicateHandle(
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial IntPtr DuplicateHandle(
             IntPtr hSourceProcessHandle,
             IntPtr hSourceHandle,
             IntPtr hTargetProcessHandle,

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.FreeLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.FreeLibrary.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
-        public static extern BOOL FreeLibrary(IntPtr hModule);
+        [LibraryImport(Libraries.Kernel32, SetLastError = true)]
+        public static partial BOOL FreeLibrary(IntPtr hModule);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetCurrentActCtx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetCurrentActCtx.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public extern static BOOL GetCurrentActCtx(out IntPtr lphActCtx);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial BOOL GetCurrentActCtx(out IntPtr lphActCtx);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetCurrentProcess.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetCurrentProcess.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern IntPtr GetCurrentProcess();
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial IntPtr GetCurrentProcess();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetCurrentProcessId.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetCurrentProcessId.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern uint GetCurrentProcessId();
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial uint GetCurrentProcessId();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetCurrentThread.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetCurrentThread.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern IntPtr GetCurrentThread();
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial IntPtr GetCurrentThread();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetCurrentThreadId.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetCurrentThreadId.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern uint GetCurrentThreadId();
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial uint GetCurrentThreadId();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetExitCodeThread.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetExitCodeThread.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern BOOL GetExitCodeThread(IntPtr hWnd, out uint lpdwExitCode);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial BOOL GetExitCodeThread(IntPtr hWnd, out uint lpdwExitCode);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetLocaleInfoEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetLocaleInfoEx.cs
@@ -12,7 +12,7 @@ internal partial class Interop
         public const string LOCALE_NAME_INVARIANT = "";
         public const string LOCALE_NAME_SYSTEM_DEFAULT = "!x-sys-default-locale";
 
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, CharSet = CharSet.Unicode, SetLastError = true)]
-        public unsafe static extern int GetLocaleInfoEx(string lpLocaleName, LCTYPE LCType, char* lpLCData, int cchData);
+        [LibraryImport(Libraries.Kernel32, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        public static unsafe partial int GetLocaleInfoEx(string lpLocaleName, LCTYPE LCType, char* lpLCData, int cchData);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetModuleHandle.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetModuleHandle.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
-        public static extern IntPtr GetModuleHandleW(string? moduleName);
+        [LibraryImport(Libraries.Kernel32, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        public static partial IntPtr GetModuleHandleW(string? moduleName);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetShortPathNameW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetShortPathNameW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true, CharSet = CharSet.Unicode)]
-        public unsafe static extern uint GetShortPathNameW(string lpszLongPath, char* lpszShortPath, uint cchBuffer);
+        [LibraryImport(Libraries.Kernel32, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        public static unsafe partial uint GetShortPathNameW(string lpszLongPath, char* lpszShortPath, uint cchBuffer);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetStartupInfoW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetStartupInfoW.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern void GetStartupInfoW(ref STARTUPINFOW lpStartupInfo);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial void GetStartupInfoW(ref STARTUPINFOW lpStartupInfo);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetSystemPowerStatus.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetSystemPowerStatus.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern BOOL GetSystemPowerStatus(ref SYSTEM_POWER_STATUS lpSystemPowerStatus);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial BOOL GetSystemPowerStatus(ref SYSTEM_POWER_STATUS lpSystemPowerStatus);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetThreadLocale.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetThreadLocale.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern LCID GetThreadLocale();
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial LCID GetThreadLocale();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetTickCount.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetTickCount.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern uint GetTickCount();
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial uint GetTickCount();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetUserDefaultLCID.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GetUserDefaultLCID.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern uint GetUserDefaultLCID();
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial uint GetUserDefaultLCID();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalAlloc.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalAlloc.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern IntPtr GlobalAlloc(GMEM uFlags, uint dwBytes);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial IntPtr GlobalAlloc(GMEM uFlags, uint dwBytes);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalFree.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalFree.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern IntPtr GlobalFree(IntPtr hMem);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial IntPtr GlobalFree(IntPtr hMem);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalLock.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalLock.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern IntPtr GlobalLock(IntPtr hMem);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial IntPtr GlobalLock(IntPtr hMem);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalReAlloc.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalReAlloc.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern IntPtr GlobalReAlloc(IntPtr hMem, uint dwBytes, GMEM uFlags);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial IntPtr GlobalReAlloc(IntPtr hMem, uint dwBytes, GMEM uFlags);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalSize.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalSize.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern int GlobalSize(IntPtr hMem);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial int GlobalSize(IntPtr hMem);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalUnlock.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.GlobalUnlock.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public static extern BOOL GlobalUnlock(IntPtr hMem);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial BOOL GlobalUnlock(IntPtr hMem);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.LoadLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.LoadLibrary.cs
@@ -11,8 +11,8 @@ internal partial class Interop
     {
         private const int LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800;
 
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
-        private static extern IntPtr LoadLibraryExW(string lpModuleName, IntPtr hFile, uint dwFlags);
+        [LibraryImport(Libraries.Kernel32, SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+        private static partial IntPtr LoadLibraryExW(string lpModuleName, IntPtr hFile, uint dwFlags);
 
         /// <summary>
         /// Loads comctl32.dll from either the <paramref name="startupPath"/>, if it is supplied;

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.MultiByteToWideChar.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.MultiByteToWideChar.cs
@@ -13,8 +13,8 @@ internal partial class Interop
         //            of WCHARs in the string, while the size of the Out buffer equals the number of bytes. To avoid a buffer overrun, be sure to specify
         //            a buffer size appropriate for the data type the buffer receives. For more information, see Security Considerations: International Features.
         //            Always call these functions passing a null destination buffer to get its size and the create the buffer with the exact size.
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
-        public unsafe static extern int MultiByteToWideChar(
+        [LibraryImport(Libraries.Kernel32, SetLastError = true)]
+        public static unsafe partial int MultiByteToWideChar(
             CP CodePage,
             uint dwFlags,
             byte* lpMultiByteStr,

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.OpenProcess.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.OpenProcess.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true, SetLastError = true)]
-        public static extern IntPtr OpenProcess(ProcessAccessOptions dwDesiredAccess, BOOL bInheritHandle, uint dwProcessId);
+        [LibraryImport(Libraries.Kernel32, SetLastError = true)]
+        public static partial IntPtr OpenProcess(ProcessAccessOptions dwDesiredAccess, BOOL bInheritHandle, uint dwProcessId);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.SetThreadLocale.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.SetThreadLocale.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, ExactSpelling = true)]
-        public extern static BOOL SetThreadLocale(LCID Locale);
+        [LibraryImport(Libraries.Kernel32)]
+        public static partial BOOL SetThreadLocale(LCID Locale);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.WideCharToMultiByte.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Kernel32/Interop.WideCharToMultiByte.cs
@@ -8,8 +8,8 @@ internal partial class Interop
 {
     internal partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
-        public unsafe static extern int WideCharToMultiByte(
+        [LibraryImport(Libraries.Kernel32, SetLastError = true)]
+        public static unsafe partial int WideCharToMultiByte(
             CP CodePage,
             uint dwFlags,
             char* lpWideCharStr,


### PR DESCRIPTION
## Proposed changes

- Use LibraryImport in some Interop Kernel32.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7279)