### PR TITLE
Fixing memory leaks of DataGridView elements accessible objects

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -32,6 +32,26 @@ namespace System.Windows.Forms
                 }
             }
 
+            internal void ReleaseChildUiaProviders()
+            {
+                if (!OsVersion.IsWindows8OrGreater())
+                {
+                    return;
+                }
+
+                if (_topRowAccessibilityObject is not null)
+                {
+                    UiaCore.UiaDisconnectProvider(_topRowAccessibilityObject);
+                    _topRowAccessibilityObject = null;
+                }
+
+                if (_selectedCellsAccessibilityObject is not null)
+                {
+                    UiaCore.UiaDisconnectProvider(_selectedCellsAccessibilityObject);
+                    _selectedCellsAccessibilityObject = null;
+                }
+            }
+
             public override AccessibleRole Role
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -26104,6 +26104,44 @@ namespace System.Windows.Forms
             Capture = false;
         }
 
+        internal override void ReleaseUiaProvider(IntPtr handle)
+        {
+            if (!IsAccessibilityObjectCreated)
+            {
+                return;
+            }
+
+            if (OsVersion.IsWindows8OrGreater())
+            {
+                foreach (DataGridViewRow row in Rows)
+                {
+                    foreach (DataGridViewCell cell in row.Cells)
+                    {
+                        cell.ReleaseUiaProvider();
+                    }
+
+                    row.HeaderCell.ReleaseUiaProvider();
+                    row.ReleaseUiaProvider();
+                }
+
+                foreach (DataGridViewColumn column in Columns)
+                {
+                    column.HeaderCell.ReleaseUiaProvider();
+                }
+
+                _editingPanel?.ReleaseUiaProvider(IntPtr.Zero);
+                _editingPanelAccessibleObject = null;
+                _topLeftHeaderCell?.ReleaseUiaProvider();
+
+                if (AccessibilityObject is DataGridViewAccessibleObject accessibleObject)
+                {
+                    accessibleObject.ReleaseChildUiaProviders();
+                }
+            }
+
+            base.ReleaseUiaProvider(handle);
+        }
+
         private void RemoveIndividualReadOnlyCellsInColumn(int columnIndex)
         {
             int cellIndex = 0;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -491,6 +491,8 @@ namespace System.Windows.Forms
             }
         }
 
+        internal bool IsAccessibilityObjectCreated => Properties.GetObject(s_propCellAccessibilityObject) is AccessibleObject;
+
         /// <summary>
         ///  Indicates whether or not the parent grid view for this element has an accessible object associated with it.
         /// </summary>
@@ -1292,8 +1294,9 @@ namespace System.Windows.Forms
                 Type editingControlType = DataGridView.EditingControl.GetType();
 
                 return
-                    (editingControlType == typeof(DataGridViewComboBoxEditingControl) && !editingControlType.IsSubclassOf(typeof(DataGridViewComboBoxEditingControl))) ||
-                    (editingControlType == typeof(DataGridViewTextBoxEditingControl) && !editingControlType.IsSubclassOf(typeof(DataGridViewTextBoxEditingControl)));
+                    IsAccessibilityObjectCreated &&
+                    ((editingControlType == typeof(DataGridViewComboBoxEditingControl) && !editingControlType.IsSubclassOf(typeof(DataGridViewComboBoxEditingControl))) ||
+                    (editingControlType == typeof(DataGridViewTextBoxEditingControl) && !editingControlType.IsSubclassOf(typeof(DataGridViewTextBoxEditingControl))));
             }
         }
 
@@ -4054,6 +4057,21 @@ namespace System.Windows.Forms
             DataGridView.EditingPanel.Location = new Point(xEditingPanel, yEditingPanel);
             DataGridView.EditingPanel.Size = new Size(wEditingPanel, hEditingPanel);
             return new Rectangle(xEditingControl, yEditingControl, wEditingControl, hEditingControl);
+        }
+
+        internal virtual void ReleaseUiaProvider()
+        {
+            if (!IsAccessibilityObjectCreated)
+            {
+                return;
+            }
+
+            if (OsVersion.IsWindows8OrGreater())
+            {
+                UiaCore.UiaDisconnectProvider(AccessibilityObject);
+            }
+
+            Properties.SetObject(s_propCellAccessibilityObject, null);
         }
 
         protected virtual bool SetValue(int rowIndex, object value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumnCollection.cs
@@ -1109,6 +1109,17 @@ namespace System.Windows.Forms
             Debug.Assert(!DataGridView.InDisplayIndexAdjustments);
 
             DataGridViewColumn dataGridViewColumn = _items[index];
+
+            if (DataGridView.IsAccessibilityObjectCreated && OsVersion.IsWindows8OrGreater())
+            {
+                foreach (DataGridViewRow row in DataGridView.Rows)
+                {
+                    row.Cells[index].ReleaseUiaProvider();
+                }
+
+                dataGridViewColumn.HeaderCell.ReleaseUiaProvider();
+            }
+
             DataGridView.OnRemovingColumn(dataGridViewColumn, out Point newCurrentCell, force);
             InvalidateCachedColumnsOrder();
             _items.RemoveAt(index);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -2547,6 +2547,13 @@ namespace System.Windows.Forms
             }
         }
 
