### PR TITLE
Removed obsolete  `DomainUpDownAccessibleObject` usage

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -36,7 +36,7 @@ The acceptance criteria for adding an obsoletion includes:
 |  __`WFDEV001`__ | Casting to/from IntPtr is unsafe, use `WParamInternal`. |
 |  __`WFDEV001`__ | Casting to/from IntPtr is unsafe, use `LParamInternal`. |
 |  __`WFDEV001`__ | Casting to/from IntPtr is unsafe, use `ResultInternal`. |
-|  __`WFDEV002`__ | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. |
+|  __`WFDEV002`__ | `DomainUpDown.DomainUpDownAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` controls. Use `ControlAccessibleObject` instead. |
 |  __`WFDEV003`__ | `DomainUpDown.DomainItemAccessibleObject` is no longer used to provide accessible support for `DomainUpDown` items. |
 
 

--- a/src/Common/src/Obsoletions.cs
+++ b/src/Common/src/Obsoletions.cs
@@ -14,13 +14,11 @@ internal static class Obsoletions
     // and ensure the "aka.ms/dotnet-warnings/{0}" URL points to documentation for the obsoletion
     // The diagnostic ids reserved for obsoletions are WFDEV### (WFDEV001 - WFDEV999).
 
-#pragma warning disable WFDEV002 // Type or member is obsolete
-    internal const string DomainUpDownAccessibleObjectMessage = $"{nameof(DomainUpDown.DomainUpDownAccessibleObject)} is no longer used to provide accessible support for {nameof(DomainUpDown)} controls.";
-#pragma warning restore WFDEV002 // Type or member is obsolete
+    internal const string DomainUpDownAccessibleObjectMessage = $"DomainUpDownAccessibleObject is no longer used to provide accessible support for {nameof(DomainUpDown)} controls. Use {nameof(Control.ControlAccessibleObject)} instead.";
     internal const string DomainUpDownAccessibleObjectDiagnosticId = "WFDEV002";
 
 #pragma warning disable WFDEV003 // Type or member is obsolete
     internal const string DomainItemAccessibleObjectMessage = $"{nameof(DomainUpDown.DomainItemAccessibleObject)} is no longer used to provide accessible support for {nameof(DomainUpDown)} items.";
-#pragma warning disable WFDEV003 // Type or member is obsolete
+#pragma warning restore WFDEV003 // Type or member is obsolete
     internal const string DomainItemAccessibleObjectDiagnosticId = "WFDEV003";
 }

--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -2718,7 +2718,6 @@ override System.Windows.Forms.Design.WindowsFormsComponentEditor.EditComponent(S
 override System.Windows.Forms.DockingAttribute.Equals(object? obj) -> bool
 override System.Windows.Forms.DockingAttribute.GetHashCode() -> int
 override System.Windows.Forms.DockingAttribute.IsDefaultAttribute() -> bool
-override System.Windows.Forms.DomainUpDown.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Name.get -> string?
 override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Name.set -> void
 override System.Windows.Forms.DomainUpDown.DomainItemAccessibleObject.Parent.get -> System.Windows.Forms.AccessibleObject?

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -9,3 +9,4 @@ override System.Windows.Forms.MaskedTextBox.OnGotFocus(System.EventArgs! e) -> v
 override System.Windows.Forms.MaskedTextBox.OnMouseDown(System.Windows.Forms.MouseEventArgs! e) -> void
 override System.Windows.Forms.TextBox.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 virtual System.Windows.Forms.AxHost.State.Dispose(bool disposing) -> void
+*REMOVED*override System.Windows.Forms.DomainUpDown.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.DomainUpDownAccessibleObject.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete(
             Obsoletions.DomainUpDownAccessibleObjectMessage,
-            error: false,
+            error: true,
             DiagnosticId = Obsoletions.DomainUpDownAccessibleObjectDiagnosticId,
             UrlFormat = Obsoletions.SharedUrlFormat)]
         public class DomainUpDownAccessibleObject : ControlAccessibleObject

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DomainUpDown.cs
@@ -208,15 +208,6 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  Constructs the new instance of the accessibility object for this control. Subclasses
-        ///  should not call base.CreateAccessibilityObject.
-        /// </summary>
-        protected override AccessibleObject CreateAccessibilityInstance()
-#pragma warning disable WFDEV002 // Type or member is obsolete
-            => new DomainUpDownAccessibleObject(this);
-#pragma warning restore WFDEV002 // Type or member is obsolete
-
-        /// <summary>
         ///  Displays the next item in the object collection.
         /// </summary>
         public override void DownButton()


### PR DESCRIPTION
Fixes #7587 

## Proposed changes

- Remove `DomainUpDownAccessibleObject` usage as an accessible object for `DomainUpDown` because this class is obsolete now
- Promote obsoletion from warning to error

![A screenshot of Visual Studio editor window demonstrating that using DomainUpDownAccessibleObject is generating a compilation error](https://user-images.githubusercontent.com/102954094/200868475-689eb725-a225-4f4d-8f31-ba2681969ea9.png)


## Customer Impact

- If customer used `DomainUpDownAccessibleObject` in their code, they would have to change it to `ControlAccessibleObject` or `AccessibleObject`. Otherwise, no impact.

## Regression? 

- No

## Risk

- Minimal

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0 RC1
- Windows 11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7584)