### PR TITLE
Remove NoWarn for nuget warnings because fix for false positives reached VS2022 IntPreview

### DIFF
--- a/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/VisualBasicRuntimeTest.csproj
+++ b/src/Microsoft.VisualBasic/tests/IntegrationTests/VisualBasicRuntimeTest/VisualBasicRuntimeTest.csproj
@@ -2,11 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!-- NU1505 reports duplicate package download for Microsoft.NETCore.App.Host.win-x64.
-         Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
-    <NoWarn>$(NoWarn);NU1505</NoWarn>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.VisualBasic.Facade.csproj" />
   </ItemGroup>

--- a/src/System.Windows.Forms/tests/AccessibilityTests/Accessibility_Core_App.csproj
+++ b/src/System.Windows.Forms/tests/AccessibilityTests/Accessibility_Core_App.csproj
@@ -8,10 +8,6 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
-    
-    <!-- NU1505 reports duplicate package download for Microsoft.NETCore.App.Host.win-x64.
-         Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
-    <NoWarn>$(NoWarn);NU1505</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/DemoConsole.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/DemoConsole.csproj
@@ -8,9 +8,7 @@
     <StartupObject />
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
-    <!-- NU1505 reports duplicate package download for Microsoft.NETCore.App.Host.win-x64.
-         Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
-    <NoWarn>$(NoWarn);SA1633;CS8002;NU1505</NoWarn>
+    <NoWarn>$(NoWarn);SA1633;CS8002</NoWarn>
     <Copyright>Copyright © Paolo Foti 2008</Copyright>
     <Company />
     <Authors>Paolo Foti</Authors>

--- a/src/System.Windows.Forms/tests/IntegrationTests/NativeHost.ManagedControl/NativeHost.ManagedControl.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/NativeHost.ManagedControl/NativeHost.ManagedControl.csproj
@@ -6,11 +6,8 @@
     <EnableComHosting>true</EnableComHosting>
     <EnableXlfLocalization>false</EnableXlfLocalization>
     <UpdateXlfOnBuild>false</UpdateXlfOnBuild>
-    <!-- NU1505 reports duplicate package download for Microsoft.NETCore.App.Host.win-x64.
-         Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
-    <NoWarn>$(NoWarn);NU1505</NoWarn>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\System.Windows.Forms.Primitives\src\System.Windows.Forms.Primitives.csproj" />
     <ProjectReference Include="..\..\..\src\System.Windows.Forms.csproj" />

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/WinformsControlsTest.csproj
@@ -13,9 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- NU1505 reports duplicate package download for Microsoft.NETCore.App.Host.win-x64.
-         Disabling this warning until https://github.com/dotnet/sdk/issues/24747 is fixed.-->
-    <NoWarn>$(NoWarn);WFDEV001;NU1505</NoWarn>
+    <NoWarn>$(NoWarn);WFDEV001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #7025


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7410)