### PR TITLE
Fully qualify code in `ApplicationConfiguration.Initialize`

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilder.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilder.cs
@@ -22,19 +22,20 @@ namespace System.Windows.Forms.Generators
             static string GenerateCode(ApplicationConfig projectConfig, string? defaultFont, string indent)
             {
                 StringBuilder code = new();
+                const string qualifier = "global::System.Windows.Forms.Application.";
                 if (projectConfig.EnableVisualStyles)
                 {
-                    code.AppendLine($"{indent}Application.EnableVisualStyles();");
+                    code.AppendLine($"{indent}{qualifier}EnableVisualStyles();");
                 }
 
-                code.AppendLine($"{indent}Application.SetCompatibleTextRenderingDefault({projectConfig.UseCompatibleTextRendering.ToString().ToLowerInvariant()});");
+                code.AppendLine($"{indent}{qualifier}SetCompatibleTextRenderingDefault({projectConfig.UseCompatibleTextRendering.ToString().ToLowerInvariant()});");
 
-                code.AppendLine($"{indent}Application.SetHighDpiMode(HighDpiMode.{projectConfig.HighDpiMode});");
+                code.AppendLine($"{indent}{qualifier}SetHighDpiMode(HighDpiMode.{projectConfig.HighDpiMode});");
 
                 // Note: we need to set the font _after_ we set the DPI scaling, as it affects how we scale the font.
                 if (!string.IsNullOrWhiteSpace(defaultFont))
                 {
-                    code.AppendLine($"{indent}Application.SetDefaultFont({defaultFont});");
+                    code.AppendLine($"{indent}{qualifier}SetDefaultFont({defaultFont});");
                 }
 
                 // Don't append line as we don't need the trailing \r\n!

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=SansSerif.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=SansSerif.verified.txt
@@ -14,17 +14,17 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.EnableVisualStyles();
-    ///  Application.SetCompatibleTextRenderingDefault(true);
-    ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
-    ///  Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)3));
+    ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  global::System.Windows.Forms.Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)3));
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(true);
-        Application.SetHighDpiMode(HighDpiMode.SystemAware);
-        Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)3));
+        global::System.Windows.Forms.Application.EnableVisualStyles();
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+        global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        global::System.Windows.Forms.Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)3));
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=Tahoma.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=Tahoma.verified.txt
@@ -14,17 +14,17 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.EnableVisualStyles();
-    ///  Application.SetCompatibleTextRenderingDefault(true);
-    ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
-    ///  Application.SetDefaultFont(new Font(new FontFamily("Tahoma"), 12f, (FontStyle)0, (GraphicsUnit)3));
+    ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  global::System.Windows.Forms.Application.SetDefaultFont(new Font(new FontFamily("Tahoma"), 12f, (FontStyle)0, (GraphicsUnit)3));
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(true);
-        Application.SetHighDpiMode(HighDpiMode.SystemAware);
-        Application.SetDefaultFont(new Font(new FontFamily("Tahoma"), 12f, (FontStyle)0, (GraphicsUnit)3));
+        global::System.Windows.Forms.Application.EnableVisualStyles();
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+        global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        global::System.Windows.Forms.Application.SetDefaultFont(new Font(new FontFamily("Tahoma"), 12f, (FontStyle)0, (GraphicsUnit)3));
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=default.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=default.verified.txt
@@ -14,17 +14,17 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.EnableVisualStyles();
-    ///  Application.SetCompatibleTextRenderingDefault(true);
-    ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
-    ///  Application.SetDefaultFont(new Font(Control.DefaultFont.FontFamily, 12f, (FontStyle)3, (GraphicsUnit)6));
+    ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  global::System.Windows.Forms.Application.SetDefaultFont(new Font(Control.DefaultFont.FontFamily, 12f, (FontStyle)3, (GraphicsUnit)6));
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(true);
-        Application.SetHighDpiMode(HighDpiMode.SystemAware);
-        Application.SetDefaultFont(new Font(Control.DefaultFont.FontFamily, 12f, (FontStyle)3, (GraphicsUnit)6));
+        global::System.Windows.Forms.Application.EnableVisualStyles();
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+        global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        global::System.Windows.Forms.Application.SetDefaultFont(new Font(Control.DefaultFont.FontFamily, 12f, (FontStyle)3, (GraphicsUnit)6));
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=null.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_DefaultFont=null.verified.txt
@@ -14,15 +14,15 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.EnableVisualStyles();
-    ///  Application.SetCompatibleTextRenderingDefault(false);
-    ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(false);
-        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        global::System.Windows.Forms.Application.EnableVisualStyles();
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+        global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_EnableVisualStyles=false.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_EnableVisualStyles=false.verified.txt
@@ -14,13 +14,13 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.SetCompatibleTextRenderingDefault(false);
-    ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.SetCompatibleTextRenderingDefault(false);
-        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+        global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_EnableVisualStyles=true.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_EnableVisualStyles=true.verified.txt
@@ -14,15 +14,15 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.EnableVisualStyles();
-    ///  Application.SetCompatibleTextRenderingDefault(false);
-    ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(false);
-        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        global::System.Windows.Forms.Application.EnableVisualStyles();
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+        global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_UseCompTextRendering=false.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_UseCompTextRendering=false.verified.txt
@@ -14,15 +14,15 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.EnableVisualStyles();
-    ///  Application.SetCompatibleTextRenderingDefault(false);
-    ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(false);
-        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        global::System.Windows.Forms.Application.EnableVisualStyles();
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+        global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_UseCompTextRendering=true.verified.txt
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/ApplicationConfigurationInitializeBuilderTests.GenerateInitialize_UseCompTextRendering=true.verified.txt
@@ -14,15 +14,15 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.EnableVisualStyles();
-    ///  Application.SetCompatibleTextRenderingDefault(true);
-    ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(true);
-        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        global::System.Windows.Forms.Application.EnableVisualStyles();
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+        global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_default_boilerplate.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_default_boilerplate.cs
@@ -15,16 +15,16 @@ namespace MyProject
         /// <summary>
         ///  Bootstrap the application as follows:
         ///  <code>
