### PR TITLE
Fixing of ToolStrip elements accessible objects

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4256,6 +4256,35 @@ namespace System.Windows.Forms
             return null;
         }
 
+        internal override void ReleaseUiaProvider(IntPtr handle)
+        {
+            base.ReleaseUiaProvider(handle);
+            if (OsVersion.IsWindows8OrGreater)
+            {
+                ReleaseToolStripItemsProviders(Items);
+            }
+        }
+
+        /// <summary>
+        ///  Call UiaDisconnectProvider for all ToolsStripItem Accessible objects.
+        ///  This method is invoked from ReleaseUiaProvider method.
+        /// </summary>
+        /// <param name="items">contains ToolStrip or ToolStripDropDown items to disconnect</param>
+        internal virtual void ReleaseToolStripItemsProviders(ToolStripItemCollection items)
+        {
+            ToolStripItem[] itemsArray = items.Cast<ToolStripItem>().ToArray();
+            foreach (ToolStripItem toolStripItem in itemsArray)
+            {
+                if (toolStripItem is ToolStripDropDownItem dropDownItem && dropDownItem.DropDownItems.Count > 0)
+                {
+                    ToolStripItemCollection dropDownMenuItems = dropDownItem.DropDownItems;
+                    ReleaseToolStripItemsProviders(dropDownMenuItems);
+                }
+
+                toolStripItem.ReleaseUiaProvider();
+            }
+        }
+
         private void RestoreFocusInternal(bool wasInMenuMode)
         {
             // This is called from the RestoreFocusFilter.  If the state of MenuMode has changed

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4258,11 +4258,17 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider(IntPtr handle)
         {
-            base.ReleaseUiaProvider(handle);
+            if (!IsAccessibilityObjectCreated)
+            {
+                return;
+            }
+
             if (OsVersion.IsWindows8OrGreater)
             {
                 ReleaseToolStripItemsProviders(Items);
             }
+
+            base.ReleaseUiaProvider(handle);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownMenu.cs
@@ -598,6 +598,10 @@ namespace System.Windows.Forms
             }
         }
 
+        internal override void ReleaseToolStripItemsProviders(ToolStripItemCollection items)
+        {
+        }
+
         internal override void ResetScaling(int newDpi)
         {
             base.ResetScaling(newDpi);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -3196,7 +3196,7 @@ namespace System.Windows.Forms
         internal void RaiseQueryContinueDragEvent(object key, QueryContinueDragEventArgs e)
             => ((QueryContinueDragEventHandler)Events[key])?.Invoke(this, e);
 
-        internal virtual void ReleaseUiaProvider()
+        internal void ReleaseUiaProvider()
         {
             if (TryGetAccessibilityObject(out AccessibleObject accessibleObject))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -3196,6 +3196,22 @@ namespace System.Windows.Forms
         internal void RaiseQueryContinueDragEvent(object key, QueryContinueDragEventArgs e)
             => ((QueryContinueDragEventHandler)Events[key])?.Invoke(this, e);
 
+        internal virtual void ReleaseUiaProvider()
+        {
+            if (TryGetAccessibilityObject(out AccessibleObject accessibleObject))
+            {
+                HRESULT result = UiaCore.UiaDisconnectProvider(accessibleObject);
+                Debug.Assert(result == HRESULT.S_OK);
+                Properties.SetObject(s_accessibilityProperty, null);
+            }
+
+            bool TryGetAccessibilityObject(out AccessibleObject accessibleObject)
+            {
+                accessibleObject = Properties.GetObject(s_accessibilityProperty) as AccessibleObject;
+                return accessibleObject is not null;
+            }
+        }
+
         private void ResetToolTipText() => _toolTipText = null;
 
         // This will only be called in PerMonitorV2 scenarios.


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7375


## Proposed changes

- Changed ToolStrip class
- Changed ToolStripItem and ToolStripDropDownItem classes

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Less memory leaks of ToolStrip


## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/102961955/178545060-da500f0f-f5fd-4a3e-b02a-ddabc9947733.png)

### After

![image](https://user-images.githubusercontent.com/102961955/178722229-469a259e-1fb3-43ff-8dd8-cf6b1317f9dc.png)


## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manually (via WinDbg)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using AI, Inspect, Narrator


 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0 Preview 5
- Windows 10


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7395)