### PR TITLE
Change ReleaseUiaProvider method to set Accessibility object to null

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3245,13 +3245,13 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider(IntPtr handle)
         {
-            base.ReleaseUiaProvider(handle);
-
             if (IsAccessibilityObjectCreated)
             {
                 var uiaProvider = AccessibilityObject as ComboBoxAccessibleObject;
                 uiaProvider?.ResetListItemAccessibleObjects();
             }
+
+            base.ReleaseUiaProvider(handle);
         }
 
         private void ResetAutoCompleteCustomSource()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -10188,6 +10188,7 @@ namespace System.Windows.Forms
             if (OsVersion.IsWindows8OrGreater && IsAccessibilityObjectCreated)
             {
                 UiaCore.UiaDisconnectProvider(AccessibilityObject);
+                Properties.SetObject(s_accessibilityProperty, null);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -2102,8 +2102,8 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider(IntPtr handle)
         {
-            base.ReleaseUiaProvider(handle);
             ClearListItemAccessibleObjects();
+            base.ReleaseUiaProvider(handle);
         }
 
         private void RemoveListItemAccessibleObjectAt(int index)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3215,8 +3215,8 @@ namespace System.Windows.Forms
 
         private bool ClearingInnerListOnDispose
         {
-            get => _listViewState1 [LISTVIEWSTATE1_clearingInnerListOnDispose];
-            set => _listViewState1 [LISTVIEWSTATE1_clearingInnerListOnDispose] = value;
+            get => _listViewState1[LISTVIEWSTATE1_clearingInnerListOnDispose];
+            set => _listViewState1[LISTVIEWSTATE1_clearingInnerListOnDispose] = value;
         }
 
         /// <summary>
@@ -5131,8 +5131,6 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider(nint handle)
         {
-            base.ReleaseUiaProvider(handle);
-
             if (!OsVersion.IsWindows8OrGreater || !IsAccessibilityObjectCreated)
             {
                 return;
@@ -5157,6 +5155,8 @@ namespace System.Windows.Forms
             {
                 columnHeader.ReleaseUiaProvider();
             }
+
+            base.ReleaseUiaProvider(handle);
         }
 
         // makes sure that the list view items which are w/o a listView group are parented to the DefaultGroup - if necessary

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarAccessibleObject.cs
@@ -46,6 +46,7 @@ namespace System.Windows.Forms
                 {
                     HRESULT result = UiaCore.UiaDisconnectProvider(_calendarHeaderAccessibleObject);
                     Debug.Assert(result == 0);
+                    _calendarHeaderAccessibleObject = null;
                 }
 
                 if (_calendarBodyAccessibleObject is not null)
@@ -53,6 +54,7 @@ namespace System.Windows.Forms
                     _calendarBodyAccessibleObject.DisconnectChildren();
                     HRESULT result = UiaCore.UiaDisconnectProvider(_calendarBodyAccessibleObject);
                     Debug.Assert(result == 0);
+                    _calendarBodyAccessibleObject = null;
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
@@ -65,6 +65,9 @@ namespace System.Windows.Forms
                     HRESULT result = UiaCore.UiaDisconnectProvider(row);
                     Debug.Assert(result == 0);
                 }
+
+                _rowsAccessibleObjects.Clear();
+                _rowsAccessibleObjects = null;
             }
 
             internal void ClearChildCollection()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
@@ -117,6 +117,9 @@ namespace System.Windows.Forms
                     HRESULT result = UiaCore.UiaDisconnectProvider(cell);
                     Debug.Assert(result == 0);
                 }
+
+                _cellsAccessibleObjects.Clear();
+                _cellsAccessibleObjects = null;
             }
 
             public override string? Description

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -88,24 +88,28 @@ namespace System.Windows.Forms
                 {
                     HRESULT result = UiaCore.UiaDisconnectProvider(_previousButtonAccessibleObject);
                     Debug.Assert(result == 0);
+                    _previousButtonAccessibleObject = null;
                 }
 
                 if (_nextButtonAccessibleObject is not null)
                 {
                     HRESULT result = UiaCore.UiaDisconnectProvider(_nextButtonAccessibleObject);
                     Debug.Assert(result == 0);
+                    _nextButtonAccessibleObject = null;
                 }
 
                 if (_todayLinkAccessibleObject is not null)
                 {
                     HRESULT result = UiaCore.UiaDisconnectProvider(_todayLinkAccessibleObject);
                     Debug.Assert(result == 0);
+                    _todayLinkAccessibleObject = null;
                 }
 
                 if (_focusedCellAccessibleObject is not null)
                 {
                     HRESULT result = UiaCore.UiaDisconnectProvider(_focusedCellAccessibleObject);
                     Debug.Assert(result == 0);
+                    _focusedCellAccessibleObject = null;
                 }
 
                 if (_calendarsAccessibleObjects is null)
@@ -119,6 +123,9 @@ namespace System.Windows.Forms
                     HRESULT result = UiaCore.UiaDisconnectProvider(calendarAccessibleObject);
                     Debug.Assert(result == 0);
                 }
+
+                _calendarsAccessibleObjects.Clear();
+                _calendarsAccessibleObjects = null;
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabPage.cs
@@ -625,14 +625,14 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider(IntPtr handle)
         {
-            base.ReleaseUiaProvider(handle);
-
             if (_tabAccessibilityObject is not null && OsVersion.IsWindows8OrGreater)
             {
                 HRESULT result = UiaCore.UiaDisconnectProvider(_tabAccessibilityObject);
                 Debug.Assert(result == HRESULT.S_OK);
                 _tabAccessibilityObject = null;
             }
+
+            base.ReleaseUiaProvider(handle);
         }
 
         internal override void RemoveToolTip(ToolTip toolTip)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -185,8 +185,6 @@ namespace System.Windows.Forms
 
         internal override void ReleaseUiaProvider(IntPtr handle)
         {
-            base.ReleaseUiaProvider(handle);
-
             foreach (TreeNode rootNode in Nodes)
             {
                 foreach (TreeNode node in rootNode.GetSelfAndChildNodes())
@@ -194,6 +192,8 @@ namespace System.Windows.Forms
                     node.ReleaseUiaProvider();
                 }
             }
+
+            base.ReleaseUiaProvider(handle);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #7567


## Proposed changes

- Added Properties.SetObject(s_accessibilityProperty, null); in Control.ReleaseUiaProvider(IntPtr handle).


<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Less memory leaks

## Regression? 

- No

## Risk

-

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- CTI
- Unit tests
- Manual

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using AI, Inspect, Narrator



 

## Test environment(s) <!-- Remove any that don't apply -->

- NET 7.0 Preview 5
- Windows 10


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7569)