-        ///  Application.EnableVisualStyles();
-        ///  Application.SetCompatibleTextRenderingDefault(false);
-        ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+        ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+        ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
         /// </code>
         /// </summary>
         public static void Initialize()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.SystemAware);
+            global::System.Windows.Forms.Application.EnableVisualStyles();
+            global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+            global::System.Windows.Forms.Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.SystemAware);
         }
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_default_top_level.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_default_top_level.cs
@@ -14,15 +14,15 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.EnableVisualStyles();
-    ///  Application.SetCompatibleTextRenderingDefault(false);
-    ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(false);
-        Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.SystemAware);
+        global::System.Windows.Forms.Application.EnableVisualStyles();
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+        global::System.Windows.Forms.Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.SystemAware);
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_user_settings_boilerplate.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_user_settings_boilerplate.cs
@@ -15,18 +15,18 @@ namespace MyProject
         /// <summary>
         ///  Bootstrap the application as follows:
         ///  <code>
-        ///  Application.EnableVisualStyles();
-        ///  Application.SetCompatibleTextRenderingDefault(true);
-        ///  Application.SetHighDpiMode(HighDpiMode.DpiUnawareGdiScaled);
-        ///  Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
+        ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+        ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+        ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.DpiUnawareGdiScaled);
+        ///  global::System.Windows.Forms.Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
         /// </code>
         /// </summary>
         public static void Initialize()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(true);
