### PR TITLE
Fixing TabPage memory leaks

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
@@ -340,6 +340,10 @@ namespace System.Windows.Forms
                 ArgumentNullException.ThrowIfNull(value);
 
                 _owner.Controls.Remove(value);
+                if (value.IsHandleCreated)
+                {
+                    value.ReleaseUiaProvider(value.HandleInternal);
+                }
             }
 
             void IList.Remove(object? value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.TabAccessibleObject.cs
@@ -73,7 +73,7 @@ namespace System.Windows.Forms
                     OwningTabControl is null
                         ? PARAM.ToInt(IntPtr.Zero)
                         : PARAM.ToInt(OwningTabControl.InternalHandle),
-                    GetChildId()
+                    GetHashCode()
                 };
 
             private int CurrentIndex => OwningTabControl?.TabPages.IndexOf(_owningTabPage) ?? -1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Drawing.Design;
 using System.Windows.Forms.Layout;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -619,6 +620,18 @@ namespace System.Windows.Forms
             else
             {
                 base.OnPaintBackground(e);
+            }
+        }
+
+        internal override void ReleaseUiaProvider(IntPtr handle)
+        {
+            base.ReleaseUiaProvider(handle);
+
+            if (_tabAccessibilityObject is not null && OsVersion.IsWindows8OrGreater)
+            {
+                HRESULT result = UiaCore.UiaDisconnectProvider(_tabAccessibilityObject);
+                Debug.Assert(result == HRESULT.S_OK);
+                _tabAccessibilityObject = null;
             }
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPage.TabAccessibleObjectTests.cs
@@ -33,6 +33,24 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(createControl, tabControl.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void TabAccessibilityObject_IsDisconnected_WhenTabPageReleasesUiaProvider()
+        {
+            using TabPage tabPage = new();
+            EnforceTabAccessibilityObjectCreation(tabPage);
+
+            tabPage.ReleaseUiaProvider(tabPage.Handle);
+
+            Assert.Null(tabPage.TestAccessor().Dynamic._tabAccessibilityObject);
+            Assert.True(tabPage.IsHandleCreated);
+
+            static void EnforceTabAccessibilityObjectCreation(TabPage tabPage)
+            {
+                _ = tabPage.TabAccessibilityObject;
+                Assert.NotNull(tabPage.TestAccessor().Dynamic._tabAccessibilityObject);
+            }
+        }
+
         [WinFormsTheory]
         [InlineData(null, "")]
         [InlineData("", "")]
@@ -1046,10 +1064,10 @@ namespace System.Windows.Forms.Tests
 
             Assert.NotNull(accessibleObject1.RuntimeId);
             Assert.Equal(tabControl.HandleInternal, (IntPtr)accessibleObject1.RuntimeId[1]);
-            Assert.Equal(accessibleObject1.GetChildId(), accessibleObject1.RuntimeId[2]);
+            Assert.Equal(accessibleObject1.GetHashCode(), accessibleObject1.RuntimeId[2]);
             Assert.NotNull(accessibleObject2.RuntimeId);
             Assert.Equal(tabControl.HandleInternal, (IntPtr)accessibleObject2.RuntimeId[1]);
-            Assert.Equal(accessibleObject2.GetChildId(), accessibleObject2.RuntimeId[2]);
+            Assert.Equal(accessibleObject2.GetHashCode(), accessibleObject2.RuntimeId[2]);
             Assert.Equal(createControl, pages[0].IsHandleCreated);
             Assert.Equal(createControl, pages[1].IsHandleCreated);
             Assert.Equal(createControl, tabControl.IsHandleCreated);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7415 


## Proposed changes

- Changed TabPage class
- Changed TabCollection class
- Changed TabPageAccessibleObject class

Unit tests affected:
- TabPage_TabAccessibleObjectTests.TabAccessibleObject_RuntimeId_ReturnsExpected (test changed)
- added a new unit test TabAccessibilityObject_IsDisconnected_WhenTabPageReleasesUiaProvider which checks for _tabAccessibilityObject to be disconnected.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Less memory leaks of TabPage 

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/102961955/179721705-ef746edf-a39f-4935-b56d-0ecbf784c586.png)

### After

![image](https://user-images.githubusercontent.com/102961955/179707383-55e03da5-5c37-4b0c-844f-d802e4979f0b.png)


## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manually (via WinDbg)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using AI, Inspect, Narrator


 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0 Preview 5
- Windows 10


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7453)