### PR TITLE
Adding AccessibleObject for ListViewItem's image

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -307,7 +307,8 @@ namespace System.Windows.Forms
                     {
                         return _owningListView.View switch
                         {
-                            View.Details => hitTestInfo.SubItem.AccessibilityObject,
+                            View.Details => ((ListViewItem.ListViewItemDetailsAccessibleObject)hitTestInfo.Item.AccessibilityObject)
+                                .GetChild(hitTestInfo.SubItem.Index, point),
 
                             // Only additional ListViewSubItem are displayed in the accessibility tree if the ListView
                             // in the "Tile" view (the first ListViewSubItem is responsible for the ListViewItem)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -51,6 +51,8 @@ namespace System.Windows.Forms
             internal int CurrentIndex
                 => _owningItem.Index;
 
+            internal virtual int FirstSubItemIndex => 0;
+
             internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
                 => _owningListView.AccessibilityObject;
 
@@ -197,7 +199,7 @@ namespace System.Windows.Forms
                     _ => base.GetPropertyValue(propertyID)
                 };
 
-            internal virtual Rectangle GetSubItemBounds(int subItemIndex) => Rectangle.Empty;
+            internal virtual Rectangle GetSubItemBounds(int index) => Rectangle.Empty;
 
             internal override int[] RuntimeId
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -11,12 +11,26 @@ namespace System.Windows.Forms
     {
         internal class ListViewItemDetailsAccessibleObject : ListViewItemBaseAccessibleObject
         {
+            private const int ImageAccessibleObjectIndex = 0;
             private readonly Dictionary<int, AccessibleObject> _listViewSubItemAccessibleObjects;
 
             public ListViewItemDetailsAccessibleObject(ListViewItem owningItem) : base(owningItem)
             {
                 _listViewSubItemAccessibleObjects = new Dictionary<int, AccessibleObject>();
             }
+
+            internal override int FirstSubItemIndex => HasImage ? 1 : 0;
+
+            private bool HasImage => _owningItem.ImageIndex != ImageList.Indexer.DefaultIndex;
+
+            private int LastChildIndex => HasImage ? _owningListView.Columns.Count : _owningListView.Columns.Count - 1;
+
+            /// <summary>
+            ///  Converts the provided index of the <see cref="AccessibleObject"/>'s child to an index of a <see cref="ListViewSubItem"/>.
+            /// </summary>
+            /// <param name="accessibleChildIndex">The index of the child <see cref="AccessibleObject"/>.</param>
+            /// <returns>The index of an owning <see cref="ListViewSubItem"/>'s object.</returns>
+            private int AccessibleChildToSubItemIndex(int accessibleChildIndex) => HasImage ? accessibleChildIndex - 1 : accessibleChildIndex;
 
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
@@ -25,24 +39,24 @@ namespace System.Windows.Forms
                     case UiaCore.NavigateDirection.FirstChild:
                         return GetChild(0);
                     case UiaCore.NavigateDirection.LastChild:
-                        return GetChild(_owningListView.Columns.Count - 1);
+                        return GetChild(LastChildIndex);
                 }
 
                 return base.FragmentNavigate(direction);
             }
 
-            // If the ListView does not support ListViewSubItems, the index is greater than the number of columns
-            // or the index is negative, then we return null
-            public override AccessibleObject? GetChild(int index)
+            public override AccessibleObject? GetChild(int accessibleChildIndex)
             {
                 if (_owningListView.View != View.Details)
                 {
                     throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewException, nameof(View.Details)));
                 }
 
-                return !_owningListView.SupportsListViewSubItems || _owningListView.Columns.Count <= index || index < 0
+                // If the ListView does not support ListViewSubItems, the accessibleChildIndex is greater than the number of columns
+                // or the accessibleChildIndex is negative, then we return null
+                return !_owningListView.SupportsListViewSubItems || accessibleChildIndex > LastChildIndex || accessibleChildIndex < 0
                     ? null
-                    : GetDetailsSubItemOrFake(index);
+                    : GetDetailsSubItemOrFakeInternal(accessibleChildIndex);
             }
 
             public override int GetChildCount()
@@ -54,14 +68,22 @@ namespace System.Windows.Forms
 
                 return !_owningListView.IsHandleCreated || !_owningListView.SupportsListViewSubItems
                     ? -1