-            Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.DpiUnawareGdiScaled);
-            Application.{|CS0117:SetDefaultFont|}(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
+            global::System.Windows.Forms.Application.EnableVisualStyles();
+            global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+            global::System.Windows.Forms.Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.DpiUnawareGdiScaled);
+            global::System.Windows.Forms.Application.{|CS0117:SetDefaultFont|}(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
         }
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_user_top_level.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationGeneratorTests.GenerateInitialize_user_top_level.cs
@@ -14,17 +14,17 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.EnableVisualStyles();
-    ///  Application.SetCompatibleTextRenderingDefault(true);
-    ///  Application.SetHighDpiMode(HighDpiMode.DpiUnawareGdiScaled);
-    ///  Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
+    ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.DpiUnawareGdiScaled);
+    ///  global::System.Windows.Forms.Application.SetDefaultFont(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(true);
-        Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.DpiUnawareGdiScaled);
-        Application.{|CS0117:SetDefaultFont|}(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
+        global::System.Windows.Forms.Application.EnableVisualStyles();
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(true);
+        global::System.Windows.Forms.Application.{|CS0117:SetHighDpiMode|}({|CS0103:HighDpiMode|}.DpiUnawareGdiScaled);
+        global::System.Windows.Forms.Application.{|CS0117:SetDefaultFont|}(new Font(new FontFamily("Microsoft Sans Serif"), 8.25f, (FontStyle)0, (GraphicsUnit)2));
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationInitializeBuilderTests.default_boilerplate.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationInitializeBuilderTests.default_boilerplate.cs
@@ -15,16 +15,16 @@ namespace MyProject
         /// <summary>
         ///  Bootstrap the application as follows:
         ///  <code>
-        ///  Application.EnableVisualStyles();
-        ///  Application.SetCompatibleTextRenderingDefault(false);
-        ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+        ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+        ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
         /// </code>
         /// </summary>
         public static void Initialize()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.SetHighDpiMode(HighDpiMode.SystemAware);
+            global::System.Windows.Forms.Application.EnableVisualStyles();
+            global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+            global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
         }
     }
 }

--- a/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationInitializeBuilderTests.default_top_level.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/tests/UnitTests/System/Windows/Forms/Generators/MockData/ApplicationConfigurationInitializeBuilderTests.default_top_level.cs
@@ -14,15 +14,15 @@ internal static partial class ApplicationConfiguration
     /// <summary>
     ///  Bootstrap the application as follows:
     ///  <code>
-    ///  Application.EnableVisualStyles();
-    ///  Application.SetCompatibleTextRenderingDefault(false);
-    ///  Application.SetHighDpiMode(HighDpiMode.SystemAware);
+    ///  global::System.Windows.Forms.Application.EnableVisualStyles();
+    ///  global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+    ///  global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     /// </code>
     /// </summary>
     public static void Initialize()
     {
-        Application.EnableVisualStyles();
-        Application.SetCompatibleTextRenderingDefault(false);
-        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        global::System.Windows.Forms.Application.EnableVisualStyles();
+        global::System.Windows.Forms.Application.SetCompatibleTextRenderingDefault(false);
+        global::System.Windows.Forms.Application.SetHighDpiMode(HighDpiMode.SystemAware);
     }
 }


### PR DESCRIPTION
Fixes #7346

## Proposed changes

- Added full qualifier to ApplicationConfiguration generated code by creating a type string variable named 'qualifier' which is equaled to the full qualifier and then adding it to the controls.
-  Changed expected result in test file by adding the full qualifier.

``` C#
static string GenerateCode(ApplicationConfig projectConfig, string? defaultFont, string indent)
            {
                StringBuilder code = new();
                string qualifier = "global::System.Windows.Forms.Application.";
                if (projectConfig.EnableVisualStyles)
                {
                    code.AppendLine($"{indent}{qualifier}EnableVisualStyles();");
                }

                code.AppendLine($"{indent}{qualifier}SetCompatibleTextRenderingDefault({projectConfig.UseCompatibleTextRendering.ToString().ToLowerInvariant()});");

                code.AppendLine($"{indent}{qualifier}SetHighDpiMode(HighDpiMode.{projectConfig.HighDpiMode});");

                // Note: we need to set the font _after_ we set the DPI scaling, as it affects how we scale the font.
                if (!string.IsNullOrWhiteSpace(defaultFont))
                {
                    code.AppendLine($"{indent}{qualifier}SetDefaultFont({defaultFont});");
                }

                // Don't append line as we don't need the trailing \r\n!
                code.Remove(code.Length - Environment.NewLine.Length, Environment.NewLine.Length);

                return code.ToString();
            }
```


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7469)