### PR TITLE
Enable nullability in classes that inherit from ToolStripItemInternalLayout

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownButton.ToolStripDropDownButtonInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownButton.ToolStripDropDownButtonInternalLayout.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownButton.ToolStripDropDownButtonInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownButton.ToolStripDropDownButtonInternalLayout.cs
@@ -11,10 +11,10 @@ namespace System.Windows.Forms
         private protected class ToolStripDropDownButtonInternalLayout : ToolStripItemInternalLayout
         {
             private ToolStripDropDownButton _ownerItem;
-            private static readonly Size s_dropDownArrowSizeUnscaled = new Size(5, 3);
+            private static readonly Size s_dropDownArrowSizeUnscaled = new(5, 3);
             private static Size s_dropDownArrowSize = s_dropDownArrowSizeUnscaled;
             private const int DROP_DOWN_ARROW_PADDING = 2;
-            private static Padding s_dropDownArrowPadding = new Padding(DROP_DOWN_ARROW_PADDING);
+            private static Padding s_dropDownArrowPadding = new(DROP_DOWN_ARROW_PADDING);
             private Padding _scaledDropDownArrowPadding = s_dropDownArrowPadding;
             private Rectangle _dropDownArrowRect = Rectangle.Empty;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownButton.ToolStripDropDownButtonInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownButton.ToolStripDropDownButtonInternalLayout.cs
@@ -10,44 +10,45 @@ namespace System.Windows.Forms
     {
         private protected class ToolStripDropDownButtonInternalLayout : ToolStripItemInternalLayout
         {
-            private ToolStripDropDownButton ownerItem;
-            private static readonly Size dropDownArrowSizeUnscaled = new Size(5, 3);
-            private static Size dropDownArrowSize = dropDownArrowSizeUnscaled;
+            private ToolStripDropDownButton _ownerItem;
+            private static readonly Size s_dropDownArrowSizeUnscaled = new Size(5, 3);
+            private static Size s_dropDownArrowSize = s_dropDownArrowSizeUnscaled;
             private const int DROP_DOWN_ARROW_PADDING = 2;
-            private static Padding dropDownArrowPadding = new Padding(DROP_DOWN_ARROW_PADDING);
-            private Padding scaledDropDownArrowPadding = dropDownArrowPadding;
-            private Rectangle dropDownArrowRect = Rectangle.Empty;
+            private static Padding s_dropDownArrowPadding = new Padding(DROP_DOWN_ARROW_PADDING);
+            private Padding _scaledDropDownArrowPadding = s_dropDownArrowPadding;
+            private Rectangle _dropDownArrowRect = Rectangle.Empty;
 
-            public ToolStripDropDownButtonInternalLayout(ToolStripDropDownButton ownerItem) : base(ownerItem)
+            public ToolStripDropDownButtonInternalLayout(ToolStripDropDownButton ownerItem)
+                : base(ownerItem)
             {
                 if (DpiHelper.IsPerMonitorV2Awareness)
                 {
-                    dropDownArrowSize = DpiHelper.LogicalToDeviceUnits(dropDownArrowSizeUnscaled, ownerItem.DeviceDpi);
-                    scaledDropDownArrowPadding = DpiHelper.LogicalToDeviceUnits(dropDownArrowPadding, ownerItem.DeviceDpi);
+                    s_dropDownArrowSize = DpiHelper.LogicalToDeviceUnits(s_dropDownArrowSizeUnscaled, ownerItem.DeviceDpi);
+                    _scaledDropDownArrowPadding = DpiHelper.LogicalToDeviceUnits(s_dropDownArrowPadding, ownerItem.DeviceDpi);
                 }
                 else if (DpiHelper.IsScalingRequired)
                 {
                     // these 2 values are used to calculate size of the clickable drop down button
                     // on the right of the image/text
-                    dropDownArrowSize = DpiHelper.LogicalToDeviceUnits(dropDownArrowSizeUnscaled);
-                    scaledDropDownArrowPadding = DpiHelper.LogicalToDeviceUnits(dropDownArrowPadding);
+                    s_dropDownArrowSize = DpiHelper.LogicalToDeviceUnits(s_dropDownArrowSizeUnscaled);
+                    _scaledDropDownArrowPadding = DpiHelper.LogicalToDeviceUnits(s_dropDownArrowPadding);
                 }
 
-                this.ownerItem = ownerItem;
+                _ownerItem = ownerItem;
             }
 
             public override Size GetPreferredSize(Size constrainingSize)
             {
                 Size preferredSize = base.GetPreferredSize(constrainingSize);
-                if (ownerItem.ShowDropDownArrow)
+                if (_ownerItem.ShowDropDownArrow)
                 {
-                    if (ownerItem.TextDirection == ToolStripTextDirection.Horizontal)
+                    if (_ownerItem.TextDirection == ToolStripTextDirection.Horizontal)
                     {
-                        preferredSize.Width += DropDownArrowRect.Width + scaledDropDownArrowPadding.Horizontal;
+                        preferredSize.Width += DropDownArrowRect.Width + _scaledDropDownArrowPadding.Horizontal;
                     }
                     else
                     {
-                        preferredSize.Height += DropDownArrowRect.Height + scaledDropDownArrowPadding.Vertical;
+                        preferredSize.Height += DropDownArrowRect.Height + _scaledDropDownArrowPadding.Vertical;
                     }
                 }
 
@@ -58,36 +59,36 @@ namespace System.Windows.Forms
             {
                 ToolStripItemLayoutOptions options = base.CommonLayoutOptions();
 
-                if (ownerItem.ShowDropDownArrow)
+                if (_ownerItem.ShowDropDownArrow)
                 {
-                    if (ownerItem.TextDirection == ToolStripTextDirection.Horizontal)
+                    if (_ownerItem.TextDirection == ToolStripTextDirection.Horizontal)
                     {
                         // We're rendering horizontal....  make sure to take care of RTL issues.
 
-                        int widthOfDropDown = dropDownArrowSize.Width + scaledDropDownArrowPadding.Horizontal;
+                        int widthOfDropDown = s_dropDownArrowSize.Width + _scaledDropDownArrowPadding.Horizontal;
                         options.Client.Width -= widthOfDropDown;
 
-                        if (ownerItem.RightToLeft == RightToLeft.Yes)
+                        if (_ownerItem.RightToLeft == RightToLeft.Yes)
                         {
                             // if RightToLeft.Yes: [ v | rest of drop down button ]
                             options.Client.Offset(widthOfDropDown, 0);
-                            dropDownArrowRect = new Rectangle(scaledDropDownArrowPadding.Left, 0, dropDownArrowSize.Width, ownerItem.Bounds.Height);
+                            _dropDownArrowRect = new Rectangle(_scaledDropDownArrowPadding.Left, 0, s_dropDownArrowSize.Width, _ownerItem.Bounds.Height);
                         }
                         else
                         {
                             // if RightToLeft.No [ rest of drop down button | v ]
-                            dropDownArrowRect = new Rectangle(options.Client.Right, 0, dropDownArrowSize.Width, ownerItem.Bounds.Height);
+                            _dropDownArrowRect = new Rectangle(options.Client.Right, 0, s_dropDownArrowSize.Width, _ownerItem.Bounds.Height);
                         }
                     }
                     else
                     {
                         // else we're rendering vertically.
-                        int heightOfDropDown = dropDownArrowSize.Height + scaledDropDownArrowPadding.Vertical;
+                        int heightOfDropDown = s_dropDownArrowSize.Height + _scaledDropDownArrowPadding.Vertical;
 
                         options.Client.Height -= heightOfDropDown;
 
                         //  [ rest of button / v]
-                        dropDownArrowRect = new Rectangle(0, options.Client.Bottom + scaledDropDownArrowPadding.Top, ownerItem.Bounds.Width - 1, dropDownArrowSize.Height);
+                        _dropDownArrowRect = new Rectangle(0, options.Client.Bottom + _scaledDropDownArrowPadding.Top, _ownerItem.Bounds.Width - 1, s_dropDownArrowSize.Height);
                     }
                 }
 
@@ -98,7 +99,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    return dropDownArrowRect;
+                    return _dropDownArrowRect;
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.ToolStripLabelLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.ToolStripLabelLayout.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class ToolStripLabel

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.ToolStripLabelLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.ToolStripLabelLayout.cs
@@ -13,7 +13,8 @@ namespace System.Windows.Forms
         /// </summary>
         private class ToolStripLabelLayout : ToolStripItemInternalLayout
         {
-            public ToolStripLabelLayout(ToolStripLabel owner) : base(owner)
+            public ToolStripLabelLayout(ToolStripLabel owner)
+                : base(owner)
             {
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemInternalLayout.cs
@@ -11,18 +11,19 @@ namespace System.Windows.Forms
     {
         private class ToolStripMenuItemInternalLayout : ToolStripItemInternalLayout
         {
-            private readonly ToolStripMenuItem ownerItem;
+            private readonly ToolStripMenuItem _ownerItem;
 
-            public ToolStripMenuItemInternalLayout(ToolStripMenuItem ownerItem) : base(ownerItem)
+            public ToolStripMenuItemInternalLayout(ToolStripMenuItem ownerItem)
+                : base(ownerItem)
             {
-                this.ownerItem = ownerItem;
+                _ownerItem = ownerItem;
             }
 
             public bool ShowCheckMargin
             {
                 get
                 {
-                    if (ownerItem.Owner is ToolStripDropDownMenu menu)
+                    if (_ownerItem.Owner is ToolStripDropDownMenu menu)
                     {
                         return menu.ShowCheckMargin;
                     }
@@ -35,7 +36,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    if (ownerItem.Owner is ToolStripDropDownMenu menu)
+                    if (_ownerItem.Owner is ToolStripDropDownMenu menu)
                     {
                         return menu.ShowImageMargin;
                     }
@@ -66,12 +67,12 @@ namespace System.Windows.Forms
                 {
                     if (UseMenuLayout)
                     {
-                        if (ownerItem.Owner is ToolStripDropDownMenu menu)
+                        if (_ownerItem.Owner is ToolStripDropDownMenu menu)
                         {
                             // since menuItem.Padding isn't taken into consideration, we've got to recalc the centering of
                             // the arrow rect per item
                             Rectangle arrowRect = menu.ArrowRectangle;
-                            arrowRect.Y = LayoutUtils.VAlign(arrowRect.Size, ownerItem.ClientBounds, ContentAlignment.MiddleCenter).Y;
+                            arrowRect.Y = LayoutUtils.VAlign(arrowRect.Size, _ownerItem.ClientBounds, ContentAlignment.MiddleCenter).Y;
                             return arrowRect;
                         }
                     }
@@ -86,12 +87,12 @@ namespace System.Windows.Forms
                 {
                     if (UseMenuLayout)
                     {
-                        if (ownerItem.Owner is ToolStripDropDownMenu menu)
+                        if (_ownerItem.Owner is ToolStripDropDownMenu menu)
                         {
                             Rectangle checkRectangle = menu.CheckRectangle;
-                            if (ownerItem.CheckedImage is not null)
+                            if (_ownerItem.CheckedImage is not null)
                             {
-                                int imageHeight = ownerItem.CheckedImage.Height;
+                                int imageHeight = _ownerItem.CheckedImage.Height;
                                 // make sure we're vertically centered
                                 checkRectangle.Y += (checkRectangle.Height - imageHeight) / 2;
                                 checkRectangle.Height = imageHeight;
@@ -110,23 +111,23 @@ namespace System.Windows.Forms
                 {
                     if (UseMenuLayout)
                     {
-                        if (ownerItem.Owner is ToolStripDropDownMenu menu)
+                        if (_ownerItem.Owner is ToolStripDropDownMenu menu)
                         {
                             // since menuItem.Padding isn't taken into consideration, we've got to recalc the centering of
                             // the image rect per item
                             Rectangle imageRect = menu.ImageRectangle;
-                            if (ownerItem.ImageScaling == ToolStripItemImageScaling.SizeToFit)
+                            if (_ownerItem.ImageScaling == ToolStripItemImageScaling.SizeToFit)
                             {
                                 imageRect.Size = menu.ImageScalingSize;
                             }
                             else
                             {
                                 //If we don't have an image, use the CheckedImage
-                                Image image = ownerItem.Image ?? ownerItem.CheckedImage;
+                                Image image = _ownerItem.Image ?? _ownerItem.CheckedImage;
                                 imageRect.Size = image.Size;
                             }
 
-                            imageRect.Y = LayoutUtils.VAlign(imageRect.Size, ownerItem.ClientBounds, ContentAlignment.MiddleCenter).Y;
+                            imageRect.Y = LayoutUtils.VAlign(imageRect.Size, _ownerItem.ClientBounds, ContentAlignment.MiddleCenter).Y;
                             return imageRect;
                         }
                     }
@@ -141,7 +142,7 @@ namespace System.Windows.Forms
                 {
                     if (UseMenuLayout)
                     {
-                        if (ownerItem.Owner is ToolStripDropDownMenu menu)
+                        if (_ownerItem.Owner is ToolStripDropDownMenu menu)
                         {
                             return menu.TextRectangle;
                         }
@@ -155,7 +156,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    return ownerItem.Owner is ToolStripDropDownMenu;
+                    return _ownerItem.Owner is ToolStripDropDownMenu;
                 }
             }
 
@@ -163,7 +164,7 @@ namespace System.Windows.Forms
             {
                 if (UseMenuLayout)
                 {
-                    if (ownerItem.Owner is ToolStripDropDownMenu menu)
+                    if (_ownerItem.Owner is ToolStripDropDownMenu menu)
                     {
                         return menu.MaxItemSize;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemInternalLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.ToolStripMenuItemInternalLayout.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 using System.Windows.Forms.Layout;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton .ToolStripSplitButtonButtonLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton .ToolStripSplitButtonButtonLayout.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton .ToolStripSplitButtonButtonLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton .ToolStripSplitButtonButtonLayout.cs
@@ -17,9 +17,10 @@ namespace System.Windows.Forms
         {
             readonly ToolStripSplitButton _owner;
 
-            public ToolStripSplitButtonButtonLayout(ToolStripSplitButton owner) : base(owner.SplitButtonButton)
+            public ToolStripSplitButtonButtonLayout(ToolStripSplitButton owner)
+                : base(owner.SplitButtonButton)
             {
-                this._owner = owner;
+                _owner = owner;
             }
 
             protected override ToolStripItem Owner

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.ToolStripStatusLabelLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.ToolStripStatusLabelLayout.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     public partial class ToolStripStatusLabel

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.ToolStripStatusLabelLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripStatusLabel.ToolStripStatusLabelLayout.cs
@@ -13,11 +13,9 @@ namespace System.Windows.Forms
         /// </summary>
         private class ToolStripStatusLabelLayout : ToolStripItemInternalLayout
         {
-            readonly ToolStripStatusLabel owner;
-
-            public ToolStripStatusLabelLayout(ToolStripStatusLabel owner) : base(owner)
+            public ToolStripStatusLabelLayout(ToolStripStatusLabel owner)
+                : base(owner)
             {
-                this.owner = owner;
             }
 
             protected override ToolStripItemLayoutOptions CommonLayoutOptions()


### PR DESCRIPTION
## Proposed changes

- Enable nullability in classes that inherit from ToolStripItemInternalLayout.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7441)