### PR TITLE
Use LibraryImport in some Interop Comctl32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Add.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Add.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_Add")]
-            public static extern int Add(IntPtr himl, Gdi32.HBITMAP hbmImage, Gdi32.HBITMAP hbmMask);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_Add")]
+            public static partial int Add(IntPtr himl, Gdi32.HBITMAP hbmImage, Gdi32.HBITMAP hbmMask);
 
             public static int Add(IHandle himl, Gdi32.HBITMAP hbmImage, Gdi32.HBITMAP hbmMask)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Create.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Create.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_Create")]
-            public static extern IntPtr Create(int cx, int cy, ILC flags, int cInitial, int cGrow);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_Create")]
+            public static partial IntPtr Create(int cx, int cy, ILC flags, int cInitial, int cGrow);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Destroy.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Destroy.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_Destroy")]
-            public static extern BOOL Destroy(IntPtr himl);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_Destroy")]
+            public static partial BOOL Destroy(IntPtr himl);
 
             public static BOOL Destroy(HandleRef himl)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Draw.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Draw.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_Draw")]
-            public static extern BOOL Draw(IntPtr himl, int i, Gdi32.HDC hdcDst, int x, int y, ILD fStyle);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_Draw")]
+            public static partial BOOL Draw(IntPtr himl, int i, Gdi32.HDC hdcDst, int x, int y, ILD fStyle);
 
             public static BOOL Draw(IHandle himl, int i, Gdi32.HDC hdcDst, int x, int y, ILD fStyle)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.DrawEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.DrawEx.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_DrawEx")]
-            public static extern BOOL DrawEx(IntPtr himl, int i, IntPtr hdcDst, int x, int y, int dx, int dy, int rgbBk, int rgbFg, ILD fStyle);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_DrawEx")]
+            public static partial BOOL DrawEx(IntPtr himl, int i, IntPtr hdcDst, int x, int y, int dx, int dy, int rgbBk, int rgbFg, ILD fStyle);
 
             public static BOOL DrawEx(IntPtr himl, int i, HandleRef hdcDst, int x, int y, int dx, int dy, int rgbBk, int rgbFg, ILD fStyle)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Duplicate.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Duplicate.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_Duplicate")]
-            public static extern IntPtr Duplicate(IntPtr himl);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_Duplicate")]
+            public static partial IntPtr Duplicate(IntPtr himl);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.GetIconSize.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.GetIconSize.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_GetIconSize")]
-            public static extern BOOL GetIconSize(IntPtr himl, out int x, out int y);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_GetIconSize")]
+            public static partial BOOL GetIconSize(IntPtr himl, out int x, out int y);
 
             public static BOOL GetIconSize(HandleRef himl, out int x, out int y)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.GetImageCount.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.GetImageCount.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_GetImageCount")]
-            public static extern int GetImageCount(IntPtr himl);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_GetImageCount")]
+            public static partial int GetImageCount(IntPtr himl);
 
             public static int GetImageCount(IHandle himl)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.GetImageInfo.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.GetImageInfo.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_GetImageInfo")]
-            public static extern BOOL GetImageInfo(IntPtr himl, int i, ref IMAGEINFO pImageInfo);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_GetImageInfo")]
+            public static partial BOOL GetImageInfo(IntPtr himl, int i, ref IMAGEINFO pImageInfo);
 
             public static BOOL GetImageInfo(HandleRef himl, int i, ref IMAGEINFO pImageInfo)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Remove.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Remove.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_Remove")]
-            public static extern BOOL Remove(IntPtr himl, int i);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_Remove")]
+            public static partial BOOL Remove(IntPtr himl, int i);
 
             public static BOOL Remove(IHandle himl, int i)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Replace.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.Replace.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_Replace")]
-            public static extern BOOL Replace(IntPtr himl, int i, IntPtr hbmImage, IntPtr hbmMask);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_Replace")]
+            public static partial BOOL Replace(IntPtr himl, int i, IntPtr hbmImage, IntPtr hbmMask);
 
             public static BOOL Replace(IHandle himl, int i, IntPtr hbmImage, IntPtr hbmMask)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.ReplaceIcon.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.ReplaceIcon.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_ReplaceIcon")]
-            public static extern int ReplaceIcon(IntPtr himl, int i, IntPtr hicon);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_ReplaceIcon")]
+            public static partial int ReplaceIcon(IntPtr himl, int i, IntPtr hicon);
 
             public static int ReplaceIcon(IHandle himl, int i, HandleRef hicon)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.SetBkColor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.ImageList.SetBkColor.cs
@@ -10,8 +10,8 @@ internal partial class Interop
     {
         public static partial class ImageList
         {
-            [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "ImageList_SetBkColor")]
-            public static extern int SetBkColor(IntPtr himl, int clrBk);
+            [LibraryImport(Libraries.Comctl32, EntryPoint = "ImageList_SetBkColor")]
+            public static partial int SetBkColor(IntPtr himl, int clrBk);
 
             public static int SetBkColor(IHandle himl, int clrBk)
             {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.InitCommonControls.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.InitCommonControls.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class ComCtl32
     {
-        [DllImport(Libraries.Comctl32, ExactSpelling = true)]
-        public static extern void InitCommonControls();
+        [LibraryImport(Libraries.Comctl32)]
+        public static partial void InitCommonControls();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.InitCommonControlsEx.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.InitCommonControlsEx.cs
@@ -8,8 +8,8 @@ internal partial class Interop
 {
     internal partial class ComCtl32
     {
-        [DllImport(Libraries.Comctl32, ExactSpelling = true, EntryPoint = "InitCommonControlsEx")]
-        private static extern BOOL InitCommonControlsExInternal(ref INITCOMMONCONTROLSEX picce);
+        [LibraryImport(Libraries.Comctl32, EntryPoint = "InitCommonControlsEx")]
+        private static partial BOOL InitCommonControlsExInternal(ref INITCOMMONCONTROLSEX picce);
 
         public static BOOL InitCommonControlsEx(ref INITCOMMONCONTROLSEX picce)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TaskDialogIndirect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/ComCtl32/Interop.TaskDialogIndirect.cs
@@ -12,8 +12,8 @@ internal static partial class Interop
         // because we currently do manual marshalling. Otherwise, the struct might be
         // accidentally marshalled by the runtime when it is no longer blittable, but we
         // also need a pointer to it for SendMessage() calls where it wouldn't be marshalled.
-        [DllImport(Libraries.Comctl32, ExactSpelling = true)]
-        public static extern unsafe HRESULT TaskDialogIndirect(
+        [LibraryImport(Libraries.Comctl32)]
+        public static unsafe partial HRESULT TaskDialogIndirect(
             TASKDIALOGCONFIG* pTaskConfig,
             out int pnButton,
             out int pnRadioButton,


### PR DESCRIPTION
## Proposed changes

- Use LibraryImport in some Interop Comctl32.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7285)