### PR TITLE
Fixing memory leaks of ComboBox elements and items accessible objects

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using static System.Windows.Forms.ComboBox.ObjectCollection;
 using static Interop;
 
@@ -214,8 +215,47 @@ namespace System.Windows.Forms
                 }
             }
 
+            internal void RemoveListItemAccessibleObjectAt(int index)
+            {
+                IReadOnlyList<Entry> entries = _owningComboBox.Items.InnerList;
+                Debug.Assert(index < entries.Count);
+
+                Entry item = entries[index];
+                if (!ItemAccessibleObjects.ContainsKey(item))
+                {
+                    return;
+                }
+
+                if (OsVersion.IsWindows8OrGreater)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(ItemAccessibleObjects[item]);
+                    Debug.Assert(result == HRESULT.S_OK);
+                }
+
+                ItemAccessibleObjects.Remove(item);
+            }
+
+            internal void ReleaseDropDownButtonUiaProvider()
+            {
+                if (OsVersion.IsWindows8OrGreater && _dropDownButtonUiaProvider is not null)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(_dropDownButtonUiaProvider);
+                    Debug.Assert(result == HRESULT.S_OK);
+                    _dropDownButtonUiaProvider = null;
+                }
+            }
+
             internal void ResetListItemAccessibleObjects()
             {
+                if (OsVersion.IsWindows8OrGreater)
+                {
+                    foreach (ComboBoxItemAccessibleObject itemAccessibleObject in ItemAccessibleObjects.Values)
+                    {
+                        HRESULT result = UiaCore.UiaDisconnectProvider(itemAccessibleObject);
+                        Debug.Assert(result == HRESULT.S_OK);
+                    }
+                }
+
                 ItemAccessibleObjects.Clear();
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ObjectCollection.cs
@@ -253,8 +253,7 @@ namespace System.Windows.Forms
                 }
 
                 InnerList.Clear();
-
-                OwnerComboBoxAccessibleObject?.ItemAccessibleObjects.Clear();
+                OwnerComboBoxAccessibleObject?.ResetListItemAccessibleObjects();
 
                 _owner._selectedIndex = -1;
                 if (_owner.AutoCompleteSource == AutoCompleteSource.ListItems)
@@ -360,7 +359,7 @@ namespace System.Windows.Forms
                             }
                             else
                             {
-                                OwnerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
+                                OwnerComboBoxAccessibleObject?.RemoveListItemAccessibleObjectAt(index);
                                 InnerList.RemoveAt(index);
                             }
                         }
@@ -385,7 +384,7 @@ namespace System.Windows.Forms
                     _owner.NativeRemoveAt(index);
                 }
 
-                OwnerComboBoxAccessibleObject?.ItemAccessibleObjects.Remove(InnerList[index]);
+                OwnerComboBoxAccessibleObject?.RemoveListItemAccessibleObjectAt(index);
                 InnerList.RemoveAt(index);
 
                 if (!_owner.IsHandleCreated)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -343,6 +343,10 @@ namespace System.Windows.Forms
             }
         }
 
+        internal void ClearChildEditAccessibleObject() => _childEditAccessibleObject = null;
+
+        internal void ClearChildListAccessibleObject() => _childListAccessibleObject = null;
+
         /// <summary>
         ///  Returns the parameters needed to create the handle.  Inheriting classes
         ///  can override this to provide extra functionality.  They should not,
