### PR TITLE
Enable nullability in DataGridViewDataErrorEventArgs

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1082,8 +1082,8 @@ override System.Windows.Forms.ToolStripContainer.OnSizeChanged(System.EventArgs!
 ~System.Windows.Forms.DataGridViewComboBoxColumn.Items.get -> System.Windows.Forms.DataGridViewComboBoxCell.ObjectCollection
 ~System.Windows.Forms.DataGridViewComboBoxColumn.ValueMember.get -> string
 ~System.Windows.Forms.DataGridViewComboBoxColumn.ValueMember.set -> void
-~System.Windows.Forms.DataGridViewDataErrorEventArgs.DataGridViewDataErrorEventArgs(System.Exception exception, int columnIndex, int rowIndex, System.Windows.Forms.DataGridViewDataErrorContexts context) -> void
-~System.Windows.Forms.DataGridViewDataErrorEventArgs.Exception.get -> System.Exception
+System.Windows.Forms.DataGridViewDataErrorEventArgs.DataGridViewDataErrorEventArgs(System.Exception? exception, int columnIndex, int rowIndex, System.Windows.Forms.DataGridViewDataErrorContexts context) -> void
+System.Windows.Forms.DataGridViewDataErrorEventArgs.Exception.get -> System.Exception?
 ~System.Windows.Forms.DataGridViewImageCell.Description.get -> string
 ~System.Windows.Forms.DataGridViewImageCell.Description.set -> void
 ~System.Windows.Forms.DataGridViewImageColumn.Description.get -> string

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataConnection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.DataConnection.cs
@@ -1200,8 +1200,11 @@ namespace System.Windows.Forms
                         throw;
                     }
 
-                    DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(exception, -1 /*columnIndex*/, rowIndex,
-                                                                                               DataGridViewDataErrorContexts.Display);
+                    DataGridViewDataErrorEventArgs dgvdee = new(
+                        exception,
+                        columnIndex: -1,
+                        rowIndex,
+                        DataGridViewDataErrorContexts.Display);
                     _owner.OnDataErrorInternal(dgvdee);
                     if (dgvdee.ThrowException)
                     {
@@ -1235,8 +1238,11 @@ namespace System.Windows.Forms
                         throw;
                     }
 
-                    DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(exception, columnIndex, rowIndex,
-                                                                                               DataGridViewDataErrorContexts.Display);
+                    DataGridViewDataErrorEventArgs dgvdee = new(
+                        exception,
+                        columnIndex,
+                        rowIndex,
+                        DataGridViewDataErrorContexts.Display);
                     _owner.OnDataErrorInternal(dgvdee);
                     if (dgvdee.ThrowException)
                     {
@@ -1269,8 +1275,11 @@ namespace System.Windows.Forms
                         throw;
                     }
 
-                    DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(exception, columnIndex, rowIndex,
-                                                                                               DataGridViewDataErrorContexts.Display);
+                    DataGridViewDataErrorEventArgs dgvdee = new(
+                        exception,
+                        columnIndex,
+                        rowIndex,
+                        DataGridViewDataErrorContexts.Display);
                     _owner.OnDataErrorInternal(dgvdee);
                     if (dgvdee.ThrowException)
                     {
@@ -1521,10 +1530,10 @@ namespace System.Windows.Forms
 
             public void ProcessException(Exception exception, DataGridViewCellCancelEventArgs e, bool beginEdit)
             {
-                DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(exception, e.ColumnIndex,
+                DataGridViewDataErrorEventArgs dgvdee = new(
+                    exception,
+                    e.ColumnIndex,
                     e.RowIndex,
-                    // null,
-                    // null,
                     DataGridViewDataErrorContexts.Commit);
                 _owner.OnDataErrorInternal(dgvdee);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -3218,7 +3218,9 @@ namespace System.Windows.Forms
                                 throw;
                             }
 
-                            dgvdee2 = new DataGridViewDataErrorEventArgs(exception, _ptCurrentCell.X,
+                            dgvdee2 = new(
+                                exception,
+                                _ptCurrentCell.X,
                                 _ptCurrentCell.Y,
                                 DataGridViewDataErrorContexts.InitialValueRestoration);
                         }
@@ -3966,12 +3968,11 @@ namespace System.Windows.Forms
                             return null;
                         }
 
-                        DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(null,
-                                                                                    _ptCurrentCell.X,
-                                                                                    _ptCurrentCell.Y,
-                                                                                    // null,
-                                                                                    // null,
-                                                                                    context)
+                        DataGridViewDataErrorEventArgs dgvdee = new(
+                            null,
+                            _ptCurrentCell.X,
+                            _ptCurrentCell.Y,
+                            context)
                         {
                             Cancel = true
                         };
@@ -4021,10 +4022,11 @@ namespace System.Windows.Forms
                                 return null;
                             }
 
