### PR TITLE
Releasing leak objects of UiaTextRange

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ITextRangeProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.ITextRangeProvider.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         public interface ITextRangeProvider
         {
-            ITextRangeProvider Clone();
+            ITextRangeProvider? Clone();
 
             BOOL Compare(ITextRangeProvider range);
 
@@ -29,7 +29,7 @@ internal static partial class Interop
 
             double[] GetBoundingRectangles();
 
-            IRawElementProviderSimple GetEnclosingElement();
+            IRawElementProviderSimple? GetEnclosingElement();
 
             string GetText(int maxLength);
 

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
@@ -98,6 +98,13 @@ namespace System.Windows.Forms.Automation
             return doubles;
         }
 
+        internal event EventHandler? OwnerDisposed;
+
+        private protected void RaiseOwnerDisposedEvent()
+        {
+            OwnerDisposed?.Invoke(null, EventArgs.Empty);
+        }
+
         public int SendInput(int inputs, ref INPUT input, int size)
         {
             Span<INPUT> currentInput = stackalloc INPUT[1];

--- a/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
+++ b/src/System.Windows.Forms.Primitives/tests/UnitTests/System/Windows/Forms/Automation/UiaTextRangeTests.cs
@@ -216,9 +216,9 @@ namespace System.Windows.Forms.Primitives.Tests.Automation
             IRawElementProviderSimple enclosingElement = new Mock<IRawElementProviderSimple>(MockBehavior.Strict).Object;
             UiaTextProvider provider = new Mock<UiaTextProvider>(MockBehavior.Strict).Object;
             UiaTextRange textRange = new UiaTextRange(enclosingElement, provider, start: 3, end: 9);
-            UiaTextRange actual = (UiaTextRange)((ITextRangeProvider)textRange).Clone();
-            Assert.Equal(textRange.Start, actual.Start);
-            Assert.Equal(textRange.End, actual.End);
+            UiaTextRange? actual = (UiaTextRange?)((ITextRangeProvider)textRange).Clone();
+            Assert.Equal(textRange.Start, actual?.Start);
+            Assert.Equal(textRange.End, actual?.End);
         }
 
         [StaTheory]
@@ -646,7 +646,7 @@ Test text on line 2.";
             IRawElementProviderSimple enclosingElement = new Mock<IRawElementProviderSimple>(MockBehavior.Strict).Object;
             UiaTextProvider provider = new Mock<UiaTextProvider>(MockBehavior.Strict).Object;
             UiaTextRange textRange = new UiaTextRange(enclosingElement, provider, start: 0, end: 0);
-            IRawElementProviderSimple actual = ((ITextRangeProvider)textRange).GetEnclosingElement();
+            IRawElementProviderSimple? actual = ((ITextRangeProvider)textRange).GetEnclosingElement();
             Assert.Equal(enclosingElement, actual);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildDropDownButtonUiaProvider.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms
             }
 
             /// <summary>
-            ///  Gets or sets the accessible Name of ComboBox's child DropDown button. ("Open" or "Close" depending on stat of the DropDown)
+            ///  Gets or sets the accessible Name of ComboBox's child DropDown button. ("Open" or "Close" depending on state of the DropDown)
             /// </summary>
             public override string Name => _owner.DroppedDown ? SR.ComboboxDropDownButtonCloseName : SR.ComboboxDropDownButtonOpenName;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -19,6 +19,13 @@ namespace System.Windows.Forms
             public TextBoxBaseUiaTextProvider(TextBoxBase owner)
             {
                 _owningTextBoxBase = owner.OrThrowIfNull();
+                _owningTextBoxBase.HandleDestroyed += OnOwnerHandleDestroyed;
+            }
+
+            private void OnOwnerHandleDestroyed(object? sender, EventArgs e)
+            {
+                _owningTextBoxBase.HandleDestroyed -= OnOwnerHandleDestroyed;
+                RaiseOwnerDisposedEvent();
             }
 
             public override UiaCore.ITextRangeProvider[]? GetSelection()
@@ -96,7 +103,10 @@ namespace System.Windows.Forms
                 return new UiaTextRange(_owningTextBoxBase.AccessibilityObject, this, start, start);
             }
 
-            public override UiaCore.ITextRangeProvider DocumentRange => new UiaTextRange(_owningTextBoxBase.AccessibilityObject, this, start: 0, TextLength);
+            public override UiaCore.ITextRangeProvider? DocumentRange
+                => _owningTextBoxBase.IsHandleCreated
+                    ? new UiaTextRange(_owningTextBoxBase.AccessibilityObject, this, start: 0, TextLength)
+                    : null;
 
             public override UiaCore.SupportedTextSelection SupportedTextSelection => UiaCore.SupportedTextSelection.Single;
 
