### PR TITLE
Fix ListBox items accessible objects memory leak 

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
@@ -177,7 +177,40 @@ namespace System.Windows.Forms
 
             internal void ResetListItemAccessibleObjects()
             {
+                if (OsVersion.IsWindows8OrGreater)
+                { 
+                    foreach (ListBoxItemAccessibleObject itemAccessibleObject in _itemAccessibleObjects.Values)
+                    {
+                        HRESULT result = UiaCore.UiaDisconnectProvider(itemAccessibleObject);
+                        Debug.Assert(result == HRESULT.S_OK);
+                    }
+                }
+
                 _itemAccessibleObjects.Clear();
+            }
+
+            internal void RemoveListItemAccessibleObjectAt(int index)
+            {
+                IReadOnlyList<ItemArray.Entry?> entries = _owningListBox.Items.InnerArray.Entries;
+                if (index >= entries.Count)
+                {
+                    return;
+                }
+
+                ItemArray.Entry? item = entries[index];
+
+                if (item is null || !_itemAccessibleObjects.ContainsKey(item))
+                {
+                    return;
+                }
+
+                if (OsVersion.IsWindows8OrGreater)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(_itemAccessibleObjects[item]);
+                    Debug.Assert(result == HRESULT.S_OK);
+                }
+
+                _itemAccessibleObjects.Remove(item);
             }
 
             internal override void SelectItem()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ObjectCollection.cs
@@ -251,7 +251,6 @@ namespace System.Windows.Forms
             {
                 //update the width.. to reset Scrollbars..
                 // Clear the selection state.
-                //
                 int cnt = _owner.Items.Count;
                 for (int i = 0; i < cnt; i++)
                 {
@@ -266,6 +265,7 @@ namespace System.Windows.Forms
                 InnerArray.Clear();
                 _owner._maxWidth = -1;
                 _owner.UpdateHorizontalExtent();
+                _owner.ClearListItemAccessibleObjects();
             }
 
             public bool Contains(object value)
@@ -343,7 +343,6 @@ namespace System.Windows.Forms
 
                 // If the List box is sorted, then nust treat this like an add
                 // because we are going to twiddle the index anyway.
-                //
                 if (_owner._sorted)
                 {
                     Add(item);
@@ -406,6 +405,10 @@ namespace System.Windows.Forms
                 }
 
                 _owner.UpdateMaxItemWidth(InnerArray.GetItem(index), true);
+
+                // Remove AccessibleObject before removing item from InnerArray because AccessibleObject relies on
+                // item's presence in InnerArray
+                _owner.RemoveListItemAccessibleObjectAt(index);
 
                 // Update InnerArray before calling NativeRemoveAt to ensure that when
                 // SelectedIndexChanged is raised (by NativeRemoveAt), InnerArray's state matches wrapped LB state.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -1346,6 +1346,14 @@ namespace System.Windows.Forms
             return Math.Max(oldMax, textSize.Width);
         }
 
+        private void ClearListItemAccessibleObjects()
+        {
+            if (IsAccessibilityObjectCreated && AccessibilityObject is ListBoxAccessibleObject accessibilityObject)
+            {
+                accessibilityObject.ResetListItemAccessibleObjects();
+            }
+        }
+
         /// <summary>
         ///  Deselects all currently selected items.
         /// </summary>
@@ -2089,6 +2097,20 @@ namespace System.Windows.Forms
         protected override void RefreshItem(int index)
         {
             Items.SetItemInternal(index, Items[index]);
+        }
+
+        internal override void ReleaseUiaProvider(IntPtr handle)
+        {
+            base.ReleaseUiaProvider(handle);
+            ClearListItemAccessibleObjects();
+        }
+
+        private void RemoveListItemAccessibleObjectAt(int index)
+        {
+            if (IsAccessibilityObjectCreated && AccessibilityObject is ListBoxAccessibleObject accessibilityObject)
+            {
+                accessibilityObject.RemoveListItemAccessibleObjectAt(index);
+            }
         }
 
         public override void ResetBackColor()


### PR DESCRIPTION
Fixes #7197.


## Proposed changes

- Add call to `UiaDisconnectProvider` for `ListBoxItemAccessibleObject`s for cases when:
    - `ListBox` is destroyed (now it only releases provider for `ListBoxAccessibleObject`)
    - All items are cleared from `ListBox`
    - An item is removed from `ListBox`
- Add unit tests for above scenarios

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- `ListBoxItemAccessibleObject`s memory will stop leaking 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

After executing steps from issue description for ListBox with 18 items:

![Screenshot 2022-06-09 184103](https://user-images.githubusercontent.com/102954094/172899825-4130454d-ab5b-48e7-a567-451497ba6184.png)

### After

![Screenshot 2022-06-09 180310](https://user-images.githubusercontent.com/102954094/172899893-95dfb5a5-16b8-459e-8b1d-317267637d70.png)

After `ListBox.Items.Clear()`:

![Screenshot 2022-06-09 183627](https://user-images.githubusercontent.com/102954094/172900100-e7cf850a-d04d-4816-b836-b4827d39bc1c.png)

One `ListBoxItemAccessibleObject` instance may be held by `ListBox._focusedItem` field, which doesn't create a memory leak, because the AO was disconnected from UIA provider and will be garbage-collected normally once form is closed.

After  `ListBox.Items.RemoveAt(0)` 5 times:

![Screenshot 2022-06-09 183839](https://user-images.githubusercontent.com/102954094/172900281-17817f20-72eb-4179-8f1f-48fc484c652e.png)


## Test methodology <!-- How did you ensure quality? -->

- Unit testing
- Manual testing with WinDbg to check memory leak, Narrator to check for regressions similar to #6230, Inspect/AI to check that removed items are inaccessible there
 

## Test environment(s)

* Windows 11 (Version 10.0.22000)
* .NET 7.0.0-preview.5.22272.3

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7284)