+        internal override void ReleaseUiaProvider()
+        {
+            EditingComboBox?.ReleaseUiaProvider(IntPtr.Zero);
+
+            base.ReleaseUiaProvider();
+        }
+
         /// <summary>
         ///  Gets the row Index and column Index of the cell.
         /// </summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.DataGridViewComboBoxEditingControlAccessibleObject.cs
@@ -26,6 +26,11 @@ namespace System.Windows.Forms
                 _ownerControl = ownerControl;
             }
 
+            internal void ClearParent()
+            {
+                _parentAccessibleObject = null;
+            }
+
             public override AccessibleObject? Parent
             {
                 get

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxEditingControl.cs
@@ -163,7 +163,20 @@ namespace System.Windows.Forms
             base.OnHandleCreated(e);
 
             // The null-check was added as a fix for a https://github.com/dotnet/winforms/issues/2138
-            _dataGridView?.SetAccessibleObjectParent(AccessibilityObject);
+            if (_dataGridView?.IsAccessibilityObjectCreated == true)
+            {
+                _dataGridView.SetAccessibleObjectParent(AccessibilityObject);
+            }
+        }
+
+        internal override void ReleaseUiaProvider(nint handle)
+        {
+            if (TryGetAccessibilityObject(out AccessibleObject accessibleObject))
+            {
+                ((DataGridViewComboBoxEditingControlAccessibleObject)accessibleObject).ClearParent();
+            }
+
+            base.ReleaseUiaProvider(handle);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRow.cs
@@ -242,6 +242,8 @@ namespace System.Windows.Forms
             }
         }
 
+        internal bool IsAccessibilityObjectCreated => Properties.GetObject(s_propRowAccessibilityObject) is AccessibleObject;
+
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsNewRow
@@ -1726,6 +1728,21 @@ namespace System.Windows.Forms
                         paintParts);
                 }
             }
+        }
+
+        internal void ReleaseUiaProvider()
+        {
+            if (!IsAccessibilityObjectCreated)
+            {
+                return;
+            }
+
+            if (OsVersion.IsWindows8OrGreater())
+            {
+                Interop.UiaCore.UiaDisconnectProvider(AccessibilityObject);
+            }
+
+            Properties.SetObject(s_propRowAccessibilityObject, null);
         }
 
         internal void SetReadOnlyCellCore(DataGridViewCell dataGridViewCell, bool readOnly)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
@@ -2259,6 +2259,17 @@ namespace System.Windows.Forms
                 throw new InvalidOperationException(SR.DataGridView_ForbiddenOperationInEventHandler);
             }
 
+            if (DataGridView.IsAccessibilityObjectCreated && OsVersion.IsWindows8OrGreater() && this[index] is DataGridViewRow row)
+            {
+                foreach (DataGridViewCell cell in row.Cells)
+                {
+                    cell.ReleaseUiaProvider();
+                }
+
+                row.HeaderCell.ReleaseUiaProvider();
+                row.ReleaseUiaProvider();
+            }
+
             if (DataGridView.DataSource is not null)
             {
                 if (DataGridView.DataConnection.List is IBindingList list && list.AllowRemove && list.SupportsChangeNotification)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
@@ -21,6 +21,11 @@ namespace System.Windows.Forms
             public DataGridViewTextBoxEditingControlAccessibleObject(DataGridViewTextBoxEditingControl ownerControl) : base(ownerControl)
             { }
 
+            internal void ClearParent()
+            {
+                _parentAccessibleObject = null;
+            }
+
             public override AccessibleObject? Parent => _parentAccessibleObject;
 
             public override string Name => Owner.AccessibleName ?? SR.DataGridView_AccEditingControlAccName;


### PR DESCRIPTION
Fixes #7347
⚠️Should be merged after #7319 because uses the ComboBox leaks fix.
⚠️Doesn't fix memory leaks of TextPattern. It will be fixed as another fix for TextBox as well.

## Proposed changes
- Add a call of UiaDisconnectProvider for DataGridView elements (rows, cells, headers) for cases when:
DataGridView is destroyed
A row is removed from a DataGridView
A column is removed from a DataGridView
Using TextPattern explorer of Inspect, Narrator


## Customer Impact
- Less memory leaks of DataGridView

## Regression? 

- No

## Risk

- Minimal

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- There are some kept object in the memory after disposing a DataGridView:
![image](https://user-images.githubusercontent.com/49272759/175780243-02cfba68-4071-4463-aa5e-d7fe318ca603.png)


### After
- These are no DataGridView elements objects in the memory after disposing (without TextPattern):
![image](https://user-images.githubusercontent.com/49272759/175780198-e55c20f2-47ae-47df-a576-92f28a680f85.png)



## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manually (via WinDbg)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using AI, Inspect, Narrator
 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0 Preview 4
- Windows 11



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7349)