### PR TITLE
Fixing text's color of DataGridViewComboBoxCell and DataGridViewTextBoxCell

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -2135,7 +2135,7 @@ namespace System.Windows.Forms
 
                     if (_defaultCellStyle.ForeColor == Color.Empty)
                     {
-                        defaultCellStyleTmp.ForeColor = base.ForeColor;
+                        defaultCellStyleTmp.ForeColor = SystemInformation.HighContrast ? DefaultForeBrush.Color : base.ForeColor;
                         _dataGridViewState1[State1_AmbientForeColor] = true;
                     }
 
@@ -2202,7 +2202,7 @@ namespace System.Windows.Forms
                 DataGridViewCellStyle defaultCellStyle = new DataGridViewCellStyle
                 {
                     BackColor = s_defaultBackColor,
-                    ForeColor = base.ForeColor,
+                    ForeColor = SystemInformation.HighContrast ? DefaultForeBrush.Color : base.ForeColor,
                     SelectionBackColor = DefaultSelectionBackBrush.Color,
                     SelectionForeColor = DefaultSelectionForeBrush.Color,
                     Font = base.Font,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewComboBoxCell.cs
@@ -2450,7 +2450,7 @@ namespace System.Windows.Forms
                                 }
 
                                 Color textColor;
-                                if (paintPostXPThemes && (drawDropDownButton || drawComboBox))
+                                if (paintPostXPThemes && (drawDropDownButton || drawComboBox) && !SystemInformation.HighContrast)
                                 {
                                     textColor = DataGridViewComboBoxCellRenderer.VisualStyleRenderer.GetColor(ColorProperty.TextColor);
                                 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DataGridViewTest.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/DataGridViewTest.Designer.cs
@@ -41,6 +41,7 @@ namespace WinformsControlsTest
             this.column4 = new System.Windows.Forms.DataGridViewComboBoxColumn();
             this.column5 = new System.Windows.Forms.DataGridViewComboBoxColumn();
             this.column6 = new System.Windows.Forms.DataGridViewImageColumn();
+            this.column7 = new System.Windows.Forms.DataGridViewButtonColumn();
             this.currentDPILabel1 = new WinformsControlsTest.CurrentDPILabel();
             this.changeFontButton = new System.Windows.Forms.Button();
             this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
@@ -67,7 +68,8 @@ namespace WinformsControlsTest
             this.column5,
             this.column3,
             this.column4,
-            this.column6});
+            this.column6,
+            this.column7 });
             dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Info;
             dataGridViewCellStyle3.Font = new System.Drawing.Font("Consolas", 8.25F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point, ((byte)(204)));
@@ -80,7 +82,7 @@ namespace WinformsControlsTest
             | System.Windows.Forms.AnchorStyles.Right)));
             this.dataGridView1.Location = new System.Drawing.Point(0, 0);
             this.dataGridView1.Name = "dataGridView1";
-            this.dataGridView1.Size = new System.Drawing.Size(492, 150);
+            this.dataGridView1.Size = new System.Drawing.Size(692, 150);
             this.dataGridView1.TabIndex = 0;
             // 
             // column1
@@ -102,6 +104,8 @@ namespace WinformsControlsTest
             // 
             this.column4.HeaderText = "Column4";
             this.column4.Name = "column4";
+            this.column4.Items.AddRange(new[] {"First", "Second"});
+            this.column4.AutoComplete = true;
             // 
             // column5
             // 
@@ -113,6 +117,13 @@ namespace WinformsControlsTest
             // 
             this.column6.HeaderText = "Column6";
             this.column6.Name = "column6";
+            // 
+            // column7
+            // 
+            this.column7.HeaderText = "Column7";
+            this.column7.Name = "column7";
+            this.column7.Text = "Button";
+            this.column7.UseColumnTextForButtonValue = true;
             // 
             // currentDPILabel1
             // 
@@ -188,7 +199,7 @@ namespace WinformsControlsTest
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(492, 272);
+            this.ClientSize = new System.Drawing.Size(692, 272);
             this.Controls.Add(this.resetFontButton);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.numericUpDown1);
@@ -214,6 +225,7 @@ namespace WinformsControlsTest
         private System.Windows.Forms.DataGridViewComboBoxColumn column4;
         private System.Windows.Forms.DataGridViewComboBoxColumn column5;
         private System.Windows.Forms.DataGridViewImageColumn column6;
+        private System.Windows.Forms.DataGridViewButtonColumn column7;
         private WinformsControlsTest.CurrentDPILabel currentDPILabel1;
         private System.Windows.Forms.Button changeFontButton;
         private System.Windows.Forms.NumericUpDown numericUpDown1;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/app.manifest
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/app.manifest
@@ -39,7 +39,7 @@
       <!-- Windows 8.1 -->
       <!--<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />-->
 
-      <!-- Windows 10 -->
+      <!-- Windows 10, Windows 11, Windows Server 2016, Windows Server 2019 and Windows Server 2022 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
 
     </application>


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #1953


## Proposed changes

- Used correct colors to Text when HC is on.
- Improved test application to check ComboBox with values and Button inside DGV.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Text inside DGV controls looks like same controls outside. They become more clear.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/186107017-ff210f4b-126d-4b80-be7b-dc52a694a777.png)

### After

![image](https://user-images.githubusercontent.com/109065597/186107093-20589e1e-3808-48b8-bfe3-c1022b70b7a4.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual using HC theme

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- High contrast


 

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.7.22377.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7644)