### PR TITLE
Refactoring of `UiaDisconnectProvider` usage implementation

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UiaDisconnectProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UiaDisconnectProvider.cs
@@ -2,13 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 internal partial class Interop
 {
     internal static partial class UiaCore
     {
-        [DllImport(Libraries.UiaCore, ExactSpelling = true)]
-        public static extern HRESULT UiaDisconnectProvider(IRawElementProviderSimple provider);
+        [DllImport(Libraries.UiaCore, EntryPoint = "UiaDisconnectProvider")]
+        private static extern HRESULT UiaDisconnectProviderInternal(IRawElementProviderSimple provider);
+
+        public static void UiaDisconnectProvider(IRawElementProviderSimple? provider)
+        {
+            if (provider is not null)
+            {
+                // E_INVALIDARG error result is for several reasons. The most common is that the `provider` argument is null.
+                // S_FALSE indicates that the same object is disconnected again.
+                HRESULT result = UiaDisconnectProviderInternal(provider);
+                Debug.Assert(result == HRESULT.S_OK);
+            }
+        }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Design;
 using static Interop;
@@ -488,8 +487,7 @@ namespace System.Windows.Forms
         {
             if (OsVersion.IsWindows8OrGreater && _accessibilityObject is not null)
             {
-                HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
-                Debug.Assert(result == HRESULT.S_OK);
+                UiaCore.UiaDisconnectProvider(_accessibilityObject);
                 _accessibilityObject = null;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
@@ -236,11 +236,12 @@ namespace System.Windows.Forms
 
             internal void ReleaseDropDownButtonUiaProvider()
             {
-                if (OsVersion.IsWindows8OrGreater && _dropDownButtonUiaProvider is not null)
+                if (OsVersion.IsWindows8OrGreater)
                 {
                     UiaCore.UiaDisconnectProvider(_dropDownButtonUiaProvider);
-                    _dropDownButtonUiaProvider = null;
                 }
+
+                _dropDownButtonUiaProvider = null;
             }
 
             internal void ResetListItemAccessibleObjects()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxAccessibleObject.cs
@@ -228,8 +228,7 @@ namespace System.Windows.Forms
 
                 if (OsVersion.IsWindows8OrGreater)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(ItemAccessibleObjects[item]);
-                    Debug.Assert(result == HRESULT.S_OK);
+                    UiaCore.UiaDisconnectProvider(ItemAccessibleObjects[item]);
                 }
 
                 ItemAccessibleObjects.Remove(item);
@@ -239,8 +238,7 @@ namespace System.Windows.Forms
             {
                 if (OsVersion.IsWindows8OrGreater && _dropDownButtonUiaProvider is not null)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(_dropDownButtonUiaProvider);
-                    Debug.Assert(result == HRESULT.S_OK);
+                    UiaCore.UiaDisconnectProvider(_dropDownButtonUiaProvider);
                     _dropDownButtonUiaProvider = null;
                 }
             }
@@ -251,8 +249,7 @@ namespace System.Windows.Forms
                 {
                     foreach (ComboBoxItemAccessibleObject itemAccessibleObject in ItemAccessibleObjects.Values)
                     {
-                        HRESULT result = UiaCore.UiaDisconnectProvider(itemAccessibleObject);
-                        Debug.Assert(result == HRESULT.S_OK);
+                        UiaCore.UiaDisconnectProvider(itemAccessibleObject);
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3247,11 +3247,12 @@ namespace System.Windows.Forms
                 return;
             }
 
-            if (_childTextAccessibleObject is not null && OsVersion.IsWindows8OrGreater)
+            if (OsVersion.IsWindows8OrGreater)
             {
                 UiaCore.UiaDisconnectProvider(_childTextAccessibleObject);
-                _childTextAccessibleObject = null;
             }
+
+            _childTextAccessibleObject = null;
 
             if (AccessibilityObject is ComboBoxAccessibleObject accessibilityObject)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3249,8 +3249,7 @@ namespace System.Windows.Forms
 
             if (_childTextAccessibleObject is not null && OsVersion.IsWindows8OrGreater)
             {
-                HRESULT result = UiaCore.UiaDisconnectProvider(_childTextAccessibleObject);
-                Debug.Assert(result == HRESULT.S_OK);
+                UiaCore.UiaDisconnectProvider(_childTextAccessibleObject);
                 _childTextAccessibleObject = null;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -10185,11 +10185,18 @@ namespace System.Windows.Forms
                 UiaCore.UiaReturnRawElementProvider(handle, 0, 0, null);
             }
 
-            if (OsVersion.IsWindows8OrGreater && IsAccessibilityObjectCreated)
+            if (OsVersion.IsWindows8OrGreater && TryGetAccessibilityObject(out AccessibleObject? accessibleObject))
             {
-                UiaCore.UiaDisconnectProvider(AccessibilityObject);
-                Properties.SetObject(s_accessibilityProperty, null);
+                UiaCore.UiaDisconnectProvider(accessibleObject);
             }
+
+            Properties.SetObject(s_accessibilityProperty, null);
+        }
+
+        private protected bool TryGetAccessibilityObject([NotNullWhen(true)] out AccessibleObject? accessibleObject)
+        {
+            accessibleObject = Properties.GetObject(s_accessibilityProperty) as AccessibleObject;
+            return accessibleObject is not null;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
@@ -181,8 +181,7 @@ namespace System.Windows.Forms
                 { 
                     foreach (ListBoxItemAccessibleObject itemAccessibleObject in _itemAccessibleObjects.Values)
                     {
-                        HRESULT result = UiaCore.UiaDisconnectProvider(itemAccessibleObject);
-                        Debug.Assert(result == HRESULT.S_OK);
+                        UiaCore.UiaDisconnectProvider(itemAccessibleObject);
                     }
                 }
 
@@ -206,8 +205,7 @@ namespace System.Windows.Forms
 
                 if (OsVersion.IsWindows8OrGreater)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(_itemAccessibleObjects[item]);
-                    Debug.Assert(result == HRESULT.S_OK);
+                    UiaCore.UiaDisconnectProvider(_itemAccessibleObjects[item]);
                 }
 
                 _itemAccessibleObjects.Remove(item);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -422,8 +422,9 @@ namespace System.Windows.Forms
             if (OsVersion.IsWindows8OrGreater && _accessibilityObject is ListViewGroupAccessibleObject accessibleObject)
             {
                 UiaCore.UiaDisconnectProvider(accessibleObject);
-                _accessibilityObject = null;
             }
+
+            _accessibilityObject = null;
         }
 
         // Should be used for the cases when sending the message `LVM.SETGROUPINFO` isn't required

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.Serialization;
@@ -422,8 +421,7 @@ namespace System.Windows.Forms
         {
             if (OsVersion.IsWindows8OrGreater && _accessibilityObject is ListViewGroupAccessibleObject accessibleObject)
             {
-                HRESULT result = UiaCore.UiaDisconnectProvider(accessibleObject);
-                Debug.Assert(result == HRESULT.S_OK);
+                UiaCore.UiaDisconnectProvider(accessibleObject);
                 _accessibilityObject = null;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Drawing;
 using static Interop;
 
@@ -124,8 +123,7 @@ namespace System.Windows.Forms
 
                 foreach (AccessibleObject accessibleObject in _listViewSubItemAccessibleObjects.Values)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(accessibleObject);
-                    Debug.Assert(result == HRESULT.S_OK);
+                    UiaCore.UiaDisconnectProvider(accessibleObject);
                 }
 
                 _listViewSubItemAccessibleObjects.Clear();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -117,6 +117,9 @@ namespace System.Windows.Forms
                     ? _owningListView.GetSubItemRect(_owningItem.Index, subItemIndex)
                     : Rectangle.Empty;
 
+            /// <devdoc>
+            /// .Caller should ensure that the current OS is Windows 8 or greater.
+            /// </devdoc>
             internal override void ReleaseChildUiaProviders()
             {
                 base.ReleaseChildUiaProviders();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.cs
@@ -249,11 +249,12 @@ namespace System.Windows.Forms
 
             internal void ReleaseUiaProvider()
             {
-                if (OsVersion.IsWindows8OrGreater && _accessibilityObject is not null)
+                if (OsVersion.IsWindows8OrGreater)
                 {
                     UiaCore.UiaDisconnectProvider(_accessibilityObject);
-                    _accessibilityObject = null;
                 }
+
+                _accessibilityObject = null;
             }
 
             public void ResetStyle()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.cs
@@ -251,8 +251,7 @@ namespace System.Windows.Forms
             {
                 if (OsVersion.IsWindows8OrGreater && _accessibilityObject is not null)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(_accessibilityObject);
-                    Debug.Assert(result == HRESULT.S_OK);
+                    UiaCore.UiaDisconnectProvider(_accessibilityObject);
                     _accessibilityObject = null;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -994,17 +994,21 @@ namespace System.Windows.Forms
 
         internal void ReleaseUiaProvider()
         {
-            if (!OsVersion.IsWindows8OrGreater || !IsAccessibilityObjectCreated)
+            if (!IsAccessibilityObjectCreated)
             {
                 return;
             }
 
-            if (AccessibilityObject is ListViewItemBaseAccessibleObject itemAccessibleObject)
+            if (OsVersion.IsWindows8OrGreater)
             {
-                itemAccessibleObject.ReleaseChildUiaProviders();
+                if (_accessibilityObject is ListViewItemBaseAccessibleObject itemAccessibleObject)
+                {
+                    itemAccessibleObject.ReleaseChildUiaProviders();
+                }
+
+                UiaCore.UiaDisconnectProvider(_accessibilityObject);
             }
 
-            UiaCore.UiaDisconnectProvider(AccessibilityObject);
             _accessibilityObject = null;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -1004,8 +1004,7 @@ namespace System.Windows.Forms
                 itemAccessibleObject.ReleaseChildUiaProviders();
             }
 
-            HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
-            Debug.Assert(result == HRESULT.S_OK);
+            UiaCore.UiaDisconnectProvider(AccessibilityObject);
             _accessibilityObject = null;
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditNativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditNativeWindow.cs
@@ -83,11 +83,12 @@ namespace System.Windows.Forms
                 UiaCore.UiaReturnRawElementProvider(Handle, wParam: 0, lParam: 0, el: null);
             }
 
-            if (OsVersion.IsWindows8OrGreater && IsAccessibilityObjectCreated)
+            if (OsVersion.IsWindows8OrGreater)
             {
-                UiaCore.UiaDisconnectProvider(AccessibilityObject);
+                UiaCore.UiaDisconnectProvider(_accessibilityObject);
             }
 
+            _accessibilityObject = null;
             base.ReleaseHandle();
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarAccessibleObject.cs
@@ -44,16 +44,14 @@ namespace System.Windows.Forms
                 Debug.Assert(OsVersion.IsWindows8OrGreater);
                 if (_calendarHeaderAccessibleObject is not null)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(_calendarHeaderAccessibleObject);
-                    Debug.Assert(result == 0);
+                    UiaCore.UiaDisconnectProvider(_calendarHeaderAccessibleObject);
                     _calendarHeaderAccessibleObject = null;
                 }
 
                 if (_calendarBodyAccessibleObject is not null)
                 {
                     _calendarBodyAccessibleObject.DisconnectChildren();
-                    HRESULT result = UiaCore.UiaDisconnectProvider(_calendarBodyAccessibleObject);
-                    Debug.Assert(result == 0);
+                    UiaCore.UiaDisconnectProvider(_calendarBodyAccessibleObject);
                     _calendarBodyAccessibleObject = null;
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarAccessibleObject.cs
@@ -42,18 +42,14 @@ namespace System.Windows.Forms
             internal void DisconnectChildren()
             {
                 Debug.Assert(OsVersion.IsWindows8OrGreater);
-                if (_calendarHeaderAccessibleObject is not null)
-                {
-                    UiaCore.UiaDisconnectProvider(_calendarHeaderAccessibleObject);
-                    _calendarHeaderAccessibleObject = null;
-                }
 
-                if (_calendarBodyAccessibleObject is not null)
-                {
-                    _calendarBodyAccessibleObject.DisconnectChildren();
-                    UiaCore.UiaDisconnectProvider(_calendarBodyAccessibleObject);
-                    _calendarBodyAccessibleObject = null;
-                }
+                UiaCore.UiaDisconnectProvider(_calendarHeaderAccessibleObject);
+                _calendarHeaderAccessibleObject = null;
+
+                _calendarBodyAccessibleObject?.DisconnectChildren();
+                UiaCore.UiaDisconnectProvider(_calendarBodyAccessibleObject);
+
+                _calendarBodyAccessibleObject = null;
             }
 
             public override Rectangle Bounds

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
@@ -54,7 +54,7 @@ namespace System.Windows.Forms
             internal void DisconnectChildren()
             {
                 Debug.Assert(OsVersion.IsWindows8OrGreater);
-                if (_rowsAccessibleObjects == null)
+                if (_rowsAccessibleObjects is null)
                 {
                     return;
                 }
@@ -62,8 +62,7 @@ namespace System.Windows.Forms
                 foreach (CalendarRowAccessibleObject row in _rowsAccessibleObjects)
                 {
                     row.DisconnectChildren();
-                    HRESULT result = UiaCore.UiaDisconnectProvider(row);
-                    Debug.Assert(result == 0);
+                    UiaCore.UiaDisconnectProvider(row);
                 }
 
                 _rowsAccessibleObjects.Clear();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
@@ -101,11 +101,9 @@ namespace System.Windows.Forms
             internal void DisconnectChildren()
             {
                 Debug.Assert(OsVersion.IsWindows8OrGreater);
-                if (_weekNumberCellAccessibleObject is not null)
-                {
-                    UiaCore.UiaDisconnectProvider(_weekNumberCellAccessibleObject);
-                    _weekNumberCellAccessibleObject = null;
-                }
+
+                UiaCore.UiaDisconnectProvider(_weekNumberCellAccessibleObject);
+                _weekNumberCellAccessibleObject = null;
 
                 if (_cellsAccessibleObjects is null)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
@@ -103,8 +103,8 @@ namespace System.Windows.Forms
                 Debug.Assert(OsVersion.IsWindows8OrGreater);
                 if (_weekNumberCellAccessibleObject is not null)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(_weekNumberCellAccessibleObject);
-                    Debug.Assert(result == 0);
+                    UiaCore.UiaDisconnectProvider(_weekNumberCellAccessibleObject);
+                    _weekNumberCellAccessibleObject = null;
                 }
 
                 if (_cellsAccessibleObjects is null)
@@ -114,8 +114,7 @@ namespace System.Windows.Forms
 
                 foreach (CalendarCellAccessibleObject cell in _cellsAccessibleObjects)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(cell);
-                    Debug.Assert(result == 0);
+                    UiaCore.UiaDisconnectProvider(cell);
                 }
 
                 _cellsAccessibleObjects.Clear();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -84,29 +84,18 @@ namespace System.Windows.Forms
             internal void DisconnectChildren()
             {
                 Debug.Assert(OsVersion.IsWindows8OrGreater);
-                if (_previousButtonAccessibleObject is not null)
-                {
-                    UiaCore.UiaDisconnectProvider(_previousButtonAccessibleObject);
-                    _previousButtonAccessibleObject = null;
-                }
 
-                if (_nextButtonAccessibleObject is not null)
-                {
-                    UiaCore.UiaDisconnectProvider(_nextButtonAccessibleObject);
-                    _nextButtonAccessibleObject = null;
-                }
+                UiaCore.UiaDisconnectProvider(_previousButtonAccessibleObject);
+                _previousButtonAccessibleObject = null;
 
-                if (_todayLinkAccessibleObject is not null)
-                {
-                    UiaCore.UiaDisconnectProvider(_todayLinkAccessibleObject);
-                    _todayLinkAccessibleObject = null;
-                }
+                UiaCore.UiaDisconnectProvider(_nextButtonAccessibleObject);
+                _nextButtonAccessibleObject = null;
 
-                if (_focusedCellAccessibleObject is not null)
-                {
-                    UiaCore.UiaDisconnectProvider(_focusedCellAccessibleObject);
-                    _focusedCellAccessibleObject = null;
-                }
+                UiaCore.UiaDisconnectProvider(_todayLinkAccessibleObject);
+                _todayLinkAccessibleObject = null;
+
+                UiaCore.UiaDisconnectProvider(_focusedCellAccessibleObject);
+                _focusedCellAccessibleObject = null;
 
                 if (_calendarsAccessibleObjects is null)
                 {
@@ -521,12 +510,12 @@ namespace System.Windows.Forms
 
             private void RebuildAccessibilityTree()
             {
-                if (!_owningMonthCalendar.IsHandleCreated || CalendarsAccessibleObjects is null)
+                if (!_owningMonthCalendar.IsHandleCreated || _calendarsAccessibleObjects is null)
                 {
                     return;
                 }
 
-                foreach (CalendarAccessibleObject calendar in CalendarsAccessibleObjects)
+                foreach (CalendarAccessibleObject calendar in _calendarsAccessibleObjects)
                 {
                     calendar.DisconnectChildren();
                     UiaCore.UiaDisconnectProvider(calendar);
@@ -539,7 +528,7 @@ namespace System.Windows.Forms
                 _focusedCellAccessibleObject = null;
 
                 // Recreate the calendars child collection and check if it is correct
-                if (CalendarsAccessibleObjects.Count > 0)
+                if (CalendarsAccessibleObjects!.Count > 0)
                 {
                     // Get the new focused cell accessible object and try to raise the focus event for it
                     FocusedCell?.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -86,29 +86,25 @@ namespace System.Windows.Forms
                 Debug.Assert(OsVersion.IsWindows8OrGreater);
                 if (_previousButtonAccessibleObject is not null)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(_previousButtonAccessibleObject);
-                    Debug.Assert(result == 0);
+                    UiaCore.UiaDisconnectProvider(_previousButtonAccessibleObject);
                     _previousButtonAccessibleObject = null;
                 }
 
                 if (_nextButtonAccessibleObject is not null)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(_nextButtonAccessibleObject);
-                    Debug.Assert(result == 0);
+                    UiaCore.UiaDisconnectProvider(_nextButtonAccessibleObject);
                     _nextButtonAccessibleObject = null;
                 }
 
                 if (_todayLinkAccessibleObject is not null)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(_todayLinkAccessibleObject);
-                    Debug.Assert(result == 0);
+                    UiaCore.UiaDisconnectProvider(_todayLinkAccessibleObject);
                     _todayLinkAccessibleObject = null;
                 }
 
                 if (_focusedCellAccessibleObject is not null)
                 {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(_focusedCellAccessibleObject);
-                    Debug.Assert(result == 0);
+                    UiaCore.UiaDisconnectProvider(_focusedCellAccessibleObject);
                     _focusedCellAccessibleObject = null;
                 }
 
@@ -120,8 +116,7 @@ namespace System.Windows.Forms
                 foreach (CalendarAccessibleObject calendarAccessibleObject in _calendarsAccessibleObjects)
                 {
                     calendarAccessibleObject.DisconnectChildren();
-                    HRESULT result = UiaCore.UiaDisconnectProvider(calendarAccessibleObject);
-                    Debug.Assert(result == 0);
+                    UiaCore.UiaDisconnectProvider(calendarAccessibleObject);
                 }
 
                 _calendarsAccessibleObjects.Clear();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -528,10 +528,14 @@ namespace System.Windows.Forms
 
                 foreach (CalendarAccessibleObject calendar in CalendarsAccessibleObjects)
                 {
+                    calendar.DisconnectChildren();
+                    UiaCore.UiaDisconnectProvider(calendar);
                     calendar.CalendarBodyAccessibleObject.ClearChildCollection();
                 }
 
                 _calendarsAccessibleObjects = null;
+
+                UiaCore.UiaDisconnectProvider(_focusedCellAccessibleObject);
                 _focusedCellAccessibleObject = null;
 
                 // Recreate the calendars child collection and check if it is correct

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1580,6 +1580,16 @@ namespace System.Windows.Forms
             _onRightToLeftLayoutChanged?.Invoke(this, e);
         }
 
+        internal override void ReleaseUiaProvider(nint handle)
+        {
+            if (OsVersion.IsWindows8OrGreater && IsAccessibilityObjectCreated)
+            {
+                (AccessibilityObject as MonthCalendarAccessibleObject)?.DisconnectChildren();
+            }
+
+            base.ReleaseUiaProvider(handle);
+        }
+
         /// <summary>
         ///  Removes all annually bolded days. Be sure to call UpdateBoldedDates() afterwards.
         /// </summary>
@@ -2322,20 +2332,6 @@ namespace System.Windows.Forms
                 case User32.WM.REFLECT_NOTIFY:
                     WmReflectCommand(ref m);
                     base.WndProc(ref m);
-                    break;
-                case User32.WM.DESTROY:
-                    base.WndProc(ref m);
-                    if (IsHandleCreated && IsAccessibilityObjectCreated)
-                    {
-                        UiaCore.UiaReturnRawElementProvider(Handle, wParam: IntPtr.Zero, lParam: IntPtr.Zero, el: null);
-
-                        if (OsVersion.IsWindows8OrGreater)
-                        {
-                            (AccessibilityObject as MonthCalendarAccessibleObject)?.DisconnectChildren();
-                            UiaCore.UiaDisconnectProvider(AccessibilityObject);
-                        }
-                    }
-
                     break;
                 case User32.WM.PAINT:
                     base.WndProc(ref m);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -2331,10 +2331,8 @@ namespace System.Windows.Forms
 
                         if (OsVersion.IsWindows8OrGreater)
                         {
-                            ((MonthCalendarAccessibleObject)AccessibilityObject).DisconnectChildren();
-
-                            HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
-                            Debug.Assert(result == 0);
+                            (AccessibilityObject as MonthCalendarAccessibleObject)?.DisconnectChildren();
+                            UiaCore.UiaDisconnectProvider(AccessibilityObject);
                         }
                     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -627,8 +627,7 @@ namespace System.Windows.Forms
         {
             if (_tabAccessibilityObject is not null && OsVersion.IsWindows8OrGreater)
             {
-                HRESULT result = UiaCore.UiaDisconnectProvider(_tabAccessibilityObject);
-                Debug.Assert(result == HRESULT.S_OK);
+                UiaCore.UiaDisconnectProvider(_tabAccessibilityObject);
                 _tabAccessibilityObject = null;
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -625,11 +625,12 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider(IntPtr handle)
         {
-            if (_tabAccessibilityObject is not null && OsVersion.IsWindows8OrGreater)
+            if (OsVersion.IsWindows8OrGreater)
             {
                 UiaCore.UiaDisconnectProvider(_tabAccessibilityObject);
-                _tabAccessibilityObject = null;
             }
+
+            _tabAccessibilityObject = null;
 
             base.ReleaseUiaProvider(handle);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -2205,17 +2205,18 @@ namespace System.Windows.Forms
                     break;
                 case WM.DESTROY:
                     base.WndProc(ref m);
-                    if (IsAccessibilityObjectCreated && !RecreatingHandle)
+
+                    if (TryGetAccessibilityObject(out AccessibleObject? @object) && !RecreatingHandle)
                     {
                         // The SupportsUiaProviders check prevents double disconnection after Control.ReleaseUiaProvider.
                         // ReleaseUiaProvider works only for controls that support UIA, so this check allows to avoid
                         // double disconnection when TextBoxBase will start UIA supporting.
                         if (OsVersion.IsWindows8OrGreater && !SupportsUiaProviders)
                         {
-                            UiaCore.UiaDisconnectProvider(AccessibilityObject);
+                            UiaCore.UiaDisconnectProvider(@object);
                         }
 
-                        if (AccessibilityObject is TextBoxBaseAccessibleObject accessibleObject)
+                        if (@object is TextBoxBaseAccessibleObject accessibleObject)
                         {
                             accessibleObject.ClearObjects();
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -2209,8 +2209,7 @@ namespace System.Windows.Forms
                     {
                         if (OsVersion.IsWindows8OrGreater)
                         {
-                            HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
-                            Debug.Assert(result == 0);
+                            UiaCore.UiaDisconnectProvider(AccessibilityObject);
                         }
 
                         if (AccessibilityObject is TextBoxBaseAccessibleObject accessibleObject)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -2207,7 +2207,10 @@ namespace System.Windows.Forms
                     base.WndProc(ref m);
                     if (IsAccessibilityObjectCreated && !RecreatingHandle)
                     {
-                        if (OsVersion.IsWindows8OrGreater)
+                        // The SupportsUiaProviders check prevents double disconnection after Control.ReleaseUiaProvider.
+                        // ReleaseUiaProvider works only for controls that support UIA, so this check allows to avoid
+                        // double disconnection when TextBoxBase will start UIA supporting.
+                        if (OsVersion.IsWindows8OrGreater && !SupportsUiaProviders)
                         {
                             UiaCore.UiaDisconnectProvider(AccessibilityObject);
                         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -3200,8 +3200,7 @@ namespace System.Windows.Forms
         {
             if (TryGetAccessibilityObject(out AccessibleObject accessibleObject))
             {
-                HRESULT result = UiaCore.UiaDisconnectProvider(accessibleObject);
-                Debug.Assert(result == HRESULT.S_OK);
+                UiaCore.UiaDisconnectProvider(accessibleObject);
                 Properties.SetObject(s_accessibilityProperty, null);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -2083,7 +2083,7 @@ namespace System.Windows.Forms
         {
             if (OsVersion.IsWindows8OrGreater && _accessibleObject is not null)
             {
-                UiaCore.UiaDisconnectProvider(AccessibilityObject);
+                UiaCore.UiaDisconnectProvider(_accessibleObject);
                 _accessibleObject = null;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -2081,11 +2081,12 @@ namespace System.Windows.Forms
 
         internal virtual void ReleaseUiaProvider()
         {
-            if (OsVersion.IsWindows8OrGreater && _accessibleObject is not null)
+            if (OsVersion.IsWindows8OrGreater)
             {
                 UiaCore.UiaDisconnectProvider(_accessibleObject);
-                _accessibleObject = null;
             }
+
+            _accessibleObject = null;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using static Interop;
@@ -118,19 +117,15 @@ namespace System.Windows.Forms
 
                 internal void ReleaseChildUiaProviders()
                 {
-                    HRESULT result;
-
                     if (_upButton is not null)
                     {
-                        result = UiaCore.UiaDisconnectProvider(_upButton);
-                        Debug.Assert(result == HRESULT.S_OK);
+                        UiaCore.UiaDisconnectProvider(_upButton);
                         _upButton = null;
                     }
 
                     if (_downButton is not null)
                     {
-                        result = UiaCore.UiaDisconnectProvider(_downButton);
-                        Debug.Assert(result == HRESULT.S_OK);
+                        UiaCore.UiaDisconnectProvider(_downButton);
                         _downButton = null;
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.cs
@@ -117,17 +117,11 @@ namespace System.Windows.Forms
 
                 internal void ReleaseChildUiaProviders()
                 {
-                    if (_upButton is not null)
-                    {
-                        UiaCore.UiaDisconnectProvider(_upButton);
-                        _upButton = null;
-                    }
+                    UiaCore.UiaDisconnectProvider(_upButton);
+                    _upButton = null;
 
-                    if (_downButton is not null)
-                    {
-                        UiaCore.UiaDisconnectProvider(_downButton);
-                        _downButton = null;
-                    }
+                    UiaCore.UiaDisconnectProvider(_downButton);
+                    _downButton = null;
                 }
 
                 public override AccessibleRole Role

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolTipTests.cs
@@ -823,6 +823,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ToolTip_WmShow_Invokes_AnnounceText_WithExpectedText_ForTabControlTabs()
         {
+            using NoAssertContext context = new();
             Mock<TabControl> mockTabControl = new() { CallBase = true, Object = { ShowToolTips = true } };
             Mock<Control.ControlAccessibleObject> mockAccessibleObject = new(MockBehavior.Strict, mockTabControl.Object);
             mockAccessibleObject


### PR DESCRIPTION
Fixes #7357

## Proposed changes
- Keep argument and result checks inside a static separate method. It allows to simplify using of `UiaDisconnectProvider`

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No

## Regression? 

- No

## Risk

- Minimal


## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manual testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
- Using Narrator/Inspect/AI and WinDbg

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0 Preview 6
- Windows 11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7362)