### PR TITLE
Fix ToolTip on MenuStrip with dropdown.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4816,10 +4816,10 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        /// Updates item ToolTip.
+        ///  Updates a tooltip for the given toolstrip item.
         /// </summary>
-        /// <param name="item">The item.</param>
-        /// <param name="refresh">If set to <see langword="true"/>, the currently displayed ToolTip (if any) will be updated.</param>
+        /// <param name="item">The toolstrip item.</param>
+        /// <param name="refresh">see langword="true"/> to force-update the tooltip (if it is configured); otherwise <see langword="false"/>.</param>
         internal void UpdateToolTip(ToolStripItem item, bool refresh = false)
         {
             if (ShowItemToolTips)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4815,15 +4815,22 @@ namespace System.Windows.Forms
             return sb.ToString();
         }
 
-        internal void UpdateToolTip(ToolStripItem item)
+        /// <summary>
+        /// Updates item ToolTip.
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <param name="refresh">If set to <see langword="true"/>, the currently displayed ToolTip (if any) will be updated.</param>
+        internal void UpdateToolTip(ToolStripItem item, bool refresh = false)
         {
             if (ShowItemToolTips)
             {
-                if (item != _currentlyActiveTooltipItem && ToolTip is not null)
+                if ((item != _currentlyActiveTooltipItem || refresh) && ToolTip is not null)
                 {
-                    ToolTip.Hide(this);
-
-                    _currentlyActiveTooltipItem = item;
+                    if (item != _currentlyActiveTooltipItem)
+                    {
+                        ToolTip.Hide(this);
+                        _currentlyActiveTooltipItem = item;
+                    }
 
                     if (_currentlyActiveTooltipItem is not null && !GetToolStripState(STATE_DRAGGING))
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -693,6 +693,8 @@ namespace System.Windows.Forms
                 dropDown.Location = DropDownLocation;
                 dropDown.Show();
                 Invalidate();
+                // Update the current ToolTip (if any) to appear above the dropDown.
+                ParentInternal?.UpdateToolTip(this, true);
 
                 AccessibilityNotifyClients(AccessibleEvents.StateChange);
                 AccessibilityNotifyClients(AccessibleEvents.NameChange);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -693,8 +693,9 @@ namespace System.Windows.Forms
                 dropDown.Location = DropDownLocation;
                 dropDown.Show();
                 Invalidate();
-                // Update the current ToolTip (if any) to appear above the dropDown.
-                ParentInternal?.UpdateToolTip(this, true);
+
+                // Render the current tooltip (if there is one) on top of the dropdown element.
+                ParentInternal?.UpdateToolTip(this, refresh: true);
 
                 AccessibilityNotifyClients(AccessibleEvents.StateChange);
                 AccessibilityNotifyClients(AccessibleEvents.NameChange);

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MenuStripAndCheckedListBox.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/MenuStripAndCheckedListBox.Designer.cs
@@ -125,6 +125,7 @@ namespace WinformsControlsTest
             this.memoryCardFileToolStripMenuItem.Name = "memoryCardFileToolStripMenuItem";
             this.memoryCardFileToolStripMenuItem.Size = new System.Drawing.Size(401, 44);
             this.memoryCardFileToolStripMenuItem.Text = "Memory Card File";
+            this.memoryCardFileToolStripMenuItem.ToolTipText = "Looooooooooooooooooooooooooooooooong ToolTip";
             //
             // navigationToolStripMenuItem
             //
@@ -133,6 +134,7 @@ namespace WinformsControlsTest
             this.navigationToolStripMenuItem.Name = "navigationToolStripMenuItem";
             this.navigationToolStripMenuItem.Size = new System.Drawing.Size(265, 44);
             this.navigationToolStripMenuItem.Text = "Navigation";
+            this.navigationToolStripMenuItem.ToolTipText = "Looooooooooooooooooooooooooooooooong ToolTip 2";
             //
             // newToolStripMenuItem1
             //


### PR DESCRIPTION
Fix #6987.

## Proposed changes
The problem happens due to the fact that we first show the tooltip, and then show the dropdown, which will overlap the tooltip. In such situations I suggest to refresh the tooltip after dropdown shown.

## Customer Impact
ToolTip on `MenuStrip` item with dropdown elements will be fully visible.

## Regression? 

- No

## Risk

- minimal.

### Before

https://user-images.githubusercontent.com/17767561/179411168-77d2976b-a9fc-4d69-a3e4-53cefa00dced.mp4


### After

https://user-images.githubusercontent.com/17767561/179411173-cbf626ff-bf9b-4572-94c1-8d8f158cef13.mp4


## Test methodology

Existing UT.
Manual.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7436)