-                    : _owningListView.Columns.Count;
+                    : LastChildIndex + 1;
             }
 
             internal override int GetChildIndex(AccessibleObject? child)
             {
-                if (child is null
-                    || !_owningListView.SupportsListViewSubItems
-                    || child is not ListViewSubItem.ListViewSubItemAccessibleObject subItemAccessibleObject)
+                if (child is null || !_owningListView.SupportsListViewSubItems)
+                {
+                    return InvalidIndex;
+                }
+
+                if (child is ListViewItemImageAccessibleObject)
+                {
+                    return ImageAccessibleObjectIndex;
+                }
+
+                if (child is not ListViewSubItem.ListViewSubItemAccessibleObject subItemAccessibleObject)
                 {
                     return InvalidIndex;
                 }
@@ -71,8 +93,9 @@ namespace System.Windows.Forms
                     return GetFakeSubItemIndex(subItemAccessibleObject);
                 }
 
-                int index = _owningItem.SubItems.IndexOf(subItemAccessibleObject.OwningSubItem);
-                return index > _owningListView.Columns.Count - 1 ? InvalidIndex : index;
+                int subItemIndex = _owningItem.SubItems.IndexOf(subItemAccessibleObject.OwningSubItem);
+                int accessibleChildIndex = SubItemToAccessibleChildIndex(subItemIndex);
+                return accessibleChildIndex > LastChildIndex ? InvalidIndex : accessibleChildIndex;
             }
 
             // This method returns an accessibility object for an existing ListViewSubItem, or creates a fake one
@@ -80,25 +103,44 @@ namespace System.Windows.Forms
             // when there is no ListViewSubItem, but the cell for it is displayed and the user can interact with it.
             internal AccessibleObject? GetDetailsSubItemOrFake(int subItemIndex)
             {
+                int accessibleChildIndex = SubItemToAccessibleChildIndex(subItemIndex);
+                return GetDetailsSubItemOrFakeInternal(accessibleChildIndex);
+            }
+
+            private AccessibleObject? GetDetailsSubItemOrFakeInternal(int accessibleChildIndex)
+            {
+                if (accessibleChildIndex == ImageAccessibleObjectIndex && HasImage)
+                {
+                    if (_listViewSubItemAccessibleObjects.ContainsKey(accessibleChildIndex))
+                    {
+                        return _listViewSubItemAccessibleObjects[accessibleChildIndex];
+                    }
+
+                    ListViewItemImageAccessibleObject imageAccessibleObject = new(_owningItem);
+                    _listViewSubItemAccessibleObjects.Add(accessibleChildIndex, imageAccessibleObject);
+                    return imageAccessibleObject;
+                }
+
+                int subItemIndex = AccessibleChildToSubItemIndex(accessibleChildIndex);
                 if (subItemIndex < _owningItem.SubItems.Count)
                 {
-                    _listViewSubItemAccessibleObjects.Remove(subItemIndex);
+                    _listViewSubItemAccessibleObjects.Remove(accessibleChildIndex);
 
                     return _owningItem.SubItems[subItemIndex].AccessibilityObject;
                 }
 
-                if (_listViewSubItemAccessibleObjects.ContainsKey(subItemIndex))
+                if (_listViewSubItemAccessibleObjects.ContainsKey(accessibleChildIndex))
                 {
-                    return _listViewSubItemAccessibleObjects[subItemIndex];
+                    return _listViewSubItemAccessibleObjects[accessibleChildIndex];
                 }
 
                 ListViewSubItem.ListViewSubItemAccessibleObject fakeAccessibleObject = new(owningSubItem: null, _owningItem);
-                _listViewSubItemAccessibleObjects.Add(subItemIndex, fakeAccessibleObject);
+                _listViewSubItemAccessibleObjects.Add(accessibleChildIndex, fakeAccessibleObject);
                 return fakeAccessibleObject;
             }
 
-            // This method is required to get the index of the fake accessibility object. Since the fake accessibility object
-            // has no ListViewSubItem from which we could get an index, we have to get its index from the dictionary
+            // This method is required to get the accessibleChildIndex of the fake accessibility object. Since the fake accessibility object
+            // has no ListViewSubItem from which we could get an accessibleChildIndex, we have to get its accessibleChildIndex from the dictionary
             private int GetFakeSubItemIndex(ListViewSubItem.ListViewSubItemAccessibleObject fakeAccessibleObject)
             {
                 foreach (KeyValuePair<int, AccessibleObject> keyValuePair in _listViewSubItemAccessibleObjects)
@@ -112,9 +154,9 @@ namespace System.Windows.Forms
                 return -1;
             }
 
-            internal override Rectangle GetSubItemBounds(int subItemIndex)
+            internal override Rectangle GetSubItemBounds(int accessibleChildIndex)
                 => _owningListView.IsHandleCreated
-                    ? _owningListView.GetSubItemRect(_owningItem.Index, subItemIndex)
+                    ? _owningListView.GetSubItemRect(_owningItem.Index, AccessibleChildToSubItemIndex(accessibleChildIndex))
                     : Rectangle.Empty;
 
             /// <devdoc>
