### PR TITLE
Fixing DataGridView mouse toolTips regression

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -2947,7 +2947,7 @@ namespace System.Windows.Forms
             }
 
             // get the tool tip string
-            string toolTipText = GetToolTipText(rowIndex);
+            string toolTipText = GetInternalToolTipText(rowIndex);
 
             if (string.IsNullOrEmpty(toolTipText))
             {

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/DataGridViewTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/DataGridViewTests.cs
@@ -26,18 +26,57 @@ namespace System.Windows.Forms.UITests
                 dataTable.Rows.Add(values: "name1");
                 dataGridView.ShowCellToolTips = true;
                 dataGridView.DataSource = dataTable;
-                Point point = dataGridView.GetCellDisplayRectangle(columnIndex: 0, rowIndex: 0, cutOverflow: false).Location;
+                Rectangle cellRectangle = dataGridView.GetCellDisplayRectangle(columnIndex: 0, rowIndex: 0, cutOverflow: false);
+                Point cellCenter = GetCenter(cellRectangle);
+                Point targetPoint = ToVirtualPoint(dataGridView.PointToScreen(cellCenter));
 
                 // Move mouse cursor over any cell of the first row to trigger a tooltip.
                 await InputSimulator.SendAsync(
                     form,
-                    inputSimulator => inputSimulator.Mouse.MoveMouseTo(point.X, point.Y));
+                    inputSimulator => inputSimulator.Mouse.MoveMouseTo(targetPoint.X, targetPoint.Y));
 
                 // Close the form to verify no exceptions thrown while showing the tooltip.
                 // Regression test for https://github.com/dotnet/winforms/issues/5496
                 form.Close();
                 dataTable.AcceptChanges();
             });
+        }
+
+        [WinFormsTheory]
+        [InlineData("short value", false)]
+        [InlineData("very long value that will be truncated by the DataGridViewCell", true)]
+        public async Task DataGridView_MouseToolTip_Appears_IfTextIsTruncatedOnly(string cellValue, bool expected)
+        {
+            await RunTestAsync(async (form, dataGridView) =>
+            {
+                using DataTable dataTable = new();
+                dataTable.Columns.Add(columnName: "name");
+                dataTable.Rows.Add(values: cellValue);
+                dataGridView.ShowCellToolTips = true;
+                dataGridView.DataSource = dataTable;
+                Rectangle cellRectangle = dataGridView.GetCellDisplayRectangle(columnIndex: 0, rowIndex: 0, cutOverflow: false);
+                Point cellCenter = GetCenter(cellRectangle);
+                Point targetPoint = ToVirtualPoint(dataGridView.PointToScreen(cellCenter));
+
+                // Move mouse cursor over any cell of the first row to trigger a tooltip.
+                // Wait 1 second to make sure that the toolTip appeared, it has some delay (500 ms by default).
+                await InputSimulator.SendAsync(
+                    form,
+                    inputSimulator => inputSimulator.Mouse.MoveMouseTo(targetPoint.X, targetPoint.Y).Sleep(1000));
+
+                // DataGridViewToolTip is private so use the reflection
+                object toolTip = dataGridView.TestAccessor().Dynamic._toolTipControl;
+                object? actual = toolTip.GetType().GetProperty("Activated")?.GetValue(toolTip);
+
+                Assert.Equal(expected, actual);
+            });
+        }
+
+        private static Point GetCenter(Rectangle cell)
+        {
+            return new Point(GetMiddle(cell.Right, cell.Left), GetMiddle(cell.Top, cell.Bottom));
+
+            static int GetMiddle(int a, int b) => (a + b) / 2;
         }
 
         private async Task RunTestAsync(Func<Form, DataGridView, Task> runTest)


### PR DESCRIPTION
Fixes #7552

The bug was a regression from PR #1681, where `GetToolTipText` was used incorrectly for mouse tooltips.

## Proposed changes

- Use the old method implementation of getting text for mouse toolTips. `GetToolTipText` was used previously, but #1681 changed this method name to `GetInternalToolTipText`. The current `GetToolTipText` is used to get keyboard toolTip text.

## Customer Impact

- User doesn't see extra unexpected mouse toolTips

## Regression? 

- Yes (since #1681)

## Risk

- Minimal

## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
- Mouse tooltips appear for all cells after any cell in row was selected
![7552-1](https://user-images.githubusercontent.com/49272759/190305661-9ce4ebbb-f304-4b41-a0c6-14c04cf1e227.gif)


### After
- Mouse tooltips work in accordance with [docs](https://docs.microsoft.com/ru-ru/dotnet/api/system.windows.forms.datagridview.showcelltooltips?view=windowsdesktop-6.0) (are shown for truncated cells)
![7552-2](https://user-images.githubusercontent.com/49272759/190305676-d97ca05a-79c7-4088-b34b-44097c1de03b.gif)

## Test methodology <!-- How did you ensure quality? -->

- Manual
- UI tests
- CTI


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0
- Windows 11


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7769)