@@ -3219,25 +3223,18 @@ namespace System.Windows.Forms
         {
             if (_childEdit is not null)
             {
-                // We do not use UI Automation provider for child edit, so do not need to release providers.
                 _childEdit.ReleaseHandle();
                 _childEdit = null;
             }
 
             if (_childListBox is not null)
             {
-                // Need to notify UI Automation that it can safely remove all map entries that refer to the specified window.
-                ReleaseUiaProvider(_childListBox.Handle);
-
                 _childListBox.ReleaseHandle();
                 _childListBox = null;
             }
 
             if (_childDropDown is not null)
             {
-                // Need to notify UI Automation that it can safely remove all map entries that refer to the specified window.
-                ReleaseUiaProvider(_childDropDown.Handle);
-
                 _childDropDown.ReleaseHandle();
                 _childDropDown = null;
             }
@@ -3245,13 +3242,25 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider(IntPtr handle)
         {
-            base.ReleaseUiaProvider(handle);
-
-            if (IsAccessibilityObjectCreated)
+            if (!IsAccessibilityObjectCreated)
             {
-                var uiaProvider = AccessibilityObject as ComboBoxAccessibleObject;
-                uiaProvider?.ResetListItemAccessibleObjects();
+                return;
             }
+
+            if (_childTextAccessibleObject is not null && OsVersion.IsWindows8OrGreater)
+            {
+                HRESULT result = UiaCore.UiaDisconnectProvider(_childTextAccessibleObject);
+                Debug.Assert(result == HRESULT.S_OK);
+                _childTextAccessibleObject = null;
+            }
+
+            if (AccessibilityObject is ComboBoxAccessibleObject accessibilityObject)
+            {
+                accessibilityObject.ResetListItemAccessibleObjects();
+                accessibilityObject.ReleaseDropDownButtonUiaProvider();
+            }
+
+            base.ReleaseUiaProvider(handle);
         }
 
         private void ResetAutoCompleteCustomSource()
@@ -3638,9 +3647,6 @@ namespace System.Windows.Forms
                 // So release the old references here.
                 if (_childDropDown is not null)
                 {
-                    // Need to notify UI Automation that it can safely remove all map entries that refer to the specified window.
-                    ReleaseUiaProvider(_childDropDown.Handle);
-
                     _childDropDown.ReleaseHandle();
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -6961,7 +6961,7 @@ namespace System.Windows.Forms
             {
                 int pos = -1; // start with -1 to handle double &'s
                 char c2 = char.ToUpper(charCode, CultureInfo.CurrentCulture);
-                for (; ;)
+                for (; ; )
                 {
                     if (pos + 1 >= text.Length)
                     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindowTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBox.ComboBoxChildNativeWindowTests.cs
@@ -19,7 +19,7 @@ namespace System.Windows.Forms.Tests
 
             foreach (var childWindowType in Enum.GetValues(childWindowTypeEnum))
             {
-                Assert.True(childNativeWindow.TestAccessor().Dynamic.GetChildAccessibleObject(childWindowType) is ComboBox.ChildAccessibleObject);
+                Assert.True(childNativeWindow.TestAccessor().Dynamic.GetChildAccessibleObject() is ComboBox.ChildAccessibleObject);
             }
         }
     }


### PR DESCRIPTION
Fixes #7318
Has the similar approach like in PR #7284
⚠️Doesn't fix memory leaks of TextPattern. It will be fixed as another fix for TextBox as well.

## Proposed changes

- Add a call of `UiaDisconnectProvider` for `ComboBox` elements (its List, TextBox, Label) and ComboBoxItemAccessibleObjects for cases when:
     - ComboBox is destroyed
     - All items are cleared from a ComboBox
     - An item is removed from a ComboBox
     - Using TextPattern explorer of Inspect

## Customer Impact

- Less memory leaks of ComboBox

## Regression? 

- No

## Risk

- Minimal


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- There are some kept object in the memory after disposing a ComboBox:
![image](https://user-images.githubusercontent.com/49272759/174157123-4749224f-2ecf-4188-8f27-0e52c6cd6cdf.png)


### After
- These are no ComboBox elements or items objects in the memory after disposing (without TextPattern):
![image](https://user-images.githubusercontent.com/49272759/174157229-5749382e-13e1-48db-9a03-db8324f47aa6.png)



## Test methodology

- CTI
- Manually (via WinDbg)

## Accessibility testing 
- Using AI, Inspect, Narrator for cases:
      - Dispose a ComboBox
      - Close a form with a ComboBox (works same as disposing)
      - Remove 1 item then dispose the ComboBox
      - Clear all items then dispose the ComboBox


## Test environment(s)

- .NET 7.0 Preview 4
- Windows 11



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7319)