@@ -131,6 +173,13 @@ namespace System.Windows.Forms
 
                 _listViewSubItemAccessibleObjects.Clear();
             }
+
+            /// <summary>
+            ///  Converts the provided index of a <see cref="ListViewSubItem"/> to an index of the <see cref="AccessibleObject"/>'s child.
+            /// </summary>
+            /// <param name="subItemIndex">The index of an owning <see cref="ListViewSubItem"/>'s object.</param>
+            /// <returns>The index of the child <see cref="AccessibleObject"/>.</returns>
+            private int SubItemToAccessibleChildIndex(int subItemIndex) => HasImage ? subItemIndex + 1 : subItemIndex;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -59,6 +59,19 @@ namespace System.Windows.Forms
                     : GetDetailsSubItemOrFakeInternal(accessibleChildIndex);
             }
 
+            internal AccessibleObject? GetChild(int subItemIndex, Point point)
+            {
+                if (!HasImage || subItemIndex > 0)
+                {
+                    return GetDetailsSubItemOrFake(subItemIndex);
+                }
+
+                return GetDetailsSubItemOrFakeInternal(ImageAccessibleObjectIndex) is ListViewItemImageAccessibleObject imageAccessibleObject &&
+                       imageAccessibleObject.GetImageRectangle().Contains(point)
+                    ? imageAccessibleObject
+                    : GetDetailsSubItemOrFake(0);
+            }
+
             public override int GetChildCount()
             {
                 if (_owningListView.View != View.Details)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemImageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemImageAccessibleObject.cs
@@ -1,0 +1,78 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Drawing;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class ListViewItem
+    {
+        internal class ListViewItemImageAccessibleObject : AccessibleObject
+        {
+            private readonly ListViewItem _owningItem;
+
+            public ListViewItemImageAccessibleObject(ListViewItem owner)
+            {
+                _owningItem = owner.OrThrowIfNull();
+            }
+
+            public override Rectangle Bounds
+            {
+                get
+                {
+                    Rectangle imageRectangle = _owningItem.ListView.GetItemRect(_owningItem.Index, ItemBoundsPortion.Icon);
+                    return _owningItem.ListView.RectangleToScreen(imageRectangle);
+                }
+            }
+
+            public override string DefaultAction => string.Empty;
+
+            internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
+                => _owningItem.ListView.AccessibilityObject;
+
+            public override AccessibleObject Parent => _owningItem.AccessibilityObject;
+
+            internal override int[] RuntimeId
+            {
+                get
+                {
+                    int[] owningItemRuntimeId = Parent.RuntimeId;
+
+                    Debug.Assert(owningItemRuntimeId.Length >= 4);
+
+                    return new[]
+                    {
+                        owningItemRuntimeId[0],
+                        owningItemRuntimeId[1],
+                        owningItemRuntimeId[2],
+                        owningItemRuntimeId[3],
+                        GetHashCode()
+                    };
+                }
+            }
+
+            public override int GetChildCount() => 0;
+
+            internal override object? GetPropertyValue(UiaCore.UIA propertyID)
+                => propertyID switch
+                {
+                    UiaCore.UIA.ControlTypePropertyId => UiaCore.UIA.ImageControlTypeId,
+                    UiaCore.UIA.HasKeyboardFocusPropertyId => false,
+                    UiaCore.UIA.IsKeyboardFocusablePropertyId => false,
+                    _ => base.GetPropertyValue(propertyID)
+                };
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+                => direction switch
+                {
+                    UiaCore.NavigateDirection.Parent => Parent,
+                    UiaCore.NavigateDirection.NextSibling => Parent.GetChild(1),
+                    UiaCore.NavigateDirection.PreviousSibling => null,
+                    _ => base.FragmentNavigate(direction)
+                };
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemImageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemImageAccessibleObject.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    Rectangle imageRectangle = _owningItem.ListView.GetItemRect(_owningItem.Index, ItemBoundsPortion.Icon);
+                    Rectangle imageRectangle = GetImageRectangle();
                     return _owningItem.ListView.RectangleToScreen(imageRectangle);
                 }
             }
@@ -55,6 +55,8 @@ namespace System.Windows.Forms
             }
 
             public override int GetChildCount() => 0;
+
+            internal Rectangle GetImageRectangle() => _owningItem.ListView.GetItemRect(_owningItem.Index, ItemBoundsPortion.Icon);
 
             internal override object? GetPropertyValue(UiaCore.UIA propertyID)
                 => propertyID switch

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -52,9 +52,9 @@ namespace System.Windows.Forms
                         // When we need to get bounds for first sub item it will return width of all item.
                         int width = bounds.Width;
 
