### PR TITLE
Adding contrast borders for a DataGridViewCheckBoxCell in Win11.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellRenderer.cs
@@ -21,9 +21,9 @@ namespace System.Windows.Forms
                 CheckBoxRenderer.DrawBackground(g, bounds, Rectangle.Truncate(g.ClipBounds));
 
                 // It uses because the checked style of the checkbox in a selected cell has a low contrast ratio with the background. Only for Windows 11.
-                // State 5 is selected, unfocused.
-                // State 6 is selected, focused.
-                if (OsVersion.IsWindows11_OrGreater && (state == 5 || state == 6))
+                const int StateSelectedUnfocused = 5;
+                const int StateSelectedFocused = 6;
+                if (OsVersion.IsWindows11_OrGreater && (state == StateSelectedUnfocused  || state ==StateSelectedFocused))
                 {
                     DrawContrastBorder(g, bounds);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCheckBoxCell.DataGridViewCheckBoxCellRenderer.cs
@@ -13,23 +13,35 @@ namespace System.Windows.Forms
         {
             private static VisualStyleRenderer? s_visualStyleRenderer;
 
-            public static VisualStyleRenderer CheckBoxRenderer
-            {
-                get
-                {
-                    if (s_visualStyleRenderer is null)
-                    {
-                        s_visualStyleRenderer = new VisualStyleRenderer(CheckBoxElement);
-                    }
-
-                    return s_visualStyleRenderer;
-                }
-            }
+            public static VisualStyleRenderer CheckBoxRenderer => s_visualStyleRenderer ??= new VisualStyleRenderer(CheckBoxElement);
 
             public static void DrawCheckBox(Graphics g, Rectangle bounds, int state)
             {
-                CheckBoxRenderer.SetParameters(CheckBoxElement.ClassName, CheckBoxElement.Part, (int)state);
+                CheckBoxRenderer.SetParameters(CheckBoxElement.ClassName, CheckBoxElement.Part, state);
                 CheckBoxRenderer.DrawBackground(g, bounds, Rectangle.Truncate(g.ClipBounds));
+
+                // It uses because the checked style of the checkbox in a selected cell has a low contrast ratio with the background. Only for Windows 11.
+                // State 5 is selected, unfocused.
+                // State 6 is selected, focused.
+                if (OsVersion.IsWindows11_OrGreater && (state == 5 || state == 6))
+                {
+                    DrawContrastBorder(g, bounds);
+                }
+            }
+
+            private static void DrawContrastBorder(Graphics g, Rectangle bounds)
+            {
+                const int penWidth = 1;
+                const int cornerRadius = 3;
+
+                var focusPen = new Pen(SystemColors.ControlText, penWidth);
+                var rectangleBounds = bounds with
+                {
+                    Width = bounds.Width - penWidth,
+                    Height = bounds.Height - penWidth
+                };
+
+                RoundedRectangle.Paint(g, focusPen, rectangleBounds, cornerRadius);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RoundedRectangle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RoundedRectangle.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+namespace System.Windows.Forms
+{
+    /// <summary>
+    ///  This class fully encapsulates the painting logic for a rounded rectangle. (Used by DataGridViewCheckBoxCell)
+    /// </summary>
+    internal static class RoundedRectangle
+    {
+        public static void Paint(Graphics graphics, Pen pen, Rectangle bounds, int cornerRadius)
+        {
+            if (graphics == null)
+                throw new ArgumentNullException(nameof(graphics));
+            if (pen == null)
+                throw new ArgumentNullException(nameof(pen));
+
+            using GraphicsPath path = CreatePath(bounds, cornerRadius);
+            graphics.DrawPath(pen, path);
+        }
+
+        private static GraphicsPath CreatePath(Rectangle bounds, int cornerRadius)
+        {
+            int diameter = cornerRadius * 2;
+            var size = new Size(diameter, diameter);
+            var arc = new Rectangle(bounds.Location, size);
+            var path = new GraphicsPath();
+
+            if (cornerRadius == 0)
+            {
+                path.AddRectangle(bounds);
+                return path;
+            }
+
+            // top left arc  
+            path.AddArc(arc, 180, 90);
+
+            // top right arc  
+            arc.X = bounds.Right - diameter;
+            path.AddArc(arc, 270, 90);
+
+            // bottom right arc  
+            arc.Y = bounds.Bottom - diameter;
+            path.AddArc(arc, 0, 90);
+
+            // bottom left arc 
+            arc.X = bounds.Left;
+            path.AddArc(arc, 90, 90);
+
+            path.CloseFigure();
+            return path;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6657 


## Proposed changes

- Added `RoundedRectangle` class which encapsulates the painting logic for a rounded rectangle.
- Used `RoundedRectangle` inside `DataGridViewCheckBoxCellRenderer` for Win11.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A user can see CheckBox inside DataGridView more clearly.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/184071575-346af970-8d27-46ff-bd72-ee33cfc126e8.png)

### After

![image](https://user-images.githubusercontent.com/109065597/184071596-27de1fb8-09df-43c8-9375-4dac606672ee.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- AI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- AI


 

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.5.22307.18


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7576)