### PR TITLE
Set Targeting Ref pack version to MicrosoftNETCoreAppRuntimewinx64PackageVersion

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -65,14 +65,13 @@
   <ItemGroup>
     <!-- Set TargetingPackVersion -->
     <FrameworkReference Update="Microsoft.NETCore.App"
-      Condition=" '$(VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion)'!='' And $(TargetFramework.StartsWith('net7.')) ">
-    <TargetingPackVersion>$(VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion)</TargetingPackVersion>
+      Condition=" '$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)'!='' And $(TargetFramework.StartsWith('net7.')) ">
+    <TargetingPackVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</TargetingPackVersion>
     </FrameworkReference>
   </ItemGroup>
 
   <PropertyGroup>
-    <!-- Set RuntimeFrameworkVersion to VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion from Core Setup to prevent large SDK cycle -->
-    <RuntimeFrameworkVersion Condition="'$(VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion)'!='' And $(TargetFramework.StartsWith('net7.')) ">$(VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)'!='' And $(TargetFramework.StartsWith('net7.')) ">$(VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion)</RuntimeFrameworkVersion>
 
     <!-- If TargetFramework is not net6.x, then reset RuntimeFrameworkVersion -->
     <RuntimeFrameworkVersion Condition="!$(TargetFramework.StartsWith('net7.'))" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -65,8 +65,8 @@
   <ItemGroup>
     <!-- Set TargetingPackVersion -->
     <FrameworkReference Update="Microsoft.NETCore.App"
-      Condition=" '$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)'!='' And $(TargetFramework.StartsWith('net7.')) ">
-    <TargetingPackVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</TargetingPackVersion>
+      Condition=" '$(Microsoft.NETCore.App.Ref)'!='' And $(TargetFramework.StartsWith('net7.')) ">
+    <TargetingPackVersion>$(Microsoft.NETCore.App.Ref)</TargetingPackVersion>
     </FrameworkReference>
   </ItemGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -71,7 +71,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)'!='' And $(TargetFramework.StartsWith('net7.')) ">$(VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion)</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition="'$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)'!='' And $(TargetFramework.StartsWith('net7.')) ">$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</RuntimeFrameworkVersion>
 
     <!-- If TargetFramework is not net6.x, then reset RuntimeFrameworkVersion -->
     <RuntimeFrameworkVersion Condition="!$(TargetFramework.StartsWith('net7.'))" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -65,8 +65,8 @@
   <ItemGroup>
     <!-- Set TargetingPackVersion -->
     <FrameworkReference Update="Microsoft.NETCore.App"
-      Condition=" '$(Microsoft.NETCore.App.Ref)'!='' And $(TargetFramework.StartsWith('net7.')) ">
-    <TargetingPackVersion>$(Microsoft.NETCore.App.Ref)</TargetingPackVersion>
+      Condition=" '$(MicrosoftNETCoreAppRefPackageVersion)'!='' And $(TargetFramework.StartsWith('net7.')) ">
+    <TargetingPackVersion>$(MicrosoftNETCoreAppRefPackageVersion)</TargetingPackVersion>
     </FrameworkReference>
   </ItemGroup>
 


### PR DESCRIPTION
Prepare branch for release.
This change was tested on https://dev.azure.com/dnceng/internal/_git/dotnet-winforms?version=GB7.0.0-test, in the .NET 7 stable test build

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7684)