### PR TITLE
Adding UIA support for WebBrowser

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+~override System.Windows.Forms.WebBrowser.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.WebBrowserAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.WebBrowserAccessibleObject.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class WebBrowser
+    {
+        internal class WebBrowserAccessibleObject : ControlAccessibleObject
+        {
+            public WebBrowserAccessibleObject(WebBrowser owner) : base(owner)
+            { }
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
+                {
+                    UiaCore.UIA.AutomationIdPropertyId
+                        => Owner.Name,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId
+                        => Owner.Focused,
+                    _ => base.GetPropertyValue(propertyID)
+                };
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
@@ -138,6 +138,8 @@ namespace System.Windows.Forms
             }
         }
 
+        internal override bool SupportsUiaProviders => true;
+
         /// <summary>
         ///  Specifies whether the browser control Shortcuts are enabled.
         ///  Maps to IDocHostUIHandler:TranslateAccelerator event.
@@ -1122,13 +1124,7 @@ namespace System.Windows.Forms
             axIWebBrowser2 = null;
         }
 
-        /// <summary>
-        ///  Returns a WebBrowserSite object.
-        /// </summary>
-        protected override WebBrowserSiteBase CreateWebBrowserSiteBase()
-        {
-            return new WebBrowserSite(this);
-        }
+        protected override AccessibleObject CreateAccessibilityInstance() => new WebBrowserAccessibleObject(this);
 
         /// <summary>
         ///  Attaches to the DWebBrowserEvents2 connection point.
@@ -1157,6 +1153,14 @@ namespace System.Windows.Forms
                 cookie.Disconnect();
                 cookie = null;
             }
+        }
+
+        /// <summary>
+        ///  Returns a WebBrowserSite object.
+        /// </summary>
+        protected override WebBrowserSiteBase CreateWebBrowserSiteBase()
+        {
+            return new WebBrowserSite(this);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Control.ControlAccessibleObjectTests.cs
@@ -43,7 +43,7 @@ namespace System.Windows.Forms.Tests
         // otherwise an error can be thrown.
         private static Type[] s_controlsIgnoringTextChangesForTests = new Type[]
         {
-            typeof(DateTimePicker),
+            typeof(DateTimePicker), typeof(WebBrowser)
         };
 
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowser.WebBrowserAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowser.WebBrowserAccessibleObjectTests.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static System.Windows.Forms.WebBrowser;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.Tests
+{
+    public class WebBrowser_WebBrowserAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void WebBrowserAccessibleObject_Ctor_Default()
+        {
+            using WebBrowser webBrowser = new();
+            WebBrowserAccessibleObject accessibleObject = (WebBrowserAccessibleObject)webBrowser.AccessibilityObject;
+
+            Assert.Equal(webBrowser, accessibleObject.Owner);
+            Assert.False(webBrowser.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData((int)UIA.NamePropertyId, "TestName")]
+        [InlineData((int)UIA.AutomationIdPropertyId, "ToolStripContainer1")]
+        public void WebBrowserAccessibleObject_GetPropertyValue_Invoke_ReturnsExpected(int propertyID, object expected)
+        {
+            using WebBrowser webBrowser = new WebBrowser
+            {
+                Name = expected.ToString(),
+                AccessibleName = expected.ToString()
+            };
+
+            WebBrowserAccessibleObject accessibleObject = (WebBrowserAccessibleObject)webBrowser.AccessibilityObject;
+            object value = accessibleObject.GetPropertyValue((UIA)propertyID);
+
+            Assert.Equal(expected, value);
+            Assert.False(webBrowser.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void WebBrowserAccessibleObject_GetPropertyValue_HasKeyboardFocus_ReturnsFalse_IfControlHasNoFocus()
+        {
+            using WebBrowser webBrowser = new();
+
+            WebBrowserAccessibleObject accessibleObject = (WebBrowserAccessibleObject)webBrowser.AccessibilityObject;
+            bool value = (bool)accessibleObject.GetPropertyValue(UIA.HasKeyboardFocusPropertyId);
+
+            Assert.False(value);
+            Assert.False(webBrowser.IsHandleCreated);
+        }
+    }
+}


### PR DESCRIPTION
Partially implements https://github.com/dotnet/winforms/issues/3421
For .Net 7

## Proposed changes

- Updated "SupportsUiaProviders" flag to WebBrowser
- Added and implemented WebBrowser.WebBrowserAccessibleObject
- Added unit tests
- Testing application 
[WebBrowserWinFormsApp.zip](https://github.com/dotnet/winforms/files/8919406/WebBrowserWinFormsApp.zip)


## Customer Impact

## Screenshots
### Before
![before](https://user-images.githubusercontent.com/102961955/174087777-ddd2fd31-17fa-48c3-8c9e-a8e9acafed37.png)

ProviderDescription:	"[pid:22832,providerId:0x402AA Main:Nested [pid:27400,providerId:0x402AA Main(parent link):Microsoft: MSAA Proxy (unmanaged:UIAutomationCore.dll)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:uiautomationcore.dll)]"
	
### After
![after](https://user-images.githubusercontent.com/102961955/174087809-9931a198-f0ec-45b4-8d8c-16bfaf77d464.png)

ProviderDescription:	"[pid:25792,providerId:0x70BA2 Main:Nested [pid:30696,providerId:0x70BA2 Main(parent link):Unidentified Provider (unmanaged:coreclr.dll)]; Hwnd(parent link):Microsoft: HWND Proxy (unmanaged:uiautomationcore.dll)]"

## Regression? 

- No

## Risk

- Minimal







## Test methodology

- Unit tests
- Manual with custom application

## Accessibility testing

- Inspect
- Accessibility Insights


 

## Test environment

dotnet : 7.0.0-preview.4.22229.4


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7314)