-                            DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(null,
-                                                                                                       _ptCurrentCell.X,
-                                                                                                       _ptCurrentCell.Y,
-                                                                                                       context)
+                            DataGridViewDataErrorEventArgs dgvdee = new(
+                                null,
+                                _ptCurrentCell.X,
+                                _ptCurrentCell.Y,
+                                context)
                             {
                                 Cancel = true
                             };
@@ -4051,12 +4053,11 @@ namespace System.Windows.Forms
                             return null;
                         }
 
-                        DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(exception,
-                                                                                    _ptCurrentCell.X,
-                                                                                    _ptCurrentCell.Y,
-                                                                                    // dataGridViewCurrentCell.Value,
-                                                                                    // formattedValue,
-                                                                                    context)
+                        DataGridViewDataErrorEventArgs dgvdee = new(
+                            exception,
+                            _ptCurrentCell.X,
+                            _ptCurrentCell.Y,
+                            context)
                         {
                             Cancel = true
                         };
@@ -9947,7 +9948,9 @@ namespace System.Windows.Forms
                     throw;
                 }
 
-                dgvdee = new DataGridViewDataErrorEventArgs(exception, _ptCurrentCell.X,
+                dgvdee = new(
+                    exception,
+                    _ptCurrentCell.X,
                     _ptCurrentCell.Y,
                     DataGridViewDataErrorContexts.InitialValueRestoration);
                 OnDataErrorInternal(dgvdee);
@@ -9992,7 +9995,9 @@ namespace System.Windows.Forms
                     throw;
                 }
 
-                dgvdee = new DataGridViewDataErrorEventArgs(exception, _ptCurrentCell.X,
+                dgvdee = new(
+                    exception,
+                    _ptCurrentCell.X,
                     _ptCurrentCell.Y,
                     DataGridViewDataErrorContexts.InitialValueRestoration);
                 OnDataErrorInternal(dgvdee);
@@ -20629,12 +20634,11 @@ namespace System.Windows.Forms
                                                 // the back-end threw an exception. At that stage, we did not delete the dataGridView row
                                                 // from our collection of dataGridView rows.
                                                 // So all we do is to throw the exception if the user wants. Otherwise we don't do anything.
-                                                dgvdee = new DataGridViewDataErrorEventArgs(exception,
-                                                                                            -1,
-                                                                                            rowIndex,
-                                                                                            // null,
-                                                                                            // null,
-                                                                                            DataGridViewDataErrorContexts.RowDeletion);
+                                                dgvdee = new(
+                                                    exception,
+                                                    -1,
+                                                    rowIndex,
+                                                    DataGridViewDataErrorContexts.RowDeletion);
                                                 OnDataErrorInternal(dgvdee);
 
                                                 if (dgvdee.ThrowException)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -3969,7 +3969,7 @@ namespace System.Windows.Forms
                         }
 
                         DataGridViewDataErrorEventArgs dgvdee = new(
-                            null,
+                            exception: null,
                             _ptCurrentCell.X,
                             _ptCurrentCell.Y,
                             context)
