### PR TITLE
[Servicing] Fixing "Collection was modified ..." exception while MonthCalendar AO tree rebuilding

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObject.cs
@@ -69,19 +69,6 @@ namespace System.Windows.Forms
                 _rowsAccessibleObjects = null;
             }
 
-            internal void ClearChildCollection()
-            {
-                if (RowsAccessibleObjects is not null)
-                {
-                    foreach (CalendarRowAccessibleObject row in RowsAccessibleObjects)
-                    {
-                        row.ClearChildCollection();
-                    }
-                }
-
-                _rowsAccessibleObjects = null;
-            }
-
             /// <remark>
             ///  A calendar always have 7 or 4 columns depending on its view.
             /// </remark>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObject.cs
@@ -96,8 +96,6 @@ namespace System.Windows.Forms
                 }
             }
 
-            internal void ClearChildCollection() => _cellsAccessibleObjects = null;
-
             internal void DisconnectChildren()
             {
                 Debug.Assert(OsVersion.IsWindows8OrGreater);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObject.cs
@@ -30,7 +30,6 @@ namespace System.Windows.Forms
                 _owningMonthCalendar = owner;
 
                 _owningMonthCalendar.DisplayRangeChanged += OnMonthCalendarStateChanged;
-                _owningMonthCalendar.CalendarViewChanged += OnMonthCalendarStateChanged;
             }
 
             // Use a LinkedList instead a List for the following reasons:
@@ -519,7 +518,6 @@ namespace System.Windows.Forms
                 {
                     calendar.DisconnectChildren();
                     UiaCore.UiaDisconnectProvider(calendar);
-                    calendar.CalendarBodyAccessibleObject.ClearChildCollection();
                 }
 
                 _calendarsAccessibleObjects = null;


### PR DESCRIPTION
Fixes https://github.com/dotnet/winforms/issues/7714
.NET 8.0 PR #7738

The reason of the bug was calling RebuildAccessibilityTree 2 times at the same time via CalendarViewChanged and DisplayRangeChanged events.
Removed CalendarViewChanged event using because it duplicates the work of DisplayRangeChanged and leads to the exception. We release elements the first rebuilding time and catch the exception while the second call.

## Servicing reasons

- The regression breaks accessibility work of `MonthCalendar` in .NET 7.0 only after [#7362](https://github.com/dotnet/winforms/pull/7362) and [#7569](https://github.com/dotnet/winforms/pull/7569)

## Proposed changes

- Remove extra `CalendarViewChanged` usage
- Remove extra cleaning methods that duplicate disconnection methods work

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- There is no the exception while using Narrator with MonthCalendar


## Regression? 

- Yes ([#7362](https://github.com/dotnet/winforms/pull/7362) and [#7569](https://github.com/dotnet/winforms/pull/7569) exposed the problem in [#4758](https://github.com/dotnet/winforms/pull/4758))

## Risk

- Minimal

## Test methodology <!-- How did you ensure quality? -->

- CTI
- Manual testing

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using Narrator and AI


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0
- Windows 11



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7739)