### PR TITLE
Moving common logic of keyboard's simulation into the helper class.

### DIFF
--- a/src/System.Windows.Forms/tests/TestUtilities/KeyboardSimulator.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/KeyboardSimulator.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using static Interop;
+using System.Windows.Forms;
+
+namespace System
+{
+    public static class KeyboardSimulator
+    {
+        public static void KeyDown(Control control, Keys key)
+        {
+            (nint keyCode, nint lParam) = GetKeyParameters(key);
+            User32.SendMessageW(control, User32.WM.KEYDOWN, keyCode, lParam);
+        }
+
+        public static void KeyPress(Control control, Keys key)
+        {
+            (nint keyCode, nint lParam) = GetKeyParameters(key);
+            User32.SendMessageW(control, User32.WM.KEYDOWN, keyCode, lParam);
+            User32.SendMessageW(control, User32.WM.KEYUP, keyCode, lParam);
+        }
+
+        private static (nint keyCode, nint lParam) GetKeyParameters(Keys key)
+        {
+            var keyCode = (nint)key;
+            var scanCode = (int)key;
+            const int repeatCount = 1;
+            nint lParam = PARAM.FromLowHighUnsigned(repeatCount, scanCode);
+            return (keyCode , lParam);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -2282,15 +2282,9 @@ namespace System.Windows.Forms.Tests
             comboBox.SelectedIndex = selectedIndex;
             comboBox.ResetEventsCount();
 
-            // https://docs.microsoft.com/windows/win32/inputdev/wm-keyup
-            // The MSDN page tells us what bits of lParam to use for each of the parameters.
-            // All we need to do is some bit shifting to assemble lParam.
-            nint keyCode = (nint)key;
-            nint lParam = 0x00000001 | keyCode << 16;
             for (int i = 0; i < expectedKeyPressesCount; i++)
             {
-                User32.SendMessageW(comboBox, User32.WM.KEYDOWN, keyCode, lParam);
-                User32.SendMessageW(comboBox, User32.WM.KEYUP, keyCode, lParam);
+                KeyboardSimulator.KeyPress(comboBox, key);
             }
 
             Assert.Equal(expectedKeyPressesCount, comboBox.EventsCount);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObjectTests.cs
@@ -759,44 +759,24 @@ namespace System.Windows.Forms.Tests
             Assert.True(listView.IsHandleCreated);
             Assert.NotEqual(IntPtr.Zero, listView.Handle);
 
-            // https://docs.microsoft.com/windows/win32/inputdev/wm-keyup
-            // The MSDN page tells us what bits of lParam to use for each of the parameters.
-            // All we need to do is some bit shifting to assemble lParam
-            // lParam = repeatCount | (scanCode << 16)
-            nint keyCode = (nint)Keys.Up;
-            nint lParam = 0x00000001 | keyCode << 16;
-            User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
-            User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
-
-            keyCode = (nint)Keys.Left;
-            lParam = 0x00000001 | keyCode << 16;
-            User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
-            User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
+            KeyboardSimulator.KeyPress(listView, Keys.Up);
+            KeyboardSimulator.KeyPress(listView, Keys.Left);
 
             Assert.Equal(ListViewGroupCollapsedState.Collapsed, listViewGroup.GetNativeCollapsedState());
             Assert.Equal(ExpandCollapseState.Collapsed, listViewGroup.AccessibilityObject.ExpandCollapseState);
 
-            keyCode = (nint)Keys.Left;
-            lParam = 0x00000001 | keyCode << 16;
-            User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
-            User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
+            KeyboardSimulator.KeyPress(listView, Keys.Left);
 
             // The second left key pressing should not change Collapsed state
             Assert.Equal(ListViewGroupCollapsedState.Collapsed, listViewGroup.GetNativeCollapsedState());
             Assert.Equal(ExpandCollapseState.Collapsed, listViewGroup.AccessibilityObject.ExpandCollapseState);
 
-            keyCode = (nint)Keys.Right;
-            lParam = 0x00000001 | keyCode << 16;
-            User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
-            User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
+            KeyboardSimulator.KeyPress(listView, Keys.Right);
 
             Assert.Equal(ListViewGroupCollapsedState.Expanded, listViewGroup.GetNativeCollapsedState());
             Assert.Equal(ExpandCollapseState.Expanded, listViewGroup.AccessibilityObject.ExpandCollapseState);
 
-            keyCode = (nint)Keys.Right;
-            lParam = 0x00000001 | keyCode << 16;
-            User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
-            User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
+            KeyboardSimulator.KeyPress(listView, Keys.Right);
 
             // The second right key pressing should not change Expanded state
             Assert.Equal(ListViewGroupCollapsedState.Expanded, listViewGroup.GetNativeCollapsedState());
@@ -829,12 +809,12 @@ namespace System.Windows.Forms.Tests
             listView.GroupCollapsedStateChanged += (_, e) => eventGroupIndices.Add(e.GroupIndex);
 
             // Navigate to the second group
-            SimulateKeyPress(Keys.Down);
+            KeyboardSimulator.KeyPress(listView, Keys.Down);
 
             if (firstGroupSate == ListViewGroupCollapsedState.Collapsed)
             {
                 // This action is necessary to navigate to the second group correctly in this specific case.
-                SimulateKeyPress(Keys.Up);
+                KeyboardSimulator.KeyPress(listView, Keys.Up);
             }
 
             // Simulate multiple selection of several groups to test a specific case,
@@ -844,7 +824,7 @@ namespace System.Windows.Forms.Tests
             item3.Selected = true;
 
             // Simulate the second group collapse action via keyboard.
-            SimulateKeyPress(Keys.Left);
+            KeyboardSimulator.KeyPress(listView, Keys.Left);
 
             Assert.Equal(firstGroupSate, group1.GetNativeCollapsedState());
             Assert.Equal(firstGroupSate, group1.CollapsedState);
@@ -862,18 +842,6 @@ namespace System.Windows.Forms.Tests
             // are still selected after keyboard navigation simulations.
             Assert.Equal(3, listView.SelectedItems.Count);
             Assert.True(listView.IsHandleCreated);
-
-            void SimulateKeyPress(Keys key)
-            {
-                // https://docs.microsoft.com/windows/win32/inputdev/wm-keyup
-                // The MSDN page tells us what bits of lParam to use for each of the parameters.
-                // All we need to do is some bit shifting to assemble lParam
-                // lParam = repeatCount | (scanCode << 16)
-                nint keyCode = (nint)key;
-                nint lParam = 0x00000001 | keyCode << 16;
-                User32.SendMessageW(listView, User32.WM.KEYDOWN, keyCode, lParam);
-                User32.SendMessageW(listView, User32.WM.KEYUP, keyCode, lParam);
-            }
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -4486,14 +4486,8 @@ namespace System.Windows.Forms.Tests
             item1.Selected = selectItems;
             item2.Selected = selectItems;
 
-            // https://docs.microsoft.com/windows/win32/inputdev/wm-keydown
-            // The MSDN page tells us what bits of lParam to use for each of the parameters.
-            // All we need to do is some bit shifting to assemble lParam
-            // lParam = repeatCount | (scanCode << 16)
-            uint keyCode = (uint)Keys.Space;
-            uint lParam = (0x00000001 | keyCode << 16);
+            KeyboardSimulator.KeyDown(control, Keys.Space);
 
-            User32.SendMessageW(control, User32.WM.KEYDOWN, (nint)keyCode, (nint)lParam);
             Assert.Equal(selectItems ? 2 : 0, control.SelectedItems.Count);
             Assert.Equal(!checkItem && selectItems && focusItem, item2.Checked);
         }
@@ -4517,15 +4511,8 @@ namespace System.Windows.Forms.Tests
             control.Groups.Add(group);
             control.CreateControl();
 
-            // https://docs.microsoft.com/windows/win32/inputdev/wm-keydown
-            // The MSDN page tells us what bits of lParam to use for each of the parameters.
-            // All we need to do is some bit shifting to assemble lParam
-            // lParam = repeatCount | (scanCode << 16)
-            uint keyCode = (uint)key;
-            uint lParam = (0x00000001 | keyCode << 16);
+            KeyboardSimulator.KeyDown(control, key);
 
-            // If control doesn't have selected items none will be focused.
-            User32.SendMessageW(control, User32.WM.KEYDOWN, (nint)keyCode, (nint)lParam);
             Assert.Empty(control.SelectedIndices);
             Assert.Null(control.FocusedItem);
             Assert.Null(control.FocusedGroup);
@@ -4562,14 +4549,9 @@ namespace System.Windows.Forms.Tests
 
                 item2.Selected = true;
 
-                // https://docs.microsoft.com/windows/win32/inputdev/wm-keydown
-                // The MSDN page tells us what bits of lParam to use for each of the parameters.
-                // All we need to do is some bit shifting to assemble lParam
-                // lParam = repeatCount | (scanCode << 16)
-                uint keyCode = (uint)(key_s == "Keys.Down" ? Keys.Down : Keys.Up);
-                uint lParam = (0x00000001 | keyCode << 16);
+                var key = key_s == "Keys.Down" ? Keys.Down : Keys.Up;
+                KeyboardSimulator.KeyDown(control, key);
 
-                User32.SendMessageW(control, User32.WM.KEYDOWN, (nint)keyCode, (nint)lParam);
                 Assert.False(control.GroupsEnabled);
                 Assert.True(control.Items.Count > 0);
                 int expectedGroupIndex = int.Parse(expectedGroupIndex_s);
@@ -4606,15 +4588,8 @@ namespace System.Windows.Forms.Tests
 
             control.CreateControl();
 
-            // https://docs.microsoft.com/windows/win32/inputdev/wm-keydown
-            // The MSDN page tells us what bits of lParam to use for each of the parameters.
-            // All we need to do is some bit shifting to assemble lParam
-            // lParam = repeatCount | (scanCode << 16)
-            uint keyCode = (uint)key;
-            uint lParam = (0x00000001 | keyCode << 16);
+            KeyboardSimulator.KeyDown(control, key);
 
-            // Actually ListView in VirtualMode can't have Groups
-            User32.SendMessageW(control, User32.WM.KEYDOWN, (nint)keyCode, (nint)lParam);
             Assert.Null(control.FocusedGroup);
         }
 
@@ -4648,15 +4623,8 @@ namespace System.Windows.Forms.Tests
             item2.Checked = false;
             control.FocusedItem = item1;
 
-            // https://docs.microsoft.com/windows/win32/inputdev/wm-keydown
-            // The MSDN page tells us what bits of lParam to use for each of the parameters.
-            // All we need to do is some bit shifting to assemble lParam
-            // lParam = repeatCount | (scanCode << 16)
-            uint keyCode = (uint)Keys.Space;
-            uint lParam = (0x00000001 | keyCode << 16);
+            KeyboardSimulator.KeyDown(control, Keys.Space);
 
-            // Actually ListView in VirtualMode doesn't check items here
-            User32.SendMessageW(control, User32.WM.KEYDOWN, (nint)keyCode, (nint)lParam);
             Assert.False(item2.Checked);
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7506


## Proposed changes

- Added KeyboardHelper class in System.Windows.Forms.TestUtilities project.
- Used this class instead of copy-pasted code in unit tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- It's a technical refactoring.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Unit tests



## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.5.22307.18


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7537)