### PR TITLE
[release/7.0] Set IsPassword property for TextBoxBaseAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
@@ -12,10 +12,12 @@ namespace System.Windows.Forms
     {
         internal class TextBoxBaseAccessibleObject : ControlAccessibleObject
         {
+            private readonly TextBoxBase _owningTextBoxBase;
             private TextBoxBaseUiaTextProvider? _textProvider;
 
             public TextBoxBaseAccessibleObject(TextBoxBase owner) : base(owner)
             {
+                _owningTextBoxBase = owner;
                 _textProvider = new TextBoxBaseUiaTextProvider(owner);
             }
 
@@ -42,6 +44,13 @@ namespace System.Windows.Forms
                 // 4) This method call should be uncommented
                 //        ClearOwnerControl();
             }
+
+            internal override object? GetPropertyValue(UIA propertyID)
+                => propertyID switch
+                {
+                    UIA.IsPasswordPropertyId => _owningTextBoxBase.PasswordProtect,
+                    _ => base.GetPropertyValue(propertyID),
+                };
 
             internal override bool IsIAccessibleExSupported() => true;
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MaskedTextBox.MaskedTextBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MaskedTextBox.MaskedTextBoxAccessibleObjectTests.cs
@@ -73,5 +73,34 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(maskedTextBox.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void MaskedTextBoxAccessibleObject_IsPassword_IsExpected_WithUseSystemPasswordChar(bool useSystemPasswordChar)
+        {
+            using MaskedTextBox maskedTextBox = new MaskedTextBox();
+            maskedTextBox.UseSystemPasswordChar = useSystemPasswordChar;
+
+            object actual = maskedTextBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsPasswordPropertyId);
+
+            Assert.Equal(useSystemPasswordChar, actual);
+            Assert.False(maskedTextBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData('\0')]
+        [InlineData('*')]
+        public void MaskedTextBoxAccessibleObject_IsPassword_IsExpected_WithPasswordChar(char passwordChar)
+        {
+            using MaskedTextBox maskedTextBox = new MaskedTextBox();
+            maskedTextBox.PasswordChar = passwordChar;
+
+            object actual = maskedTextBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.IsPasswordPropertyId);
+            bool expected = passwordChar != '\0';
+
+            Assert.Equal(expected, actual);
+            Assert.False(maskedTextBox.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TextBoxAccessibleObjectTests.cs
@@ -88,5 +88,67 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(textBox.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TextBoxAccessibleObject_IsPassword_IsExpected_WithUseSystemPasswordChar(bool useSystemPasswordChar)
+        {
+            using TextBox textBox = new TextBox();
+            textBox.UseSystemPasswordChar = useSystemPasswordChar;
+
+            object actual = textBox.AccessibilityObject.GetPropertyValue(Interop.UiaCore.UIA.IsPasswordPropertyId);
+
+            Assert.Equal(useSystemPasswordChar, actual);
+            // Handle is recreated when setting UseSystemPasswordChar
+            Assert.True(textBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData('\0')]
+        [InlineData('*')]
+        public void TextBoxAccessibleObject_IsPassword_IsExpected_WithPasswordChar(char passwordChar)
+        {
+            using TextBox textBox = new TextBox();
+            textBox.PasswordChar = passwordChar;
+
+            object actual = textBox.AccessibilityObject.GetPropertyValue(Interop.UiaCore.UIA.IsPasswordPropertyId);
+            bool expected = passwordChar != '\0';
+
+            Assert.Equal(expected, actual);
+            // Handle is recreated when getting PasswordChar
+            Assert.True(textBox.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void TextBoxAccessibleObject_IsPassword_IsFalse_ForMultilineTextBox_WithUseSystemPasswordChar()
+        {
+            using TextBox textBox = new TextBox();
+            textBox.Multiline = true;
+            textBox.UseSystemPasswordChar = true;
+
+            bool actual = (bool)textBox.AccessibilityObject.GetPropertyValue(Interop.UiaCore.UIA.IsPasswordPropertyId);
+
+            Assert.False(actual);
+            // Handle is recreated when setting UseSystemPasswordChar
+            Assert.True(textBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData('\0')]
+        [InlineData('*')]
+        public void TextBoxAccessibleObject_IsPassword_IsExpected_ForMultilineTextBox_WithPasswordChar(char passwordChar)
+        {
+            using TextBox textBox = new TextBox();
+            textBox.PasswordChar = passwordChar;
+            textBox.Multiline = true;
+
+            object actual = textBox.AccessibilityObject.GetPropertyValue(Interop.UiaCore.UIA.IsPasswordPropertyId);
+            bool expected = passwordChar != '\0';
+
+            Assert.Equal(expected, actual);
+            // Handle is recreated when getting PasswordChar
+            Assert.True(textBox.IsHandleCreated);
+        }
     }
 }


### PR DESCRIPTION
Fixes #7816.
.NET 8.0 PR: #7825
IsPassword property determines whether keystrokes should be read out by screen reader as the user types them.

This is a regression from https://github.com/dotnet/winforms/pull/6640, which sets `IsPassword` as false for every control. Before it, `IsPassword` was `null` for `TextBoxBaseAccessibleObject` and therefore its value was taken from MSAA provider.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

## Servicing reasons

- This regression makes screen readers announce content entered into TextBoxes configured for password input, which may expose sensitive information for screen reader users.

## Proposed changes

- Use `TextBoxBase.PasswordProtect` to determine `IsPassword` property value

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- When `TextBox` is configured as password input, screen readers will not announce keystrokes as the user types them, because it may expose private information.

## Regression? 

- Yes

## Risk

- Minimal - we are putting the old code back

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

`IsPassword` value is `False` for `TextBox` with `UseSystemPasswordChar = true`:

![A screenshot with Application Insights showing that IsPassword is false for TextBox containing a password](https://user-images.githubusercontent.com/102954094/191802455-0f83549e-5a79-481f-a8b9-65464e4a3323.png)

Narrator Buddy output as "qwerty" is entered into the `TextBox`:

> edit, 
> <say-as interpret-as="spell">q</say-as>
> <say-as interpret-as="spell">w</say-as>
> <say-as interpret-as="spell">e</say-as>
> <say-as interpret-as="spell">r</say-as>
> <say-as interpret-as="spell">t</say-as>
> <say-as interpret-as="spell">y</say-as>

Same result for:

- `TextBox` with non-empty `PasswordChar`
- `MaskedTextBox` with `UseSystemPasswordChar = true` or non-empty `PasswordChar`
- `TextBox` with `Multiline = true` and non-empty `PasswordChar`

### After

`IsPassword` value is `True` for `TextBox` with `UseSystemPasswordChar = true`:
![A screenshot with Application Insights showing that IsPassword is true for TextBox containing a password](https://user-images.githubusercontent.com/102954094/191799987-ef76a1c6-f616-4e79-9046-dab4640c97bb.png)

Narrator Buddy output as "qwerty" is entered into the `TextBox`:

> edit, 
> Hidden
> Hidden
> Hidden
> Hidden
> Hidden
> Hidden

Same result for:

- `TextBox` with non-empty `PasswordChar`
- `MaskedTextBox` with `UseSystemPasswordChar = true` or non-empty `PasswordChar`
- `TextBox` with `Multiline = true` and non-empty `PasswordChar`

For `TextBox` with `Multiline = true` and `UseSystemPasswordChar = true`, `IsPassword` property remains `False`, because with this combination it's not formatted as password:
![A screenshot with Application Insights showing that IsPassword is false for Multiline TextBox with UseSystemPasswordChar = true](https://user-images.githubusercontent.com/102954094/191801510-f26ce1f7-611c-4388-bde4-dbb1bc851bb7.png)


## Test methodology <!-- How did you ensure quality? -->

- Manual testing
- Unit tests
- CTI

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Using Narrator and AI
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->
 

## Test environment(s) <!-- Remove any that don't apply -->

- 7.0.100-rc.1.22431.12
- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7826)