### PR TITLE
Fix TreeNode accessible objects memory leak

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -2074,7 +2074,18 @@ namespace System.Windows.Forms
                 _handle = IntPtr.Zero;
             }
 
+            ReleaseUiaProvider();
+
             treeView = null;
+        }
+
+        internal virtual void ReleaseUiaProvider()
+        {
+            if (OsVersion.IsWindows8OrGreater && _accessibleObject is not null)
+            {
+                UiaCore.UiaDisconnectProvider(AccessibilityObject);
+                _accessibleObject = null;
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -183,6 +183,19 @@ namespace System.Windows.Forms
             SetStyle(ControlStyles.UseTextForAccessibility, false);
         }
 
+        internal override void ReleaseUiaProvider(IntPtr handle)
+        {
+            base.ReleaseUiaProvider(handle);
+
+            foreach (TreeNode rootNode in Nodes)
+            {
+                foreach (TreeNode node in rootNode.GetSelfAndChildNodes())
+                {
+                    node.ReleaseUiaProvider();
+                }
+            }
+        }
+
         /// <summary>
         ///  The background color for this control. Specifying null for
         ///  this parameter sets the

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeNode.TreeNodeAccessibleObjectTests.cs
@@ -488,5 +488,95 @@ namespace System.Windows.Forms.Tests
             Assert.True(node.childCount > 0);
             Assert.False(control.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_IsDisconnected_WhenTreeViewIsReleased()
+        {
+            using TreeView control = new();
+            AccessibilityObjectDisconnectTrackingTreeNode firstLevelNode = new(control);
+            control.Nodes.Add(firstLevelNode);
+            AccessibilityObjectDisconnectTrackingTreeNode secondLevelNode = new(control);
+            firstLevelNode.Nodes.Add(secondLevelNode);
+            AccessibilityObjectDisconnectTrackingTreeNode thirdLevelNode = new(control);
+            secondLevelNode.Nodes.Add(thirdLevelNode);
+            control.CreateControl();
+
+            control.ReleaseUiaProvider(control.Handle);
+
+            Assert.True(firstLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(secondLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(thirdLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_IsDisconnected_WhenRemoved()
+        {
+            using TreeView control = new();
+            AccessibilityObjectDisconnectTrackingTreeNode firstLevelNode = new(control);
+            control.Nodes.Add(firstLevelNode);
+            AccessibilityObjectDisconnectTrackingTreeNode secondLevelNode = new(control);
+            firstLevelNode.Nodes.Add(secondLevelNode);
+            control.CreateControl();
+
+            control.Nodes.Remove(firstLevelNode);
+
+            Assert.True(firstLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(secondLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_IsDisconnected_WhenCleared()
+        {
+            using TreeView control = new();
+            AccessibilityObjectDisconnectTrackingTreeNode firstLevelNode = new(control);
+            control.Nodes.Add(firstLevelNode);
+            AccessibilityObjectDisconnectTrackingTreeNode secondLevelNode = new(control);
+            firstLevelNode.Nodes.Add(secondLevelNode);
+            AccessibilityObjectDisconnectTrackingTreeNode thirdLevelNode = new(control);
+            secondLevelNode.Nodes.Add(thirdLevelNode);
+            control.CreateControl();
+
+            control.Nodes.Clear();
+
+            Assert.True(firstLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(secondLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(thirdLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TreeNodeAccessibleObject_IsDisconnected_WhenReplacedByIndex()
+        {
+            using TreeView control = new();
+            AccessibilityObjectDisconnectTrackingTreeNode firstLevelNode = new(control);
+            control.Nodes.Add(firstLevelNode);
+            AccessibilityObjectDisconnectTrackingTreeNode secondLevelNode = new(control);
+            firstLevelNode.Nodes.Add(secondLevelNode);
+            AccessibilityObjectDisconnectTrackingTreeNode thirdLevelNode = new(control);
+            secondLevelNode.Nodes.Add(thirdLevelNode);
+            control.CreateControl();
+
+            control.Nodes[0] = new TreeNode();
+
+            Assert.True(firstLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(secondLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(thirdLevelNode.IsAccessibilityObjectDisconnected);
+            Assert.True(control.IsHandleCreated);
+        }
+
+        private class AccessibilityObjectDisconnectTrackingTreeNode : TreeNode
+        {
+            public AccessibilityObjectDisconnectTrackingTreeNode(TreeView treeView) : base(treeView) { }
+
+            public bool IsAccessibilityObjectDisconnected { get; private set; }
+
+            internal override void ReleaseUiaProvider()
+            {
+                base.ReleaseUiaProvider();
+                IsAccessibilityObjectDisconnected = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #7196


## Proposed changes

- Add call to `UiaDisconnectProvider` for `TreeNodeAccessibleObject`s for cases when:
    - `TreeView` is destroyed (now it only releases `TreeViewAccessibleObject`)
    - All nodes are cleared from `TreeView`
    - A node is removed from `TreeView`
- Add unit tests for above scenarios

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- `TreeNodeAccessibleObject` memory will stop leaking 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

After executing steps from issue description for `TreeView` with 16 nodes:

![Screenshot 2022-06-10 161803](https://user-images.githubusercontent.com/102954094/173408896-0f8a12d6-34e3-48aa-9748-d07e6a67256b.png)

### After

![Screenshot 2022-06-13 183507](https://user-images.githubusercontent.com/102954094/173408956-cbb1b9c4-56ac-450d-8c26-eb8246f79daf.png)

Ideally there should be 0 objects, but two empty `TreeNode[]` are still left. I tried to find the cause of it but couldn't quickly do so. It would also be present even without using accessibility tools, therefore out of scope of this task. Considering it has a very small footprint, I don't think we should raise a separate issue for it.

After `TreeView.Nodes.Clear()` — no `TreeNodeAccessibleObject` instances:

![Screenshot 2022-06-13 184741](https://user-images.githubusercontent.com/102954094/173412001-21b0a52e-1335-4a1d-ad17-f397268df9c2.png)

After  `TreeView.Nodes.RemoveAt()` for several nodes, leaving only 9:

![Screenshot 2022-06-13 184641](https://user-images.githubusercontent.com/102954094/173411528-06c367cf-9c93-4e7d-a49e-7c525b5d6ee1.png)


## Test methodology <!-- How did you ensure quality? -->

- Unit testing
- Manual testing with WinDbg to check memory leak, Narrator to check for regressions similar to #6230, Inspect/AI to check that removed nodes are inaccessible there
 


## Test environment(s) <!-- Remove any that don't apply -->

* Windows 11 (Version 10.0.22000)
* .NET 7.0.0-preview.5.22272.3



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7296)