### PR TITLE
Fixed accessibility BoundingRectangle of nested Forms

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
@@ -25,7 +25,25 @@ namespace System.Windows.Forms
 
             public override Rectangle Bounds => _owner.IsHandleCreated ? _owner.RectangleToScreen(_owner.ClientRectangle) : Rectangle.Empty;
 
-            internal override Rectangle BoundingRectangle => _owner.IsHandleCreated ? _owner.Bounds : Rectangle.Empty;
+            internal override Rectangle BoundingRectangle
+            {
+                get
+                {
+                    if (!_owner.IsHandleCreated)
+                    {
+                        return Rectangle.Empty;
+                    }
+
+                    if (_owner.Parent is null)
+                    {
+                        // If the Forms is a main window and a root object. 
+                        return _owner.Bounds;
+                    }
+
+                    // If the Form is placed on another control, eg. Form or Panel.
+                    return _owner.Parent.RectangleToScreen(_owner.Bounds);
+                }
+            }
 
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Form.FormAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Form.FormAccessibleObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Drawing;
 using Xunit;
 using static System.Windows.Forms.Form;
 using static Interop;
@@ -126,6 +127,45 @@ namespace System.Windows.Forms.Tests
             // The child control gets the focus changed event instead of the form.
             // Native control does it itself, so a screen reader should focus on the inner control.
             Assert.Equal(0, accessibleObject.RaiseAutomationFocusEventCallsCount);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void FormAccessibleObject_BoundingRectangle_ReturnsExpected_ForRootForm(bool createControl)
+        {
+            using Form form = new();
+
+            if (createControl)
+            {
+                form.CreateControl(true);
+            }
+
+            Rectangle actual = form.AccessibilityObject.BoundingRectangle;
+            Rectangle expected = createControl ? form.Bounds : Rectangle.Empty;
+
+            Assert.Equal(expected, actual);
+            Assert.Equal(createControl, form.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void FormAccessibleObject_BoundingRectangle_ReturnsExpected_ForEmbeddedForm(bool createControl)
+        {
+            using Form form = new();
+            using Form embeddedForm = new() { TopLevel = false };
+            form.Controls.Add(embeddedForm);
+
+            if (createControl)
+            {
+                form.CreateControl(true);
+            }
+
+            Rectangle actual = form.AccessibilityObject.BoundingRectangle;
+
+            Assert.Equal(createControl, actual.Location != Point.Empty);
+            Assert.Equal(createControl, form.IsHandleCreated);
         }
 
         private class FocusEventsCounterForm : Form


### PR DESCRIPTION
Fixes #7245

## Proposed changes

- Recalculate a nested Form BoundingRectangle location regarding its Parent position on screen.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Nested Forms have correct BoundingRectangle value

## Regression? 

- Yes (since #2096)

## Risk

- Minimal


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/49272759/175831780-55e3c79f-7978-4964-a2e5-d3d3c2906c5d.png)


### After

![image](https://user-images.githubusercontent.com/49272759/175831733-d8bedca6-6f8b-41fa-b655-a5a6ecbd07f1.png)



## Test methodology

- Manual
- CTI
- Unit tests

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using AI and Inspect. Tested cases when:
     - The nested form is placed on the root form
     - The nested form is places on a Panel inside the root form
     - The nested form has different location coordinated inside the parent control

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.6.22281.2
- Windows 11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7350)