### PR TITLE
Fixed HasKeyboardFocusProperty for DGV's AO

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewAccessibleObjectTests.cs
@@ -528,7 +528,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsTheory]
         [InlineData(true)]
         [InlineData(false)]
-        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_IsExpected_ForNotEmptyDGV(bool focused)
+        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_False_ForNotEmptyDGV(bool focused)
         {
             using DataGridView dataGridView = new FakeFocusDataGridView(focused);
             dataGridView.Columns.Add(new DataGridViewButtonColumn());
@@ -538,7 +538,37 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(focused, dataGridView.Focused);
             Assert.Equal(1, dataGridView.RowCount); // One new row for editing, it will be in focus instead of whole DGV
-            Assert.Equal(focused, actual);
+            Assert.False(actual);
+            Assert.False(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewAccessibleObject_GetPropertyValue_HasKeyboardFocus_AsExpected_DependsOnForm(bool modal)
+        {
+            using Form form = new();
+            using DataGridView dataGridView = new FakeFocusDataGridView(true);
+            dataGridView.Columns.Add(new DataGridViewButtonColumn());
+            dataGridView.Parent = form;
+
+            bool? actualValue = null;
+            form.Load += (_, _) =>
+            {
+                actualValue = (bool)dataGridView.AccessibilityObject
+                    .GetPropertyValue(UiaCore.UIA.HasKeyboardFocusPropertyId);
+                form.Close();
+            };
+            if (modal)
+            {
+                form.ShowDialog();
+            }
+            else
+            {
+                form.Show();
+            }
+
+            Assert.Equal(modal, actualValue);
             Assert.False(dataGridView.IsHandleCreated);
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7723


## Proposed changes

- Restored condition as suggested (https://github.com/dotnet/winforms/pull/6102/files#r851568124)
- Fixed unit tests 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The Narrator has correct focus on non-empty DGV.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/188867740-3301495b-626a-4ec6-baa8-6ad73c4c7ac9.png)
_Not modal window._
![188046113-107a653d-41eb-4aac-aba5-37ce9970c83b](https://user-images.githubusercontent.com/109065597/188867875-4f89cd89-060d-4056-83c6-45a71db10ca1.gif)
_Modal window._
### After

![EPE0pxu8aQ](https://user-images.githubusercontent.com/109065597/188868156-55bcacff-14f4-453c-9bf9-4fc15d1f23cf.gif)
_Not modal window._
![cE08RXuR73](https://user-images.githubusercontent.com/109065597/188868178-a2429334-0765-4cec-a8bf-582ca2f6f970.gif)
_Modal window._


## Test methodology <!-- How did you ensure quality? -->

- Manually.
- Narrator.
- Unit testing.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Narrator.


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.100-alpha.1.22423.9


In modal window announces the content of the dialog up to the focused control. (https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-automation-element-propids, see UIA_IsDialogPropertyId)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7748)