### PR TITLE
Enable nullability in ToolStripItemInternalLayout

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.ToolStripLayoutData.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.ToolStripLayoutData.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Forms
                     _size = toolStrip.Size;
                 }
 
-                public bool IsCurrent(ToolStrip toolStrip)
+                public bool IsCurrent(ToolStrip? toolStrip)
                     => toolStrip is not null && toolStrip.Size == _size && toolStrip.LayoutStyle == _layoutStyle && toolStrip.AutoSize == _autoSize;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
@@ -170,6 +170,9 @@ namespace System.Windows.Forms
 
                 if (_ownerItem is not null)
                 {
+                    // _currentLayoutOptions will always be initialised if EnsureLayout() is called,
+                    // because it will get called at least once (for _layoutData is null) and, in turn,
+                    // it'll invoke PerformLayout() that'll unconditionally invoke GetLayoutData().
                     _lastPreferredSize = _currentLayoutOptions!.GetPreferredSizeCore(constrainingSize);
                     return _lastPreferredSize;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Windows.Forms.ButtonInternal;
 
@@ -46,7 +47,7 @@ namespace System.Windows.Forms
                 get
                 {
                     EnsureLayout();
-                    return _layoutData!;
+                    return _layoutData;
                 }
             }
 
@@ -133,6 +134,7 @@ namespace System.Windows.Forms
                 return layoutOptions;
             }
 
+            [MemberNotNull(nameof(_layoutData))]
             private bool EnsureLayout()
             {
                 if (_layoutData is null || _parentLayoutData is null || !_parentLayoutData.IsCurrent(ParentInternal))
@@ -175,6 +177,7 @@ namespace System.Windows.Forms
                 return Size.Empty;
             }
 
+            [MemberNotNull(nameof(_layoutData))]
             internal void PerformLayout()
             {
                 _layoutData = GetLayoutData();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms.ButtonInternal;
 
@@ -16,14 +14,14 @@ namespace System.Windows.Forms
         /// </summary>
         internal partial class ToolStripItemInternalLayout
         {
-            private ToolStripItemLayoutOptions _currentLayoutOptions;
+            private ToolStripItemLayoutOptions? _currentLayoutOptions;
             private readonly ToolStripItem _ownerItem;
-            private ButtonBaseAdapter.LayoutData _layoutData;
+            private ButtonBaseAdapter.LayoutData? _layoutData;
             private const int BorderWidth = 2;
             private readonly static Size s_invalidSize = new Size(int.MinValue, int.MinValue);
 
             private Size _lastPreferredSize = s_invalidSize;
-            private ToolStripLayoutData _parentLayoutData;
+            private ToolStripLayoutData? _parentLayoutData;
 
             public ToolStripItemInternalLayout(ToolStripItem ownerItem)
             {
@@ -37,7 +35,7 @@ namespace System.Windows.Forms
                 get
                 {
                     Rectangle imageRect = LayoutData.ImageBounds;
-                    imageRect.Intersect(_layoutData.Field);
+                    imageRect.Intersect(_layoutData!.Field);
                     return imageRect;
                 }
             }
@@ -47,20 +45,20 @@ namespace System.Windows.Forms
                 get
                 {
                     EnsureLayout();
-                    return _layoutData;
+                    return _layoutData!;
                 }
             }
 
             public Size PreferredImageSize => Owner.PreferredImageSize;
 
-            protected virtual ToolStrip ParentInternal => _ownerItem?.ParentInternal;
+            protected virtual ToolStrip? ParentInternal => _ownerItem?.ParentInternal;
 
             public virtual Rectangle TextRectangle
             {
                 get
                 {
                     Rectangle textRect = LayoutData.TextBounds;
-                    textRect.Intersect(_layoutData.Field);
+                    textRect.Intersect(_layoutData!.Field);
                     return textRect;
                 }
             }
@@ -128,7 +126,7 @@ namespace System.Windows.Forms
                 layoutOptions.GdiTextFormatFlags = ContentAlignToTextFormat(Owner.TextAlign, Owner.RightToLeft == RightToLeft.Yes);
 
                 // Hide underlined &File unless ALT is pressed
-                layoutOptions.GdiTextFormatFlags = (Owner.ShowKeyboardCues) ? layoutOptions.GdiTextFormatFlags : layoutOptions.GdiTextFormatFlags | TextFormatFlags.HidePrefix;
+                layoutOptions.GdiTextFormatFlags = Owner.ShowKeyboardCues ? layoutOptions.GdiTextFormatFlags : layoutOptions.GdiTextFormatFlags | TextFormatFlags.HidePrefix;
 
                 return layoutOptions;
             }
@@ -159,7 +157,6 @@ namespace System.Windows.Forms
 
             public virtual Size GetPreferredSize(Size constrainingSize)
             {
-                Size preferredSize = Size.Empty;
                 EnsureLayout();
                 // we would prefer not to be larger than the ToolStrip itself.
                 // so we'll ask the ButtonAdapter layout guy what it thinks
@@ -169,7 +166,7 @@ namespace System.Windows.Forms
 
                 if (_ownerItem is not null)
                 {
-                    _lastPreferredSize = _currentLayoutOptions.GetPreferredSizeCore(constrainingSize);
+                    _lastPreferredSize = _currentLayoutOptions!.GetPreferredSizeCore(constrainingSize);
                     return _lastPreferredSize;
                 }
 
@@ -179,7 +176,7 @@ namespace System.Windows.Forms
             internal void PerformLayout()
             {
                 _layoutData = GetLayoutData();
-                ToolStrip parent = ParentInternal;
+                ToolStrip? parent = ParentInternal;
                 if (parent is not null)
                 {
                     _parentLayoutData = new ToolStripLayoutData(parent);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
@@ -34,8 +34,9 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    Rectangle imageRect = LayoutData.ImageBounds;
-                    imageRect.Intersect(_layoutData!.Field);
+                    ButtonBaseAdapter.LayoutData layoutData = LayoutData;
+                    Rectangle imageRect = layoutData.ImageBounds;
+                    imageRect.Intersect(layoutData.Field);
                     return imageRect;
                 }
             }
@@ -57,8 +58,9 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    Rectangle textRect = LayoutData.TextBounds;
-                    textRect.Intersect(_layoutData!.Field);
+                    ButtonBaseAdapter.LayoutData layoutData = LayoutData;
+                    Rectangle textRect = layoutData.TextBounds;
+                    textRect.Intersect(layoutData.Field);
                     return textRect;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemInternalLayout.cs
@@ -135,17 +135,15 @@ namespace System.Windows.Forms
             }
 
             [MemberNotNull(nameof(_layoutData))]
-            private bool EnsureLayout()
+            private void EnsureLayout()
             {
                 if (_layoutData is null || _parentLayoutData is null || !_parentLayoutData.IsCurrent(ParentInternal))
                 {
                     PerformLayout();
-                    return true;
                 }
-
-                return false;
             }
 
+            [MemberNotNull(nameof(_currentLayoutOptions))]
             private ButtonBaseAdapter.LayoutData GetLayoutData()
             {
                 _currentLayoutOptions = CommonLayoutOptions();
@@ -181,6 +179,7 @@ namespace System.Windows.Forms
             }
 
             [MemberNotNull(nameof(_layoutData))]
+            [MemberNotNull(nameof(_currentLayoutOptions))]
             internal void PerformLayout()
             {
                 _layoutData = GetLayoutData();


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripItemInternalLayout.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7298)