### PR TITLE
Adding supports of UIA provider for ToolStripPanel

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -23,6 +23,7 @@ abstract System.Windows.Forms.CommonDialog.RunDialog(nint hwndOwner) -> bool
 override System.Windows.Forms.ColorDialog.RunDialog(nint hwndOwner) -> bool
 override System.Windows.Forms.FontDialog.HookProc(nint hWnd, int msg, nint wparam, nint lparam) -> nint
 override System.Windows.Forms.FontDialog.RunDialog(nint hWndOwner) -> bool
+override System.Windows.Forms.ToolStripPanel.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 static System.Windows.Forms.Control.FromChildHandle(nint handle) -> System.Windows.Forms.Control?
 static System.Windows.Forms.Control.FromHandle(nint handle) -> System.Windows.Forms.Control?
 static System.Windows.Forms.Control.ReflectMessage(nint hWnd, ref System.Windows.Forms.Message m) -> bool

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.ToolStripPanelAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.ToolStripPanelAccessibleObject.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class ToolStripPanel
+    {
+        internal class ToolStripPanelAccessibleObject : ControlAccessibleObject
+        {
+            private readonly ToolStripPanel _owningLabel;
+
+            public ToolStripPanelAccessibleObject(ToolStripPanel owner) : base(owner)
+            {
+                _owningLabel = owner;
+            }
+
+            public override AccessibleRole Role
+            {
+                get
+                {
+                    AccessibleRole role = _owningLabel.AccessibleRole;
+
+                    if (role != AccessibleRole.Default)
+                    {
+                        return role;
+                    }
+
+                    return AccessibleRole.Client;
+                }
+            }
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyId)
+                => propertyId switch
+                {
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId
+                        => Owner.CanFocus,
+                    _ => base.GetPropertyValue(propertyId)
+                };
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
@@ -313,6 +313,8 @@ namespace System.Windows.Forms
             }
         }
 
+        internal override bool SupportsUiaProviders => true;
+
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -396,15 +398,11 @@ namespace System.Windows.Forms
 
         #endregion ISupportInitialize
 
-        private ToolStripPanelRowCollection CreateToolStripPanelRowCollection()
-        {
-            return new ToolStripPanelRowCollection(this);
-        }
+        private ToolStripPanelRowCollection CreateToolStripPanelRowCollection() => new(this);
 
-        protected override ControlCollection CreateControlsInstance()
-        {
-            return new ToolStripPanelControlCollection(this);
-        }
+        protected override AccessibleObject CreateAccessibilityInstance() => new ToolStripPanelAccessibleObject(this);
+
+        protected override ControlCollection CreateControlsInstance() => new ToolStripPanelControlCollection(this);
 
         /// <summary>
         ///  Disposes of the resources (other than memory) used by

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanel.ToolStripPanelAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripPanel.ToolStripPanelAccessibleObjectTests.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static System.Windows.Forms.ToolStripPanel;
+using static Interop.UiaCore;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ToolStripPanel_ToolStripPanelAccessibleObjectTests : IClassFixture<ThreadExceptionFixture>
+    {
+        [WinFormsFact]
+        public void ToolStripPanelAccessibleObject_Ctor_Default()
+        {
+            using ToolStripPanel control = new();
+            var accessibleObject = (ToolStripPanelAccessibleObject)control.AccessibilityObject;
+
+            Assert.Equal(control, accessibleObject.Owner);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ToolStripPanelAccessibleObject_GetPropertyValue_IsKeyboardFocusable_False()
+        {
+            using ToolStripPanel control = new();
+
+            var accessibleObject = (ToolStripPanelAccessibleObject)control.AccessibilityObject;
+            bool value = (bool)accessibleObject.GetPropertyValue(UIA.IsKeyboardFocusablePropertyId);
+
+            Assert.False(value);
+            Assert.False(control.IsHandleCreated);
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Partially implements #3421


## Proposed changes

- Updated "SupportsUiaProviders" flag to ToolStripPanel
- Added and implemented ToolStripPanel.ToolStripPanelAccessibleObject
- Added unit tests

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Improving development experience for ToolStripPanel control accessibility.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/179958079-aec2a508-30dd-449f-a40c-11755b743a25.png)

### After

![image](https://user-images.githubusercontent.com/109065597/179957244-8f8f9ec0-a057-4d71-9be0-8224e6873cbd.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect


 

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.5.22307.18


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7459)