-                        if (!_owningListView.FullRowSelect && index == 0 && _owningListView.Columns.Count > 1)
+                        if (!_owningListView.FullRowSelect && index == ParentInternal.FirstSubItemIndex && _owningListView.Columns.Count > 1)
                         {
-                            width = ParentInternal.GetSubItemBounds(subItemIndex: 1).X - bounds.X;
+                            width = ParentInternal.GetSubItemBounds(ParentInternal.FirstSubItemIndex + 1).X - bounds.X;
                         }
 
                         if (width <= 0)

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/ListViewTest.cs
@@ -81,7 +81,7 @@ namespace WinformsControlsTest
             item2.SubItems.Add("4");
             item2.SubItems.Add("5");
             item2.SubItems.Add("6");
-            ListViewItem item3 = new("item3", 0)
+            ListViewItem item3 = new("item3")
             {
                 // Place a check mark next to the item.
                 Checked = true

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -1608,6 +1608,27 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(true, 1)]
+        [InlineData(false, 0)]
+        public void ListViewItemAccessibleObject_GetChildIndex_ReturnsExpected_Image(bool hasImage, int expectedFirstSubItemIndex)
+        {
+            using ImageList imageCollection = new();
+            imageCollection.Images.Add(Form.DefaultIcon);
+            using ListView listView = new()
+            {
+                View = View.Details,
+                SmallImageList = imageCollection
+            };
+            listView.Columns.Add(new ColumnHeader());
+            var listViewItem = new ListViewItem("Item 1", imageIndex: hasImage ? 0 : -1);
+            listView.Items.Add(listViewItem);
+            var accessibleObject = (ListViewItemDetailsAccessibleObject)listView.Items[0].AccessibilityObject;
+            
+            Assert.Equal(expectedFirstSubItemIndex, accessibleObject.GetChildIndex(listView.Items[0].SubItems[0].AccessibilityObject));
+            Assert.False(listView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
         [InlineData(View.Details)]
         [InlineData(View.LargeIcon)]
         [InlineData(View.List)]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemImageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemImageAccessibleObjectTests.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static Interop;
+using static System.Windows.Forms.ListViewItem;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ListViewItem_ListViewItemImageAccessibleObjectTests
+    {
+        [WinFormsFact]
+        public void ListViewItemImageAccessibleObject_GetChild_ReturnCorrectValue()
+        {
+            using ImageList imageCollection = new();
+            imageCollection.Images.Add(Form.DefaultIcon);
+
+            ListViewItem listViewItem = new("Test", 0);
+            using ListView list = new()
+            {
+                View = View.Details,
+                SmallImageList = imageCollection
+            };
+            using ColumnHeader column = new();
+            list.Columns.Add(column);
+            list.Items.Add(listViewItem);
+
+            list.CreateControl();
+
+            AccessibleObject imageAccessibleObject = listViewItem.AccessibilityObject.GetChild(0);
+
+            Assert.NotNull(imageAccessibleObject);
+            Assert.IsType<ListViewItemImageAccessibleObject>(imageAccessibleObject);
+            Assert.True(list.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void ListViewItemImageAccessibleObject_GetPropertyValue_ReturnsExpected()
+        {
+            using ImageList imageCollection = new();
+            imageCollection.Images.Add(Form.DefaultIcon);
+
+            ListViewItem listViewItem = new("Test", 0);
+
+            using ListView list = new()
+            {
+                View = View.Details,
+                SmallImageList = imageCollection
+            };
+            using ColumnHeader column = new();
+            list.Columns.Add(column);
+            list.Items.Add(listViewItem);
+
+            list.CreateControl();
+
+            AccessibleObject imageAccessibleObject = listViewItem.AccessibilityObject.GetChild(0);
+
+            Assert.Equal(UiaCore.UIA.ImageControlTypeId, (UiaCore.UIA)imageAccessibleObject.GetPropertyValue(UiaCore.UIA.ControlTypePropertyId));
+            Assert.False((bool)imageAccessibleObject.GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId));
+            Assert.False((bool)imageAccessibleObject.GetPropertyValue(UiaCore.UIA.IsKeyboardFocusablePropertyId));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4690 Details.Case 2


## Proposed changes

- Added ListViewItemImageAccessibleObject
- Used AO for image inside ListViewItemDetailsAccessibleObject
- Added unit tests

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- User can see information about ListViewItem's image via accessibility tools

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/186829864-fa141be3-b18e-43cc-b833-8d5cbe356eab.png)

### After

![image](https://user-images.githubusercontent.com/109065597/186829469-51d6ea0d-4dd1-42c1-8fdf-7ec677f67ff6.png)

## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit tests
- AI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- AI


 

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-preview.7.22377.5


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7672)