### PR TITLE
Setting UIA_IsDialogPropertyId correctly when Form.ShowDialog() was called

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UIA.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/UiaCore/Interop.UIA.cs
@@ -250,6 +250,7 @@ internal static partial class Interop
             CenterPointPropertyId = 30165,
             RotationPropertyId = 30166,
             SizePropertyId = 30167,
+            IsDialogPropertyId = 30174,
 
             // UIA_ControlTypeIds
             ButtonControlTypeId = 50000,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
@@ -55,6 +55,7 @@ namespace System.Windows.Forms
                     UiaCore.UIA.ControlTypePropertyId => Role == AccessibleRole.Client
                                                          ? UiaCore.UIA.WindowControlTypeId
                                                          : base.GetPropertyValue(propertyID),
+                    UiaCore.UIA.IsDialogPropertyId => _owner.Modal,
                     _ => base.GetPropertyValue(propertyID)
                 };
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Form.FormAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Form.FormAccessibleObjectTests.cs
@@ -35,6 +35,42 @@ namespace System.Windows.Forms.Tests
             Assert.False(form.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void FormAccessibleObject_ControlType_IsDialog_True()
+        {
+            using Form form = new();
+
+            bool? actualValue = null;
+            form.Load += (_, _) =>
+            {
+                AccessibleObject accessibleObject = form.AccessibilityObject;
+                actualValue = (bool?)accessibleObject.GetPropertyValue(UiaCore.UIA.IsDialogPropertyId);
+                form.Close();
+            };
+            form.ShowDialog();
+
+            Assert.True(actualValue);
+            Assert.False(form.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void FormAccessibleObject_ControlType_IsDialog_False()
+        {
+            using Form form = new();
+
+            bool? actualValue = null;
+            form.Load += (_, _) =>
+            {
+                AccessibleObject accessibleObject = form.AccessibilityObject;
+                actualValue = (bool?)accessibleObject.GetPropertyValue(UiaCore.UIA.IsDialogPropertyId);
+                form.Close();
+            };
+            form.Show();
+
+            Assert.False(actualValue);
+            Assert.False(form.IsHandleCreated);
+        }
+
         public static IEnumerable<object[]> FormAccessibleObject_GetPropertyValue_ControlType_IsExpected_ForCustomRole_TestData()
         {
             Array roles = Enum.GetValues(typeof(AccessibleRole));


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #2907


## Proposed changes

- Added new  UIAutomation PropertyId IsDialogPropertyId.
- Set IsDialogPropertyId in FormAccessibleObject.GetPropertyValue(UiaCore.UIA propertyID)
- Added unit tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The form will programmatically be exposed as a dialog, which is the correct match for its semantics. 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/179181950-e3bfebe8-e9a1-4af0-a182-45d078c6abc7.png)

### After

![image](https://user-images.githubusercontent.com/109065597/179182439-414511b6-dccc-4d76-9d44-60f5818f4a25.png)



## Test methodology <!-- How did you ensure quality? -->

- Manually tested the change in a winforms app
- Unit tests 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Used Inspect


 

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.5.22307.18


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7421)