@@ -4023,7 +4023,7 @@ namespace System.Windows.Forms
                             }
 
                             DataGridViewDataErrorEventArgs dgvdee = new(
-                                null,
+                                exception: null,
                                 _ptCurrentCell.X,
                                 _ptCurrentCell.Y,
                                 context)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -1806,7 +1806,8 @@ namespace System.Windows.Forms
                     }
 
                     // Formatting failed, raise OnDataError event.
-                    DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(exception,
+                    DataGridViewDataErrorEventArgs dgvdee = new(
+                        exception,
                         ColumnIndex,
                         rowIndex,
                         context);
@@ -1842,7 +1843,8 @@ namespace System.Windows.Forms
                     exception = new FormatException(SR.DataGridViewCell_FormattedValueHasWrongType);
                 }
 
-                DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(exception,
+                DataGridViewDataErrorEventArgs dgvdee = new(
+                    exception,
                     ColumnIndex,
                     rowIndex,
                     context);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -1109,9 +1109,11 @@ namespace System.Windows.Forms
 
                 if (DataGridView is not null)
                 {
-                    DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(
-                        new FormatException(SR.DataGridViewComboBoxCell_InvalidValue), ColumnIndex,
-                        rowIndex, context);
+                    DataGridViewDataErrorEventArgs dgvdee = new(
+                        new FormatException(SR.DataGridViewComboBoxCell_InvalidValue),
+                        ColumnIndex,
+                        rowIndex,
+                        context);
                     RaiseDataError(dgvdee);
                     if (dgvdee.ThrowException)
                     {
@@ -1138,9 +1140,11 @@ namespace System.Windows.Forms
                     }
                     else if (DataGridView is not null)
                     {
-                        DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(
-                            new ArgumentException(SR.DataGridViewComboBoxCell_InvalidValue), ColumnIndex,
-                            rowIndex, context);
+                        DataGridViewDataErrorEventArgs dgvdee = new(
+                            new ArgumentException(SR.DataGridViewComboBoxCell_InvalidValue),
+                            ColumnIndex,
+                            rowIndex,
+                            context);
                         RaiseDataError(dgvdee);
                         if (dgvdee.ThrowException)
                         {
@@ -1165,9 +1169,11 @@ namespace System.Windows.Forms
                 {
                     if (DataGridView is not null)
                     {
-                        DataGridViewDataErrorEventArgs dgvdee = new DataGridViewDataErrorEventArgs(
-                            new ArgumentException(SR.DataGridViewComboBoxCell_InvalidValue), ColumnIndex,
-                            rowIndex, context);
+                        DataGridViewDataErrorEventArgs dgvdee = new(
+                            new ArgumentException(SR.DataGridViewComboBoxCell_InvalidValue),
+                            ColumnIndex,
+                            rowIndex,
+                            context);
                         RaiseDataError(dgvdee);
                         if (dgvdee.ThrowException)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewDataErrorEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewDataErrorEventArgs.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public class DataGridViewDataErrorEventArgs : DataGridViewCellCancelEventArgs
     {
         private bool _throwException;
 
-        public DataGridViewDataErrorEventArgs(Exception exception, int columnIndex, int rowIndex, DataGridViewDataErrorContexts context) : base(columnIndex, rowIndex)
+        public DataGridViewDataErrorEventArgs(Exception? exception, int columnIndex, int rowIndex, DataGridViewDataErrorContexts context)
+            : base(columnIndex, rowIndex)
         {
             Exception = exception;
             Context = context;
@@ -18,7 +17,7 @@ namespace System.Windows.Forms
 
         public DataGridViewDataErrorContexts Context { get; }
 
-        public Exception Exception { get; }
+        public Exception? Exception { get; }
 
         public bool ThrowException
         {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in DataGridViewDataErrorEventArgs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7438)