### PR TITLE
Use LibraryImport in Interop Imm32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmAssociateContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmAssociateContext.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Imm32
     {
-        [DllImport(Libraries.Imm32, ExactSpelling = true)]
-        public static extern IntPtr ImmAssociateContext(IntPtr hWnd, IntPtr hIMC);
+        [LibraryImport(Libraries.Imm32)]
+        public static partial IntPtr ImmAssociateContext(IntPtr hWnd, IntPtr hIMC);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmCreateContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmCreateContext.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Imm32
     {
-        [DllImport(Libraries.Imm32, ExactSpelling = true)]
-        public static extern IntPtr ImmCreateContext();
+        [LibraryImport(Libraries.Imm32)]
+        public static partial IntPtr ImmCreateContext();
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmGetContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmGetContext.cs
@@ -8,8 +8,8 @@ internal partial class Interop
 {
     internal partial class Imm32
     {
-        [DllImport(Libraries.Imm32, ExactSpelling = true)]
-        public static extern IntPtr ImmGetContext(IntPtr hWnd);
+        [LibraryImport(Libraries.Imm32)]
+        public static partial IntPtr ImmGetContext(IntPtr hWnd);
 
         public static IntPtr ImmGetContext(IHandle hWnd)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmGetConversionStatus.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmGetConversionStatus.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Imm32
     {
-        [DllImport(Libraries.Imm32, ExactSpelling = true)]
-        public static extern BOOL ImmGetConversionStatus(IntPtr hIMC, out IME_CMODE lpfdwConversion, out IME_SMODE lpfdwSentence);
+        [LibraryImport(Libraries.Imm32)]
+        public static partial BOOL ImmGetConversionStatus(IntPtr hIMC, out IME_CMODE lpfdwConversion, out IME_SMODE lpfdwSentence);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmGetOpenStatus.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmGetOpenStatus.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Imm32
     {
-        [DllImport(Libraries.Imm32, ExactSpelling = true)]
-        public static extern BOOL ImmGetOpenStatus(IntPtr hIMC);
+        [LibraryImport(Libraries.Imm32)]
+        public static partial BOOL ImmGetOpenStatus(IntPtr hIMC);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmNotifyIME.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmNotifyIME.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Imm32
     {
-        [DllImport(Libraries.Imm32, ExactSpelling = true)]
-        public static extern BOOL ImmNotifyIME(IntPtr hIMC, NI dwAction, CPS dwIndex, int dwValue);
+        [LibraryImport(Libraries.Imm32)]
+        public static partial BOOL ImmNotifyIME(IntPtr hIMC, NI dwAction, CPS dwIndex, int dwValue);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmReleaseContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmReleaseContext.cs
@@ -8,8 +8,8 @@ internal partial class Interop
 {
     internal partial class Imm32
     {
-        [DllImport(Libraries.Imm32, ExactSpelling = true)]
-        public static extern BOOL ImmReleaseContext(IntPtr hWnd, IntPtr hIMC);
+        [LibraryImport(Libraries.Imm32)]
+        public static partial BOOL ImmReleaseContext(IntPtr hWnd, IntPtr hIMC);
 
         public static BOOL ImmReleaseContext(IHandle hWnd, IntPtr hIMC)
         {

--- a/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmSetConversionStatus.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmSetConversionStatus.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Imm32
     {
-        [DllImport(Libraries.Imm32, ExactSpelling = true)]
-        public static extern BOOL ImmSetConversionStatus(IntPtr hIMC, IME_CMODE conversion, IME_SMODE sentence);
+        [LibraryImport(Libraries.Imm32)]
+        public static partial BOOL ImmSetConversionStatus(IntPtr hIMC, IME_CMODE conversion, IME_SMODE sentence);
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmSetOpenStatus.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Imm32/Interop.ImmSetOpenStatus.cs
@@ -8,7 +8,7 @@ internal partial class Interop
 {
     internal partial class Imm32
     {
-        [DllImport(Libraries.Imm32, ExactSpelling = true)]
-        public static extern BOOL ImmSetOpenStatus(IntPtr hIMC, BOOL open);
+        [LibraryImport(Libraries.Imm32)]
+        public static partial BOOL ImmSetOpenStatus(IntPtr hIMC, BOOL open);
     }
 }


### PR DESCRIPTION
## Proposed changes

- Use LibraryImport in Interop Imm32.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7286)