### PR TITLE
Workaround for empty finalizer in ApplicationContext.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ModalApplicationContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ModalApplicationContext.cs
@@ -6,6 +6,8 @@ namespace System.Windows.Forms
 {
     public sealed partial class Application
     {
+        internal static readonly Type s_typeOfModalApplicationContext = typeof(ModalApplicationContext);
+
         private class ModalApplicationContext : ApplicationContext
         {
             private ThreadContext? _parentWindowContext;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ApplicationContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ApplicationContext.cs
@@ -16,16 +16,6 @@ namespace System.Windows.Forms
     /// </summary>
     public class ApplicationContext : IDisposable
     {
-        /// <summary>
-        ///  These are subclasses of the <see cref="ApplicationContext"/> for which we don't need to call the finalizer,
-        ///  because it's empty. See https://github.com/dotnet/winforms/issues/6858.
-        /// </summary>
-        private static readonly HashSet<Type> s_typesWithEmptyFinalizer = new()
-        {
-            typeof(ApplicationContext),
-            Application.s_typeOfModalApplicationContext
-        };
-
         private Form? _mainForm;
 
         /// <summary>
@@ -42,14 +32,16 @@ namespace System.Windows.Forms
         /// </summary>
         public ApplicationContext(Form? mainForm)
         {
-            if (s_typesWithEmptyFinalizer.Contains(GetType()))
+            //  These are subclasses of the ApplicationContext for which we don't need to call the finalizer,
+            //  because it's empty. See https://github.com/dotnet/winforms/issues/6858.
+            if (GetType() == typeof(ApplicationContext) || GetType() == Application.s_typeOfModalApplicationContext)
                 GC.SuppressFinalize(this);
 
             MainForm = mainForm;
         }
 
         // NOTE: currently this finalizer is unneeded (empty). See https://github.com/dotnet/winforms/issues/6858.
-        // All classes that are not need to be finalized contains in ApplicationContext.s_typesWithEmptyFinalizer collection.
+        // All classes that are not need to be finalized must be checked in ApplicationContext(Form? mainForm) constructor.
         // Consider to modify it if needed.
         ~ApplicationContext() => Dispose(false);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ApplicationContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ApplicationContext.cs
@@ -17,8 +17,8 @@ namespace System.Windows.Forms
     public class ApplicationContext : IDisposable
     {
         /// <summary>
-        /// These are subclasses of the <see cref="ApplicationContext"/> for which we don't need to call the finalizer, because it's empty.
-        /// See https://github.com/dotnet/winforms/issues/6858.
+        ///  These are subclasses of the <see cref="ApplicationContext"/> for which we don't need to call the finalizer,
+        ///  because it's empty. See https://github.com/dotnet/winforms/issues/6858.
         /// </summary>
         private static readonly HashSet<Type> s_typesWithEmptyFinalizer = new()
         {
@@ -49,7 +49,8 @@ namespace System.Windows.Forms
         }
 
         // NOTE: currently this finalizer is unneeded (empty). See https://github.com/dotnet/winforms/issues/6858.
-        // All classes that are not need to be finalized contains in ApplicationContext.s_typesWithEmptyFinalizer collection. Consider to modify it if needed.
+        // All classes that are not need to be finalized contains in ApplicationContext.s_typesWithEmptyFinalizer collection.
+        // Consider to modify it if needed.
         ~ApplicationContext() => Dispose(false);
 
         /// <summary>
@@ -119,9 +120,9 @@ namespace System.Windows.Forms
             }
 
             // If you are adding releasing unmanaged resources code here (disposing == false), you need to:
-            // remove GC.SuppressFinalize from constructor of this class and from all of its subclasses
-            // remove ApplicationContext_Subclasses_SuppressFinalizeCall test
-            // modify ~ApplicationContext() description.
+            // 1. remove GC.SuppressFinalize from constructor of this class and from all of its subclasses
+            // 2. remove ApplicationContext_Subclasses_SuppressFinalizeCall test
+            // 3. modify ~ApplicationContext() description.
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationContextTests.cs
@@ -379,15 +379,12 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ApplicationContext_Subclasses_SuppressFinalizeCall()
         {
-            TestAccessor<ApplicationContext> testAccessor = new(null);
-            var typesWithEmptyFinalizer = testAccessor.Dynamic.s_typesWithEmptyFinalizer as HashSet<Type>;
-
             foreach (var type in typeof(ApplicationContext).Assembly.GetTypes().
                 Where(type => type == typeof(ApplicationContext) || type.IsSubclassOf(typeof(ApplicationContext))))
             {
-                Assert.True(typesWithEmptyFinalizer.Contains(type),
-                    $"Type {type} is not present in the ApplicationContext.s_typesWithEmptyFinalizer collection. " +
-                    $"Consider adding it or add exclusion to this test (if a new class really needs a finalizer).");
+                Assert.True(type == typeof(ApplicationContext) || type == Application.s_typeOfModalApplicationContext,
+                    $"Type {type} is not one of [{typeof(ApplicationContext)}, {Application.s_typeOfModalApplicationContext}]. " +
+                    $"Consider adding it here and to the ApplicationContext(Form? mainForm) constructor. Or add exclusion to this test (if a new class really needs a finalizer).");
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationContextTests.cs
@@ -382,9 +382,11 @@ namespace System.Windows.Forms.Tests
             TestAccessor<ApplicationContext> testAccessor = new(null);
             var typesWithEmptyFinalizer = testAccessor.Dynamic.s_typesWithEmptyFinalizer as HashSet<Type>;
 
-            foreach (var type in typeof(ApplicationContext).Assembly.GetTypes().Where(type => type == typeof(ApplicationContext) || type.IsSubclassOf(typeof(ApplicationContext))))
+            foreach (var type in typeof(ApplicationContext).Assembly.GetTypes().
+                Where(type => type == typeof(ApplicationContext) || type.IsSubclassOf(typeof(ApplicationContext))))
             {
-                Assert.True(typesWithEmptyFinalizer.Contains(type), $"Type {type} is not present in the ApplicationContext.s_typesWithEmptyFinalizer collection. " +
+                Assert.True(typesWithEmptyFinalizer.Contains(type),
+                    $"Type {type} is not present in the ApplicationContext.s_typesWithEmptyFinalizer collection. " +
                     $"Consider adding it or add exclusion to this test (if a new class really needs a finalizer).");
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationContextTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ApplicationContextTests.cs
@@ -376,6 +376,19 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(2, callCount);
         }
 
+        [WinFormsFact]
+        public void ApplicationContext_Subclasses_SuppressFinalizeCall()
+        {
+            TestAccessor<ApplicationContext> testAccessor = new(null);
+            var typesWithEmptyFinalizer = testAccessor.Dynamic.s_typesWithEmptyFinalizer as HashSet<Type>;
+
+            foreach (var type in typeof(ApplicationContext).Assembly.GetTypes().Where(type => type == typeof(ApplicationContext) || type.IsSubclassOf(typeof(ApplicationContext))))
+            {
+                Assert.True(typesWithEmptyFinalizer.Contains(type), $"Type {type} is not present in the ApplicationContext.s_typesWithEmptyFinalizer collection. " +
+                    $"Consider adding it or add exclusion to this test (if a new class really needs a finalizer).");
+            }
+        }
+
         private class SubApplicationContext : ApplicationContext
         {
             public SubApplicationContext() : base()


### PR DESCRIPTION
Contribute to https://github.com/dotnet/winforms/issues/6858.
This is continuation of https://github.com/dotnet/winforms/pull/6878 based on discussion.
Documentation for calling `GC.SuppressFinalize` on users subclasses also need to be updated some how...

The benefit of this change is not obvious like with `DataGridView`. The one I see is that `ModalApplicationContext` is never disposed after `ShowDialog` call, so it's ending up in Freachable queue.

## Test methodology
Existing UT.
New UT for all subclasses coverage.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7431)