### PR TITLE
Fixing the border's color of TextBox inside MenuStrip

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
@@ -252,8 +252,9 @@ namespace System.Windows.Forms
 
                 // Don't set the clipping region based on the WParam - windows seems to take out the two pixels intended for the non-client border.
 
-                Color outerBorderColor = (MouseIsOver || Focused) ? ColorTable.TextBoxBorder : BackColor;
-                Color innerBorderColor = BackColor;
+                bool focused = MouseIsOver || Focused;
+                Color outerBorderColor = focused ? ColorTable.TextBoxBorder : BackColor;
+                Color innerBorderColor = SystemInformation.HighContrast && !focused ? ColorTable.MenuBorder : BackColor;
 
                 if (!Enabled)
                 {


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7740


## Proposed changes

- Changed the border's color for `ToolStripTextBoxControl` for HC.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- A `TextBox` inside `MenuStrip` will be looked clear.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/189602785-32f48c1c-ffb6-45b2-8c43-d8c300dffb81.png)

### After

![image](https://user-images.githubusercontent.com/109065597/189602752-58e2c810-247d-4f78-a182-dffa5085ba76.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- AI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- HC


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK: 
 Version:   8.0.100-alpha.1.22423.9

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22000


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7759)