### PR TITLE
Skip Button_Anchor_ResizeOnWindowSizeTallerAsync test

### DIFF
--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/ButtonTests.cs
@@ -185,7 +185,8 @@ namespace System.Windows.Forms.UITests
             });
         }
 
-        [WinFormsFact]
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/7407")]
+        [WinFormsFact(Skip = "Flaky tests, see: https://github.com/dotnet/winforms/issues/7407")]
         public async Task Button_Anchor_ResizeOnWindowSizeTallerAsync()
         {
             await RunTestAsync(async (form, button) =>


### PR DESCRIPTION
Skip Button_Anchor_ResizeOnWindowSizeTallerAsync test
Related to #7407 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7411)