### PR TITLE
Updating Microsoft.CodeAnalysis.*.Testing.XUnit Packages version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -89,7 +89,7 @@
     <MicrosoftCodeAnalysisCSharpPackageVersion>4.2.0</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesVersion>4.0.0-2.final</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftCodeAnalysisVisualBasicWorkspacesVersion>4.0.0-2.final</MicrosoftCodeAnalysisVisualBasicWorkspacesVersion>
-    <MicrosoftCodeAnalysisPackagesVersion>1.1.2-beta1.22403.2</MicrosoftCodeAnalysisPackagesVersion>
+    <MicrosoftCodeAnalysisPackagesVersion>1.1.2-beta1.22415.2</MicrosoftCodeAnalysisPackagesVersion>
     <MicrosoftCodeAnalysisPublicApiAnalyzers>3.3.0-beta1.final</MicrosoftCodeAnalysisPublicApiAnalyzers>
     <!--
       TODO: Remove pinned version once arcade supplies a compiler that enables the repo to compile.


### PR DESCRIPTION
This change is an addendum to commit: https://github.com/dotnet/winforms/pull/7571

Roslyn team has provided newer version of Microsoft.CodeAnalysis.*.Testing.XUnit packages which consume newer version of Newtonsoft.Json v13.0.1.




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7598)