### PR TITLE
Adding a unit test to check ListView.GroupCollapsedStateChanged event work

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -785,6 +785,79 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(ListViewGroupCollapsedState.Collapsed)]
+        [InlineData(ListViewGroupCollapsedState.Expanded)]
+        public void ListViewGroupAccessibleObject_GroupCollapsedStateChanged_IsExpected_ForMultipleSelection(ListViewGroupCollapsedState firstGroupSate)
+        {
+            using ListView listView = new() { ShowGroups = true };
+
+            // This test checks the case of collapsing of the second group.
+            // The first group state might affect behaviour, so check both states.
+            ListViewGroup group1 = new("Group 1") { CollapsedState = firstGroupSate };
+            ListViewGroup group2 = new("Group 2") { CollapsedState = ListViewGroupCollapsedState.Expanded };
+            ListViewGroup group3 = new("Group 3") { CollapsedState = ListViewGroupCollapsedState.Expanded };
+            listView.Groups.AddRange(new[] { group1, group2, group3 });
+            ListViewItem item1 = new("Item 1", group1);
+            ListViewItem item2 = new("Item 2", group2);
+            ListViewItem item3 = new("Item 2", group3);
+            listView.Items.AddRange(new[] { item1, item2, item3 });
+            listView.CreateControl();
+            item1.Focused = true;
+
+            // Keep indices of groups, that GroupCollapsedStateChanged event was raised for.
+            // It will help to understand if the event was raised for a correct group and was raised at all.
+            List<int> eventGroupIndices = new();
+            listView.GroupCollapsedStateChanged += (_, e) => eventGroupIndices.Add(e.GroupIndex);
+
+            // Navigate to the second group
+            SimulateKeyPress(Keys.Down);
+
+            if (firstGroupSate == ListViewGroupCollapsedState.Collapsed)
+            {
+                // This action is necessary to navigate to the second group correctly in this specific case.
+                SimulateKeyPress(Keys.Up);
+            }
+
+            // Simulate multiple selection of several groups to test a specific case,
+            // described in https://github.com/dotnet/winforms/issues/6708
+            item1.Selected = true;
+            item2.Selected = true;
+            item3.Selected = true;
+
+            // Simulate the second group collapse action via keyboard.
+            SimulateKeyPress(Keys.Left);
+
+            Assert.Equal(firstGroupSate, group1.GetNativeCollapsedState());
+            Assert.Equal(firstGroupSate, group1.CollapsedState);
+            Assert.Equal(ListViewGroupCollapsedState.Collapsed, group2.GetNativeCollapsedState());
+            Assert.Equal(ListViewGroupCollapsedState.Collapsed, group2.CollapsedState);
+            Assert.Equal(ListViewGroupCollapsedState.Expanded, group3.GetNativeCollapsedState());
+            Assert.Equal(ListViewGroupCollapsedState.Expanded, group3.CollapsedState);
+
+            // GroupCollapsedStateChanged event should be raised
+            // for the second group only in this specific case.
+            Assert.Equal(1, eventGroupIndices.Count);
+            Assert.Equal(1, eventGroupIndices[0]); 
+
+            // Make sure that we really cheched multiple selection case and the items
+            // are still selected after keyboard navigation simulations.
+            Assert.Equal(3, listView.SelectedItems.Count);
+            Assert.True(listView.IsHandleCreated);
+
+            void SimulateKeyPress(Keys key)
+            {
+                // https://docs.microsoft.com/windows/win32/inputdev/wm-keyup
+                // The MSDN page tells us what bits of lParam to use for each of the parameters.
+                // All we need to do is some bit shifting to assemble lParam
+                // lParam = repeatCount | (scanCode << 16)
+                nint keyCode = (nint)key;
+                nint lParam = 0x00000001 | keyCode << 16;
+                User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
+                User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
+            }
+        }
+
+        [WinFormsTheory]
         [InlineData(View.Details)]
         [InlineData(View.LargeIcon)]
         [InlineData(View.SmallIcon)]


### PR DESCRIPTION
This is continue of PR #7412.
The test check case, described in Issue #6708.

## Proposed changes

- Add a unit test, that check the case of collapsing of the second ListView group, when several group items are selected.

## Test environment(s)
- .NET 7.0.0-rc.1.22371.7
- Windows 11



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7489)