### PR TITLE
Make wrapper explicit on IHandle<T>

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/IHandle.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/IHandle.cs
@@ -51,4 +51,16 @@ internal interface IHandle
 internal interface IHandle<THandle> where THandle : unmanaged
 {
     THandle Handle { get; }
+
+    /// <summary>
+    ///  Owner of the <see cref="Handle"/> that might close it when finalized. Default is the
+    ///  <see cref="IHandle{THandle}"/> implementer.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This allows decoupling the owner from the <typeparamref name="THandle"/> provider and avoids boxing when
+    ///   <see cref="IHandle{THandle}"/> is on a struct. See <see cref="HandleRef{THandle}"/> for a concrete usage.
+    ///  </para>
+    /// </remarks>
+    object? Wrapper => this;
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.BitBlt.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.BitBlt.cs
@@ -9,8 +9,8 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL BitBlt(
-            IHandle hdc,
+        public static BOOL BitBlt<T>(
+            in T hdc,
             int x,
             int y,
             int cx,
@@ -18,10 +18,10 @@ namespace Windows.Win32
             HDC hdcSrc,
             int x1,
             int y1,
-            ROP_CODE rop)
+            ROP_CODE rop) where T : IHandle<HDC>
         {
             BOOL result = BitBlt(
-                (HDC)hdc.Handle,
+                hdc.Handle,
                 x,
                 y,
                 cx,
@@ -30,20 +30,20 @@ namespace Windows.Win32
                 x1,
                 y1,
                 rop);
-            GC.KeepAlive(hdc);
+            GC.KeepAlive(hdc.Handle);
             return result;
         }
 
-        public static BOOL BitBlt(
+        public static BOOL BitBlt<T>(
             HDC hdc,
             int x,
             int y,
             int cx,
             int cy,
-            IHandle hdcSrc,
+            in T hdcSrc,
             int x1,
             int y1,
-            ROP_CODE rop)
+            ROP_CODE rop) where T : IHandle<HDC>
         {
             BOOL result = BitBlt(
                 hdc,
@@ -51,11 +51,11 @@ namespace Windows.Win32
                 y,
                 cx,
                 cy,
-                (HDC)hdcSrc.Handle,
+                hdcSrc.Handle,
                 x1,
                 y1,
                 rop);
-            GC.KeepAlive(hdcSrc);
+            GC.KeepAlive(hdcSrc.Handle);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetAncestor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetAncestor.cs
@@ -12,7 +12,7 @@ namespace Windows.Win32
         public static HWND GetAncestor<T>(in T hwnd, GET_ANCESTOR_FLAGS flags) where T : IHandle<HWND>
         {
             HWND result = GetAncestor(hwnd.Handle, flags);
-            GC.KeepAlive(hwnd);
+            GC.KeepAlive(hwnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetClientRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetClientRect.cs
@@ -8,10 +8,11 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL GetClientRect(IHandle hWnd, out RECT lpRect)
+        public static BOOL GetClientRect<T>(T hWnd, out RECT lpRect)
+            where T : IHandle<HWND>
         {
-            BOOL result = GetClientRect((HWND)hWnd.Handle, out lpRect);
-            GC.KeepAlive(hWnd);
+            BOOL result = GetClientRect(hWnd.Handle, out lpRect);
+            GC.KeepAlive(hWnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetParent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetParent.cs
@@ -11,7 +11,7 @@ namespace Windows.Win32
         public static HWND GetParent<T>(in T hwnd) where T : IHandle<HWND>
         {
             HWND result = GetParent(hwnd.Handle);
-            GC.KeepAlive(hwnd);
+            GC.KeepAlive(hwnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetSystemMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetSystemMenu.cs
@@ -12,7 +12,7 @@ namespace Windows.Win32
         public static HMENU GetSystemMenu<T>(in T hwnd, BOOL bRevert) where T : IHandle<HWND>
         {
             HMENU result = GetSystemMenu(hwnd.Handle, bRevert);
-            GC.KeepAlive(hwnd);
+            GC.KeepAlive(hwnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindow.cs
@@ -12,7 +12,7 @@ namespace Windows.Win32
         public static HWND GetWindow<T>(in T hWnd, GET_WINDOW_CMD uCmd) where T : IHandle<HWND>
         {
             HWND result = GetWindow(hWnd.Handle, uCmd);
-            GC.KeepAlive(hWnd);
+            GC.KeepAlive(hWnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowRect.cs
@@ -11,7 +11,7 @@ namespace Windows.Win32
         public static BOOL GetWindowRect<T>(in T hWnd, out RECT lpRect) where T : IHandle<HWND>
         {
             BOOL result = GetWindowRect(hWnd.Handle, out lpRect);
-            GC.KeepAlive(hWnd);
+            GC.KeepAlive(hWnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsChild.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsChild.cs
@@ -11,22 +11,22 @@ namespace Windows.Win32
         public static BOOL IsChild<T>(HWND hWndParent, T hWnd) where T : IHandle<HWND>
         {
             BOOL result = IsChild(hWndParent, hWnd.Handle);
-            GC.KeepAlive(hWnd);
+            GC.KeepAlive(hWnd.Wrapper);
             return result;
         }
 
         public static BOOL IsChild<T>(in T hWndParent, HWND hWnd) where T : IHandle<HWND>
         {
             BOOL result = IsChild(hWndParent.Handle, hWnd);
-            GC.KeepAlive(hWndParent);
+            GC.KeepAlive(hWndParent.Wrapper);
             return result;
         }
 
         public static BOOL IsChild<T>(in T hWndParent, T hWnd) where T : IHandle<HWND>
         {
             BOOL result = IsChild(hWndParent.Handle, hWnd.Handle);
-            GC.KeepAlive(hWndParent);
-            GC.KeepAlive(hWnd);
+            GC.KeepAlive(hWndParent.Wrapper);
+            GC.KeepAlive(hWnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindow.cs
@@ -11,7 +11,7 @@ namespace Windows.Win32
         public static BOOL IsWindow<T>(in T hWnd) where T : IHandle<HWND>
         {
             BOOL result = IsWindow(hWnd.Handle);
-            GC.KeepAlive(hWnd);
+            GC.KeepAlive(hWnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindowVisible.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindowVisible.cs
@@ -11,7 +11,7 @@ namespace Windows.Win32
         public static BOOL IsWindowVisible<T>(in T hWnd) where T : IHandle<HWND>
         {
             BOOL result = IsWindowVisible(hWnd.Handle);
-            GC.KeepAlive(hWnd);
+            GC.KeepAlive(hWnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MapWindowPoints.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MapWindowPoints.cs
@@ -23,7 +23,7 @@ namespace Windows.Win32
             fixed (void* p = &lpRect)
             {
                 int result = MapWindowPoints(hWndFrom.Handle, hWndTo, (POINT*)p, cPoints: 2);
-                GC.KeepAlive(hWndFrom);
+                GC.KeepAlive(hWndFrom.Wrapper);
                 return result;
             }
         }
@@ -34,7 +34,7 @@ namespace Windows.Win32
             fixed (void* p = &lpRect)
             {
                 int result = MapWindowPoints(hWndFrom, hWndTo.Handle, (POINT*)p, cPoints: 2);
-                GC.KeepAlive(hWndTo);
+                GC.KeepAlive(hWndTo.Wrapper);
                 return result;
             }
         }
@@ -54,7 +54,7 @@ namespace Windows.Win32
             fixed (void* p = &lpPoint)
             {
                 int result = MapWindowPoints(hWndFrom, hWndTo.Handle, (POINT*)p, cPoints: 1);
-                GC.KeepAlive(hWndTo);
+                GC.KeepAlive(hWndTo.Wrapper);
                 return result;
             }
         }
@@ -65,7 +65,7 @@ namespace Windows.Win32
             fixed (void* p = &lpPoint)
             {
                 int result = MapWindowPoints(hWndFrom.Handle, hWndTo, (POINT*)p, cPoints: 1);
-                GC.KeepAlive(hWndFrom);
+                GC.KeepAlive(hWndFrom.Wrapper);
                 return result;
             }
         }
@@ -76,8 +76,8 @@ namespace Windows.Win32
             fixed (void* p = &lpPoint)
             {
                 int result = MapWindowPoints(hWndFrom.Handle, hWndTo.Handle, (POINT*)p, cPoints: 1);
-                GC.KeepAlive(hWndFrom);
-                GC.KeepAlive(hWndTo);
+                GC.KeepAlive(hWndFrom.Wrapper);
+                GC.KeepAlive(hWndTo.Wrapper);
                 return result;
             }
         }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.PostMessage.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.PostMessage.cs
@@ -16,7 +16,7 @@ namespace Windows.Win32
            LPARAM lParam = default)
         {
             BOOL result = PostMessage(hWnd.Handle, (uint)Msg, wParam, lParam);
-            GC.KeepAlive(hWnd);
+            GC.KeepAlive(hWnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetActiveWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetActiveWindow.cs
@@ -11,7 +11,7 @@ namespace Windows.Win32
         public static HWND SetActiveWindow<T>(in T hWnd) where T : IHandle<HWND>
         {
             HWND result = SetActiveWindow(hWnd.Handle);
-            GC.KeepAlive(hWnd);
+            GC.KeepAlive(hWnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetFocus.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetFocus.cs
@@ -11,7 +11,7 @@ namespace Windows.Win32
         public static HWND SetFocus<T>(in T hWnd) where T : IHandle<HWND>
         {
             HWND result = SetFocus(hWnd.Handle);
-            GC.KeepAlive(hWnd);
+            GC.KeepAlive(hWnd.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetParent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetParent.cs
@@ -11,22 +11,22 @@ namespace Windows.Win32
         public static HWND SetParent<T>(in T hWndChild, HWND hWndNewParent) where T : IHandle<HWND>
         {
             HWND result = SetParent(hWndChild.Handle, hWndNewParent);
-            GC.KeepAlive(hWndChild);
+            GC.KeepAlive(hWndChild.Wrapper);
             return result;
         }
 
         public static HWND SetParent<T>(HWND hWndChild, in T hWndNewParent) where T : IHandle<HWND>
         {
             HWND result = SetParent(hWndChild, hWndNewParent.Handle);
-            GC.KeepAlive(hWndNewParent);
+            GC.KeepAlive(hWndNewParent.Wrapper);
             return result;
         }
 
         public static HWND SetParent<T>(in T hWndChild, in T hWndNewParent) where T : IHandle<HWND>
         {
             HWND result = SetParent(hWndChild.Handle, hWndNewParent.Handle);
-            GC.KeepAlive(hWndChild);
-            GC.KeepAlive(hWndNewParent);
+            GC.KeepAlive(hWndChild.Wrapper);
+            GC.KeepAlive(hWndNewParent.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms/src/GlobalUsings.cs
+++ b/src/System.Windows.Forms/src/GlobalUsings.cs
@@ -5,6 +5,7 @@
 global using Windows.Win32;
 global using Windows.Win32.UI.WindowsAndMessaging;
 global using Foundation = Windows.Win32.Foundation;
+global using Gdi = Windows.Win32.Graphics.Gdi;
 global using HWND = Windows.Win32.Foundation.HWND;
 global using LPARAM = Windows.Win32.Foundation.LPARAM;
 global using LRESULT = Windows.Win32.Foundation.LRESULT;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CachedItemHdcInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CachedItemHdcInfo.cs
@@ -7,17 +7,17 @@ using static Interop;
 
 namespace System.Windows.Forms
 {
-    internal class CachedItemHdcInfo : IDisposable, IHandle
+    internal class CachedItemHdcInfo : IDisposable, IHandle<Gdi.HDC>
     {
         internal CachedItemHdcInfo()
         {
         }
 
-        private Gdi32.HDC _cachedItemHDC;
+        private Gdi.HDC _cachedItemHDC;
         private Size _cachedHDCSize = Size.Empty;
         private Gdi32.HBITMAP _cachedItemBitmap;
 
-        public IntPtr Handle => (IntPtr)_cachedItemHDC;
+        public Gdi.HDC Handle => _cachedItemHDC;
 
         // this DC is cached and should only be deleted on Dispose or when the size changes.
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -17,7 +17,6 @@ using Windows.Win32.Graphics.Gdi;
 using static System.Windows.Forms.ComboBox.ObjectCollection;
 using static Interop;
 using static Interop.User32;
-using Gdi = Windows.Win32.Graphics.Gdi;
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -18,7 +18,6 @@ using System.Windows.Forms.Layout;
 using Microsoft.Win32;
 using static Interop;
 using Encoding = System.Text.Encoding;
-using Gdi = Windows.Win32.Graphics.Gdi;
 using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 
 namespace System.Windows.Forms

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -10,7 +10,6 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using static Interop;
-using Gdi = Windows.Win32.Graphics.Gdi;
 
 namespace System.Windows.Forms
 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -13,7 +13,6 @@ using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using static Interop;
 using static Windows.Win32.System.Memory.GLOBAL_ALLOC_FLAGS;
-using Gdi = Windows.Win32.Graphics.Gdi;
 using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 
 namespace System.Windows.Forms


### PR DESCRIPTION
With an explicit `IHandle<T>.Wrapper` we can avoid boxing when `IHandle<T>` is implmented on a struct and passing `IHandle<T>` to `GC.KeepAlive()`.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7554)