### PR TITLE
Fix IndexOutOfRangeException When Opening FileDialog with Filters

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -228,12 +228,15 @@ namespace System.Windows.Forms
                     // Odd numbered tokens are the associated extensions
                     for (int i = 1; i < tokens.Length; i += 2)
                     {
-                        fixed (char* token = tokens[i])
-                        fixed (char* tokenOne = tokens[i + 1])
+                        fixed (char* tokenName = tokens[i - 1])
+                        fixed (char* tokenSpec = tokens[i])
                         {
-                            COMDLG_FILTERSPEC extension;
-                            extension.pszSpec = token;        // This may be a semicolon delimited list of extensions (that's ok)
-                            extension.pszName = tokenOne;
+                            COMDLG_FILTERSPEC extension = new()
+                            {
+                                pszName = tokenName,
+                                pszSpec = tokenSpec // This may be a semicolon delimited list of extensions (that's ok)
+                            };
+
                             extensions.Add(extension);
                         }
                     }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7850

Expected input for FileDialog filter is in format : "filterName1|filterSpec1|filterName2|filterSpec2|filterName3|filterSpec3....etc". When processing the filter, we split it with separator "|" into an array and we were mismatching filter name/spec pairs, e.g. we were grabbing filterSpec2 and filterName3, leading to IndexOutOfRangeException once getting to the end of the array.

## Regression? 

- Yes, regressed in [#7674](https://github.com/dotnet/winforms/pull/7674)

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before
Received IndexOutOfRangeException whenever 

![image](https://user-images.githubusercontent.com/30007367/192901368-31f0ac69-f5bc-4cc8-9608-33d19dc7bbc8.png)
![image](https://user-images.githubusercontent.com/30007367/192901407-b58994ca-894c-4a37-86c8-7a877a9955a0.png)


### After
FileDialog opens as expected
![fix](https://user-images.githubusercontent.com/30007367/192901504-39a88cc5-3ea1-49cd-a7ee-787fe7acb261.gif)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7860)