### PR TITLE
Returning the AccessibilityObject of a DataGridViewRowHeaderCell instead of a DataGrid...

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.AccessibleObject.cs
@@ -184,13 +184,11 @@ namespace System.Windows.Forms
                             // increment the childIndex because the first child in the TopRowAccessibleObject is the TopLeftHeaderCellAccObj
                             return TopRowAccessibilityObject.GetChild(actualDisplayIndex + 1);
                         }
-                        else
-                        {
-                            return TopRowAccessibilityObject.GetChild(actualDisplayIndex);
-                        }
+
+                        return TopRowAccessibilityObject.GetChild(actualDisplayIndex);
 
                     case DataGridViewHitTestType.RowHeader:
-                        return _ownerDataGridView.Rows[hti.RowIndex].AccessibilityObject;
+                        return _ownerDataGridView.Rows[hti.RowIndex].HeaderCell.AccessibilityObject;
                     case DataGridViewHitTestType.TopLeftHeader:
                         return _ownerDataGridView.TopLeftHeaderCell.AccessibilityObject;
                     case DataGridViewHitTestType.VerticalScrollBar:


### PR DESCRIPTION
…ViewRow for display bounds correctly.


<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6570


## Proposed changes

- Return the AccessibilityObject of a DataGridViewRowHeaderCell instead of a DataGridViewRow when the user hovers over a DataGridViewRowHeaderCell.
- Remove redundant 'else'.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Border of DataGridViewRowHeaderCell draws correctly in Inspect or AI.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/178902238-c300fe32-c3b9-43e5-aa76-35a5d4d308d2.png)

### After

![image](https://user-images.githubusercontent.com/109065597/178901949-4a034237-2f96-42f9-bbbd-f44dd75cc9a2.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually tested the change in a winforms app

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using AI, Inspect


 

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.5.22307.18
- Windows 11
<!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7409)