@@ -130,10 +140,10 @@ namespace System.Windows.Forms
             /// <returns>
             ///  A text range that contains the annotation target text.
             /// </returns>
-            public override UiaCore.ITextRangeProvider RangeFromAnnotation(UiaCore.IRawElementProviderSimple annotationElement)
-            {
-                return new UiaTextRange(_owningTextBoxBase.AccessibilityObject, this, start: 0, end: 0);
-            }
+            public override UiaCore.ITextRangeProvider? RangeFromAnnotation(UiaCore.IRawElementProviderSimple annotationElement)
+                => _owningTextBoxBase.IsHandleCreated
+                    ? new UiaTextRange(_owningTextBoxBase.AccessibilityObject, this, start: 0, end: 0)
+                    : null;
 
             public override Rectangle BoundingRectangle
                 => _owningTextBoxBase.IsHandleCreated

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1599,7 +1599,12 @@ namespace System.Windows.Forms
         }
 
         private protected virtual void RaiseAccessibilityTextChangedEvent()
-            => AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextChangedEventId);
+        {
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextChangedEventId);
+            }
+        }
 
         /// <summary>
         ///  Returns the character nearest to the given point.

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProviderTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProviderTests.cs
@@ -115,9 +115,10 @@ namespace System.Windows.Forms.Tests
         public void TextBoxBaseUiaTextProvider_DocumentRange_IsNotNull()
         {
             using TextBoxBase textBoxBase = new SubTextBoxBase();
+            textBoxBase.CreateControl();
             TextBoxBaseUiaTextProvider provider = new TextBoxBaseUiaTextProvider(textBoxBase);
             Assert.NotNull(provider.DocumentRange);
-            Assert.False(textBoxBase.IsHandleCreated);
+            Assert.True(textBoxBase.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -753,16 +754,24 @@ namespace System.Windows.Forms.Tests
             Assert.False(textBoxBase.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void TextBoxBaseUiaTextProvider_RangeFromAnnotation_DoesntThrowAnException()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TextBoxBaseUiaTextProvider_RangeFromAnnotation_DoesntThrowAnException(bool createControl)
         {
             using TextBoxBase textBoxBase = new SubTextBoxBase();
             TextBoxBaseUiaTextProvider provider = new TextBoxBaseUiaTextProvider(textBoxBase);
 
+            if (createControl)
+            {
+                textBoxBase.CreateControl();
+            }
+
             // RangeFromAnnotation doesn't throw an exception
             UiaCore.ITextRangeProvider range = provider.RangeFromAnnotation(textBoxBase.AccessibilityObject);
             // RangeFromAnnotation implementation can be changed so this test can be changed too
-            Assert.NotNull(range);
+            // Range shouldn't be null if the control is created.
+            Assert.Equal(createControl, range is not null);
         }
 
         [WinFormsFact]


### PR DESCRIPTION
Fixes #7248

## Proposed changes

- Use HandleDestroyed events to release related objects of UiaTextRange objects. We create new instances of the ranges and send them to UIA (eg. Inspect). When TextBox disposing UIA tool keeps several ranges thereby keep the provider and the TextBox accessible object. Due to we have many unregistered text ranges we don't have access to all of them, so I think it would be better to use events and subscription on them for every text range. 

## Customer Impact

- Application slows down or hangs to perform GC 
- This change related to DataGrdiViewTextBoxCell, PropertyGrid edit field, ComboBox, Numeric/DomainUpDown edit field, etc. TextPatterns leaks affect all controls with edit field and keep all their leaked objects, so this fix resolves it.

## Regression? 

- No

## Risk

- We make some fields as null. UIA can call some method or property after disposing, thereby try to get some value of null-object. So we can catch NRE. To avoid it needs to add necessary null checks.

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

- UIA keeps text ranges and TextBox accessible object
- TextBox accessible object keeps TextBox control (will be fixed next)
![image](https://user-images.githubusercontent.com/49272759/173382118-97f41e7d-ff72-4943-b3fa-bf844ae36a5e.png)
![image](https://user-images.githubusercontent.com/49272759/173382453-78690d1b-6173-4de0-b2b8-88ff5b63b3fa.png)


### After

- TextBox text provider is released
![image](https://user-images.githubusercontent.com/49272759/173383046-ab741603-76d1-47bc-89e1-c862510c4714.png)



## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
-  Using Inspect and Narrator:
     - Focus on a TextBox
     - Navigate through characters
     - Select some range
     - Use Inspect TextPattern explorer to get all possible ranges

## Test environment(s) <!-- Remove any that don't apply -->

- dotnet 7.0.0-preview.5.22272.3
- Windows 11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7295)