### PR TITLE
Fix ListView memory leaks

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -11,7 +11,6 @@ System.Windows.Forms.IWin32Window.Handle.get -> nint
 System.Windows.Forms.IWindowTarget.OnHandleChange(nint newHandle) -> void
 System.Windows.Forms.ImageList.Handle.get -> nint
 System.Windows.Forms.InputLanguage.Handle.get -> nint
-System.Windows.Forms.ListViewGroup.ListViewGroup(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 System.Windows.Forms.NativeWindow.AssignHandle(nint handle) -> void
 System.Windows.Forms.NativeWindow.Handle.get -> nint
 System.Windows.Forms.TaskDialog.Handle.get -> nint

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -11,6 +11,7 @@ System.Windows.Forms.IWin32Window.Handle.get -> nint
 System.Windows.Forms.IWindowTarget.OnHandleChange(nint newHandle) -> void
 System.Windows.Forms.ImageList.Handle.get -> nint
 System.Windows.Forms.InputLanguage.Handle.get -> nint
+System.Windows.Forms.ListViewGroup.ListViewGroup(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 System.Windows.Forms.NativeWindow.AssignHandle(nint handle) -> void
 System.Windows.Forms.NativeWindow.Handle.get -> nint
 System.Windows.Forms.TaskDialog.Handle.get -> nint

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Design;
 using static Interop;
@@ -481,6 +482,15 @@ namespace System.Windows.Forms
             }
 
             base.Dispose(disposing);
+        }
+
+        internal virtual void ReleaseUiaProvider()
+        {
+            if (OsVersion.IsWindows8OrGreater && _accessibilityObject is not null)
+            {
+                HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
+                Debug.Assert(result == HRESULT.S_OK);
+            }
         }
 
         private void ResetText()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -484,12 +484,13 @@ namespace System.Windows.Forms
             base.Dispose(disposing);
         }
 
-        internal virtual void ReleaseUiaProvider()
+        internal void ReleaseUiaProvider()
         {
             if (OsVersion.IsWindows8OrGreater && _accessibilityObject is not null)
             {
                 HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
                 Debug.Assert(result == HRESULT.S_OK);
+                _accessibilityObject = null;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ColumnHeaderCollection.cs
@@ -329,6 +329,7 @@ namespace System.Windows.Forms
                         {
                             int w = _owner._columnHeaders[colIdx].Width; // Update width before detaching from ListView
                             _owner._columnHeaders[colIdx].OwnerListview = null;
+                            _owner._columnHeaders[colIdx].ReleaseUiaProvider();
                         }
 
                         _owner._columnHeaders = null;
@@ -348,6 +349,7 @@ namespace System.Windows.Forms
                             }
 
                             _owner._columnHeaders[colIdx].OwnerListview = null;
+                            _owner._columnHeaders[colIdx].ReleaseUiaProvider();
                         }
 
                         _owner._columnHeaders = null;
@@ -547,6 +549,7 @@ namespace System.Windows.Forms
                 }
 
                 removeHdr.DisplayIndexInternal = -1;
+                removeHdr.ReleaseUiaProvider();
 
                 _owner._columnHeaders[index].OwnerListview = null;
                 int columnCount = _owner._columnHeaders.Length;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -158,7 +158,7 @@ namespace System.Windows.Forms
                 UiaCore.IRawElementProviderSimple[] columnHeaders = new UiaCore.IRawElementProviderSimple[_owningListView.Columns.Count];
                 for (int i = 0; i < columnHeaders.Length; i++)
                 {
-                    columnHeaders[i] = new ColumnHeader.ListViewColumnHeaderAccessibleObject(_owningListView.Columns[i]);
+                    columnHeaders[i] = _owningListView.Columns[i].AccessibilityObject;
                 }
 
                 return columnHeaders;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5127,6 +5127,36 @@ namespace System.Windows.Forms
             }
         }
 
