### PR TITLE
Fix KeyNotFoundException in KeysConverter.ConvertFrom

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeysConverter.cs
@@ -177,9 +177,12 @@ namespace System.Windows.Forms
 
                     for (int i = 0; i < tokens.Length; i++)
                     {
-                        Keys obj = KeyNames[tokens[i]];
-
-                        Keys currentKey = (Keys)obj;
+                        if (!KeyNames.TryGetValue(tokens[i], out Keys currentKey))
+                        {
+                            // Key was not found in our dictionary.  See if it is a valid value in
+                            // the Keys enum.
+                            currentKey = (Keys)Enum.Parse(typeof(Keys), tokens[i]);
+                        }
 
                         if ((currentKey & Keys.KeyCode) != 0)
                         {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/KeysConverterTests.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class KeysConverterTests
+    {
+        [Theory]
+        [InlineData("Ctrl + N", Keys.Control | Keys.N)]
+        [InlineData("G", Keys.G)]
+        public void ConvertFrom_ShouldConvertKeys(string input, Keys keys)
+        {
+            KeysConverter converter = new();
+
+            var result = (Keys)converter.ConvertFrom(input);
+
+            Assert.Equal(keys, result);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #7610

## Proposed changes

- Add test for regression.
- Use `TryGetValue` and `Enum.Parse` instead of Dictionary indexer. The changes resemble the state of the code before #6448.

## Customer Impact

- `new KeysConverter().ConvertFrom("Ctrl + N")` throws KeyNotFoundException.

## Regression? 

- Yes

## Risk

- Low

## Test methodology

- Added test


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7632)