### PR TITLE
Address over release in DragDropFormat tests

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DragDropFormat.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DragDropFormat.cs
@@ -98,6 +98,8 @@ namespace System.Windows.Forms
                 mediumDestination.tymed = mediumSource.tymed;
                 mediumDestination.pUnkForRelease = mediumSource.pUnkForRelease;
 
+                // If the object is non-null, perform an indirect AddRef() by
+                // requesting the IUnknown.
                 if (mediumSource.pUnkForRelease is not null)
                 {
                     Marshal.GetIUnknownForObject(mediumSource.pUnkForRelease);


### PR DESCRIPTION
There is an over release in `DragDropFormatTests.cs`. The main issue is the `DragDropFormat` class has a "copy" semantic that is default in all tests. Since there are no copies being made, ownership of the passed in artifacts is implied so calling [`DragDropFormat.Dispose()`](https://github.com/dotnet/winforms/blob/de1f12d7404f627539ab81cc98a054a12d8020aa/src/System.Windows.Forms/src/System/Windows/Forms/DragDropFormat.cs#L115-L130) means they will be released then and there is no need to call `Ole32.ReleaseStgMedium()` as well.

https://github.com/dotnet/winforms/blob/de1f12d7404f627539ab81cc98a054a12d8020aa/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropFormatTests.cs#L63

https://github.com/dotnet/winforms/blob/de1f12d7404f627539ab81cc98a054a12d8020aa/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropFormatTests.cs#L87

https://github.com/dotnet/winforms/blob/de1f12d7404f627539ab81cc98a054a12d8020aa/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DragDropFormatTests.cs#L130



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7505)