### PR TITLE
Fix Narrator not announcing content of RichTextBox

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -2491,12 +2491,14 @@ namespace System.Windows.Forms
         {
             base.OnGotFocus(e);
 
-            if (IsAccessibilityObjectCreated)
+            // Use parent's accessible object because RichTextBox doesn't support UIA Providers, and its
+            // AccessibilityObject doesn't get created even when assistive tech (e.g. Narrator) is used
+            if (Parent?.IsAccessibilityObjectCreated == true)
             {
-                AccessibilityObject.RaiseAutomationNotification(
-                        Automation.AutomationNotificationKind.Other,
-                        Automation.AutomationNotificationProcessing.MostRecent,
-                        Text);
+                Parent.AccessibilityObject.InternalRaiseAutomationNotification(
+                    Automation.AutomationNotificationKind.Other,
+                    Automation.AutomationNotificationProcessing.MostRecent,
+                    Text);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.cs
@@ -1599,7 +1599,12 @@ namespace System.Windows.Forms
         }
 
         private protected virtual void RaiseAccessibilityTextChangedEvent()
-            => AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextChangedEventId);
+        {
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.Text_TextChangedEventId);
+            }
+        }
 
         /// <summary>
         ///  Returns the character nearest to the given point.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7387 


## Proposed changes

- Use parent's accessible object for notification because RIchTextBox doesn't support UIA providers — its own accessibility object doesn't gets created, and notification is not raised.
- Add missing IsAccessibilityObjectCreated check for TextBoxBase (not directly related to this issue, found while working in this area)

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Narrator announces text of RichTextBox when it's focused. This behavior was present in .NET 6 but missing from .NET 7.


## Regression? 

- Yes 

## Risk

- Minimal


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/102954094/178036310-4d40aa42-2e27-4c5b-abf7-160350f721f7.png)

### After

![Screenshot 2022-07-08 185823](https://user-images.githubusercontent.com/102954094/178037341-5c1bdec5-c20c-4c61-bce4-6d0dfb59d4a7.png)


## Test methodology <!-- How did you ensure quality? -->

- Unit test
- Manual testing with Narrator
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->
* Using Narrator

 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0.100-preview.6.22281.2
- Microsoft Windows: 10.0.22000 (Windows 11)

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7389)