### PR TITLE
Fix incorrect WarningsAsErrors element

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/VisualBasicTemplate/VbWinForms.vbproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/VisualBasicTemplate/VbWinForms.vbproj
@@ -7,11 +7,8 @@
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</WarningsAsErrors>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</WarningsAsErrors>
+  <PropertyGroup>
+    <WarningsAsErrors>$(WarningsAsErrors),41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Using the below syntax performs a complete replacement of warning codes which should be treated as errors.

```xml
<WarningsAsErrors>aaaaa;bbbbb;ccccc;...</WarningsAsErrors>
```

Instead, the following syntax should be used, which inherits the base list coming from the SDK and augments the list with your desired warning codes.

```xml
<WarningsAsErrors>$(WarningsAsErrors);aaaaa;bbbbb;ccccc;...</WarningsAsErrors>
```

> Exception: If you're intentionally trying to suppress the SDK's base list, please ignore this rule.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7401)