### PR TITLE
Supress C# keword warning.

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CreateWindowExW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/User32/Interop.CreateWindowExW.cs
@@ -21,7 +21,12 @@ internal static partial class Interop
             IntPtr hWndParent,
             IntPtr hMenu,
             IntPtr hInst,
+            // AsAny is obsoleted, but we currently allow (via CreateParams) specifying arbitrary objects
+            // when creating Controls. We could remove this if it is fully removed by manually doing the
+            // same conversions that the marshaller currently does.
+#pragma warning disable CS0618
             [MarshalAs(UnmanagedType.AsAny)] object? lpParam);
+#pragma warning restore CS0618
 
         public unsafe static IntPtr CreateWindowExW(
             WS_EX dwExStyle,

--- a/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
+++ b/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
@@ -5,9 +5,14 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>true</CLSCompliant>
     <Nullable>enable</Nullable>
-    <!--the obsolete usage in public surface can't be removed-->
-    <NoWarn>$(NoWarn);618</NoWarn>
-    <!-- 
+    <!--
+      We align casing and naming with Win32 API. As such some types have all lower case names, which
+      in theory may conflict with new C# keywords in the future. Our types here are internal so end
+      users won't be impacted. If some name becomes difficult to adapt to with the @ symbol we can
+      cross that bridge when we hit it (if ever).
+    -->
+    <NoWarn>$(NoWarn);CS8981</NoWarn>
+    <!--
       IL Trim warnings which should be removed in order to make WinForms trimmable
       See https://github.com/dotnet/winforms/issues/4649
     -->

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/ClientUtils.cs
@@ -8,19 +8,13 @@ namespace System.Windows.Forms
 {
     static internal class ClientUtils
     {
-        // ExecutionEngineException is obsolete and shouldn't be used (to catch, throw or reference) anymore.
-        // Pragma added to prevent converting the "type is obsolete" warning into build error.
-        // File owner should fix this.
         public static bool IsCriticalException(Exception ex)
-        {
-            return ex is NullReferenceException
-                    || ex is StackOverflowException
-                    || ex is OutOfMemoryException
-                    || ex is Threading.ThreadAbortException
-                    || ex is ExecutionEngineException
-                    || ex is IndexOutOfRangeException
-                    || ex is AccessViolationException;
-        }
+            => ex is NullReferenceException
+                || ex is StackOverflowException
+                || ex is OutOfMemoryException
+                || ex is ThreadAbortException
+                || ex is IndexOutOfRangeException
+                || ex is AccessViolationException;
 
         private enum CharType
         {


### PR DESCRIPTION
Supressing new CS8981 warning for the Primitives assembly.
We match Win32 casing for intereop.
Moved obsolete warning into code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7380)