### PR TITLE
Skipping disabled items from ToolStrip.

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -3483,7 +3483,6 @@ override System.Windows.Forms.ToolStrip.ToolStripAccessibleObject.GetChildCount(
 override System.Windows.Forms.ToolStrip.ToolStripAccessibleObject.HitTest(int x, int y) -> System.Windows.Forms.AccessibleObject?
 override System.Windows.Forms.ToolStrip.ToolStripAccessibleObject.Role.get -> System.Windows.Forms.AccessibleRole
 override System.Windows.Forms.ToolStrip.WndProc(ref System.Windows.Forms.Message m) -> void
-override System.Windows.Forms.ToolStripButton.CanSelect.get -> bool
 override System.Windows.Forms.ToolStripButton.DefaultAutoToolTip.get -> bool
 override System.Windows.Forms.ToolStripButton.GetPreferredSize(System.Drawing.Size constrainingSize) -> System.Drawing.Size
 override System.Windows.Forms.ToolStripComboBox.BackgroundImageLayout.get -> System.Windows.Forms.ImageLayout

--- a/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 System.Windows.Forms.PrintPreviewControl.TabStop.get -> bool
 System.Windows.Forms.PrintPreviewControl.TabStop.set -> void
 System.Windows.Forms.PrintPreviewControl.TabStopChanged -> System.EventHandler?
+*REMOVED* override System.Windows.Forms.ToolStripButton.CanSelect.get -> bool

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.cs
@@ -57,8 +57,6 @@ namespace System.Windows.Forms
             set => base.AutoToolTip = value;
         }
 
-        public override bool CanSelect => true;
-
         [DefaultValue(false)]
         [SRCategory(nameof(SR.CatBehavior))]
         [SRDescription(nameof(SR.ToolStripButtonCheckOnClickDescr))]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -616,7 +616,7 @@ namespace System.Windows.Forms
         ///  Determines whether or not the item can be selected.
         /// </summary>
         [Browsable(false)]
-        public virtual bool CanSelect => true;
+        public virtual bool CanSelect => Enabled;
 
         /// <remarks>
         ///  Usually the same as can select, but things like the control box in an MDI window are exceptions

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
@@ -1059,9 +1059,9 @@ namespace System.Windows.Forms.Tests
         [InlineData(true, CheckState.Checked, AccessibleStates.Focusable | AccessibleStates.Checked)]
         [InlineData(true, CheckState.Indeterminate, AccessibleStates.Focusable | AccessibleStates.Checked)]
         [InlineData(true, CheckState.Unchecked, AccessibleStates.Focusable)]
-        [InlineData(false, CheckState.Checked, AccessibleStates.Unavailable)]
-        [InlineData(false, CheckState.Indeterminate, AccessibleStates.Unavailable)]
-        [InlineData(false, CheckState.Unchecked, AccessibleStates.Unavailable)]
+        [InlineData(false, CheckState.Checked, AccessibleStates.None)]
+        [InlineData(false, CheckState.Indeterminate, AccessibleStates.None)]
+        [InlineData(false, CheckState.Unchecked, AccessibleStates.None)]
         public void ToolStripButton_CreateAccessibilityInstance_InvokeChecked_ReturnsExpected(bool enabled, CheckState checkState, AccessibleStates expectedState)
         {
             using var item = new SubToolStripButton
@@ -1078,7 +1078,7 @@ namespace System.Windows.Forms.Tests
 
         [WinFormsTheory]
         [InlineData(true, AccessibleStates.Focused | AccessibleStates.HotTracked | AccessibleStates.Focusable)]
-        [InlineData(false, AccessibleStates.Unavailable | AccessibleStates.Focused)]
+        [InlineData(false, AccessibleStates.None)]
         public void ToolStripButton_CreateAccessibilityInstance_InvokeSelected_ReturnsExpected(bool enabled, AccessibleStates expectedState)
         {
             using var item = new SubToolStripButton
@@ -1086,7 +1086,7 @@ namespace System.Windows.Forms.Tests
                 Enabled = enabled
             };
             item.Select();
-            Assert.True(item.Selected);
+            Assert.Equal(item.CanSelect, item.Selected);
 
             ToolStripItem.ToolStripItemAccessibleObject accessibleObject = Assert.IsAssignableFrom<ToolStripItem.ToolStripItemAccessibleObject>(item.CreateAccessibilityInstance());
             Assert.Equal(AccessibleRole.PushButton, accessibleObject.Role);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
@@ -14273,11 +14273,11 @@ namespace System.Windows.Forms.Tests
             };
 
             item.Select();
-            Assert.True(item.Selected);
+            Assert.Equal(item.CanSelect, item.Selected);
 
             // Select again.
             item.Select();
-            Assert.True(item.Selected);
+            Assert.Equal(item.CanSelect, item.Selected);
         }
 
         public static IEnumerable<object[]> Select_WithoutToolStripItemAccessibleObject_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -5792,7 +5792,7 @@ namespace System.Windows.Forms.Tests
             toolStrip.SetDisplayedItems();
 
             toolStrip.OnMouseMove(new MouseEventArgs(MouseButtons.Left, 1, item.Bounds.X, item.Bounds.Y, 0));
-            Assert.True(item.Selected);
+            Assert.Equal(item.CanSelect, item.Selected);
 
             toolStrip.OnMouseLeave(new EventArgs());
             Assert.False(item.Selected);


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7601 


## Proposed changes

- Disabled the `CanSelect` property of a `ToolStripItem` when the `Enabled` property is `false`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Narrator won't announce disabled items from a `ToolStrip`.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![185018404-40cb63ea-fadd-424f-95da-1788e66a4ad9](https://user-images.githubusercontent.com/109065597/185376042-e404033f-6303-4489-890d-18d7479d67e2.gif)

### After

![ab88wUSCpy](https://user-images.githubusercontent.com/109065597/185375687-ae93cc35-66d2-4431-94e5-1a4e9fdb35da.gif)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Narrator

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Narrator


 

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.7.22377.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7611)