### PR TITLE
Add not null check for ListView's DefaultGroup before releasing its UIA provider

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -5141,7 +5141,10 @@ namespace System.Windows.Forms
                 Items[i].ReleaseUiaProvider();
             }
 
-            DefaultGroup.ReleaseUiaProvider();
+            if (_defaultGroup is not null)
+            {
+                DefaultGroup.ReleaseUiaProvider();
+            }
 
             foreach (ListViewGroup group in Groups)
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5773,6 +5773,18 @@ namespace System.Windows.Forms.Tests
             Assert.Null(listView.FocusedItem);
         }
 
+        [WinFormsFact]
+        public void ListView_ReleaseUiaProvider_DoesNotForceDefaultGroupCreation()
+        {
+            using ListView listView = new();
+            _ = listView.AccessibilityObject;
+
+            listView.ReleaseUiaProvider(listView.Handle);
+
+            Assert.Null(listView.TestAccessor().Dynamic._defaultGroup);
+            Assert.True(listView.IsHandleCreated);
+        }
+
         private class SubListViewItem : ListViewItem
         {
             public AccessibleObject CustomAccessibleObject { get; set; }


### PR DESCRIPTION
Follow-up for #7385 (see https://github.com/dotnet/winforms/pull/7478#discussion_r934996360)

Accessing DefaultGroup forces its creation, so we need to make sure it exists before releasing to prevent unwanted creation.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->


## Proposed changes

- Add not null check for `DefaultGroup` before releasing its provider

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Unnecessary `DefaultGroup` object is not created for ListViews without groups when ListView releases its UIA provider

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Unit testing
- Manual


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0.100-rc.1.22368.24
- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7524)