### PR TITLE
Make the TreeView respect the DoubleBuffered property

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2082,22 +2082,16 @@ namespace System.Windows.Forms
                 return;
             }
 
-            TVS_EX extendedStyles = (TVS_EX)User32.SendMessageW(this, (User32.WM)TVM.GETEXTENDEDSTYLE);
+            TVS_EX extendedStyles = 0;
 
-            SetExtendedStyle(ref extendedStyles, TVS_EX.DOUBLEBUFFER, DoubleBuffered);
-
-            User32.SendMessageW(this, (User32.WM)TVM.SETEXTENDEDSTYLE, (int)extendedStyles, (int)extendedStyles);
-
-            static void SetExtendedStyle(ref TVS_EX extendedStyles, TVS_EX mask, bool value)
+            if (DoubleBuffered)
             {
-                if (value)
-                {
-                    extendedStyles |= mask;
-                }
-                else
-                {
-                    extendedStyles &= ~mask;
-                }
+                extendedStyles |= TVS_EX.DOUBLEBUFFER;
+            }
+
+            if (extendedStyles != 0)
+            {
+                User32.SendMessageW(this, (User32.WM)TVM.SETEXTENDEDSTYLE, (int)extendedStyles, (int)extendedStyles);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -438,10 +438,9 @@ namespace System.Windows.Forms
             get => base.DoubleBuffered;
             set
             {
-                base.DoubleBuffered = value;
-
-                if (IsHandleCreated)
+                if (DoubleBuffered != value)
                 {
+                    base.DoubleBuffered = value;
                     UpdateTreeViewExtendedStyles();
                 }
             }
@@ -2078,6 +2077,11 @@ namespace System.Windows.Forms
 
         private void UpdateTreeViewExtendedStyles()
         {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
             TVS_EX extendedStyles = (TVS_EX)User32.SendMessageW(this, (User32.WM)TVM.GETEXTENDEDSTYLE);
 
             SetExtendedStyle(ref extendedStyles, TVS_EX.DOUBLEBUFFER, DoubleBuffered);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2075,16 +2075,6 @@ namespace System.Windows.Forms
             SelectedNode = savedSelectedNode;
         }
 
-        private void UpdateTreeViewExtendedStyles()
-        {
-            if (!IsHandleCreated)
-            {
-                return;
-            }
-
-            User32.SendMessageW(this, (User32.WM)TVM.SETEXTENDEDSTYLE, (nint)TVS_EX.DOUBLEBUFFER, (nint)(DoubleBuffered ? TVS_EX.DOUBLEBUFFER : 0));
-        }
-
         // Replace the native control's ImageList with our current stateImageList
         // set the value of internalStateImageList to the new list
         private void UpdateNativeStateImageList()
@@ -2748,6 +2738,16 @@ namespace System.Windows.Forms
                     }
                 }
             }
+        }
+
+        private void UpdateTreeViewExtendedStyles()
+        {
+            if (!IsHandleCreated)
+            {
+                return;
+            }
+
+            User32.SendMessageW(this, (User32.WM)TVM.SETEXTENDEDSTYLE, (nint)TVS_EX.DOUBLEBUFFER, (nint)(DoubleBuffered ? TVS_EX.DOUBLEBUFFER : 0));
         }
 
         /// <remarks>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2082,17 +2082,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            TVS_EX extendedStyles = 0;
-
-            if (DoubleBuffered)
-            {
-                extendedStyles |= TVS_EX.DOUBLEBUFFER;
-            }
-
-            if (extendedStyles != 0)
-            {
-                User32.SendMessageW(this, (User32.WM)TVM.SETEXTENDEDSTYLE, (int)extendedStyles, (int)extendedStyles);
-            }
+            User32.SendMessageW(this, (User32.WM)TVM.SETEXTENDEDSTYLE, (nint)TVS_EX.DOUBLEBUFFER, (nint)(DoubleBuffered ? TVS_EX.DOUBLEBUFFER : 0));
         }
 
         // Replace the native control's ImageList with our current stateImageList

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -76,6 +76,7 @@ namespace System.Windows.Forms
         private const int TREEVIEWSTATE_lastControlValidated = 0x00004000;
         private const int TREEVIEWSTATE_stopResizeWindowMsgs = 0x00008000;
         private const int TREEVIEWSTATE_ignoreSelects = 0x00010000;
+        private const int TREEVIEWSTATE_doubleBufferedPropertySet = 0x00020000;
 
         // PERF: take all the bools and put them into a state variable
         private Collections.Specialized.BitVector32 treeViewState; // see TREEVIEWSTATE_ consts above
@@ -441,6 +442,7 @@ namespace System.Windows.Forms
                 if (DoubleBuffered != value)
                 {
                     base.DoubleBuffered = value;
+                    treeViewState[TREEVIEWSTATE_doubleBufferedPropertySet] = true;
                     UpdateTreeViewExtendedStyles();
                 }
             }
@@ -2747,7 +2749,12 @@ namespace System.Windows.Forms
                 return;
             }
 
-            User32.SendMessageW(this, (User32.WM)TVM.SETEXTENDEDSTYLE, (nint)TVS_EX.DOUBLEBUFFER, (nint)(DoubleBuffered ? TVS_EX.DOUBLEBUFFER : 0));
+            // Only set the TVS_EX_DOUBLEBUFFER style if the DoubleBuffered property setter has been executed.
+            // This stops the style from being removed for any derived classes that set it using P/Invoke.
+            if (treeViewState[TREEVIEWSTATE_doubleBufferedPropertySet])
+            {
+                User32.SendMessageW(this, (User32.WM)TVM.SETEXTENDEDSTYLE, (nint)TVS_EX.DOUBLEBUFFER, (nint)(DoubleBuffered ? TVS_EX.DOUBLEBUFFER : 0)); 
+            }
         }
 
         /// <remarks>


### PR DESCRIPTION
Fixes #4883

## Proposed changes

- The TreeView will respect the DoubleBuffered property.

## Customer Impact

- Double buffering can be enabled in a derived class without needing to use P/Invoke.

## Regression? 

- No

## Risk

Probably minimal.

## Test methodology 

- Manually tested the change in a winforms app

## Test environment(s) 

- 7.0.100-preview.5.22307.18 (x64)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7403)