### PR TITLE
Adding notification to Narrator about a subtitle.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -99,7 +99,9 @@ namespace System.Windows.Forms
                 => _owningListView.AccessibilityObject;
 
             public override string Name
-                => _owningGroup.Header;
+                => !string.IsNullOrEmpty(_owningGroup.Subtitle)
+                    ? $"{_owningGroup.Header}. {_owningGroup.Subtitle}"
+                    : _owningGroup.Header;
 
             public override AccessibleRole Role
                 => AccessibleRole.Grouping;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -170,6 +170,7 @@ namespace WinformsControlsTest
         private void AddGroupTasks()
         {
             listView1.Groups[0].TaskLink = "Task";
+            listView1.Groups[0].Subtitle = "Subtitle";
             listView1.GroupTaskLinkClick += listView1_GroupTaskLinkClick;
 
             var lvgroup1 = new ListViewGroup

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -110,6 +110,25 @@ namespace System.Windows.Forms.Tests
             Assert.False(list.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void ListViewGroupAccessibleObject_GetPropertyValue_ReturnsExpected_WithSubtitle()
+        {
+            using ListView list = new ListView();
+            const string name = "Group1";
+            const string subtitle = "Subtitle";
+            ListViewGroup listGroup = new ListViewGroup(name) { Subtitle = subtitle };
+            listGroup.Items.Add(new ListViewItem());
+            list.Groups.Add(listGroup);
+
+            AccessibleObject accessibleObject = listGroup.AccessibilityObject;
+            Assert.False(list.IsHandleCreated);
+
+            object accessibleName = accessibleObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+            Assert.Equal($"{name}. {subtitle}", accessibleName);
+
+            Assert.False(list.IsHandleCreated);
+        }
+
         [WinFormsTheory]
         [MemberData(nameof(ListViewGroupAccessibleObject_TestData))]
         public void ListViewGroupAccessibleObject_FragmentNavigate_ReturnsExpected_WithDefaultGroup(View view, bool showGroups, bool createHandle)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #3261


## Proposed changes

- Raised a notificatoin contained a subtitle values on setting focus.
- Added check for focus state in SetState method.
- Added unit test.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- User can hear a subtitle of ListViewGroup.


## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/180731938-9ce4f8a6-b12f-4800-92b7-ff4b717b7d08.png)

### After

![image](https://user-images.githubusercontent.com/109065597/180731641-40666953-489f-4b29-8fbd-c55e7d3542b1.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Narrator
- Unit test

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Narrator


 

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.5.22307.18


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7490)