### PR TITLE
Adding the ListViewItem CheckBox check announcement

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -77,7 +77,9 @@ namespace System.Windows.Forms
             ///  Gets the accessible role.
             /// </summary>
             public override AccessibleRole Role
-                => AccessibleRole.ListItem;
+                => _owningListView.CheckBoxes
+                    ? AccessibleRole.CheckButton
+                    : AccessibleRole.ListItem;
 
             /// <summary>
             ///  Gets the accessible state.
@@ -107,10 +109,29 @@ namespace System.Windows.Forms
                 => SelectItem();
 
             public override string DefaultAction
-                => SR.AccessibleActionDoubleClick;
+            {
+                get
+                {
+                    if (_owningListView.CheckBoxes)
+                    {
+                        return _owningItem.Checked
+                            ? SR.AccessibleActionUncheck
+                            : SR.AccessibleActionCheck;
+                    }
+
+                    return SR.AccessibleActionDoubleClick;
+                }
+            }
 
             public override void DoDefaultAction()
-                => SetFocus();
+            {
+                if (_owningListView.CheckBoxes)
+                {
+                    Toggle();
+                }
+
+                SetFocus();
+            }
 
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
@@ -279,6 +279,55 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ListViewItemBaseAccessibleObject_IsCheckable_IfListViewHasCheckBoxes(bool itemIsChecked)
+        {
+            using ListView listView = new();
+            listView.CheckBoxes = true;
+            ListViewItem item = new();
+            listView.Items.Add(item);
+            item.Checked = itemIsChecked;
+
+            AccessibleObject itemAccessibleObject = item.AccessibilityObject;
+            itemAccessibleObject.DoDefaultAction();
+
+            Assert.Equal(!itemIsChecked, item.Checked);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemBaseAccessibleObject_IfCheckableListViewItem_HasCheckButtonRole()
+        {
+            using ListView listView = new();
+            listView.CheckBoxes = true;
+            ListViewItem item = new();
+            listView.Items.Add(item);
+
+            AccessibleObject itemAccessibleObject = item.AccessibilityObject;
+
+            Assert.Equal(AccessibleRole.CheckButton, itemAccessibleObject.Role);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ListViewItemBaseAccessibleObject_IfCheckableListViewItem_HasExpectedDefaultAction(bool itemIsChecked)
+        {
+            using ListView listView = new();
+            listView.CheckBoxes = true;
+            ListViewItem item = new();
+            item.Checked = itemIsChecked;
+            listView.Items.Add(item);
+
+            AccessibleObject itemAccessibleObject = item.AccessibilityObject;
+
+            Assert.Equal(itemIsChecked ? SR.AccessibleActionUncheck : SR.AccessibleActionCheck, itemAccessibleObject.DefaultAction);
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
         [InlineData((int)UiaCore.UIA.ScrollItemPatternId)]
         [InlineData((int)UiaCore.UIA.LegacyIAccessiblePatternId)]
         [InlineData((int)UiaCore.UIA.SelectionItemPatternId)]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4690 (Common Case 1)


## Proposed changes

- Changed ListViewItemBaseAccessibleObject: added announcement by Narrator the same way as in TreeView
- Added the unit test ListViewItemBaseAccessibleObject_IsCheckable_IfListViewHasCheckBoxes


## Customer Impact

- Narrator announces ListViewItem with checkbox as either selected or not selected

## Regression? 

- No

## Risk

- Minimal




## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manually

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using Inspect and Narrator


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET 7.0 Preview 6
Windows 10


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7532)