+        internal override void ReleaseUiaProvider(nint handle)
+        {
+            base.ReleaseUiaProvider(handle);
+
+            if (!OsVersion.IsWindows8OrGreater)
+            {
+                return;
+            }
+
+            for (int i = 0; i < Items.Count; i++)
+            {
+                Items[i].ReleaseUiaProvider();
+            }
+
+            DefaultGroup.ReleaseUiaProvider();
+
+            for (int i = 0; i < Groups.Count; i++)
+            {
+                Groups[i].ReleaseUiaProvider();
+            }
+
+            if (_columnHeaders is not null)
+            {
+                for (int i = 0; i < _columnHeaders.Length; i++)
+                {
+                    _columnHeaders[i].ReleaseUiaProvider();
+                }
+            }
+        }
+
         // makes sure that the list view items which are w/o a listView group are parented to the DefaultGroup - if necessary
         // and then tell win32 to remove this group
         internal void RemoveGroupFromListView(ListViewGroup group)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5131,7 +5131,7 @@ namespace System.Windows.Forms
         {
             base.ReleaseUiaProvider(handle);
 
-            if (!OsVersion.IsWindows8OrGreater)
+            if (!OsVersion.IsWindows8OrGreater || !IsAccessibilityObjectCreated)
             {
                 return;
             }
@@ -5143,17 +5143,14 @@ namespace System.Windows.Forms
 
             DefaultGroup.ReleaseUiaProvider();
 
-            for (int i = 0; i < Groups.Count; i++)
+            foreach (ListViewGroup group in Groups)
             {
-                Groups[i].ReleaseUiaProvider();
+                group.ReleaseUiaProvider();
             }
 
-            if (_columnHeaders is not null)
+            foreach (ColumnHeader columnHeader in Columns)
             {
-                for (int i = 0; i < _columnHeaders.Length; i++)
-                {
-                    _columnHeaders[i].ReleaseUiaProvider();
-                }
+                columnHeader.ReleaseUiaProvider();
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -117,7 +117,7 @@ namespace System.Windows.Forms
                         owningListViewRuntimeId[0],
                         owningListViewRuntimeId[1],
                         4, // Win32-control specific RuntimeID constant, is used in similar Win32 controls and is used in WinForms controls for consistency.
-                        CurrentIndex
+                        GetHashCode()
                     };
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms
     [DesignTimeVisible(false)]
     [DefaultProperty(nameof(Header))]
     [Serializable] // This type is participating in resx serialization scenarios.
-    public partial class ListViewGroup : ISerializable
+    public sealed partial class ListViewGroup : ISerializable
     {
         private string? _header;
         private HorizontalAlignment _headerAlignment = HorizontalAlignment.Left;
@@ -49,7 +49,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Creates a ListViewItem object from an Stream.
         /// </summary>
-        protected ListViewGroup(SerializationInfo info, StreamingContext context) : this()
+        private ListViewGroup(SerializationInfo info, StreamingContext context) : this()
         {
             Deserialize(info);
         }
@@ -418,12 +418,13 @@ namespace System.Windows.Forms
             return state.HasFlag(LVGS.COLLAPSED) ? ListViewGroupCollapsedState.Collapsed : ListViewGroupCollapsedState.Expanded;
         }
 
-        internal virtual void ReleaseUiaProvider()
+        internal void ReleaseUiaProvider()
         {
             if (OsVersion.IsWindows8OrGreater && _accessibilityObject is ListViewGroupAccessibleObject accessibleObject)
             {
                 HRESULT result = UiaCore.UiaDisconnectProvider(accessibleObject);
                 Debug.Assert(result == HRESULT.S_OK);
+                _accessibilityObject = null;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.Serialization;
@@ -19,7 +20,7 @@ namespace System.Windows.Forms
     [DesignTimeVisible(false)]
     [DefaultProperty(nameof(Header))]
     [Serializable] // This type is participating in resx serialization scenarios.
-    public sealed partial class ListViewGroup : ISerializable
+    public partial class ListViewGroup : ISerializable
     {
         private string? _header;
         private HorizontalAlignment _headerAlignment = HorizontalAlignment.Left;
@@ -48,7 +49,7 @@ namespace System.Windows.Forms
         /// <summary>
         ///  Creates a ListViewItem object from an Stream.
         /// </summary>
-        private ListViewGroup(SerializationInfo info, StreamingContext context) : this()
+        protected ListViewGroup(SerializationInfo info, StreamingContext context) : this()
         {
             Deserialize(info);
         }
@@ -415,6 +416,15 @@ namespace System.Windows.Forms
             }
 
             return state.HasFlag(LVGS.COLLAPSED) ? ListViewGroupCollapsedState.Collapsed : ListViewGroupCollapsedState.Expanded;
+        }
+
+        internal virtual void ReleaseUiaProvider()
+        {
+            if (OsVersion.IsWindows8OrGreater && _accessibilityObject is ListViewGroupAccessibleObject accessibleObject)
+            {
+                HRESULT result = UiaCore.UiaDisconnectProvider(accessibleObject);
+                Debug.Assert(result == HRESULT.S_OK);
+            }
         }
 
         // Should be used for the cases when sending the message `LVM.SETGROUPINFO` isn't required

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroupCollection.cs
@@ -199,6 +199,7 @@ namespace System.Windows.Forms
             for (int i = 0; i < Count; i++)
             {
                 this[i].ListView = null;
+                this[i].ReleaseUiaProvider();
             }
 
             List.Clear();
@@ -281,6 +282,7 @@ namespace System.Windows.Forms
         {
             group.ListView = null;
             List.Remove(group);
+            group.ReleaseUiaProvider();
 
             if (_listView.IsHandleCreated)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -225,9 +225,9 @@ namespace System.Windows.Forms
 
             internal virtual void ReleaseChildUiaProviders()
             {
-                for (int i = 0; i < _owningItem.SubItemCount; i++)
+                foreach (ListViewSubItem subItem in _owningItem.SubItems)
                 {
-                    _owningItem.SubItems[i].ReleaseUiaProvider();
+                    subItem.ReleaseUiaProvider();
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -223,6 +223,14 @@ namespace System.Windows.Forms
                     _ => base.IsPatternSupported(patternId)
                 };
 
+            internal virtual void ReleaseChildUiaProviders()
+            {
+                for (int i = 0; i < _owningItem.SubItemCount; i++)
+                {
+                    _owningItem.SubItems[i].ReleaseUiaProvider();
+                }
+            }
+
             internal override void RemoveFromSelection()
             {
                 // Do nothing, C++ implementation returns UIA_E_INVALIDOPERATION 0x80131509

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -127,6 +127,8 @@ namespace System.Windows.Forms
                     HRESULT result = UiaCore.UiaDisconnectProvider(accessibleObject);
                     Debug.Assert(result == HRESULT.S_OK);
                 }
+
+                _listViewSubItemAccessibleObjects.Clear();
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Drawing;
 using static Interop;
 
@@ -116,6 +117,17 @@ namespace System.Windows.Forms
                 => _owningListView.IsHandleCreated
                     ? _owningListView.GetSubItemRect(_owningItem.Index, subItemIndex)
                     : Rectangle.Empty;
+
+            internal override void ReleaseChildUiaProviders()
+            {
+                base.ReleaseChildUiaProviders();
+
+                foreach (AccessibleObject accessibleObject in _listViewSubItemAccessibleObjects.Values)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(accessibleObject);
+                    Debug.Assert(result == HRESULT.S_OK);
+                }
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemListAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemListAccessibleObject.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Drawing;
 using static Interop;
 
@@ -41,24 +40,6 @@ namespace System.Windows.Forms
                 }
 
                 return base.FragmentNavigate(direction);
-            }
-
-            internal override int[] RuntimeId
-            {
-                get
-                {
-                    var owningListViewRuntimeId = _owningListView.AccessibilityObject.RuntimeId;
-
-                    Debug.Assert(owningListViewRuntimeId.Length >= 2);
-
-                    return new int[]
-                    {
-                        owningListViewRuntimeId[0],
-                        owningListViewRuntimeId[1],
-                        4, // Win32-control specific RuntimeID constant.
-                        CurrentIndex
-                    };
-                }
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -114,7 +114,7 @@ namespace System.Windows.Forms
                             owningItemRuntimeId[1],
                             owningItemRuntimeId[2],
                             owningItemRuntimeId[3],
-                            ParentInternal.GetChildIndex(this)
+                            GetHashCode()
                         };
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Runtime.Serialization;
+using static Interop;
 
 namespace System.Windows.Forms
 {
@@ -70,8 +71,6 @@ namespace System.Windows.Forms
                     return _accessibilityObject;
                 }
             }
-
-            internal bool IsAccessibilityObjectCreated => _accessibilityObject is not null;
 
             public Color BackColor
             {
@@ -246,6 +245,15 @@ namespace System.Windows.Forms
             [OnSerialized]
             private static void OnSerialized(StreamingContext ctx)
             {
+            }
+
+            internal virtual void ReleaseUiaProvider()
+            {
+                if (OsVersion.IsWindows8OrGreater && _accessibilityObject is not null)
+                {
+                    HRESULT result = UiaCore.UiaDisconnectProvider(_accessibilityObject);
+                    Debug.Assert(result == HRESULT.S_OK);
+                }
             }
 
             public void ResetStyle()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.cs
@@ -247,12 +247,13 @@ namespace System.Windows.Forms
             {
             }
 
-            internal virtual void ReleaseUiaProvider()
+            internal void ReleaseUiaProvider()
             {
                 if (OsVersion.IsWindows8OrGreater && _accessibilityObject is not null)
                 {
                     HRESULT result = UiaCore.UiaDisconnectProvider(_accessibilityObject);
                     Debug.Assert(result == HRESULT.S_OK);
+                    _accessibilityObject = null;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItemCollection.cs
@@ -65,6 +65,7 @@ namespace System.Windows.Forms
                     value._owner = _owner;
 
                     oldSubItem._owner = null;
+                    oldSubItem.ReleaseUiaProvider();
 
                     _owner.UpdateSubItems(index);
                 }
@@ -200,6 +201,7 @@ namespace System.Windows.Forms
                     for (int i = 0; i < oldCount; i++)
                     {
                         _owner.SubItems[i]._owner = null;
+                        _owner.subItems[i].ReleaseUiaProvider();
                     }
 
                     _owner.SubItemCount = 0;
@@ -396,6 +398,7 @@ namespace System.Windows.Forms
 
                 // Remove ourselves as the owner.
                 _owner.subItems[index]._owner = null;
+                _owner.subItems[index].ReleaseUiaProvider();
 
                 // Collapse the items
                 for (int i = index + 1; i < _owner.SubItemCount; i++)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -992,6 +992,22 @@ namespace System.Windows.Forms
             KeyboardToolTipStateMachine.Instance.Hook(this, listView.KeyboardToolTip);
         }
 
+        internal virtual void ReleaseUiaProvider()
+        {
+            if (!OsVersion.IsWindows8OrGreater || !IsAccessibilityObjectCreated)
+            {
+                return;
+            }
+
+            if (AccessibilityObject is ListViewItemBaseAccessibleObject itemAccessibleObject)
+            {
+                itemAccessibleObject.ReleaseChildUiaProviders();
+            }
+
+            HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
+            Debug.Assert(result == HRESULT.S_OK);
+        }
+
         /// <summary>
         ///  This is used to map list view items w/ their respective groups in localized forms.
         /// </summary>
@@ -1135,23 +1151,7 @@ namespace System.Windows.Forms
                 KeyboardToolTipStateMachine.Instance.Unhook(this, listView.KeyboardToolTip);
             }
 
-            if (OsVersion.IsWindows8OrGreater)
-            {
-                for (int i = 0; i < SubItemCount; i++)
-                {
-                    if (SubItems[i].IsAccessibilityObjectCreated)
-                    {
-                        HRESULT result = UiaCore.UiaDisconnectProvider(SubItems[i].AccessibilityObject);
-                        Debug.Assert(result == HRESULT.S_OK);
-                    }
-                }
-
-                if (IsAccessibilityObjectCreated)
-                {
-                    HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
-                    Debug.Assert(result == HRESULT.S_OK);
-                }
-            }
+            ReleaseUiaProvider();
 
             // Make sure you do these last, as the first several lines depends on this information
             ID = -1;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -992,7 +992,7 @@ namespace System.Windows.Forms
             KeyboardToolTipStateMachine.Instance.Hook(this, listView.KeyboardToolTip);
         }
 
