### PR TITLE
Fix replacing TreeNode by index in TreeView

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNodeCollection.cs
@@ -85,11 +85,8 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                tv._nodesByHandle.Remove(actual._handle);
-                value.parent = owner;
-                value.index = index;
-                owner.children[index] = value;
-                value.Realize(false);
+                Remove(actual);
+                Insert(index, value);
             }
         }
 


### PR DESCRIPTION
Fixes #7504

## Proposed changes

Use `Remove` and `Insert` methods to correctly replace `TreeNode` in a `TreeNodeCollection`. It will still execute the same code as before but with a few additional important methods.
- Calling `Remove` sends missing `TVM.DELETEITEM` message for the replaced node which fixes appending blank space.
- Additionally, `Remove` method disposes Keyboard ToolTip for the node. `Insert` hooks it to the new tree node and its children, which also fixes not working keyboard tooltip after replacement.
- Memory leak of replaced node's accessible object will be fixed with https://github.com/dotnet/winforms/pull/7296 which adds a `UiaDisconnectProvider` call in `Remove` method.
- This is also how it's implemented for setter by index in `ListViewNativeItemCollection` and `ListBox.ObjectCollection`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Fixes appending blank space on setting `TreeNode` by index
- Prevents from exceptions when using Narrator
- Fixes not working keyboard tooltip for new node if it was set this way

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

Button click executes following code:
```
treeView1.Nodes[0] = new TreeNode(new Random().Next().ToString());
```

### Before

![Animation1](https://user-images.githubusercontent.com/102954094/181583383-de43f208-8175-4440-8a06-6c760a68f484.gif)

### After


![Animation4](https://user-images.githubusercontent.com/102954094/181584091-4916eea7-6bc5-410c-a3ff-c65c3d77e237.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manual
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Tested with Narrator to make sure there are no issues with replaced nodes
 

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0.0-rc.1.22366.1
- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7509)