### PR TITLE
Deprecate `WebBrowser`, `HtmlDocument` and associated types

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -38,4 +38,5 @@ The acceptance criteria for adding an obsoletion includes:
 |  __`WFDEV001`__ | Casting to/from IntPtr is unsafe, use `ResultInternal`. |
 |  __`WFDEV002`__ | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. |
 |  __`WFDEV003`__ | `DomainUpDown.DomainItemAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` items. |
+|  __`WFDEV004`__ | `WebBrowser`, `HtmlDocument` and associated types are deprecated. Consider WebView2 as replacement. |
 

--- a/src/Common/src/Obsoletions.cs
+++ b/src/Common/src/Obsoletions.cs
@@ -17,4 +17,7 @@ internal static class Obsoletions
 
     internal const string DomainItemAccessibleObjectMessage = $"{nameof(System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject)} is no longer used to provide accessible support for {nameof(System.Windows.Forms.DomainUpDown)} items.";
     internal const string DomainItemAccessibleObjectDiagnosticId = "WFDEV003";
+
+    internal const string WebBrowserMessage = $"{nameof(System.Windows.Forms.WebBrowser)}, {nameof(System.Windows.Forms.HtmlDocument)} and associated types are deprecated. Consider WebView2 as replacement.";
+    internal const string WebBrowserDiagnosticId = "WFDEV004";
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
@@ -14,6 +14,11 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms
 {
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public sealed partial class HtmlDocument
     {
         internal static object s_eventClick = new();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
@@ -12,6 +12,11 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms
 {
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public sealed partial class HtmlElement
     {
         internal static readonly object s_eventClick = new();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementCollection.cs
@@ -10,6 +10,11 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms
 {
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public sealed class HtmlElementCollection : ICollection
     {
         private readonly IHTMLElementCollection htmlElementCollection;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementErrorEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementErrorEventArgs.cs
@@ -7,6 +7,11 @@ namespace System.Windows.Forms
     /// <summary>
     ///  EventArgs for onerror event of HtmlElement
     /// </summary>
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public sealed class HtmlElementErrorEventArgs : EventArgs
     {
         private readonly string _urlString;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementErrorEventHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementErrorEventHandler.cs
@@ -7,5 +7,10 @@ namespace System.Windows.Forms
     /// <summary>
     ///  EventHandler for HtmlElementErrorEventArgs
     /// </summary>
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public delegate void HtmlElementErrorEventHandler(object? sender, HtmlElementErrorEventArgs e);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementEventArgs.cs
@@ -11,6 +11,11 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms
 {
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public sealed class HtmlElementEventArgs : EventArgs
     {
         private readonly HtmlShimManager _shimManager;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementEventHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementEventHandler.cs
@@ -4,5 +4,10 @@
 
 namespace System.Windows.Forms
 {
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public delegate void HtmlElementEventHandler(object? sender, HtmlElementEventArgs e);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementInsertionOrientation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElementInsertionOrientation.cs
@@ -4,6 +4,11 @@
 
 namespace System.Windows.Forms
 {
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public enum HtmlElementInsertionOrientation
     {
         BeforeBegin,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlHistory.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlHistory.cs
@@ -9,6 +9,11 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms
 {
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public sealed class HtmlHistory : IDisposable
     {
         private IOmHistory htmlHistory;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.cs
@@ -11,6 +11,11 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms
 {
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public sealed partial class HtmlWindow
     {
         internal static readonly object s_eventError = new();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindowCollection.cs
@@ -11,6 +11,11 @@ using static Interop.Mshtml;
 
 namespace System.Windows.Forms
 {
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public class HtmlWindowCollection : ICollection
     {
         private readonly IHTMLFramesCollection2 htmlFramesCollection2;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.WebBrowserSite.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.WebBrowserSite.cs
@@ -17,6 +17,11 @@ namespace System.Windows.Forms
         ///  Provides a default WebBrowserSite implementation for use in the CreateWebBrowserSite
         ///  method in the WebBrowser class.
         /// </summary>
+        [Obsolete(
+            Obsoletions.WebBrowserMessage,
+            error: false,
+            DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+            UrlFormat = Obsoletions.SharedUrlFormat)]
         protected class WebBrowserSite : WebBrowserSiteBase, IDocHostUIHandler
         {
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
@@ -21,7 +21,12 @@ namespace System.Windows.Forms
     [DefaultEvent(nameof(DocumentCompleted))]
     [Docking(DockingBehavior.AutoDock)]
     [SRDescription(nameof(SR.DescriptionWebBrowser))]
-    [Designer("System.Windows.Forms.Design.WebBrowserDesigner, " + AssemblyRef.SystemDesign)]
+    [Designer($"System.Windows.Forms.Design.WebBrowserDesigner, {AssemblyRef.SystemDesign}")]
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public partial class WebBrowser : WebBrowserBase
     {
         // Reference to the native ActiveX control's IWebBrowser2

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -31,7 +31,12 @@ namespace System.Windows.Forms
     /// </summary>
     [DefaultProperty(nameof(Name))]
     [DefaultEvent(nameof(Enter))]
-    [Designer("System.Windows.Forms.Design.AxDesigner, " + AssemblyRef.SystemDesign)]
+    [Designer($"System.Windows.Forms.Design.AxDesigner, {AssemblyRef.SystemDesign}")]
+    [Obsolete(
+            Obsoletions.WebBrowserMessage,
+            error: false,
+            DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+            UrlFormat = Obsoletions.SharedUrlFormat)]
     public partial class WebBrowserBase : Control
     {
         private WebBrowserHelper.AXState axState = WebBrowserHelper.AXState.Passive;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserDocumentCompletedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserDocumentCompletedEventArgs.cs
@@ -7,6 +7,11 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Provides data for the <see cref="WebBrowser.OnDocumentCompleted"/> event.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public class WebBrowserDocumentCompletedEventArgs : EventArgs
     {
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserDocumentCompletedEventHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserDocumentCompletedEventHandler.cs
@@ -7,5 +7,10 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Delegate to the WebBrowser DocumentCompleted event.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public delegate void WebBrowserDocumentCompletedEventHandler(object? sender, WebBrowserDocumentCompletedEventArgs e);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserEncryptionLevel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserEncryptionLevel.cs
@@ -8,6 +8,11 @@ namespace System.Windows.Forms
     ///  Specifies the EncryptionLevel of the document in the WebBrowser control.
     ///  Returned by the <see cref="WebBrowser.EncryptionLevel"/> property.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public enum WebBrowserEncryptionLevel
     {
         Insecure = 0,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserNavigatedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserNavigatedEventArgs.cs
@@ -7,6 +7,11 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Provides data for the <see cref="WebBrowser.OnNavigated"/> event.
     /// </summary>
+    [Obsolete(
+       Obsoletions.WebBrowserMessage,
+       error: false,
+       DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+       UrlFormat = Obsoletions.SharedUrlFormat)]
     public class WebBrowserNavigatedEventArgs : EventArgs
     {
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserNavigatedEventHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserNavigatedEventHandler.cs
@@ -7,5 +7,10 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Delegate to the WebBrowser Navigated event.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public delegate void WebBrowserNavigatedEventHandler(object? sender, WebBrowserNavigatedEventArgs e);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserNavigatingEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserNavigatingEventArgs.cs
@@ -9,6 +9,11 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Provides data for the <see cref="WebBrowser.OnNavigating"/> event.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public class WebBrowserNavigatingEventArgs : CancelEventArgs
     {
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserNavigatingEventHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserNavigatingEventHandler.cs
@@ -7,5 +7,10 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Delegate to the WebBrowser Navigating event.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public delegate void WebBrowserNavigatingEventHandler(object? sender, WebBrowserNavigatingEventArgs e);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserProgressChangedEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserProgressChangedEventArgs.cs
@@ -7,6 +7,11 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Provides data for the <see cref="WebBrowser.OnProgressChanged"/> event.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public class WebBrowserProgressChangedEventArgs : EventArgs
     {
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserProgressChangedEventHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserProgressChangedEventHandler.cs
@@ -7,5 +7,10 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Delegate to the WebBrowser ProgressChanged event.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public delegate void WebBrowserProgressChangedEventHandler(object? sender, WebBrowserProgressChangedEventArgs e);
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserReadyState.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserReadyState.cs
@@ -10,6 +10,11 @@ namespace System.Windows.Forms
     ///  Specifies the ReadyState of the WebBrowser control.
     ///  Returned by the <see cref="WebBrowser.ReadyState"/> property.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public enum WebBrowserReadyState
     {
         Uninitialized = Ole32.READYSTATE.UNINITIALIZED,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserRefreshOption.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserRefreshOption.cs
@@ -7,6 +7,11 @@ namespace System.Windows.Forms
     /// <summary>
     ///  Specifies the RefreshOptions in the <see cref="WebBrowser.Refresh(WebBrowserRefreshOption)"/> method.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public enum WebBrowserRefreshOption
     {
         Normal = 0,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserSiteBase.cs
@@ -25,6 +25,11 @@ namespace System.Windows.Forms
     ///  means that inheritors who want to override even a single method of one
     ///  of these interfaces will have to implement the whole interface.
     /// </summary>
+    [Obsolete(
+        Obsoletions.WebBrowserMessage,
+        error: false,
+        DiagnosticId = Obsoletions.WebBrowserDiagnosticId,
+        UrlFormat = Obsoletions.SharedUrlFormat)]
     public class WebBrowserSiteBase :
         IOleControlSite,
         IOleInPlaceSite,

--- a/src/System.Windows.Forms/tests/InteropTests/System.Windows.Forms.Interop.Tests.csproj
+++ b/src/System.Windows.Forms/tests/InteropTests/System.Windows.Forms.Interop.Tests.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>System.Windows.Forms.Interop.Tests</AssemblyName>
     <Platforms>x86;x64</Platforms>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>$(NoWarn);WFDEV004</NoWarn>
   </PropertyGroup>
 
   <Import Project="ProjectReference.targets" Sdk="Microsoft.DotNet.CMake.Sdk" />

--- a/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
+++ b/src/System.Windows.Forms/tests/UnitTests/System.Windows.Forms.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn),1573,1591,1712,WFDEV001</NoWarn>
+    <NoWarn>$(NoWarn),1573,1591,1712,WFDEV001,WFDEV004</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The WebBrowser control is based on IE Trident engine, which is almost universally unusable for general web browsing these days. It is also based on COM/ActiveX, which poses difficulties in trimming/native AOT scenarios.

Also, Internet Explorer 11 has been retired and is officially out of support as of 15 June 2022. Whilst the underlying Trident engine (mshtml.dll)  isn't being removed (yet?) from Windows, the general guidance is to use the modern replacement, which is WebView2 web browser control.

Resolves #6964


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7582)