-        internal virtual void ReleaseUiaProvider()
+        internal void ReleaseUiaProvider()
         {
             if (!OsVersion.IsWindows8OrGreater || !IsAccessibilityObjectCreated)
             {
@@ -1006,6 +1006,7 @@ namespace System.Windows.Forms
 
             HRESULT result = UiaCore.UiaDisconnectProvider(AccessibilityObject);
             Debug.Assert(result == HRESULT.S_OK);
+            _accessibilityObject = null;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObjectTests.cs
@@ -43,12 +43,14 @@ namespace System.Windows.Forms.Tests
         public void ListViewColumnHeaderAccessibleObject_IsDisconnected_WhenListViewReleasesUiaProvider()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingColumnHeader columnHeader = new();
+            using ColumnHeader columnHeader = new();
             listView.Columns.Add(columnHeader);
+            EnforceAccessibleObjectCreation(columnHeader);
+            _ = listView.AccessibilityObject;
 
             listView.ReleaseUiaProvider(listView.Handle);
 
-            Assert.True(columnHeader.IsAccessibilityObjectDisconnected);
+            Assert.Null(columnHeader.TestAccessor().Dynamic._accessibilityObject);
             Assert.True(listView.IsHandleCreated);
         }
 
@@ -56,12 +58,13 @@ namespace System.Windows.Forms.Tests
         public void ListViewColumnHeaderAccessibleObject_IsDisconnected_WhenListViewIsCleared()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingColumnHeader columnHeader = new();
+            using ColumnHeader columnHeader = new();
             listView.Columns.Add(columnHeader);
+            EnforceAccessibleObjectCreation(columnHeader);
 
             listView.Clear();
 
-            Assert.True(columnHeader.IsAccessibilityObjectDisconnected);
+            Assert.Null(columnHeader.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -69,12 +72,13 @@ namespace System.Windows.Forms.Tests
         public void ListViewColumnHeaderAccessibleObject_IsDisconnected_WhenColumnsAreCleared()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingColumnHeader columnHeader = new();
+            using ColumnHeader columnHeader = new();
             listView.Columns.Add(columnHeader);
+            EnforceAccessibleObjectCreation(columnHeader);
 
             listView.Columns.Clear();
 
-            Assert.True(columnHeader.IsAccessibilityObjectDisconnected);
+            Assert.Null(columnHeader.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -82,28 +86,20 @@ namespace System.Windows.Forms.Tests
         public void ListViewColumnHeaderAccessibleObject_IsDisconnected_WhenColumnIsRemoved()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingColumnHeader columnHeader = new();
+            using ColumnHeader columnHeader = new();
             listView.Columns.Add(columnHeader);
+            EnforceAccessibleObjectCreation(columnHeader);
 
             listView.Columns.Remove(columnHeader);
 
-            Assert.True(columnHeader.IsAccessibilityObjectDisconnected);
+            Assert.Null(columnHeader.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
-        private class AccessibilityObjectDisconnectTrackingColumnHeader : ColumnHeader
+        private static void EnforceAccessibleObjectCreation(ColumnHeader columnHeader)
         {
-            public AccessibilityObjectDisconnectTrackingColumnHeader() : base()
-            {
-            }
-
-            public bool IsAccessibilityObjectDisconnected { get; private set; }
-
-            internal override void ReleaseUiaProvider()
-            {
-                base.ReleaseUiaProvider();
-                IsAccessibilityObjectDisconnected = true;
-            }
+            _ = columnHeader.AccessibilityObject;
+            Assert.NotNull(columnHeader.TestAccessor().Dynamic._accessibilityObject);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ColumnHeader.ListViewColumnHeaderAccessibleObjectTests.cs
@@ -38,5 +38,72 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(testText, accessibleObject.GetPropertyValue(UIA.LegacyIAccessibleNamePropertyId));
             Assert.Null(accessibleObject.GetPropertyValue(UIA.LegacyIAccessibleDefaultActionPropertyId));
         }
+
+        [WinFormsFact]
+        public void ListViewColumnHeaderAccessibleObject_IsDisconnected_WhenListViewReleasesUiaProvider()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingColumnHeader columnHeader = new();
+            listView.Columns.Add(columnHeader);
+
+            listView.ReleaseUiaProvider(listView.Handle);
+
+            Assert.True(columnHeader.IsAccessibilityObjectDisconnected);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewColumnHeaderAccessibleObject_IsDisconnected_WhenListViewIsCleared()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingColumnHeader columnHeader = new();
+            listView.Columns.Add(columnHeader);
+
+            listView.Clear();
+
+            Assert.True(columnHeader.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewColumnHeaderAccessibleObject_IsDisconnected_WhenColumnsAreCleared()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingColumnHeader columnHeader = new();
+            listView.Columns.Add(columnHeader);
+
+            listView.Columns.Clear();
+
+            Assert.True(columnHeader.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewColumnHeaderAccessibleObject_IsDisconnected_WhenColumnIsRemoved()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingColumnHeader columnHeader = new();
+            listView.Columns.Add(columnHeader);
+
+            listView.Columns.Remove(columnHeader);
+
+            Assert.True(columnHeader.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        private class AccessibilityObjectDisconnectTrackingColumnHeader : ColumnHeader
+        {
+            public AccessibilityObjectDisconnectTrackingColumnHeader() : base()
+            {
+            }
+
+            public bool IsAccessibilityObjectDisconnected { get; private set; }
+
+            internal override void ReleaseUiaProvider()
+            {
+                base.ReleaseUiaProvider();
+                IsAccessibilityObjectDisconnected = true;
+            }
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -1288,14 +1288,15 @@ namespace System.Windows.Forms.Tests
         public void ListViewGroupAccessibleObject_IsDisconnected_WhenListViewReleasesUiaProvider()
         {
             using ListView listView = new();
-            listView.TestAccessor().Dynamic._defaultGroup = new AccessibilityObjectDisconnectTrackingListViewGroup();
-            AccessibilityObjectDisconnectTrackingListViewGroup group = new();
+            ListViewGroup group = new();
             listView.Groups.Add(group);
+            EnforceAccessibleObjectCreation(group);
+            EnforceAccessibleObjectCreation(listView.DefaultGroup);
 
             listView.ReleaseUiaProvider(listView.Handle);
 
-            Assert.True(group.IsAccessibilityObjectDisconnected);
-            Assert.True(listView.TestAccessor().Dynamic.DefaultGroup.IsAccessibilityObjectDisconnected);
+            Assert.Null(group.TestAccessor().Dynamic._accessibilityObject);
+            Assert.Null(listView.DefaultGroup.TestAccessor().Dynamic._accessibilityObject);
             Assert.True(listView.IsHandleCreated);
         }
 
@@ -1303,12 +1304,13 @@ namespace System.Windows.Forms.Tests
         public void ListViewGroupAccessibleObject_IsDisconnected_WhenGroupsAreCleared()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingListViewGroup group = new();
+            ListViewGroup group = new();
             listView.Groups.Add(group);
+            EnforceAccessibleObjectCreation(group);
 
             listView.Groups.Clear();
 
-            Assert.True(group.IsAccessibilityObjectDisconnected);
+            Assert.Null(group.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -1316,28 +1318,20 @@ namespace System.Windows.Forms.Tests
         public void ListViewGroupAccessibleObject_IsDisconnected_WhenGroupIsRemoved()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingListViewGroup group = new();
+            ListViewGroup group = new();
             listView.Groups.Add(group);
+            EnforceAccessibleObjectCreation(group);
 
             listView.Groups.Remove(group);
 
-            Assert.True(group.IsAccessibilityObjectDisconnected);
+            Assert.Null(group.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
-        private class AccessibilityObjectDisconnectTrackingListViewGroup : ListViewGroup
+        private static void EnforceAccessibleObjectCreation(ListViewGroup group)
         {
-            public AccessibilityObjectDisconnectTrackingListViewGroup() : base()
-            {
-            }
-
-            public bool IsAccessibilityObjectDisconnected { get; private set; }
-
-            internal override void ReleaseUiaProvider()
-            {
-                base.ReleaseUiaProvider();
-                IsAccessibilityObjectDisconnected = true;
-            }
+            _ = group.AccessibilityObject;
+            Assert.NotNull(group.TestAccessor().Dynamic._accessibilityObject);
         }
 
         private ListView GetListViewItemWithInvisibleItems(View view)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -1284,6 +1284,62 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(createHandle, listView.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ListViewGroupAccessibleObject_IsDisconnected_WhenListViewReleasesUiaProvider()
+        {
+            using ListView listView = new();
+            listView.TestAccessor().Dynamic._defaultGroup = new AccessibilityObjectDisconnectTrackingListViewGroup();
+            AccessibilityObjectDisconnectTrackingListViewGroup group = new();
+            listView.Groups.Add(group);
+
+            listView.ReleaseUiaProvider(listView.Handle);
+
+            Assert.True(group.IsAccessibilityObjectDisconnected);
+            Assert.True(listView.TestAccessor().Dynamic.DefaultGroup.IsAccessibilityObjectDisconnected);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewGroupAccessibleObject_IsDisconnected_WhenGroupsAreCleared()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingListViewGroup group = new();
+            listView.Groups.Add(group);
+
+            listView.Groups.Clear();
+
+            Assert.True(group.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewGroupAccessibleObject_IsDisconnected_WhenGroupIsRemoved()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingListViewGroup group = new();
+            listView.Groups.Add(group);
+
+            listView.Groups.Remove(group);
+
+            Assert.True(group.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        private class AccessibilityObjectDisconnectTrackingListViewGroup : ListViewGroup
+        {
+            public AccessibilityObjectDisconnectTrackingListViewGroup() : base()
+            {
+            }
+
+            public bool IsAccessibilityObjectDisconnected { get; private set; }
+
+            internal override void ReleaseUiaProvider()
+            {
+                base.ReleaseUiaProvider();
+                IsAccessibilityObjectDisconnected = true;
+            }
+        }
+
         private ListView GetListViewItemWithInvisibleItems(View view)
         {
             ListView listView = new ListView() { View = view };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -1839,6 +1839,71 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(createControl, listView.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ListViewItemAccessibleObject_IsDisconnected_WhenListViewReleasesUiaProvider()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingListViewItem item = new("ListItem");
+            listView.Items.Add(item);
+
+            listView.ReleaseUiaProvider(listView.Handle);
+
+            Assert.True(item.IsAccessibilityObjectDisconnected);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemAccessibleObject_IsDisconnected_WhenListViewIsCleared()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingListViewItem item = new("ListItem");
+            listView.Items.Add(item);
+
+            listView.Clear();
+
+            Assert.True(item.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemAccessibleObject_IsDisconnected_WhenItemsAreCleared()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingListViewItem item = new("ListItem");
+            listView.Items.Add(item);
+
+            listView.Items.Clear();
+
+            Assert.True(item.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemAccessibleObject_IsDisconnected_WhenItemIsRemoved()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingListViewItem item = new("ListItem");
+            listView.Items.Add(item);
+
+            listView.Items.Remove(item);
+
+            Assert.True(item.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemAccessibleObject_IsDisconnected_WhenItemIsReplaced()
+        {
+            using ListView listView = new();
+            AccessibilityObjectDisconnectTrackingListViewItem item = new("ListItem");
+            listView.Items.Add(item);
+
+            listView.Items[0] = new ListViewItem();
+
+            Assert.True(item.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
         private ListView GetBoundsListView(View view, bool showGroups, bool virtualMode)
         {
             ListView listView = new()
@@ -1900,6 +1965,21 @@ namespace System.Windows.Forms.Tests
 
             listView.Columns.Add(new ColumnHeader());
             return listView;
+        }
+
+        private class AccessibilityObjectDisconnectTrackingListViewItem : ListViewItem
+        {
+            public AccessibilityObjectDisconnectTrackingListViewItem(string text) : base(text)
+            {
+            }
+
+            public bool IsAccessibilityObjectDisconnected { get; private set; }
+
+            internal override void ReleaseUiaProvider()
+            {
+                base.ReleaseUiaProvider();
+                IsAccessibilityObjectDisconnected = true;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -1843,12 +1843,13 @@ namespace System.Windows.Forms.Tests
         public void ListViewItemAccessibleObject_IsDisconnected_WhenListViewReleasesUiaProvider()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingListViewItem item = new("ListItem");
+            ListViewItem item = new("ListItem");
             listView.Items.Add(item);
+            EnforceAccessibleObjectCreation(item);
 
             listView.ReleaseUiaProvider(listView.Handle);
 
-            Assert.True(item.IsAccessibilityObjectDisconnected);
+            Assert.Null(item.TestAccessor().Dynamic._accessibilityObject);
             Assert.True(listView.IsHandleCreated);
         }
 
@@ -1856,12 +1857,13 @@ namespace System.Windows.Forms.Tests
         public void ListViewItemAccessibleObject_IsDisconnected_WhenListViewIsCleared()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingListViewItem item = new("ListItem");
+            ListViewItem item = new("ListItem");
             listView.Items.Add(item);
+            EnforceAccessibleObjectCreation(item);
 
             listView.Clear();
 
-            Assert.True(item.IsAccessibilityObjectDisconnected);
+            Assert.Null(item.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -1869,12 +1871,13 @@ namespace System.Windows.Forms.Tests
         public void ListViewItemAccessibleObject_IsDisconnected_WhenItemsAreCleared()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingListViewItem item = new("ListItem");
+            ListViewItem item = new("ListItem");
             listView.Items.Add(item);
+            EnforceAccessibleObjectCreation(item);
 
             listView.Items.Clear();
 
-            Assert.True(item.IsAccessibilityObjectDisconnected);
+            Assert.Null(item.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -1882,12 +1885,13 @@ namespace System.Windows.Forms.Tests
         public void ListViewItemAccessibleObject_IsDisconnected_WhenItemIsRemoved()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingListViewItem item = new("ListItem");
+            ListViewItem item = new("ListItem");
             listView.Items.Add(item);
+            EnforceAccessibleObjectCreation(item);
 
             listView.Items.Remove(item);
 
-            Assert.True(item.IsAccessibilityObjectDisconnected);
+            Assert.Null(item.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -1895,13 +1899,20 @@ namespace System.Windows.Forms.Tests
         public void ListViewItemAccessibleObject_IsDisconnected_WhenItemIsReplaced()
         {
             using ListView listView = new();
-            AccessibilityObjectDisconnectTrackingListViewItem item = new("ListItem");
+            ListViewItem item = new("ListItem");
             listView.Items.Add(item);
+            EnforceAccessibleObjectCreation(item);
 
             listView.Items[0] = new ListViewItem();
 
-            Assert.True(item.IsAccessibilityObjectDisconnected);
+            Assert.Null(item.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
+        }
+
+        private static void EnforceAccessibleObjectCreation(ListViewItem listViewItem)
+        {
+            _ = listViewItem.AccessibilityObject;
+            Assert.NotNull(listViewItem.TestAccessor().Dynamic._accessibilityObject);
         }
 
         private ListView GetBoundsListView(View view, bool showGroups, bool virtualMode)
@@ -1965,21 +1976,6 @@ namespace System.Windows.Forms.Tests
 
             listView.Columns.Add(new ColumnHeader());
             return listView;
-        }
-
-        private class AccessibilityObjectDisconnectTrackingListViewItem : ListViewItem
-        {
-            public AccessibilityObjectDisconnectTrackingListViewItem(string text) : base(text)
-            {
-            }
-
-            public bool IsAccessibilityObjectDisconnected { get; private set; }
-
-            internal override void ReleaseUiaProvider()
-            {
-                base.ReleaseUiaProvider();
-                IsAccessibilityObjectDisconnected = true;
-            }
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObjectTests.cs
@@ -108,5 +108,25 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(control.Columns.Count, accessibleObject.GetChildCount());
             Assert.True(control.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void ListViewItemDetailsAccessibleObject_SubItemAccessibleObjects_AreDisconnected_WhenItemIsReleased()
+        {
+            using ListView control = new() { View = View.Details };
+            ListViewItem item = new();
+            control.Items.Add(item);
+            control.Columns.AddRange(new ColumnHeader[] { new(), new(), new() });
+
+            // Enforce subitems' accessible objects creation.
+            Assert.NotNull(item.AccessibilityObject.GetChild(0));
+            Assert.NotNull(item.AccessibilityObject.GetChild(1));
+            Assert.NotNull(item.AccessibilityObject.GetChild(2));
+            Assert.NotEmpty(item.AccessibilityObject.TestAccessor().Dynamic._listViewSubItemAccessibleObjects);
+
+            item.ReleaseUiaProvider();
+
+            Assert.Empty(item.AccessibilityObject.TestAccessor().Dynamic._listViewSubItemAccessibleObjects);
+            Assert.False(control.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -990,16 +990,14 @@ namespace System.Windows.Forms.Tests
         {
             using ListView listView = new();
             ListViewItem listViewItem = new();
-            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            ListViewItem.ListViewSubItem listViewSubItem = new();
             listViewItem.SubItems.Add(listViewSubItem);
             listView.Items.Add(listViewItem);
-
-            // Enforce accessible object creation.
-            _ = listViewItem.AccessibilityObject;
+            EnforceAccessibleObjectCreation(listViewItem);
 
             listView.ReleaseUiaProvider(listView.Handle);
 
-            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.Null(listViewSubItem.TestAccessor().Dynamic._accessibilityObject);
             Assert.True(listView.IsHandleCreated);
         }
 
@@ -1008,16 +1006,14 @@ namespace System.Windows.Forms.Tests
         {
             using ListView listView = new();
             ListViewItem listViewItem = new();
-            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            ListViewItem.ListViewSubItem listViewSubItem = new();
             listViewItem.SubItems.Add(listViewSubItem);
             listView.Items.Add(listViewItem);
-
-            // Enforce accessible object creation.
-            _ = listViewItem.AccessibilityObject;
+            EnforceAccessibleObjectCreation(listViewItem);
 
             listView.Clear();
 
-            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.Null(listViewSubItem.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -1026,16 +1022,14 @@ namespace System.Windows.Forms.Tests
         {
             using ListView listView = new();
             ListViewItem listViewItem = new();
-            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            ListViewItem.ListViewSubItem listViewSubItem = new();
             listViewItem.SubItems.Add(listViewSubItem);
             listView.Items.Add(listViewItem);
-
-            // Enforce accessible object creation.
-            _ = listViewItem.AccessibilityObject;
+            EnforceAccessibleObjectCreation(listViewItem);
 
             listView.Items.RemoveAt(0);
 
-            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.Null(listViewSubItem.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -1044,16 +1038,14 @@ namespace System.Windows.Forms.Tests
         {
             using ListView listView = new();
             ListViewItem listViewItem = new();
-            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            ListViewItem.ListViewSubItem listViewSubItem = new();
             listViewItem.SubItems.Add(listViewSubItem);
             listView.Items.Add(listViewItem);
-
-            // Enforce accessible object creation.
-            _ = listViewItem.AccessibilityObject;
+            EnforceAccessibleObjectCreation(listViewItem);
 
             listView.Items[0].SubItems.Remove(listViewSubItem);
 
-            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.Null(listViewSubItem.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -1062,16 +1054,14 @@ namespace System.Windows.Forms.Tests
         {
             using ListView listView = new();
             ListViewItem listViewItem = new();
-            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            ListViewItem.ListViewSubItem listViewSubItem = new();
             listViewItem.SubItems.Add(listViewSubItem);
             listView.Items.Add(listViewItem);
-
-            // Enforce accessible object creation.
-            _ = listViewItem.AccessibilityObject;
+            EnforceAccessibleObjectCreation(listViewItem);
 
             listView.Items[0].SubItems.Clear();
 
-            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.Null(listViewSubItem.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -1080,16 +1070,14 @@ namespace System.Windows.Forms.Tests
         {
             using ListView listView = new();
             ListViewItem listViewItem = new();
-            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            ListViewItem.ListViewSubItem listViewSubItem = new();
             listViewItem.SubItems.Add(listViewSubItem);
             listView.Items.Add(listViewItem);
-
-            // Enforce accessible object creation.
-            _ = listViewItem.AccessibilityObject;
+            EnforceAccessibleObjectCreation(listViewItem);
 
             listView.Items[0] = new ListViewItem();
 
-            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.Null(listViewSubItem.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
@@ -1098,32 +1086,26 @@ namespace System.Windows.Forms.Tests
         {
             using ListView listView = new();
             ListViewItem listViewItem = new();
-            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            ListViewItem.ListViewSubItem listViewSubItem = new();
             listViewItem.SubItems.Add(listViewSubItem);
             listView.Items.Add(listViewItem);
-
-            // Enforce accessible object creation.
-            _ = listViewItem.AccessibilityObject;
+            EnforceAccessibleObjectCreation(listViewItem);
 
             int subItemIndex = listView.Items[0].SubItems.IndexOf(listViewSubItem);
             listView.Items[0].SubItems[subItemIndex] = new ListViewItem.ListViewSubItem();
 
-            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.Null(listViewSubItem.TestAccessor().Dynamic._accessibilityObject);
             Assert.False(listView.IsHandleCreated);
         }
 
-        private class AccessibilityObjectDisconnectTrackingListViewSubItem : ListViewItem.ListViewSubItem
+        private static void EnforceAccessibleObjectCreation(ListViewItem item)
         {
-            public AccessibilityObjectDisconnectTrackingListViewSubItem() : base()
+            _ = item.AccessibilityObject;
+            Assert.NotNull(item.TestAccessor().Dynamic._accessibilityObject);
+            foreach (ListViewItem.ListViewSubItem subItem in item.SubItems)
             {
-            }
-
-            public bool IsAccessibilityObjectDisconnected { get; private set; }
-
-            internal override void ReleaseUiaProvider()
-            {
-                base.ReleaseUiaProvider();
-                IsAccessibilityObjectDisconnected = true;
+                _ = subItem.AccessibilityObject;
+                Assert.NotNull(subItem.TestAccessor().Dynamic._accessibilityObject);
             }
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -911,8 +911,7 @@ namespace System.Windows.Forms.Tests
             ListViewItem listViewItem = new("Test item");
             listView.Items.Add(listViewItem);
             ListViewItem.ListViewSubItem listViewSubItem = new(listViewItem, "Test subItem");
-            ListViewSubItemAccessibleObject listViewSubItemAccessibleObject = new(listViewSubItem, listViewItem);
-            object actual = listViewSubItemAccessibleObject.GetPropertyValue(UiaCore.UIA.RuntimeIdPropertyId);
+            object actual = listViewSubItem.AccessibilityObject.GetPropertyValue(UiaCore.UIA.RuntimeIdPropertyId);
 
             Assert.Equal(listViewSubItem.AccessibilityObject.RuntimeId, actual);
             Assert.False(listView.IsHandleCreated);
@@ -984,6 +983,148 @@ namespace System.Windows.Forms.Tests
             listview.Items.Add(listViewItem);
 
             Assert.Equal(AccessibleStates.Focusable, listViewSubItem.AccessibilityObject.State);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_IsDisconnected_WhenListViewReleasesUiaProvider()
+        {
+            using ListView listView = new();
+            ListViewItem listViewItem = new();
+            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            listViewItem.SubItems.Add(listViewSubItem);
+            listView.Items.Add(listViewItem);
+
+            // Enforce accessible object creation.
+            _ = listViewItem.AccessibilityObject;
+
+            listView.ReleaseUiaProvider(listView.Handle);
+
+            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.True(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_IsDisconnected_WhenListViewIsCleared()
+        {
+            using ListView listView = new();
+            ListViewItem listViewItem = new();
+            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            listViewItem.SubItems.Add(listViewSubItem);
+            listView.Items.Add(listViewItem);
+
+            // Enforce accessible object creation.
+            _ = listViewItem.AccessibilityObject;
+
+            listView.Clear();
+
+            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_IsDisconnected_WhenOwningItemIsRemoved()
+        {
+            using ListView listView = new();
+            ListViewItem listViewItem = new();
+            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            listViewItem.SubItems.Add(listViewSubItem);
+            listView.Items.Add(listViewItem);
+
+            // Enforce accessible object creation.
+            _ = listViewItem.AccessibilityObject;
+
+            listView.Items.RemoveAt(0);
+
+            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_IsDisconnected_WhenSubItemIsRemoved()
+        {
+            using ListView listView = new();
+            ListViewItem listViewItem = new();
+            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            listViewItem.SubItems.Add(listViewSubItem);
+            listView.Items.Add(listViewItem);
+
+            // Enforce accessible object creation.
+            _ = listViewItem.AccessibilityObject;
+
+            listView.Items[0].SubItems.Remove(listViewSubItem);
+
+            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_IsDisconnected_WhenSubItemsAreCleared()
+        {
+            using ListView listView = new();
+            ListViewItem listViewItem = new();
+            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            listViewItem.SubItems.Add(listViewSubItem);
+            listView.Items.Add(listViewItem);
+
+            // Enforce accessible object creation.
+            _ = listViewItem.AccessibilityObject;
+
+            listView.Items[0].SubItems.Clear();
+
+            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_IsDisconnected_WhenSubItemIsReplaced()
+        {
+            using ListView listView = new();
+            ListViewItem listViewItem = new();
+            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            listViewItem.SubItems.Add(listViewSubItem);
+            listView.Items.Add(listViewItem);
+
+            // Enforce accessible object creation.
+            _ = listViewItem.AccessibilityObject;
+
+            listView.Items[0] = new ListViewItem();
+
+            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_IsDisconnected_WhenOwningItemIsReplaced()
+        {
+            using ListView listView = new();
+            ListViewItem listViewItem = new();
+            AccessibilityObjectDisconnectTrackingListViewSubItem listViewSubItem = new();
+            listViewItem.SubItems.Add(listViewSubItem);
+            listView.Items.Add(listViewItem);
+
+            // Enforce accessible object creation.
+            _ = listViewItem.AccessibilityObject;
+
+            int subItemIndex = listView.Items[0].SubItems.IndexOf(listViewSubItem);
+            listView.Items[0].SubItems[subItemIndex] = new ListViewItem.ListViewSubItem();
+
+            Assert.True(listViewSubItem.IsAccessibilityObjectDisconnected);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        private class AccessibilityObjectDisconnectTrackingListViewSubItem : ListViewItem.ListViewSubItem
+        {
+            public AccessibilityObjectDisconnectTrackingListViewSubItem() : base()
+            {
+            }
+
+            public bool IsAccessibilityObjectDisconnected { get; private set; }
+
+            internal override void ReleaseUiaProvider()
+            {
+                base.ReleaseUiaProvider();
+                IsAccessibilityObjectDisconnected = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #7385

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Proposed changes

- Add a call of `UiaDisconnectProvider` for `ListView` elements (items, subitems, groups, column headers) for cases when:
    - `ListView` is destroyed
    - Collection is cleared
    - Element is removed from a collection
    - Element is replaced in a collection (where applicable)
- Change `RuntimeId` of some accessible objects to be independent from its index in a collection. When collection is modified, e.g. some elements are removed or inserted at the beginning, indexes (and therefore `RuntimeId`s) of elements change. It then leads to a possible disconnection of wrong items, which had the index initially.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Less memory leaks for `ListView`

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/102954094/180423743-b904cc03-1aa2-4b92-b6f1-e6a0bc2e6100.png)

### After

![image](https://user-images.githubusercontent.com/102954094/180423059-bd73208b-2495-4f26-b90e-2db487f5de38.png)


## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manually (via WinDbg)
- Unit tests — we don't always add unit tests for memory leaks fixes, but here I wanted to make sure that all disconnects are properly called through the hierarchy, and in addition use unit tests as a form of documentation for main scenarios

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->
- Using AI, Inspect, Narrator
 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0 RC1
- Windows 11
<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7478)