### PR TITLE
Fixing incorrect selection of ListViewGroup for ListView.GroupCollapsedStateChanged event (#6708)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6934,7 +6934,7 @@ namespace System.Windows.Forms
                         foreach (ListViewItem selectedItem in SelectedItems)
                         {
                             ListViewGroup group = selectedItem.Group;
-                            if (group is null || !groups.Add(group.ID) || group.CollapsedState is ListViewGroupCollapsedState.Default)
+                            if (group is null || group.CollapsedState is ListViewGroupCollapsedState.Default || !groups.Add(group.ID))
                             {
                                 continue;
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -6926,21 +6926,25 @@ namespace System.Windows.Forms
                 case User32.WM.KEYUP:
                     int key = (int)m.WParamInternal;
 
-                    // User can collapse/expand a group using the keyboard by focusing the group header and using left/right
+                    // User can collapse/expand a group using the keyboard by focusing the group header and using left/right.
                     if (GroupsDisplayed && (key is User32.VK.LEFT or User32.VK.RIGHT) && SelectedItems.Count > 0)
                     {
-                        ListViewGroup group = SelectedItems[0].Group;
-
-                        if (group is null || group.CollapsedState is ListViewGroupCollapsedState.Default)
+                        // User can select more than one group.
+                        HashSet<int> groups = new();
+                        foreach (ListViewItem selectedItem in SelectedItems)
                         {
-                            break;
-                        }
+                            ListViewGroup group = selectedItem.Group;
+                            if (group is null || !groups.Add(group.ID) || group.CollapsedState is ListViewGroupCollapsedState.Default)
+                            {
+                                continue;
+                            }
 
-                        ListViewGroupCollapsedState nativeState = group.GetNativeCollapsedState();
-                        if (nativeState != group.CollapsedState)
-                        {
-                            group.SetCollapsedStateInternal(nativeState);
-                            OnGroupCollapsedStateChanged(new ListViewGroupEventArgs(Groups.IndexOf(group)));
+                            ListViewGroupCollapsedState nativeState = group.GetNativeCollapsedState();
+                            if (nativeState != group.CollapsedState)
+                            {
+                                group.SetCollapsedStateInternal(nativeState);
+                                OnGroupCollapsedStateChanged(new ListViewGroupEventArgs(Groups.IndexOf(group)));
+                            }
                         }
                     }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6708

## Proposed changes

- Processed all unique groups of selected items through collapse. The collapse state had been validated in cycle and correct group(s) triggered for GroupCollapsedStateChanged.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- ListView.GroupCollapsedStateChanged event works correctly in case of multiple groups selection.


## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![154516575-62709402-0a92-4ace-9579-1ea66eeef564](https://user-images.githubusercontent.com/109065597/178964523-34595f6f-6592-41f0-a3ed-3e6a86bdab93.gif)


### After

![dECVUwE2AK](https://user-images.githubusercontent.com/109065597/178964332-749ee0a4-85b0-451d-995f-52e000036742.gif)



## Test methodology <!-- How did you ensure quality? -->

- Manually tested the change in a winforms app


## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.5.22307.18
- Windows 11


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7412)