### PR TITLE
added support of C#11 to templates

### DIFF
--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsApplication-CSharp/.template.config/template.json
@@ -85,7 +85,7 @@
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(|10\\.0|10|11.\\0|11|preview|latest|default|latestMajor)$",
         "source": "langVersion"
       }
     },

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsControlLibrary-CSharp/.template.config/template.json
@@ -85,7 +85,7 @@
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(|10\\.0|10|11.\\0|11|preview|latest|default|latestMajor)$",
         "source": "langVersion"
       }
     },

--- a/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
+++ b/pkg/Microsoft.Dotnet.WinForms.ProjectTemplates/content/WinFormsLibrary-CSharp/.template.config/template.json
@@ -85,7 +85,7 @@
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(|10\\.0|10|11.\\0|11|preview|latest|default|latestMajor)$",
         "source": "langVersion"
       }
     },


### PR DESCRIPTION
## Problem
In the templates, the generators which determine minimum language version in use were not considering C#11. 
Fixed regex to support it.

## Customer impact 
Without this fix, using C# 11.0 via `--langVersion` option will result in old style template (no top level statements, file scoped namespaces, implicit usings)

## Testing
Automated

## Risk
Very low. 
Language version option is only available in CLI and not exposed in Visual Studio.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7645)