### PR TITLE
 Set TreeView.Sorted = false when set TreeView.TreeNodeSorter by null, fix GH issues #7027

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -1357,6 +1357,11 @@ namespace System.Windows.Forms
                     {
                         Sort();
                     }
+                    else
+                    {
+                        Sorted = false;
+                        RefreshNodes();
+                    }
                 }
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -4726,6 +4726,28 @@ namespace System.Windows.Forms.Tests
             Assert.Same(value, treeView.TreeViewNodeSorter);
         }
 
+        public static IEnumerable<object[]> TreeViewNodeSorter_TestData_NullFirst()
+        {
+            yield return new object[] { StringComparer.CurrentCulture };
+            yield return new object[] { null };
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(TreeViewNodeSorter_TestData_NullFirst))]
+        public void TreeViewNodeSorter_Set_SetSortedFalseIfNull(IComparer value)
+        {
+            using var treeView = new TreeView
+            {
+                TreeViewNodeSorter = value
+            };
+            Assert.Same(value, treeView.TreeViewNodeSorter);
+            Assert.True(treeView.Sorted);
+
+            treeView.TreeViewNodeSorter = value;
+            Assert.Same(value, treeView.TreeViewNodeSorter);
+            Assert.False(treeView.Sorted);
+        }
+
         [WinFormsFact]
         public void AddExistingNodeAsChild_ThrowsArgumentException()
         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TreeViewTests.cs
@@ -4726,25 +4726,17 @@ namespace System.Windows.Forms.Tests
             Assert.Same(value, treeView.TreeViewNodeSorter);
         }
 
-        public static IEnumerable<object[]> TreeViewNodeSorter_TestData_NullFirst()
-        {
-            yield return new object[] { StringComparer.CurrentCulture };
-            yield return new object[] { null };
-        }
 
-        [WinFormsTheory]
-        [MemberData(nameof(TreeViewNodeSorter_TestData_NullFirst))]
-        public void TreeViewNodeSorter_Set_SetSortedFalseIfNull(IComparer value)
+        [WinFormsFact]
+        public void TreeViewNodeSorter_Set_SetSortedFalseIfNull()
         {
             using var treeView = new TreeView
             {
-                TreeViewNodeSorter = value
+                TreeViewNodeSorter = StringComparer.CurrentCulture
             };
-            Assert.Same(value, treeView.TreeViewNodeSorter);
             Assert.True(treeView.Sorted);
 
-            treeView.TreeViewNodeSorter = value;
-            Assert.Same(value, treeView.TreeViewNodeSorter);
+            treeView.TreeViewNodeSorter = null;
             Assert.False(treeView.Sorted);
         }
 


### PR DESCRIPTION

Fixes #7027 

## Customer Impact

N/A

## Regression? 

No

## Risk

No


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7374)