### PR TITLE
Skip Button_Anchor_ResizeOnWindowSizeWiderAsync test

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
@@ -155,7 +155,8 @@ namespace System.Windows.Forms.UITests
             });
         }
 
-        [WinFormsFact]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/7297")]
+        [WinFormsFact(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/7297")]
         public async Task Button_Anchor_ResizeOnWindowSizeWiderAsync()
         {
             await RunTestAsync(async (form, button) =>


### PR DESCRIPTION
Skip Button_Anchor_ResizeOnWindowSizeWiderAsync test
Related to https://github.com/dotnet/winforms/issues/7297


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7406)