### PR TITLE
Released AccessibleObjects of ToolStripItems

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
@@ -42,7 +42,10 @@ namespace System.Windows.Forms
             /// <returns>Returns the element in the specified direction.</returns>
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
-                if (!_owningComboBox.IsHandleCreated)
+                if (!_owningComboBox.IsHandleCreated ||
+                    // Created is set to false in WM_DESTROY, but the window Handle is released on NCDESTROY, which comes after DESTROY.
+                    // But between these calls, AccessibleObject can be recreated which is going to memory leaking.
+                    !_owningComboBox.Created)
                 {
                     return null;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildEditUiaProvider.cs
@@ -44,7 +44,7 @@ namespace System.Windows.Forms
             {
                 if (!_owningComboBox.IsHandleCreated ||
                     // Created is set to false in WM_DESTROY, but the window Handle is released on NCDESTROY, which comes after DESTROY.
-                    // But between these calls, AccessibleObject can be recreated which is going to memory leaking.
+                    // But between these calls, AccessibleObject can be recreated and might cause memory leaks.
                     !_owningComboBox.Created)
                 {
                     return null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
@@ -65,7 +65,7 @@ namespace System.Windows.Forms
             {
                 if (!_owningComboBox.IsHandleCreated ||
                     // Created is set to false in WM_DESTROY, but the window Handle is released on NCDESTROY, which comes after DESTROY.
-                    // But between these calls, AccessibleObject can be recreated which is going to memory leaking.
+                    // But between these calls, AccessibleObject can be recreated and might cause memory leaks.
                     !_owningComboBox.Created)
                 {
                     return null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxChildListUiaProvider.cs
@@ -63,7 +63,10 @@ namespace System.Windows.Forms
             /// <returns>Returns the element in the specified direction.</returns>
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
-                if (!_owningComboBox.IsHandleCreated)
+                if (!_owningComboBox.IsHandleCreated ||
+                    // Created is set to false in WM_DESTROY, but the window Handle is released on NCDESTROY, which comes after DESTROY.
+                    // But between these calls, AccessibleObject can be recreated which is going to memory leaking.
+                    !_owningComboBox.Created)
                 {
                     return null;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -4266,6 +4266,9 @@ namespace System.Windows.Forms
             if (OsVersion.IsWindows8OrGreater)
             {
                 ReleaseToolStripItemsProviders(Items);
+
+                _toolStripGrip?.ReleaseUiaProvider();
+                _toolStripOverflowButton?.ReleaseUiaProvider();
             }
 
             base.ReleaseUiaProvider(handle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -876,6 +876,12 @@ namespace System.Windows.Forms
 
         private void SuspendSizeSync() => _suspendSyncSizeCount++;
 
+        internal override void ReleaseUiaProvider()
+        {
+            _control?.ReleaseUiaProvider(IntPtr.Zero);
+            base.ReleaseUiaProvider();
+        }
+
         private void ResumeSizeSync() => _suspendSyncSizeCount--;
 
         internal override bool ShouldSerializeBackColor()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -615,6 +615,12 @@ namespace System.Windows.Forms
             return base.ProcessDialogKey(keyData);
         }
 
+        internal override void ReleaseUiaProvider()
+        {
+            dropDown?.ReleaseUiaProvider(IntPtr.Zero);
+            base.ReleaseUiaProvider();
+        }
+
         private ToolStripDropDownDirection RTLTranslateDropDownDirection(ToolStripDropDownDirection dropDownDirection, RightToLeft rightToLeft)
         {
             switch (dropDownDirection)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -3196,7 +3196,7 @@ namespace System.Windows.Forms
         internal void RaiseQueryContinueDragEvent(object key, QueryContinueDragEventArgs e)
             => ((QueryContinueDragEventHandler)Events[key])?.Invoke(this, e);
 
-        internal void ReleaseUiaProvider()
+        internal virtual void ReleaseUiaProvider()
         {
             if (TryGetAccessibilityObject(out AccessibleObject accessibleObject))
             {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripComboBox.ToolStripComboBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripComboBox.ToolStripComboBoxAccessibleObjectTests.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ToolStripComboBox_ToolStripComboBoxAccessibleObjectTests
+    {
+        [WinFormsFact]
+        public void ToolStripComboBoxAccessibleObject_ReleaseUiaProvider_ToolStripComboBoxControl()
+        {
+            using var toolStrip = new ToolStrip();
+            using var toolStripComboBox = new ToolStripComboBox();
+            toolStrip.Items.Add(toolStripComboBox);
+            toolStripComboBox.Parent = toolStrip;
+            toolStrip.CreateControl();
+
+            _ = toolStripComboBox.AccessibilityObject;
+            _ = toolStripComboBox.Control.AccessibilityObject;
+
+            Assert.True(toolStripComboBox.Control.IsAccessibilityObjectCreated);
+
+            toolStripComboBox.ReleaseUiaProvider();
+
+            Assert.False(toolStripComboBox.Control.IsAccessibilityObjectCreated);
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHost.ToolStripControlHostAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHost.ToolStripControlHostAccessibleObjectTests.cs
@@ -63,5 +63,25 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(control.AccessibilityObject, accessibleObject.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
             Assert.False(toolStrip.Control.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void ToolStripControlHostAccessibleObject_ReleaseUiaProvider_ToolStripControlHostControl()
+        {
+            using var toolStrip = new ToolStrip();
+            using Control control = new();
+            using ToolStripControlHost toolStripControlHost = new(control);
+            toolStrip.Items.Add(toolStripControlHost);
+            toolStripControlHost.Parent = toolStrip;
+            toolStrip.CreateControl();
+
+            _ = toolStripControlHost.AccessibilityObject;
+            _ = toolStripControlHost.Control.AccessibilityObject;
+
+            Assert.True(toolStripControlHost.Control.IsAccessibilityObjectCreated);
+
+            toolStripControlHost.ReleaseUiaProvider();
+
+            Assert.False(toolStripControlHost.Control.IsAccessibilityObjectCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownItemAccessibleObjectTests.cs
@@ -204,6 +204,22 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(-1, accessibleObject.GetChildFragmentIndex(accessibleObjectNotItem));
         }
 
+        [WinFormsFact]
+        public void ToolStripDropDownItemAccessibleObject_ReleaseUiaProvider_DropDown()
+        {
+            using NoAssertContext context = new();
+            using var toolStripDropDownItem = new SubToolStripDropDownItem();
+
+            _ = toolStripDropDownItem.AccessibilityObject;
+            _ = toolStripDropDownItem.DropDown.AccessibilityObject;
+
+            Assert.True(toolStripDropDownItem.DropDown.IsAccessibilityObjectCreated);
+
+            toolStripDropDownItem.ReleaseUiaProvider();
+
+            Assert.False(toolStripDropDownItem.DropDown.IsAccessibilityObjectCreated);
+        }
+
         private class SubToolStripDropDownItem : ToolStripDropDownItem
         {
             public SubToolStripDropDownItem() : base() { }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7713 


## Proposed changes

- Added a condition to access `AccessibleObject` via `FragmentNavigate` for `ComboBoxChildEditUiaProvider` and `ComboBoxChildListUiaProvider` if an owning `ComboBox` wasn't created.
- Released `Grip` and `OverflowButton` with `ToolStrip` releasing.
- Released `Control` with `ToolStripControlHost` releasing.
- Released `DropDown` with `ToolStripDropDownItem` releasing.
- Added unit tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- No memory leaks from `ToolStrip`.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/109065597/190598257-4a450390-24c2-45c4-b031-c8a95b5b8273.png)

### After

![image](https://user-images.githubusercontent.com/109065597/190597395-48cf7553-db1a-4c74-abc4-86bdb78c6b1e.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- WinDbg

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect


 

## Test environment(s) <!-- Remove any that don't apply -->

- 8.0.0-alpha.1.22464.17


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7788)