### PR TITLE
Cleanup trimming warnings from Primitives project

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
+++ b/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
@@ -11,7 +11,7 @@
       IL Trim warnings which should be removed in order to make WinForms trimmable
       See https://github.com/dotnet/winforms/issues/4649
     -->
-    <NoWarn>$(NoWarn);IL2026;IL2046;IL2050;IL2067</NoWarn>
+    <NoWarn>$(NoWarn);IL2026;IL2050</NoWarn>
     <Deterministic>true</Deterministic>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <UsePublicApiAnalyzers>true</UsePublicApiAnalyzers>

--- a/src/System.Windows.Forms.Primitives/src/System/TrimmingConstants.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/TrimmingConstants.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    internal static class TrimmingConstants
+    {
+        internal const string TypeConverterGetPropertiesMessage = "The Type of value cannot be statically discovered. The public parameterless constructor or the 'Default' static field may be trimmed from the Attribute's Type.";
+    }
+}

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
@@ -5,6 +5,7 @@
 #if DEBUG
 using System.Diagnostics;
 #endif
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using static Interop;
 
@@ -83,7 +84,9 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Gets the <see cref="LParam"/> value, and converts the value to an object.
         /// </summary>
-        public object? GetLParam(Type cls) => Marshal.PtrToStructure(LParamInternal, cls);
+        public object? GetLParam(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+            Type cls) => Marshal.PtrToStructure(LParamInternal, cls);
 
         internal static Message Create(IntPtr hWnd, User32.WM msg, nint wparam, nint lparam)
             => Create(hWnd, (int)msg, wparam, lparam);

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/PaddingConverter.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/PaddingConverter.cs
@@ -5,6 +5,7 @@
 using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Windows.Forms.Primitives.Resources;
 
@@ -160,6 +161,7 @@ namespace System.Windows.Forms
 
         public override bool GetCreateInstanceSupported(ITypeDescriptorContext? context) => true;
 
+        [RequiresUnreferencedCode(TrimmingConstants.TypeConverterGetPropertiesMessage)]
         public override PropertyDescriptorCollection GetProperties(ITypeDescriptorContext? context, object value, Attribute[]? attributes)
         {
             PropertyDescriptorCollection props = TypeDescriptor.GetProperties(typeof(Padding), attributes);


### PR DESCRIPTION
- IL2050 requires more ComWrappers work, don't want touch that
- IL2026 is `RequiresUnreferencedCodeAttribute` which require a bit more
brainpower.  Better keep that for later when more code would be annotated.

Jab at https://github.com/dotnet/winforms/issues/4649

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7304)