### PR TITLE
Revert "Replace hashtable with generic dictionary in ListView (#7029)"

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable disable
+
 using System.Collections;
 using System.Diagnostics;
 using static Interop;
@@ -78,7 +80,7 @@ namespace System.Windows.Forms
 
                         if (_owner.IsHandleCreated && !_owner.ListViewHandleDestroyed)
                         {
-                            return _owner._listItemsById[DisplayIndexToID(displayIndex)];
+                            return (ListViewItem)_owner._listItemsTable[DisplayIndexToID(displayIndex)];
                         }
                         else
                         {
@@ -150,12 +152,12 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.ListViewCantAddItemsToAVirtualListView);
                 }
 
-                IComparer? comparer = _owner._listItemSorter;
+                IComparer comparer = _owner._listItemSorter;
                 _owner._listItemSorter = null;
 
                 Debug.Assert(!_owner.FlipViewToLargeIconAndSmallIcon || Count == 0, "the FlipView... bit is turned off after adding 1 item.");
 
-                bool[]? checkedValues = null;
+                bool[] checkedValues = null;
 
                 if (_owner.IsHandleCreated && !_owner.CheckBoxes)
                 {
@@ -299,7 +301,7 @@ namespace System.Windows.Forms
                     _owner._listViewItems.Clear();
                 }
 
-                _owner._listItemsById.Clear();
+                _owner._listItemsTable.Clear();
                 if (_owner.IsHandleCreated && !_owner.CheckBoxes)
                 {
                     _owner._savedCheckedItems = null;
@@ -318,7 +320,7 @@ namespace System.Windows.Forms
                 _owner.ApplyUpdateCachedItems();
                 if (_owner.IsHandleCreated && !_owner.ListViewHandleDestroyed)
                 {
-                    return _owner._listItemsById[item.ID] == item;
+                    return _owner._listItemsTable[item.ID] == item;
                 }
                 else
                 {
@@ -442,7 +444,7 @@ namespace System.Windows.Forms
                 }
 
                 _owner._itemCount--;
-                _owner._listItemsById.Remove(itemID);
+                _owner._listItemsTable.Remove(itemID);
 
                 if (_owner.ExpectingMouseUp)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -129,11 +129,11 @@ namespace System.Windows.Forms
         private ListViewGroup? _defaultGroup;
         private ListViewGroup? _focusedGroup;
 
-        // Invariant: the dictionary always contains all Items in the ListView, and maps IDs -> Items.
+        // Invariant: the table always contains all Items in the ListView, and maps IDs -> Items.
         // listItemsArray is null if the handle is created; otherwise, it contains all Items.
         // We do not try to sort listItemsArray as items are added, but during a handle recreate
         // we will make sure we get the items in the same order the ListView displays them.
-        private readonly Dictionary<int, ListViewItem> _listItemsById = new();
+        private readonly Hashtable _listItemsTable = new Hashtable(); // elements are ListViewItem's
         private List<ListViewItem>? _listViewItems = new();
 
         private Size _tileSize = Size.Empty;
@@ -2506,7 +2506,7 @@ namespace System.Windows.Forms
             Debug.Assert(_listItemSorter is not null, "null sorter!");
             if (_listItemSorter is not null)
             {
-                return _listItemSorter.Compare(_listItemsById[(int)lparam1], _listItemsById[(int)lparam2]);
+                return _listItemSorter.Compare(_listItemsTable[(int)lparam1], _listItemsTable[(int)lparam2]);
             }
             else
             {
@@ -4121,8 +4121,8 @@ namespace System.Windows.Forms
 
                 // create an ID..
                 int itemID = GenerateUniqueID();
-                Debug.Assert(!_listItemsById.ContainsKey(itemID), "internal hash table inconsistent -- inserting item, but it's already in the hash table");
-                _listItemsById.Add(itemID, item);
+                Debug.Assert(!_listItemsTable.ContainsKey(itemID), "internal hash table inconsistent -- inserting item, but it's already in the hash table");
+                _listItemsTable.Add(itemID, item);
 
                 _itemCount++;
                 item.Host(this, itemID, -1);


### PR DESCRIPTION
Hashtable is rather forgiving, and if a supplied key does not exist in the table, the result is null. Dictionary, however, throws if the key can't be found.
This reverts commit 6da845914ff924e56bbea3271003539730848e0d.

I had to revert NRTA as well, as `this[int]` _can_ result in a null, and additional safe guards will be required.

Closes #7089


/cc: @gpetrou  @dreddy-work

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7327)