### PR TITLE
Raising AutomationPropertyChanged event on TextChanged for ButtonBase a…

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -1078,6 +1078,11 @@ namespace System.Windows.Forms
                 base.OnTextChanged(e);
                 Invalidate();
             }
+
+            if (IsAccessibilityObjectCreated)
+            {
+                AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.NamePropertyId, Text, Text);
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Label.cs
@@ -1271,10 +1271,17 @@ namespace System.Windows.Forms
                 Invalidate();
             }
 
-            if (IsAccessibilityObjectCreated && LiveSetting != AutomationLiveSetting.Off)
+            if (!IsAccessibilityObjectCreated)
+            {
+                return;
+            }
+
+            if (LiveSetting != AutomationLiveSetting.Off)
             {
                 AccessibilityObject.RaiseLiveRegionChanged();
             }
+
+            AccessibilityObject.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.NamePropertyId, Text, Text);
         }
 
         protected virtual void OnTextAlignChanged(EventArgs e)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBase.ButtonBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBase.ButtonBaseAccessibleObjectTests.cs
@@ -246,6 +246,26 @@ namespace System.Windows.Forms.Tests
             Assert.False(ownerControl.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ButtonBaseAccessibleObject_TextChanged_AutomationPropertyChanged_Raised()
+        {
+            const string newText = "New text";
+            using var control = new ButtonWithCustomAccessibleObject(
+                (propertyId, value) => propertyId == UiaCore.UIA.NamePropertyId && ReferenceEquals(value, newText))
+            {
+                Text = "Text"
+            };
+
+            var accessibilityObject = control.AccessibilityObject as ControlAccessibleObjectWithNotificationCounter;
+            Assert.NotNull(accessibilityObject);
+            Assert.True(control.IsAccessibilityObjectCreated);
+            Assert.Equal(0, accessibilityObject.RaiseAutomationNotificationCallCount);
+
+            control.Text = newText;
+
+            Assert.Equal(1, accessibilityObject.RaiseAutomationNotificationCallCount);
+        }
+
         private class SubButtonBase : ButtonBase
         {
             public Action PerformClickAction { get; set; }
@@ -255,6 +275,40 @@ namespace System.Windows.Forms.Tests
             public new void OnMouseDown(MouseEventArgs e) => base.OnMouseDown(e);
 
             public void PerformClick() => PerformClickAction();
+        }
+
+        private class ButtonWithCustomAccessibleObject : ButtonBase
+        {
+            private readonly Func<UiaCore.UIA, object, bool> _checkRaisedEvent;
+
+            public ButtonWithCustomAccessibleObject(Func<UiaCore.UIA, object, bool> checkRaisedEvent)
+            {
+                _checkRaisedEvent = checkRaisedEvent;
+            }
+
+            protected override AccessibleObject CreateAccessibilityInstance() => new ControlAccessibleObjectWithNotificationCounter(this, _checkRaisedEvent);
+        }
+
+        private class ControlAccessibleObjectWithNotificationCounter : Control.ControlAccessibleObject
+        {
+            private readonly Func<UiaCore.UIA, object, bool> _checkRaisedEvent;
+
+            public ControlAccessibleObjectWithNotificationCounter(Control ownerControl, Func<UiaCore.UIA, object, bool> checkRaisedEvent) : base(ownerControl)
+            {
+                _checkRaisedEvent = checkRaisedEvent;
+            }
+            
+            internal int RaiseAutomationNotificationCallCount { get; private set; }
+
+            internal override bool RaiseAutomationPropertyChangedEvent(UiaCore.UIA propertyId, object oldValue, object newValue)
+            {
+                if (_checkRaisedEvent(propertyId, newValue))
+                {
+                    RaiseAutomationNotificationCallCount++;
+                }
+
+                return base.RaiseAutomationPropertyChangedEvent(propertyId, oldValue, newValue);
+            }
         }
     }
 }


### PR DESCRIPTION
…nd Label

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7261


## Proposed changes

- Raised AutomationPropertyChanged event with NamePropertyId parameter in ButtonBase class.
- Raised AutomationPropertyChanged event with NamePropertyId parameter in Label class.
- Added unit tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- User can receives an event of NameProperty changes via AI.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/179908820-07dcd4c5-885e-461a-81db-989ba9659b76.png)

### After

![image](https://user-images.githubusercontent.com/109065597/179908544-21607d3a-615c-4aa9-8a5d-088b377d5df5.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually tested the change in a winforms app.
- Unit tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Used AI


 

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.5.22307.18


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7458)