### PR TITLE
Enable CA1852/CA1812 Analyzers

### DIFF
--- a/eng/ApiCompatibility/PublicApiAnalyzer.targets
+++ b/eng/ApiCompatibility/PublicApiAnalyzer.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup Condition="'$(UsePublicApiAnalyzers)' == 'true'">
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzers)">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1,1430 +1,1744 @@
 is_global = true
 
-# Analyzer threw an exception
+# AD0001: Analyzer threw an exception
 dotnet_diagnostic.AD0001.severity = suggestion
 
-# Do not declare static members on generic types
+# CA1000: Do not declare static members on generic types
 dotnet_diagnostic.CA1000.severity = none
 
-# Types that own disposable fields should be disposable
+# CA1001: Types that own disposable fields should be disposable
 dotnet_diagnostic.CA1001.severity = none
 
-# Do not expose generic lists
+# CA1002: Do not expose generic lists
 dotnet_diagnostic.CA1002.severity = none
 
-# Use generic event handler instances
+# CA1003: Use generic event handler instances
 dotnet_diagnostic.CA1003.severity = none
 
-# Avoid excessive parameters on generic types
+# CA1005: Avoid excessive parameters on generic types
 dotnet_diagnostic.CA1005.severity = none
 
-# Enums should have zero value
+# CA1008: Enums should have zero value
 dotnet_diagnostic.CA1008.severity = none
 
-# Generic interface should also be implemented
+# CA1010: Generic interface should also be implemented
 dotnet_diagnostic.CA1010.severity = none
 
-# Abstract types should not have public constructors
+# CA1012: Abstract types should not have public constructors
 dotnet_diagnostic.CA1012.severity = none
 
-# Mark assemblies with CLSCompliant
+# CA1014: Mark assemblies with CLSCompliant
 dotnet_diagnostic.CA1014.severity = none
 
-# Mark assemblies with assembly version
+# CA1016: Mark assemblies with assembly version
 dotnet_diagnostic.CA1016.severity = none
 
-# Mark assemblies with ComVisible
+# CA1017: Mark assemblies with ComVisible
 dotnet_diagnostic.CA1017.severity = none
 
-# Mark attributes with AttributeUsageAttribute
+# CA1018: Mark attributes with AttributeUsageAttribute
 dotnet_diagnostic.CA1018.severity = warning
 
-# Define accessors for attribute arguments
+# CA1019: Define accessors for attribute arguments
 dotnet_diagnostic.CA1019.severity = none
 
-# Avoid out parameters
+# CA1021: Avoid out parameters
 dotnet_diagnostic.CA1021.severity = none
 
-# Use properties where appropriate
+# CA1024: Use properties where appropriate
 dotnet_diagnostic.CA1024.severity = none
 
-# Mark enums with FlagsAttribute
+# CA1027: Mark enums with FlagsAttribute
 dotnet_diagnostic.CA1027.severity = none
 
-# Enum Storage should be Int32
+# CA1028: Enum Storage should be Int32
 dotnet_diagnostic.CA1028.severity = none
 
-# Use events where appropriate
+# CA1030: Use events where appropriate
 dotnet_diagnostic.CA1030.severity = none
 
-# Do not catch general exception types
+# CA1031: Do not catch general exception types
 dotnet_diagnostic.CA1031.severity = none
 
-# Implement standard exception constructors
+# CA1032: Implement standard exception constructors
 dotnet_diagnostic.CA1032.severity = none
 
-# Interface methods should be callable by child types
+# CA1033: Interface methods should be callable by child types
 dotnet_diagnostic.CA1033.severity = none
 
-# Nested types should not be visible
+# CA1034: Nested types should not be visible
 dotnet_diagnostic.CA1034.severity = none
 
-# Override methods on comparable types
+# CA1036: Override methods on comparable types
 dotnet_diagnostic.CA1036.severity = none
 
-# Avoid empty interfaces
+# CA1040: Avoid empty interfaces
 dotnet_diagnostic.CA1040.severity = none
 
-# Provide ObsoleteAttribute message
+# CA1041: Provide ObsoleteAttribute message
 dotnet_diagnostic.CA1041.severity = none
 
-# Use Integral Or String Argument For Indexers
+# CA1043: Use Integral Or String Argument For Indexers
 dotnet_diagnostic.CA1043.severity = none
 
-# Properties should not be write only
+# CA1044: Properties should not be write only
 dotnet_diagnostic.CA1044.severity = none
 
-# Do not pass types by reference
+# CA1045: Do not pass types by reference
 dotnet_diagnostic.CA1045.severity = none
 
-# Do not overload equality operator on reference types
+# CA1046: Do not overload equality operator on reference types
 dotnet_diagnostic.CA1046.severity = none
 
-# Do not declare protected member in sealed type
+# CA1047: Do not declare protected member in sealed type
 dotnet_diagnostic.CA1047.severity = warning
 
-# Declare types in namespaces
+# CA1050: Declare types in namespaces
 dotnet_diagnostic.CA1050.severity = warning
 
-# Do not declare visible instance fields
+# CA1051: Do not declare visible instance fields
 dotnet_diagnostic.CA1051.severity = none
 
-# Static holder types should be Static or NotInheritable
+# CA1052: Static holder types should be Static or NotInheritable
 dotnet_diagnostic.CA1052.severity = warning
 dotnet_code_quality.CA1052.api_surface = private, internal
 
-# URI-like parameters should not be strings
+# CA1054: URI-like parameters should not be strings
 dotnet_diagnostic.CA1054.severity = none
 
-# URI-like return values should not be strings
+# CA1055: URI-like return values should not be strings
 dotnet_diagnostic.CA1055.severity = none
 
-# URI-like properties should not be strings
+# CA1056: URI-like properties should not be strings
 dotnet_diagnostic.CA1056.severity = none
 
-# Types should not extend certain base types
+# CA1058: Types should not extend certain base types
 dotnet_diagnostic.CA1058.severity = none
 
-# Move pinvokes to native methods class
+# CA1060: Move pinvokes to native methods class
 dotnet_diagnostic.CA1060.severity = none
 
-# Do not hide base class methods
+# CA1061: Do not hide base class methods
 dotnet_diagnostic.CA1061.severity = none
 
-# Validate arguments of public methods
+# CA1062: Validate arguments of public methods
 dotnet_diagnostic.CA1062.severity = none
 
-# Implement IDisposable Correctly
+# CA1063: Implement IDisposable Correctly
 dotnet_diagnostic.CA1063.severity = none
 
-# Exceptions should be public
+# CA1064: Exceptions should be public
 dotnet_diagnostic.CA1064.severity = none
 
-# Do not raise exceptions in unexpected locations
+# CA1065: Do not raise exceptions in unexpected locations
 dotnet_diagnostic.CA1065.severity = none
 
-# Implement IEquatable when overriding Object.Equals
+# CA1066: Implement IEquatable when overriding Object.Equals
 dotnet_diagnostic.CA1066.severity = warning
 
-# Override Object.Equals(object) when implementing IEquatable<T>
+# CA1067: Override Object.Equals(object) when implementing IEquatable<T>
 dotnet_diagnostic.CA1067.severity = warning
 
-# CancellationToken parameters must come last
+# CA1068: CancellationToken parameters must come last
 dotnet_diagnostic.CA1068.severity = none
 
-# Enums values should not be duplicated
+# CA1069: Enums values should not be duplicated
 dotnet_diagnostic.CA1069.severity = none
 
-# Do not declare event fields as virtual
+# CA1070: Do not declare event fields as virtual
 dotnet_diagnostic.CA1070.severity = suggestion
 
-# Avoid using cref tags with a prefix
+# CA1200: Avoid using cref tags with a prefix
 dotnet_diagnostic.CA1200.severity = suggestion
 
-# Do not pass literals as localized parameters
+# CA1303: Do not pass literals as localized parameters
 dotnet_diagnostic.CA1303.severity = none
 
-# Specify CultureInfo
+# CA1304: Specify CultureInfo
 dotnet_diagnostic.CA1304.severity = none
 
-# Specify IFormatProvider
+# CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity = none
 
-# Specify StringComparison for clarity
+# CA1307: Specify StringComparison for clarity
 dotnet_diagnostic.CA1307.severity = none
 
-# Normalize strings to uppercase
+# CA1308: Normalize strings to uppercase
 dotnet_diagnostic.CA1308.severity = none
 
-# Use ordinal string comparison
+# CA1309: Use ordinal string comparison
 dotnet_diagnostic.CA1309.severity = none
 
-# Specify StringComparison for correctness
+# CA1310: Specify StringComparison for correctness
 dotnet_diagnostic.CA1310.severity = suggestion
 
-# P/Invokes should not be visible
+# CA1311: Specify a culture or use an invariant version
+dotnet_diagnostic.CA1311.severity = warning
+
+# CA1401: P/Invokes should not be visible
 dotnet_diagnostic.CA1401.severity = warning
 
-# Validate platform compatibility
+# CA1416: Validate platform compatibility
 dotnet_diagnostic.CA1416.severity = none # TODO: warning
 
-# Do not use 'OutAttribute' on string parameters for P/Invokes
+# CA1417: Do not use 'OutAttribute' on string parameters for P/Invokes
 dotnet_diagnostic.CA1417.severity = warning
 
-# Use valid platform string
+# CA1418: Use valid platform string
 dotnet_diagnostic.CA1418.severity = warning
 
-# Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# CA1419: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
 dotnet_diagnostic.CA1419.severity = warning
 
-# Property, type, or attribute requires runtime marshalling
+# CA1420: Property, type, or attribute requires runtime marshalling
 dotnet_diagnostic.CA1420.severity = warning
 
-# This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# CA1421: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
 dotnet_diagnostic.CA1421.severity = suggestion
 
-# Avoid excessive inheritance
+# CA1501: Avoid excessive inheritance
 dotnet_diagnostic.CA1501.severity = none
 
-# Avoid excessive complexity
+# CA1502: Avoid excessive complexity
 dotnet_diagnostic.CA1502.severity = none
 
-# Avoid unmaintainable code
+# CA1505: Avoid unmaintainable code
 dotnet_diagnostic.CA1505.severity = none
 
-# Avoid excessive class coupling
+# CA1506: Avoid excessive class coupling
 dotnet_diagnostic.CA1506.severity = none
 
-# Use nameof to express symbol names
+# CA1507: Use nameof to express symbol names
 dotnet_diagnostic.CA1507.severity = warning
 
-# Avoid dead conditional code
+# CA1508: Avoid dead conditional code
 dotnet_diagnostic.CA1508.severity = none
 
-# Invalid entry in code metrics rule specification file
+# CA1509: Invalid entry in code metrics rule specification file
 dotnet_diagnostic.CA1509.severity = none
 
-# Do not name enum values 'Reserved'
+# CA1700: Do not name enum values 'Reserved'
 dotnet_diagnostic.CA1700.severity = none
 
-# Identifiers should not contain underscores
+# CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = none
 
-# Identifiers should differ by more than case
+# CA1708: Identifiers should differ by more than case
 dotnet_diagnostic.CA1708.severity = none
 
-# Identifiers should have correct suffix
+# CA1710: Identifiers should have correct suffix
 dotnet_diagnostic.CA1710.severity = none
 
-# Identifiers should not have incorrect suffix
+# CA1711: Identifiers should not have incorrect suffix
 dotnet_diagnostic.CA1711.severity = none
 
-# Do not prefix enum values with type name
+# CA1712: Do not prefix enum values with type name
 dotnet_diagnostic.CA1712.severity = none
 
-# Events should not have 'Before' or 'After' prefix
+# CA1713: Events should not have 'Before' or 'After' prefix
 dotnet_diagnostic.CA1713.severity = none
 
-# Identifiers should have correct prefix
+# CA1715: Identifiers should have correct prefix
 dotnet_diagnostic.CA1715.severity = none
 
-# Identifiers should not match keywords
+# CA1716: Identifiers should not match keywords
 dotnet_diagnostic.CA1716.severity = none
 
-# Identifier contains type name
+# CA1720: Identifier contains type name
 dotnet_diagnostic.CA1720.severity = none
 
-# Property names should not match get methods
+# CA1721: Property names should not match get methods
 dotnet_diagnostic.CA1721.severity = none
 
-# Type names should not match namespaces
+# CA1724: Type names should not match namespaces
 dotnet_diagnostic.CA1724.severity = none
 
-# Parameter names should match base declaration
+# CA1725: Parameter names should match base declaration
 dotnet_diagnostic.CA1725.severity = suggestion
 
-# Use PascalCase for named placeholders
-dotnet_diagnostic.CA1727.severity = suggestion
+# CA1727: Use PascalCase for named placeholders
+dotnet_diagnostic.CA1727.severity = suggestion # TODO: warning
 
-# Use literals where appropriate
+# CA1802: Use literals where appropriate
 dotnet_diagnostic.CA1802.severity = warning
 dotnet_code_quality.CA1802.api_surface = private, internal
 
-# Do not initialize unnecessarily
+# CA1805: Do not initialize unnecessarily
 dotnet_diagnostic.CA1805.severity = warning
 
-# Do not ignore method results
+# CA1806: Do not ignore method results
 dotnet_diagnostic.CA1806.severity = none
 
-# Initialize reference type static fields inline
+# CA1810: Initialize reference type static fields inline
 dotnet_diagnostic.CA1810.severity = none # TODO: warning
 
-# Avoid uninstantiated internal classes
-dotnet_diagnostic.CA1812.severity = none
+# CA1812: Avoid uninstantiated internal classes
+dotnet_diagnostic.CA1812.severity = warning
 
-# Avoid unsealed attributes
+# CA1813: Avoid unsealed attributes
 dotnet_diagnostic.CA1813.severity = none
 
-# Prefer jagged arrays over multidimensional
+# CA1814: Prefer jagged arrays over multidimensional
 dotnet_diagnostic.CA1814.severity = none
 
-# Override equals and operator equals on value types
+# CA1815: Override equals and operator equals on value types
 dotnet_diagnostic.CA1815.severity = none
 
-# Dispose methods should call SuppressFinalize
+# CA1816: Dispose methods should call SuppressFinalize
 dotnet_diagnostic.CA1816.severity = none
 
-# Properties should not return arrays
+# CA1819: Properties should not return arrays
 dotnet_diagnostic.CA1819.severity = none
 
-# Test for empty strings using string length
+# CA1820: Test for empty strings using string length
 dotnet_diagnostic.CA1820.severity = none
 
-# Remove empty Finalizers
+# CA1821: Remove empty Finalizers
 dotnet_diagnostic.CA1821.severity = none # TODO: warning
 
-# Mark members as static
+# CA1822: Mark members as static
 dotnet_diagnostic.CA1822.severity = warning
 dotnet_code_quality.CA1822.api_surface = private, internal
 
-# Avoid unused private fields
+# CA1823: Avoid unused private fields
 dotnet_diagnostic.CA1823.severity = warning
 
-# Mark assemblies with NeutralResourcesLanguageAttribute
+# CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
 dotnet_diagnostic.CA1824.severity = warning
 
-# Avoid zero-length array allocations
+# CA1825: Avoid zero-length array allocations
 dotnet_diagnostic.CA1825.severity = warning
 
-# Do not use Enumerable methods on indexable collections
+# CA1826: Do not use Enumerable methods on indexable collections
 dotnet_diagnostic.CA1826.severity = warning
 
-# Do not use Count() or LongCount() when Any() can be used
+# CA1827: Do not use Count() or LongCount() when Any() can be used
 dotnet_diagnostic.CA1827.severity = warning
 
-# Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
 dotnet_diagnostic.CA1828.severity = warning
 
-# Use Length/Count property instead of Count() when available
+# CA1829: Use Length/Count property instead of Count() when available
 dotnet_diagnostic.CA1829.severity = warning
 
-# Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
 dotnet_diagnostic.CA1830.severity = warning
 
-# Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1831.severity = warning
 
-# Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1832.severity = warning
 
-# Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1833.severity = warning
 
-# Consider using 'StringBuilder.Append(char)' when applicable
+# CA1834: Consider using 'StringBuilder.Append(char)' when applicable
 dotnet_diagnostic.CA1834.severity = warning
 
-# Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
 dotnet_diagnostic.CA1835.severity = warning
 
-# Prefer IsEmpty over Count
+# CA1836: Prefer IsEmpty over Count
 dotnet_diagnostic.CA1836.severity = warning
 
-# Use 'Environment.ProcessId'
+# CA1837: Use 'Environment.ProcessId'
 dotnet_diagnostic.CA1837.severity = warning
 
-# Avoid 'StringBuilder' parameters for P/Invokes
+# CA1838: Avoid 'StringBuilder' parameters for P/Invokes
 dotnet_diagnostic.CA1838.severity = warning
 
-# Use 'Environment.ProcessPath'
+# CA1839: Use 'Environment.ProcessPath'
 dotnet_diagnostic.CA1839.severity = warning
 
-# Use 'Environment.CurrentManagedThreadId'
+# CA1840: Use 'Environment.CurrentManagedThreadId'
 dotnet_diagnostic.CA1840.severity = warning
 
-# Prefer Dictionary.Contains methods
+# CA1841: Prefer Dictionary.Contains methods
 dotnet_diagnostic.CA1841.severity = warning
 
-# Do not use 'WhenAll' with a single task
+# CA1842: Do not use 'WhenAll' with a single task
 dotnet_diagnostic.CA1842.severity = warning
 
-# Do not use 'WaitAll' with a single task
+# CA1843: Do not use 'WaitAll' with a single task
 dotnet_diagnostic.CA1843.severity = warning
 
-# Provide memory-based overrides of async methods when subclassing 'Stream'
+# CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
 dotnet_diagnostic.CA1844.severity = warning
 
-# Use span-based 'string.Concat'
+# CA1845: Use span-based 'string.Concat'
 dotnet_diagnostic.CA1845.severity = warning
 
-# Prefer 'AsSpan' over 'Substring'
+# CA1846: Prefer 'AsSpan' over 'Substring'
 dotnet_diagnostic.CA1846.severity = warning
 
-# Use char literal for a single character lookup
+# CA1847: Use char literal for a single character lookup
 dotnet_diagnostic.CA1847.severity = warning
 
-# Use the LoggerMessage delegates
+# CA1848: Use the LoggerMessage delegates
 dotnet_diagnostic.CA1848.severity = none
 
-# Call async methods when in an async method
+# CA1849: Call async methods when in an async method
 dotnet_diagnostic.CA1849.severity = suggestion
 
-# Prefer static 'HashData' method over 'ComputeHash'
+# CA1850: Prefer static 'HashData' method over 'ComputeHash'
 dotnet_diagnostic.CA1850.severity = warning
 
-# Possible multiple enumerations of 'IEnumerable' collection
+# CA1851: Possible multiple enumerations of 'IEnumerable' collection
 dotnet_diagnostic.CA1851.severity = suggestion
 
-# Dispose objects before losing scope
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = warning
+
+# CA1853: Unnecessary call to 'Dictionary.ContainsKey(key)'
+dotnet_diagnostic.CA1853.severity =  none # TODO: warning
+
+# CA1854: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+dotnet_diagnostic.CA1854.severity =  none # TODO: warning
+
+# CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none
 
-# Do not lock on objects with weak identity
+# CA2002: Do not lock on objects with weak identity
 dotnet_diagnostic.CA2002.severity = none
 
-# Consider calling ConfigureAwait on the awaited task
+# CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = none # TODO: warning
 
-# Do not create tasks without passing a TaskScheduler
+# CA2008: Do not create tasks without passing a TaskScheduler
 dotnet_diagnostic.CA2008.severity = warning
 
-# Do not call ToImmutableCollection on an ImmutableCollection value
+# CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
 dotnet_diagnostic.CA2009.severity = warning
 
-# Avoid infinite recursion
+# CA2011: Avoid infinite recursion
 dotnet_diagnostic.CA2011.severity = warning
 
-# Use ValueTasks correctly
+# CA2012: Use ValueTasks correctly
 dotnet_diagnostic.CA2012.severity = warning
 
-# Do not use ReferenceEquals with value types
+# CA2013: Do not use ReferenceEquals with value types
 dotnet_diagnostic.CA2013.severity = warning
 
-# Do not use stackalloc in loops
+# CA2014: Do not use stackalloc in loops
 dotnet_diagnostic.CA2014.severity = warning
 
-# Do not define finalizers for types derived from MemoryManager<T>
+# CA2015: Do not define finalizers for types derived from MemoryManager<T>
 dotnet_diagnostic.CA2015.severity = warning
 
-# Forward the 'CancellationToken' parameter to methods
+# CA2016: Forward the 'CancellationToken' parameter to methods
 dotnet_diagnostic.CA2016.severity = warning
 
-# Parameter count mismatch
+# CA2017: Parameter count mismatch
 dotnet_diagnostic.CA2017.severity = warning
 
-# 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# CA2018: 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
 dotnet_diagnostic.CA2018.severity = warning
 
-# Improper 'ThreadStatic' field initialization
-dotnet_diagnostic.CA2019.severity = warning
+# CA2019: Improper 'ThreadStatic' field initialization
+dotnet_diagnostic.CA2019.severity = none # TODO: warning
 
-# Review SQL queries for security vulnerabilities
+# CA2100: Review SQL queries for security vulnerabilities
 dotnet_diagnostic.CA2100.severity = none
 
-# Specify marshaling for P/Invoke string arguments
+# CA2101: Specify marshaling for P/Invoke string arguments
 dotnet_diagnostic.CA2101.severity = none
 
-# Review visible event handlers
+# CA2109: Review visible event handlers
 dotnet_diagnostic.CA2109.severity = none
 
-# Seal methods that satisfy private interfaces
+# CA2119: Seal methods that satisfy private interfaces
 dotnet_diagnostic.CA2119.severity = none
 
-# Do Not Catch Corrupted State Exceptions
+# CA2153: Do Not Catch Corrupted State Exceptions
 dotnet_diagnostic.CA2153.severity = none
 
-# Rethrow to preserve stack details
+# CA2200: Rethrow to preserve stack details
 dotnet_diagnostic.CA2200.severity = warning
 
-# Do not raise reserved exception types
+# CA2201: Do not raise reserved exception types
 dotnet_diagnostic.CA2201.severity = none
 
-# Initialize value type static fields inline
+# CA2207: Initialize value type static fields inline
 dotnet_diagnostic.CA2207.severity = warning
 
-# Instantiate argument exceptions correctly
+# CA2208: Instantiate argument exceptions correctly
 dotnet_diagnostic.CA2208.severity = none # TODO: warning
 dotnet_code_quality.CA2208.api_surface = public
 
-# Non-constant fields should not be visible
+# CA2211: Non-constant fields should not be visible
 dotnet_diagnostic.CA2211.severity = none
 
-# Disposable fields should be disposed
+# CA2213: Disposable fields should be disposed
 dotnet_diagnostic.CA2213.severity = none
 
-# Do not call overridable methods in constructors
+# CA2214: Do not call overridable methods in constructors
 dotnet_diagnostic.CA2214.severity = none
 
-# Dispose methods should call base class dispose
+# CA2215: Dispose methods should call base class dispose
 dotnet_diagnostic.CA2215.severity = none
 
-# Disposable types should declare finalizer
+# CA2216: Disposable types should declare finalizer
 dotnet_diagnostic.CA2216.severity = none
 
-# Do not mark enums with FlagsAttribute
+# CA2217: Do not mark enums with FlagsAttribute
 dotnet_diagnostic.CA2217.severity = none
 
-# Override GetHashCode on overriding Equals
+# CA2218: Override GetHashCode on overriding Equals
 dotnet_diagnostic.CA2218.severity = none
 
-# Do not raise exceptions in finally clauses
+# CA2219: Do not raise exceptions in finally clauses
 dotnet_diagnostic.CA2219.severity = none
 
-# Override Equals on overloading operator equals
+# CA2224: Override Equals on overloading operator equals
 dotnet_diagnostic.CA2224.severity = none
 
-# Operator overloads have named alternates
+# CA2225: Operator overloads have named alternates
 dotnet_diagnostic.CA2225.severity = none
 
-# Operators should have symmetrical overloads
+# CA2226: Operators should have symmetrical overloads
 dotnet_diagnostic.CA2226.severity = none
 
-# Collection properties should be read only
+# CA2227: Collection properties should be read only
 dotnet_diagnostic.CA2227.severity = none
 
-# Implement serialization constructors
+# CA2229: Implement serialization constructors
 dotnet_diagnostic.CA2229.severity = warning
 
-# Overload operator equals on overriding value type Equals
+# CA2231: Overload operator equals on overriding value type Equals
 dotnet_diagnostic.CA2231.severity = none
 
-# Pass system uri objects instead of strings
+# CA2234: Pass system uri objects instead of strings
 dotnet_diagnostic.CA2234.severity = none
 
-# Mark all non-serializable fields
+# CA2235: Mark all non-serializable fields
 dotnet_diagnostic.CA2235.severity = none
 
-# Mark ISerializable types with serializable
+# CA2237: Mark ISerializable types with serializable
 dotnet_diagnostic.CA2237.severity = none
 
-# Provide correct arguments to formatting methods
+# CA2241: Provide correct arguments to formatting methods
 dotnet_diagnostic.CA2241.severity = warning
 
-# Test for NaN correctly
+# CA2242: Test for NaN correctly
 dotnet_diagnostic.CA2242.severity = warning
 
-# Attribute string literals should parse correctly
+# CA2243: Attribute string literals should parse correctly
 dotnet_diagnostic.CA2243.severity = warning
 
-# Do not duplicate indexed element initializations
+# CA2244: Do not duplicate indexed element initializations
 dotnet_diagnostic.CA2244.severity = warning
 
-# Do not assign a property to itself
+# CA2245: Do not assign a property to itself
 dotnet_diagnostic.CA2245.severity = none # TODO: warning
 
-# Assigning symbol and its member in the same statement
+# CA2246: Assigning symbol and its member in the same statement
 dotnet_diagnostic.CA2246.severity = warning
 
-# Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
 dotnet_diagnostic.CA2247.severity = warning
 
-# Provide correct 'enum' argument to 'Enum.HasFlag'
+# CA2248: Provide correct 'enum' argument to 'Enum.HasFlag'
 dotnet_diagnostic.CA2248.severity = warning
 
-# Consider using 'string.Contains' instead of 'string.IndexOf'
+# CA2249: Consider using 'string.Contains' instead of 'string.IndexOf'
 dotnet_diagnostic.CA2249.severity = warning
 
-# Use 'ThrowIfCancellationRequested'
+# CA2250: Use 'ThrowIfCancellationRequested'
 dotnet_diagnostic.CA2250.severity = warning
 
-# Use 'string.Equals'
+# CA2251: Use 'string.Equals'
 dotnet_diagnostic.CA2251.severity = warning
 
-# This API requires opting into preview features
+# CA2252: This API requires opting into preview features
 dotnet_diagnostic.CA2252.severity = error
 
-# Named placeholders should not be numeric values
-dotnet_diagnostic.CA2253.severity = none
+# CA2253: Named placeholders should not be numeric values
+dotnet_diagnostic.CA2253.severity = none # TODO: warning
 
-# Template should be a static expression
+# CA2254: Template should be a static expression
 dotnet_diagnostic.CA2254.severity = none
 
-# The 'ModuleInitializer' attribute should not be used in libraries
+# CA2255: The 'ModuleInitializer' attribute should not be used in libraries
 dotnet_diagnostic.CA2255.severity = warning
 
-# All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
 dotnet_diagnostic.CA2256.severity = warning
 
-# Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
 dotnet_diagnostic.CA2257.severity = warning
 
-# Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# CA2258: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
 dotnet_diagnostic.CA2258.severity = warning
 
-# 'ThreadStatic' only affects static fields
+# CA2259: 'ThreadStatic' only affects static fields
 dotnet_diagnostic.CA2259.severity = warning
 
-# Do not use insecure deserializer BinaryFormatter
+# CA2300: Do not use insecure deserializer BinaryFormatter
 dotnet_diagnostic.CA2300.severity = none
 
-# Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# CA2301: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
 dotnet_diagnostic.CA2301.severity = none
 
-# Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# CA2302: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
 dotnet_diagnostic.CA2302.severity = none
 
-# Do not use insecure deserializer LosFormatter
+# CA2305: Do not use insecure deserializer LosFormatter
 dotnet_diagnostic.CA2305.severity = none
 
-# Do not use insecure deserializer NetDataContractSerializer
+# CA2310: Do not use insecure deserializer NetDataContractSerializer
 dotnet_diagnostic.CA2310.severity = none
 
-# Do not deserialize without first setting NetDataContractSerializer.Binder
+# CA2311: Do not deserialize without first setting NetDataContractSerializer.Binder
 dotnet_diagnostic.CA2311.severity = none
 
-# Ensure NetDataContractSerializer.Binder is set before deserializing
+# CA2312: Ensure NetDataContractSerializer.Binder is set before deserializing
 dotnet_diagnostic.CA2312.severity = none
 
-# Do not use insecure deserializer ObjectStateFormatter
+# CA2315: Do not use insecure deserializer ObjectStateFormatter
 dotnet_diagnostic.CA2315.severity = none
 
-# Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# CA2321: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
 dotnet_diagnostic.CA2321.severity = none
 
-# Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# CA2322: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
 dotnet_diagnostic.CA2322.severity = none
 
-# Do not use TypeNameHandling values other than None
+# CA2326: Do not use TypeNameHandling values other than None
 dotnet_diagnostic.CA2326.severity = none
 
-# Do not use insecure JsonSerializerSettings
+# CA2327: Do not use insecure JsonSerializerSettings
 dotnet_diagnostic.CA2327.severity = none
 
-# Ensure that JsonSerializerSettings are secure
+# CA2328: Ensure that JsonSerializerSettings are secure
 dotnet_diagnostic.CA2328.severity = none
 
-# Do not deserialize with JsonSerializer using an insecure configuration
+# CA2329: Do not deserialize with JsonSerializer using an insecure configuration
 dotnet_diagnostic.CA2329.severity = none
 
-# Ensure that JsonSerializer has a secure configuration when deserializing
+# CA2330: Ensure that JsonSerializer has a secure configuration when deserializing
 dotnet_diagnostic.CA2330.severity = none
 
-# Do not use DataTable.ReadXml() with untrusted data
+# CA2350: Do not use DataTable.ReadXml() with untrusted data
 dotnet_diagnostic.CA2350.severity = none
 
-# Do not use DataSet.ReadXml() with untrusted data
+# CA2351: Do not use DataSet.ReadXml() with untrusted data
 dotnet_diagnostic.CA2351.severity = none
 
-# Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# CA2352: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
 dotnet_diagnostic.CA2352.severity = none
 
-# Unsafe DataSet or DataTable in serializable type
+# CA2353: Unsafe DataSet or DataTable in serializable type
 dotnet_diagnostic.CA2353.severity = none
 
-# Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# CA2354: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
 dotnet_diagnostic.CA2354.severity = none
 
-# Unsafe DataSet or DataTable type found in deserializable object graph
+# CA2355: Unsafe DataSet or DataTable type found in deserializable object graph
 dotnet_diagnostic.CA2355.severity = none
 
-# Unsafe DataSet or DataTable type in web deserializable object graph
+# CA2356: Unsafe DataSet or DataTable type in web deserializable object graph
 dotnet_diagnostic.CA2356.severity = none
 
-# Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# CA2361: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
 dotnet_diagnostic.CA2361.severity = none
 
-# Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# CA2362: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
 dotnet_diagnostic.CA2362.severity = none
 
-# Review code for SQL injection vulnerabilities
+# CA3001: Review code for SQL injection vulnerabilities
 dotnet_diagnostic.CA3001.severity = none
 
-# Review code for XSS vulnerabilities
+# CA3002: Review code for XSS vulnerabilities
 dotnet_diagnostic.CA3002.severity = none
 
-# Review code for file path injection vulnerabilities
+# CA3003: Review code for file path injection vulnerabilities
 dotnet_diagnostic.CA3003.severity = none
 
-# Review code for information disclosure vulnerabilities
+# CA3004: Review code for information disclosure vulnerabilities
 dotnet_diagnostic.CA3004.severity = none
 
-# Review code for LDAP injection vulnerabilities
+# CA3005: Review code for LDAP injection vulnerabilities
 dotnet_diagnostic.CA3005.severity = none
 
-# Review code for process command injection vulnerabilities
+# CA3006: Review code for process command injection vulnerabilities
 dotnet_diagnostic.CA3006.severity = none
 
-# Review code for open redirect vulnerabilities
+# CA3007: Review code for open redirect vulnerabilities
 dotnet_diagnostic.CA3007.severity = none
 
-# Review code for XPath injection vulnerabilities
+# CA3008: Review code for XPath injection vulnerabilities
 dotnet_diagnostic.CA3008.severity = none
 
-# Review code for XML injection vulnerabilities
+# CA3009: Review code for XML injection vulnerabilities
 dotnet_diagnostic.CA3009.severity = none
 
-# Review code for XAML injection vulnerabilities
+# CA3010: Review code for XAML injection vulnerabilities
 dotnet_diagnostic.CA3010.severity = none
 
-# Review code for DLL injection vulnerabilities
+# CA3011: Review code for DLL injection vulnerabilities
 dotnet_diagnostic.CA3011.severity = none
 
-# Review code for regex injection vulnerabilities
+# CA3012: Review code for regex injection vulnerabilities
 dotnet_diagnostic.CA3012.severity = none
 
-# Do Not Add Schema By URL
+# CA3061: Do Not Add Schema By URL
 dotnet_diagnostic.CA3061.severity = warning
 
-# Insecure DTD processing in XML
+# CA3075: Insecure DTD processing in XML
 dotnet_diagnostic.CA3075.severity = warning
 
-# Insecure XSLT script processing.
+# CA3076: Insecure XSLT script processing.
 dotnet_diagnostic.CA3076.severity = warning
 
-# Insecure Processing in API Design, XmlDocument and XmlTextReader
+# CA3077: Insecure Processing in API Design, XmlDocument and XmlTextReader
 dotnet_diagnostic.CA3077.severity = warning
 
-# Mark Verb Handlers With Validate Antiforgery Token
+# CA3147: Mark Verb Handlers With Validate Antiforgery Token
 dotnet_diagnostic.CA3147.severity = warning
 
-# Do Not Use Weak Cryptographic Algorithms
+# CA5350: Do Not Use Weak Cryptographic Algorithms
 dotnet_diagnostic.CA5350.severity = warning
 
-# Do Not Use Broken Cryptographic Algorithms
+# CA5351: Do Not Use Broken Cryptographic Algorithms
 dotnet_diagnostic.CA5351.severity = warning
 
-# Review cipher mode usage with cryptography experts
+# CA5358: Review cipher mode usage with cryptography experts
 dotnet_diagnostic.CA5358.severity = none
 
-# Do Not Disable Certificate Validation
+# CA5359: Do Not Disable Certificate Validation
 dotnet_diagnostic.CA5359.severity = warning
 
-# Do Not Call Dangerous Methods In Deserialization
+# CA5360: Do Not Call Dangerous Methods In Deserialization
 dotnet_diagnostic.CA5360.severity = warning
 
-# Do Not Disable SChannel Use of Strong Crypto
+# CA5361: Do Not Disable SChannel Use of Strong Crypto
 dotnet_diagnostic.CA5361.severity = warning
 
-# Potential reference cycle in deserialized object graph
+# CA5362: Potential reference cycle in deserialized object graph
 dotnet_diagnostic.CA5362.severity = none
 
-# Do Not Disable Request Validation
+# CA5363: Do Not Disable Request Validation
 dotnet_diagnostic.CA5363.severity = warning
 
-# Do Not Use Deprecated Security Protocols
+# CA5364: Do Not Use Deprecated Security Protocols
 dotnet_diagnostic.CA5364.severity = warning
 
-# Do Not Disable HTTP Header Checking
+# CA5365: Do Not Disable HTTP Header Checking
 dotnet_diagnostic.CA5365.severity = warning
 
-# Use XmlReader for 'DataSet.ReadXml()'
+# CA5366: Use XmlReader for 'DataSet.ReadXml()'
 dotnet_diagnostic.CA5366.severity = none
 
-# Do Not Serialize Types With Pointer Fields
+# CA5367: Do Not Serialize Types With Pointer Fields
 dotnet_diagnostic.CA5367.severity = none
 
-# Set ViewStateUserKey For Classes Derived From Page
+# CA5368: Set ViewStateUserKey For Classes Derived From Page
 dotnet_diagnostic.CA5368.severity = warning
 
-# Use XmlReader for 'XmlSerializer.Deserialize()'
+# CA5369: Use XmlReader for 'XmlSerializer.Deserialize()'
 dotnet_diagnostic.CA5369.severity = none
 
-# Use XmlReader for XmlValidatingReader constructor
+# CA5370: Use XmlReader for XmlValidatingReader constructor
 dotnet_diagnostic.CA5370.severity = warning
 
-# Use XmlReader for 'XmlSchema.Read()'
+# CA5371: Use XmlReader for 'XmlSchema.Read()'
 dotnet_diagnostic.CA5371.severity = none
 
-# Use XmlReader for XPathDocument constructor
+# CA5372: Use XmlReader for XPathDocument constructor
 dotnet_diagnostic.CA5372.severity = none
 
-# Do not use obsolete key derivation function
+# CA5373: Do not use obsolete key derivation function
 dotnet_diagnostic.CA5373.severity = warning
 
-# Do Not Use XslTransform
+# CA5374: Do Not Use XslTransform
 dotnet_diagnostic.CA5374.severity = warning
 
-# Do Not Use Account Shared Access Signature
+# CA5375: Do Not Use Account Shared Access Signature
 dotnet_diagnostic.CA5375.severity = none
 
-# Use SharedAccessProtocol HttpsOnly
+# CA5376: Use SharedAccessProtocol HttpsOnly
 dotnet_diagnostic.CA5376.severity = warning
 
-# Use Container Level Access Policy
+# CA5377: Use Container Level Access Policy
 dotnet_diagnostic.CA5377.severity = warning
 
-# Do not disable ServicePointManagerSecurityProtocols
+# CA5378: Do not disable ServicePointManagerSecurityProtocols
 dotnet_diagnostic.CA5378.severity = warning
 
-# Ensure Key Derivation Function algorithm is sufficiently strong
+# CA5379: Ensure Key Derivation Function algorithm is sufficiently strong
 dotnet_diagnostic.CA5379.severity = warning
 
-# Do Not Add Certificates To Root Store
+# CA5380: Do Not Add Certificates To Root Store
 dotnet_diagnostic.CA5380.severity = warning
 
-# Ensure Certificates Are Not Added To Root Store
+# CA5381: Ensure Certificates Are Not Added To Root Store
 dotnet_diagnostic.CA5381.severity = warning
 
-# Use Secure Cookies In ASP.NET Core
+# CA5382: Use Secure Cookies In ASP.NET Core
 dotnet_diagnostic.CA5382.severity = none
 
-# Ensure Use Secure Cookies In ASP.NET Core
+# CA5383: Ensure Use Secure Cookies In ASP.NET Core
 dotnet_diagnostic.CA5383.severity = none
 
-# Do Not Use Digital Signature Algorithm (DSA)
+# CA5384: Do Not Use Digital Signature Algorithm (DSA)
 dotnet_diagnostic.CA5384.severity = warning
 
-# Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# CA5385: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
 dotnet_diagnostic.CA5385.severity = warning
 
-# Avoid hardcoding SecurityProtocolType value
+# CA5386: Avoid hardcoding SecurityProtocolType value
 dotnet_diagnostic.CA5386.severity = none
 
-# Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# CA5387: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
 dotnet_diagnostic.CA5387.severity = none
 
-# Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# CA5388: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
 dotnet_diagnostic.CA5388.severity = none
 
-# Do Not Add Archive Item's Path To The Target File System Path
+# CA5389: Do Not Add Archive Item's Path To The Target File System Path
 dotnet_diagnostic.CA5389.severity = none
 
-# Do not hard-code encryption key
+# CA5390: Do not hard-code encryption key
 dotnet_diagnostic.CA5390.severity = none
 
-# Use antiforgery tokens in ASP.NET Core MVC controllers
+# CA5391: Use antiforgery tokens in ASP.NET Core MVC controllers
 dotnet_diagnostic.CA5391.severity = none
 
-# Use DefaultDllImportSearchPaths attribute for P/Invokes
+# CA5392: Use DefaultDllImportSearchPaths attribute for P/Invokes
 dotnet_diagnostic.CA5392.severity = none
 
-# Do not use unsafe DllImportSearchPath value
+# CA5393: Do not use unsafe DllImportSearchPath value
 dotnet_diagnostic.CA5393.severity = none
 
-# Do not use insecure randomness
+# CA5394: Do not use insecure randomness
 dotnet_diagnostic.CA5394.severity = none
 
-# Miss HttpVerb attribute for action methods
+# CA5395: Miss HttpVerb attribute for action methods
 dotnet_diagnostic.CA5395.severity = none
 
-# Set HttpOnly to true for HttpCookie
+# CA5396: Set HttpOnly to true for HttpCookie
 dotnet_diagnostic.CA5396.severity = none
 
-# Do not use deprecated SslProtocols values
+# CA5397: Do not use deprecated SslProtocols values
 dotnet_diagnostic.CA5397.severity = none
 
-# Avoid hardcoded SslProtocols values
+# CA5398: Avoid hardcoded SslProtocols values
 dotnet_diagnostic.CA5398.severity = none
 
-# HttpClients should enable certificate revocation list checks
+# CA5399: HttpClients should enable certificate revocation list checks
 dotnet_diagnostic.CA5399.severity = none
 
-# Ensure HttpClient certificate revocation list check is not disabled
+# CA5400: Ensure HttpClient certificate revocation list check is not disabled
 dotnet_diagnostic.CA5400.severity = none
 
-# Do not use CreateEncryptor with non-default IV
+# CA5401: Do not use CreateEncryptor with non-default IV
 dotnet_diagnostic.CA5401.severity = none
 
-# Use CreateEncryptor with the default IV
+# CA5402: Use CreateEncryptor with the default IV
 dotnet_diagnostic.CA5402.severity = none
 
-# Do not hard-code certificate
+# CA5403: Do not hard-code certificate
 dotnet_diagnostic.CA5403.severity = none
 
-# Do not disable token validation checks
+# CA5404: Do not disable token validation checks
 dotnet_diagnostic.CA5404.severity = none
 
-# Do not always skip token validation in delegates
+# CA5405: Do not always skip token validation in delegates
 dotnet_diagnostic.CA5405.severity = none
 
-# Avoid using accessing Assembly file path when publishing as a single-file
+# IL3000: Avoid using accessing Assembly file path when publishing as a single-file
 dotnet_diagnostic.IL3000.severity = none # TODO: warning
 
-# Avoid using accessing Assembly file path when publishing as a single-file
+# IL3001: Avoid using accessing Assembly file path when publishing as a single-file
 dotnet_diagnostic.IL3001.severity = warning
 
-# Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app
+# IL3002: Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app
 dotnet_diagnostic.IL3002.severity = warning
 
-# Public members should not use oblivious types
+# RS0041: Public members should not use oblivious types
 dotnet_diagnostic.RS0041.severity = none
 
-# XML comment analysis disabled
+# SA0001: XML comments
 dotnet_diagnostic.SA0001.severity = none
 
-# Invalid settings file
+# SA0002: Invalid settings file
 dotnet_diagnostic.SA0002.severity = none
 
-# Keywords should be spaced correctly
-dotnet_diagnostic.SA1000.severity = none
+# SA1000: Spacing around keywords
+# suggestion until https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3478 is resolved
+dotnet_diagnostic.SA1000.severity = suggestion
 
-# Commas should be spaced correctly
-dotnet_diagnostic.SA1001.severity = none
+# SA1001: Commas should not be preceded by whitespace
+dotnet_diagnostic.SA1001.severity = none # TODO: warning
 
-# Semicolons should be spaced correctly
+# SA1002: Semicolons should not be preceded by a space
 dotnet_diagnostic.SA1002.severity = none
 
-# Symbols should be spaced correctly
+# SA1003: Operator should not appear at the end of a line
 dotnet_diagnostic.SA1003.severity = none
 
-# Documentation lines should begin with single space
+# SA1004: Documentation line should begin with a space
 dotnet_diagnostic.SA1004.severity = none
 
-# Single line comments should begin with single space
+# SA1005: Single line comment should begin with a space
 dotnet_diagnostic.SA1005.severity = none
 
-# Preprocessor keywords should not be preceded by space
+# SA1006: Preprocessor keywords should not be preceded by space
 dotnet_diagnostic.SA1006.severity = none
 
-# Operator keyword should be followed by space
+# SA1007: Operator keyword should be followed by space
 dotnet_diagnostic.SA1007.severity = none
 
-# Opening parenthesis should be spaced correctly
+# SA1008: Opening parenthesis should not be preceded by a space
 dotnet_diagnostic.SA1008.severity = none
 
-# Closing parenthesis should be spaced correctly
+# SA1009: Closing parenthesis should not be followed by a space
 dotnet_diagnostic.SA1009.severity = none
 
-# Opening square brackets should be spaced correctly
+# SA1010: Opening square brackets should not be preceded by a space
 dotnet_diagnostic.SA1010.severity = none
 
-# Closing square brackets should be spaced correctly
+# SA1011: Closing square bracket should be followed by a space
 dotnet_diagnostic.SA1011.severity = none
 
-# Opening braces should be spaced correctly
+# SA1012: Opening brace should be followed by a space
 dotnet_diagnostic.SA1012.severity = none
 
-# Closing braces should be spaced correctly
+# SA1013: Closing brace should be preceded by a space
 dotnet_diagnostic.SA1013.severity = none
 
-# Opening generic brackets should be spaced correctly
-dotnet_diagnostic.SA1014.severity = none
+# SA1014: Opening generic brackets should not be preceded by a space
+dotnet_diagnostic.SA1014.severity = none # TODO: warning
 
-# Closing generic brackets should be spaced correctly
+# SA1015: Closing generic bracket should not be followed by a space
 dotnet_diagnostic.SA1015.severity = none
 
-# Opening attribute brackets should be spaced correctly
+# SA1016: Opening attribute brackets should be spaced correctly
 dotnet_diagnostic.SA1016.severity = none
 
-# Closing attribute brackets should be spaced correctly
+# SA1017: Closing attribute brackets should be spaced correctly
 dotnet_diagnostic.SA1017.severity = none
 
-# Nullable type symbols should be spaced correctly
-dotnet_diagnostic.SA1018.severity = none
+# SA1018: Nullable type symbol should not be preceded by a space
+dotnet_diagnostic.SA1018.severity = none # TODO: warning
 
-# Member access symbols should be spaced correctly
+# SA1019: Member access symbols should be spaced correctly
 dotnet_diagnostic.SA1019.severity = none
 
-# Increment decrement symbols should be spaced correctly
-dotnet_diagnostic.SA1020.severity = none
+# SA1020: Increment symbol should not be preceded by a space
+dotnet_diagnostic.SA1020.severity = none # TODO: warning
 
-# Negative signs should be spaced correctly
+# SA1021: Negative sign should be preceded by a space
 dotnet_diagnostic.SA1021.severity = none
 
-# Positive signs should be spaced correctly
+# SA1022: Positive signs should be spaced correctly
 dotnet_diagnostic.SA1022.severity = none
 
-# Dereference and access of symbols should be spaced correctly
+# SA1023: Dereference symbol '*' should not be preceded by a space."
 dotnet_diagnostic.SA1023.severity = none
 
-# Colons should be spaced correctly
+# SA1024: Colon should be followed by a space
 dotnet_diagnostic.SA1024.severity = none
 
-# Code should not contain multiple whitespace in a row
+# SA1025: Code should not contain multiple whitespace characters in a row
 dotnet_diagnostic.SA1025.severity = none
 
-# Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
-dotnet_diagnostic.SA1026.severity = none
+# SA1026: Keyword followed by span or blank line
+dotnet_diagnostic.SA1026.severity = none # TODO: warning
 
-# Use tabs correctly
-dotnet_diagnostic.SA1027.severity = none
+# SA1027: Tabs and spaces should be used correctly
+dotnet_diagnostic.SA1027.severity = none # TODO: warning
 
-# Code should not contain trailing whitespace
-dotnet_diagnostic.SA1028.severity = none
+# SA1028: Code should not contain trailing whitespace
+dotnet_diagnostic.SA1028.severity = none # TODO: warning
 
-# Do not prefix calls with base unless local implementation exists
+# SA1100: Do not prefix calls with base unless local implementation exists
 dotnet_diagnostic.SA1100.severity = none
 
-# Prefix local calls with this
+# SA1101: Prefix local calls with this
 dotnet_diagnostic.SA1101.severity = none
 
-# Query clause should follow previous clause
-dotnet_diagnostic.SA1102.severity = none
+# SA1102: Query clause should follow previous clause
+dotnet_diagnostic.SA1102.severity = none # TODO: warning
 
-# Query clauses should be on separate lines or all on one line
-dotnet_diagnostic.SA1103.severity = none
+# SA1105: Query clauses spanning multiple lines should begin on own line
+dotnet_diagnostic.SA1105.severity = none # TODO: warning
 
-# Query clause should begin on new line when previous clause spans multiple lines
+# SA1104: Query clause should begin on new line when previous clause spans multiple lines
 dotnet_diagnostic.SA1104.severity = none
 
-# Query clauses spanning multiple lines should begin on own line
+# SA1105: Query clauses spanning multiple lines should begin on own line
 dotnet_diagnostic.SA1105.severity = none
 
-# Code should not contain empty statements
+# SA1106: Code should not contain empty statements
 dotnet_diagnostic.SA1106.severity = none
 
-# Code should not contain multiple statements on one line
+# SA1107: Code should not contain multiple statements on one line
 dotnet_diagnostic.SA1107.severity = none
 
-# Block statements should not contain embedded comments
+# SA1108: Block statements should not contain embedded comments
 dotnet_diagnostic.SA1108.severity = none
 
-# Block statements should not contain embedded regions
+# SA1109: Block statements should not contain embedded regions
 dotnet_diagnostic.SA1109.severity = none
 
-# Opening parenthesis or bracket should be on declaration line
+# SA1110: Opening parenthesis or bracket should be on declaration line
 dotnet_diagnostic.SA1110.severity = none
 
-# Closing parenthesis should be on line of last parameter
+# SA1111: Closing parenthesis should be on line of last parameter
 dotnet_diagnostic.SA1111.severity = none
 
-# Closing parenthesis should be on line of opening parenthesis
+# SA1112: Closing parenthesis should be on line of opening parenthesis
 dotnet_diagnostic.SA1112.severity = none
 
-# Comma should be on the same line as previous parameter
-dotnet_diagnostic.SA1113.severity = none
+# SA1113: Comma should be on the same line as previous parameter
+dotnet_diagnostic.SA1113.severity = none # TODO: warning
 
-# Parameter list should follow declaration
+# SA1114: Parameter list should follow declaration
 dotnet_diagnostic.SA1114.severity = none
 
-# Parameter should follow comma
-dotnet_diagnostic.SA1115.severity = none
+# SA1115: Parameter should begin on the line after the previous parameter
+dotnet_diagnostic.SA1115.severity = none # TODO: warning
 
-# Split parameters should start on line after declaration
+# SA1116: Split parameters should start on line after declaration
 dotnet_diagnostic.SA1116.severity = none
 
-# Parameters should be on same line or separate lines
+# SA1117: Parameters should be on same line or separate lines
 dotnet_diagnostic.SA1117.severity = none
 
-# Parameter should not span multiple lines
+# SA1118: Parameter should not span multiple lines
 dotnet_diagnostic.SA1118.severity = none
 
-# Statement should not use unnecessary parenthesis
+# SA1119: Statement should not use unnecessary parenthesis
 dotnet_diagnostic.SA1119.severity = none
 
-# Comments should contain text
+# SA1120: Comments should contain text
 dotnet_diagnostic.SA1120.severity = none
 
-# Use built-in type alias
-dotnet_diagnostic.SA1121.severity = none
+# SA1121: Use built-in type alias
+dotnet_diagnostic.SA1121.severity = none # TODO: warning
 
-# Use string.Empty for empty strings
+# SA1122: Use string.Empty for empty strings
 dotnet_diagnostic.SA1122.severity = none
 
-# Do not place regions within elements
+# SA1123: Region should not be located within a code element
 dotnet_diagnostic.SA1123.severity = none
 
-# Do not use regions
+# SA1124: Do not use regions
 dotnet_diagnostic.SA1124.severity = none
 
-# Use shorthand for nullable types
+# SA1125: Use shorthand for nullable types
 dotnet_diagnostic.SA1125.severity = none
 
-# Prefix calls correctly
+# SA1126: Prefix calls correctly
 dotnet_diagnostic.SA1126.severity = none
 
-# Generic type constraints should be on their own line
+# SA1127: Generic type constraints should be on their own line
 dotnet_diagnostic.SA1127.severity = none
 
-# Put constructor initializers on their own line
+# SA1128: Put constructor initializers on their own line
 dotnet_diagnostic.SA1128.severity = none
 
-# Do not use default value type constructor
-dotnet_diagnostic.SA1129.severity = none
+# SA1129: Do not use default value type constructor
+dotnet_diagnostic.SA1129.severity = none # TODO: warning
 
-# Use lambda syntax
+# SA1130: Use lambda syntax
 dotnet_diagnostic.SA1130.severity = none
 
-# Use readable conditions
+# SA1131: Constant values should appear on the right-hand side of comparisons
 dotnet_diagnostic.SA1131.severity = none
 
-# Do not combine fields
+# SA1132: Do not combine fields
 dotnet_diagnostic.SA1132.severity = none
 
-# Do not combine attributes
+# SA1133: Do not combine attributes
 dotnet_diagnostic.SA1133.severity = none
 
-# Attributes should not share line
+# SA1134: Each attribute should be placed on its own line of code
 dotnet_diagnostic.SA1134.severity = none
 
-# Using directives should be qualified
+# SA1135: Using directive should be qualified
 dotnet_diagnostic.SA1135.severity = none
 
-# Enum values should be on separate lines
+# SA1136: Enum values should be on separate lines
 dotnet_diagnostic.SA1136.severity = none
 
-# Elements should have the same indentation
+# SA1137: Elements should have the same indentation
 dotnet_diagnostic.SA1137.severity = none
 
-# Use literal suffix notation instead of casting
+# SA1139: Use literal suffix notation instead of casting
 dotnet_diagnostic.SA1139.severity = none
 
-# Using directives should be placed correctly
+# SA1141: Use tuple syntax
+dotnet_diagnostic.SA1141.severity = none # TODO: warning
+
+# SA1142: Refer to tuple elements by name
+dotnet_diagnostic.SA1142.severity = none # TODO: warning
+
+# SA1200: Using directive should appear within a namespace declaration
 dotnet_diagnostic.SA1200.severity = none
 
-# Elements should appear in the correct order
+# SA1201: Elements should appear in the correct order
 dotnet_diagnostic.SA1201.severity = none
 
-# Elements should be ordered by access
+# SA1202: Elements should be ordered by access
 dotnet_diagnostic.SA1202.severity = none
 
-# Constants should appear before fields
+# SA1203: Constants should appear before fields
 dotnet_diagnostic.SA1203.severity = none
 
-# Static elements should appear before instance elements
+# SA1204: Static elements should appear before instance elements
 dotnet_diagnostic.SA1204.severity = none
 
-# Partial elements should declare access
-dotnet_diagnostic.SA1205.severity = none
+# SA1205: Partial elements should declare an access modifier
+dotnet_diagnostic.SA1205.severity = none # TODO: warning
 
-# Declaration keywords should follow order
-dotnet_diagnostic.SA1206.severity = none
+# SA1206: Keyword ordering - TODO Re-enable as warning after https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3527
+dotnet_diagnostic.SA1206.severity = suggestion
 
-# Protected should come before internal
+# SA1207: Protected should come before internal
 dotnet_diagnostic.SA1207.severity = none
 
-# System using directives should be placed before other using directives
+# SA1208: Using directive ordering
 dotnet_diagnostic.SA1208.severity = none
 
-# Using alias directives should be placed after other using directives
+# SA1209: Using alias directives should be placed after all using namespace directives
 dotnet_diagnostic.SA1209.severity = none
 
-# Using directives should be ordered alphabetically by namespace
+# SA1210: Using directives should be ordered alphabetically by the namespaces
 dotnet_diagnostic.SA1210.severity = none
 
-# Using alias directives should be ordered alphabetically by alias name
+# SA1211: Using alias directive ordering
 dotnet_diagnostic.SA1211.severity = none
 
-# Property accessors should follow order
-dotnet_diagnostic.SA1212.severity = none
+# SA1212: A get accessor appears after a set accessor within a property or indexer
+dotnet_diagnostic.SA1212.severity = none # TODO: warning
 
-# Event accessors should follow order
+# SA1213: Event accessors should follow order
 dotnet_diagnostic.SA1213.severity = none
 
-# Readonly fields should appear before non-readonly fields
+# SA1214: Readonly fields should appear before non-readonly fields
 dotnet_diagnostic.SA1214.severity = none
 
-# Using static directives should be placed at the correct location
+# SA1216: Using static directives should be placed at the correct location
 dotnet_diagnostic.SA1216.severity = none
 
-# Using static directives should be ordered alphabetically
+# SA1217: Using static directives should be ordered alphabetically
 dotnet_diagnostic.SA1217.severity = none
 
-# Element should begin with upper-case letter
+# SA1300: Element should begin with an uppercase letter
 dotnet_diagnostic.SA1300.severity = none
 
-# Element should begin with lower-case letter
+# SA1301: Element should begin with lower-case letter
 dotnet_diagnostic.SA1301.severity = none
 
-# Interface names should begin with I
-dotnet_diagnostic.SA1302.severity = none
+# SA1302: Interface names should begin with I
+dotnet_diagnostic.SA1302.severity = none # TODO: warning
 
-# Const field names should begin with upper-case letter
+# SA1303: Const field names should begin with upper-case letter
 dotnet_diagnostic.SA1303.severity = none
 
-# Non-private readonly fields should begin with upper-case letter
+# SA1304: Non-private readonly fields should begin with upper-case letter
 dotnet_diagnostic.SA1304.severity = none
 
-# Field names should not use Hungarian notation
+# SA1305: Field names should not use Hungarian notation
 dotnet_diagnostic.SA1305.severity = none
 
-# Field names should begin with lower-case letter
+# SA1306: Field should begin with lower-case letter
 dotnet_diagnostic.SA1306.severity = none
 
-# Accessible fields should begin with upper-case letter
+# SA1307: Field should begin with upper-case letter
 dotnet_diagnostic.SA1307.severity = none
 
-# Variable names should not be prefixed
+# SA1308: Field should not begin with the prefix 's_'
 dotnet_diagnostic.SA1308.severity = none
 
-# Field names should not begin with underscore
+# SA1309: Field names should not begin with underscore
 dotnet_diagnostic.SA1309.severity = none
 
-# Field names should not contain underscore
+# SA1310: Field should not contain an underscore
 dotnet_diagnostic.SA1310.severity = none
 
-# Static readonly fields should begin with upper-case letter
+# SA1311: Static readonly fields should begin with upper-case letter
 dotnet_diagnostic.SA1311.severity = none
 
-# Variable names should begin with lower-case letter
+# SA1312: Variable should begin with lower-case letter
 dotnet_diagnostic.SA1312.severity = none
 
-# Parameter names should begin with lower-case letter
+# SA1313: Parameter should begin with lower-case letter
 dotnet_diagnostic.SA1313.severity = none
 
-# Type parameter names should begin with T
+# SA1314: Type parameter names should begin with T
 dotnet_diagnostic.SA1314.severity = none
 
 # SA1316: Tuple element names should use correct casing
 dotnet_diagnostic.SA1316.severity = none
 
-# Access modifier should be declared
-dotnet_diagnostic.SA1400.severity = none
+# SA1400: Member should declare an access modifier
+dotnet_diagnostic.SA1400.severity = none # TODO: warning
 
-# Fields should be private
+# SA1401: Fields should be private
 dotnet_diagnostic.SA1401.severity = none
 
-# File may only contain a single type
+# SA1402: File may only contain a single type
 dotnet_diagnostic.SA1402.severity = none
 
-# File may only contain a single namespace
+# SA1403: File may only contain a single namespace
 dotnet_diagnostic.SA1403.severity = none
 
-# Code analysis suppression should have justification
-dotnet_diagnostic.SA1404.severity = none
+# SA1404: Code analysis suppression should have justification
+dotnet_diagnostic.SA1404.severity = none # TODO: warning
 
-# Debug.Assert should provide message text
+# SA1405: Debug.Assert should provide message text
 dotnet_diagnostic.SA1405.severity = none
 
-# Debug.Fail should provide message text
+# SA1406: Debug.Fail should provide message text
 dotnet_diagnostic.SA1406.severity = none
 
-# Arithmetic expressions should declare precedence
+# SA1407: Arithmetic expressions should declare precedence
 dotnet_diagnostic.SA1407.severity = none
 
-# Conditional expressions should declare precedence
-dotnet_diagnostic.SA1408.severity = warning
+# SA1408: Conditional expressions should declare precedence
+dotnet_diagnostic.SA1408.severity = none # TODO: warning
 
-# Remove unnecessary code
+# SA1409: Remove unnecessary code
 dotnet_diagnostic.SA1409.severity = none
 
-# Remove delegate parenthesis when possible
-dotnet_diagnostic.SA1410.severity = none
+# SA1410: Remove delegate parens when possible
+dotnet_diagnostic.SA1410.severity = warning
 
-# Attribute constructor should not use unnecessary parenthesis
-dotnet_diagnostic.SA1411.severity = none
+# SA1411: Attribute constructor shouldn't use unnecessary parenthesis
+dotnet_diagnostic.SA1411.severity = none # TODO: warning
 
-# Store files as UTF-8 with byte order mark
+# SA1412: Store files as UTF-8 with byte order mark
 dotnet_diagnostic.SA1412.severity = none
 
-# Use trailing comma in multi-line initializers
+# SA1413: Use trailing comma in multi-line initializers
 dotnet_diagnostic.SA1413.severity = none
 
-# Tuple types in signatures should have element names
+# SA1414: Tuple types in signatures should have element names
 dotnet_diagnostic.SA1414.severity = none
 
-# Braces for multi-line statements should not share line
+# SA1500: Braces for multi-line statements should not share line
 dotnet_diagnostic.SA1500.severity = error
 
-# Statement should not be on a single line
+# SA1501: Statement should not be on a single line
 dotnet_diagnostic.SA1501.severity = none
 
-# Element should not be on a single line
+# SA1502: Element should not be on a single line
 dotnet_diagnostic.SA1502.severity = none
 
-# Braces should not be omitted
+# SA1503: Braces should not be omitted
 dotnet_diagnostic.SA1503.severity = none
 
-# All accessors should be single-line or multi-line
+# SA1504: All accessors should be single-line or multi-line
 dotnet_diagnostic.SA1504.severity = none
 
-# Opening braces should not be followed by blank line
+# SA1505: An opening brace should not be followed by a blank line
 dotnet_diagnostic.SA1505.severity = warning
 
-# Element documentation headers should not be followed by blank line
+# SA1506: Element documentation headers should not be followed by blank line
 dotnet_diagnostic.SA1506.severity = none
 
-# Code should not contain multiple blank lines in a row
+# SA1507: Code should not contain multiple blank lines in a row
 dotnet_diagnostic.SA1507.severity = warning
 
-# Closing braces should not be preceded by blank line
+# SA1508: A closing brace should not be preceded by a blank line
 dotnet_diagnostic.SA1508.severity = warning
 
-# Opening braces should not be preceded by blank line
+# SA1509: Opening braces should not be preceded by blank line
 dotnet_diagnostic.SA1509.severity = warning
 
-# Chained statement blocks should not be preceded by blank line
+# SA1510: 'else' statement should not be preceded by a blank line
 dotnet_diagnostic.SA1510.severity = none
 
-# While-do footer should not be preceded by blank line
+# SA1511: While-do footer should not be preceded by blank line
 dotnet_diagnostic.SA1511.severity = none
 
-# Single-line comments should not be followed by blank line
+# SA1512: Single-line comments should not be followed by blank line
 dotnet_diagnostic.SA1512.severity = none
 
-# Closing brace should be followed by blank line
+# SA1513: Closing brace should be followed by blank line
 dotnet_diagnostic.SA1513.severity = error
 
-# Element documentation header should be preceded by blank line
+# SA1514: Element documentation header should be preceded by blank line
 dotnet_diagnostic.SA1514.severity = none
 
-# Single-line comment should be preceded by blank line
+# SA1515: Single-line comment should be preceded by blank line
 dotnet_diagnostic.SA1515.severity = none
 
-# Elements should be separated by blank line
+# SA1516: Elements should be separated by blank line
 dotnet_diagnostic.SA1516.severity = none
 
-# Code should not contain blank lines at start of file
+# SA1517: Code should not contain blank lines at start of file
 dotnet_diagnostic.SA1517.severity = warning
 
-# Use line endings correctly at end of file
-dotnet_diagnostic.SA1518.severity = none
+# SA1518: Code should not contain blank lines at the end of the file
+dotnet_diagnostic.SA1518.severity = none # TODO: warning
 
-# Braces should not be omitted from multi-line child statement
+# SA1519: Braces should not be omitted from multi-line child statement
 dotnet_diagnostic.SA1519.severity = none
 
-# Use braces consistently
+# SA1520: Use braces consistently
 dotnet_diagnostic.SA1520.severity = none
 
-# Elements should be documented
+# SA1600: Elements should be documented
 dotnet_diagnostic.SA1600.severity = none
 
-# Partial elements should be documented
+# SA1601: Partial elements should be documented
 dotnet_diagnostic.SA1601.severity = none
 
-# Enumeration items should be documented
+# SA1602: Enumeration items should be documented
 dotnet_diagnostic.SA1602.severity = none
 
-# Documentation should contain valid XML
+# SA1603: Documentation should contain valid XML
 dotnet_diagnostic.SA1603.severity = none
 
-# Element documentation should have summary
+# SA1604: Element documentation should have summary
 dotnet_diagnostic.SA1604.severity = none
 
-# Partial element documentation should have summary
+# SA1605: Partial element documentation should have summary
 dotnet_diagnostic.SA1605.severity = none
 
-# Element documentation should have summary text
+# SA1606: Element documentation should have summary text
 dotnet_diagnostic.SA1606.severity = none
 
-# Partial element documentation should have summary text
+# SA1607: Partial element documentation should have summary text
 dotnet_diagnostic.SA1607.severity = none
 
-# Element documentation should not have default summary
+# SA1608: Element documentation should not have default summary
 dotnet_diagnostic.SA1608.severity = none
 
-# Property documentation should have value
+# SA1609: Property documentation should have value
 dotnet_diagnostic.SA1609.severity = none
 
-# Property documentation should have value text
+# SA1610: Property documentation should have value text
 dotnet_diagnostic.SA1610.severity = none
 
-# Element parameters should be documented
+# SA1611: The documentation for parameter 'message' is missing
 dotnet_diagnostic.SA1611.severity = none
 
-# Element parameter documentation should match element parameters
+# SA1612: The parameter documentation is at incorrect position
 dotnet_diagnostic.SA1612.severity = none
 
-# Element parameter documentation should declare parameter name
+# SA1613: Element parameter documentation should declare parameter name
 dotnet_diagnostic.SA1613.severity = none
 
-# Element parameter documentation should have text
+# SA1614: Element parameter documentation should have text
 dotnet_diagnostic.SA1614.severity = none
 
-# Element return value should be documented
+# SA1615: Element return value should be documented
 dotnet_diagnostic.SA1615.severity = none
 
-# Element return value documentation should have text
+# SA1616: Element return value documentation should have text
 dotnet_diagnostic.SA1616.severity = none
 
-# Void return value should not be documented
+# SA1617: Void return value should not be documented
 dotnet_diagnostic.SA1617.severity = none
 
-# Generic type parameters should be documented
+# SA1618: The documentation for type parameter is missing
 dotnet_diagnostic.SA1618.severity = none
 
-# Generic type parameters should be documented partial class
+# SA1619: The documentation for type parameter is missing
 dotnet_diagnostic.SA1619.severity = none
 
-# Generic type parameter documentation should match type parameters
+# SA1620: Generic type parameter documentation should match type parameters
 dotnet_diagnostic.SA1620.severity = none
 
-# Generic type parameter documentation should declare parameter name
+# SA1621: Generic type parameter documentation should declare parameter name
 dotnet_diagnostic.SA1621.severity = none
 
-# Generic type parameter documentation should have text
+# SA1622: Generic type parameter documentation should have text
 dotnet_diagnostic.SA1622.severity = none
 
-# Property summary documentation should match accessors
+# SA1623: Property documentation text
 dotnet_diagnostic.SA1623.severity = none
 
-# Property summary documentation should omit accessor with restricted access
+# SA1624: Because the property only contains a visible get accessor, the documentation summary text should begin with 'Gets'
 dotnet_diagnostic.SA1624.severity = none
 
-# Element documentation should not be copied and pasted
+# SA1625: Element documentation should not be copied and pasted
 dotnet_diagnostic.SA1625.severity = none
 
-# Single-line comments should not use documentation style slashes
+# SA1626: Single-line comments should not use documentation style slashes
 dotnet_diagnostic.SA1626.severity = none
 
-# Documentation text should not be empty
+# SA1627: The documentation text within the \'exception\' tag should not be empty
 dotnet_diagnostic.SA1627.severity = none
 
-# Documentation text should begin with a capital letter
+# SA1628: Documentation text should begin with a capital letter
 dotnet_diagnostic.SA1628.severity = none
 
-# Documentation text should end with a period
+# SA1629: Documentation text should end with a period
 dotnet_diagnostic.SA1629.severity = none
 
-# Documentation text should contain whitespace
+# SA1630: Documentation text should contain whitespace
 dotnet_diagnostic.SA1630.severity = none
 
-# Documentation should meet character percentage
+# SA1631: Documentation should meet character percentage
 dotnet_diagnostic.SA1631.severity = none
 
-# Documentation text should meet minimum character length
+# SA1632: Documentation text should meet minimum character length
 dotnet_diagnostic.SA1632.severity = none
 
-# File should have header
+# SA1633: File should have header
 dotnet_diagnostic.SA1633.severity = none
 
-# File header should show copyright
+# SA1634: File header should show copyright
 dotnet_diagnostic.SA1634.severity = none
 
-# File header should have copyright text
+# SA1635: File header should have copyright text
 dotnet_diagnostic.SA1635.severity = none
 
-# File header copyright text should match
+# SA1636: File header copyright text should match
 dotnet_diagnostic.SA1636.severity = none
 
-# File header should contain file name
+# SA1637: File header should contain file name
 dotnet_diagnostic.SA1637.severity = none
 
-# File header file name documentation should match file name
+# SA1638: File header file name documentation should match file name
 dotnet_diagnostic.SA1638.severity = none
 
-# File header should have summary
+# SA1639: File header should have summary
 dotnet_diagnostic.SA1639.severity = none
 
-# File header should have valid company text
+# SA1640: File header should have valid company text
 dotnet_diagnostic.SA1640.severity = none
 
-# File header company name text should match
+# SA1641: File header company name text should match
 dotnet_diagnostic.SA1641.severity = none
 
-# Constructor summary documentation should begin with standard text
+# SA1642: Constructor summary documentation should begin with standard text
 dotnet_diagnostic.SA1642.severity = none
 
-# Destructor summary documentation should begin with standard text
+# SA1643: Destructor summary documentation should begin with standard text
 dotnet_diagnostic.SA1643.severity = none
 
-# Documentation headers should not contain blank lines
+# SA1644: Documentation headers should not contain blank lines
 dotnet_diagnostic.SA1644.severity = none
 
-# Included documentation file does not exist
+# SA1645: Included documentation file does not exist
 dotnet_diagnostic.SA1645.severity = none
 
-# Included documentation XPath does not exist
+# SA1646: Included documentation XPath does not exist
 dotnet_diagnostic.SA1646.severity = none
 
-# Include node does not contain valid file and path
+# SA1647: Include node does not contain valid file and path
 dotnet_diagnostic.SA1647.severity = none
 
-# Inheritdoc should be used with inheriting class
+# SA1648: Inheritdoc should be used with inheriting class
 dotnet_diagnostic.SA1648.severity = none
 
-# File name should match first type name
+# SA1649: File name should match first type name
 dotnet_diagnostic.SA1649.severity = none
 
-# Element documentation should be spelled correctly
+# SA1650: Element documentation should be spelled correctly
 dotnet_diagnostic.SA1650.severity = none
 
-# Do not use placeholder elements
+# SA1651: Do not use placeholder elements
 dotnet_diagnostic.SA1651.severity = none
 
-# Do not prefix local calls with 'this.'
+# SX1101: Do not prefix local calls with 'this.'
 dotnet_diagnostic.SX1101.severity = none
 
-# Field names should begin with underscore
+# SX1309: Field names should begin with underscore
 dotnet_diagnostic.SX1309.severity = none
 
 # Static field names should begin with underscore
 dotnet_diagnostic.SX1309S.severity = none
+
+# IDE0001: Simplify name
+dotnet_diagnostic.IDE0001.severity = suggestion
+
+# IDE0002: Simplify member access
+dotnet_diagnostic.IDE0002.severity = suggestion
+
+# IDE0003: Remove this or Me qualification
+dotnet_diagnostic.IDE0003.severity = suggestion
+
+# IDE0004: Remove Unnecessary Cast
+dotnet_diagnostic.IDE0004.severity = suggestion
+
+# IDE0005: Using directive is unnecessary.
+dotnet_diagnostic.IDE0005.severity = suggestion
+
+# IDE0007: Use implicit type
+dotnet_diagnostic.IDE0007.severity = silent
+
+# IDE0008: Use explicit type
+dotnet_diagnostic.IDE0008.severity = suggestion
+
+# IDE0009: Add this or Me qualification
+dotnet_diagnostic.IDE0009.severity = silent
+
+# IDE0010: Add missing cases
+dotnet_diagnostic.IDE0010.severity = silent
+
+# IDE0011: Add braces
+dotnet_diagnostic.IDE0011.severity = silent
+
+# IDE0016: Use 'throw' expression
+dotnet_diagnostic.IDE0016.severity = silent
+
+# IDE0017: Simplify object initialization
+dotnet_diagnostic.IDE0017.severity = suggestion
+
+# IDE0018: Inline variable declaration
+dotnet_diagnostic.IDE0018.severity = suggestion
+
+# IDE0019: Use pattern matching to avoid as followed by a null check
+dotnet_diagnostic.IDE0019.severity = suggestion
+
+# IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
+dotnet_diagnostic.IDE0020.severity = none # TODO: warning
+
+# IDE0021: Use expression body for constructors
+dotnet_diagnostic.IDE0021.severity = silent
+
+# IDE0022: Use expression body for methods
+dotnet_diagnostic.IDE0022.severity = silent
+
+# IDE0023: Use expression body for operators
+dotnet_diagnostic.IDE0023.severity = silent
+
+# IDE0024: Use expression body for operators
+dotnet_diagnostic.IDE0024.severity = silent
+
+# IDE0025: Use expression body for properties
+dotnet_diagnostic.IDE0025.severity = silent
+
+# IDE0026: Use expression body for indexers
+dotnet_diagnostic.IDE0026.severity = silent
+
+# IDE0027: Use expression body for accessors
+dotnet_diagnostic.IDE0027.severity = silent
+
+# IDE0028: Simplify collection initialization
+dotnet_diagnostic.IDE0028.severity = suggestion
+
+# IDE0029: Use coalesce expression
+dotnet_diagnostic.IDE0029.severity = none # TODO: warning
+
+# IDE0030: Use coalesce expression
+dotnet_diagnostic.IDE0030.severity = warning
+
+# IDE0031: Use null propagation
+dotnet_diagnostic.IDE0031.severity = none # TODO: warning
+
+# IDE0032: Use auto property
+dotnet_diagnostic.IDE0032.severity = silent
+
+# IDE0033: Use explicitly provided tuple name
+dotnet_diagnostic.IDE0033.severity = suggestion
+
+# IDE0034: Simplify 'default' expression
+dotnet_diagnostic.IDE0034.severity = suggestion
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = suggestion
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = none # TODO: warning
+
+# IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = silent
+
+# IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
+dotnet_diagnostic.IDE0038.severity = suggestion
+
+# IDE0039: Use local function
+dotnet_diagnostic.IDE0039.severity = suggestion
+
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = suggestion
+
+# IDE0041: Use 'is null' check
+dotnet_diagnostic.IDE0041.severity = warning
+
+# IDE0042: Deconstruct variable declaration
+dotnet_diagnostic.IDE0042.severity = silent
+
+# IDE0043: Invalid format string
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Add readonly modifier
+dotnet_diagnostic.IDE0044.severity = suggestion
+
+# IDE0045: Use conditional expression for assignment
+dotnet_diagnostic.IDE0045.severity = suggestion
+
+# IDE0046: Use conditional expression for return
+dotnet_diagnostic.IDE0046.severity = suggestion
+
+# IDE0047: Remove unnecessary parentheses
+dotnet_diagnostic.IDE0047.severity = silent
+
+# IDE0048: Add parentheses for clarity
+dotnet_diagnostic.IDE0048.severity = silent
+
+# IDE0049: Use language keywords instead of framework type names for type references
+dotnet_diagnostic.IDE0049.severity = warning
+
+# IDE0051: Remove unused private members
+dotnet_diagnostic.IDE0051.severity = suggestion
+
+# IDE0052: Remove unread private members
+dotnet_diagnostic.IDE0052.severity = suggestion
+
+# IDE0053: Use expression body for lambdas
+dotnet_diagnostic.IDE0053.severity = silent
+
+# IDE0054: Use compound assignment
+dotnet_diagnostic.IDE0054.severity = none # TODO: warning
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = suggestion
+
+# IDE0056: Use index operator
+dotnet_diagnostic.IDE0056.severity = suggestion
+
+# IDE0057: Use range operator
+dotnet_diagnostic.IDE0057.severity = suggestion
+
+# IDE0058: Expression value is never used
+dotnet_diagnostic.IDE0058.severity = silent
+
+# IDE0059: Unnecessary assignment of a value
+dotnet_diagnostic.IDE0059.severity = none # TODO: warning
+
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = silent
+dotnet_code_quality_unused_parameters = non_public
+
+# IDE0061: Use expression body for local functions
+dotnet_diagnostic.IDE0061.severity = silent
+
+# IDE0062: Make local function 'static'
+dotnet_diagnostic.IDE0062.severity = none # TODO: warning
+
+# IDE0063: Use simple 'using' statement
+dotnet_diagnostic.IDE0063.severity = silent
+
+# IDE0064: Make readonly fields writable
+dotnet_diagnostic.IDE0064.severity = silent
+
+# IDE0065: Misplaced using directive
+dotnet_diagnostic.IDE0065.severity = none # TODO: warning
+
+# IDE0066: Convert switch statement to expression
+dotnet_diagnostic.IDE0066.severity = suggestion
+
+# IDE0070: Use 'System.HashCode'
+dotnet_diagnostic.IDE0070.severity = suggestion
+
+# IDE0071: Simplify interpolation
+dotnet_diagnostic.IDE0071.severity = warning
+
+# IDE0072: Add missing cases
+dotnet_diagnostic.IDE0072.severity = silent
+
+# IDE0073: The file header is missing or not located at the top of the file
+dotnet_diagnostic.IDE0073.severity = warning
+
+# IDE0074: Use compound assignment
+dotnet_diagnostic.IDE0074.severity = none # TODO: warning
+
+# IDE0075: Simplify conditional expression
+dotnet_diagnostic.IDE0075.severity = silent
+
+# IDE0076: Invalid global 'SuppressMessageAttribute'
+dotnet_diagnostic.IDE0076.severity = warning
+
+# IDE0077: Avoid legacy format target in 'SuppressMessageAttribute'
+dotnet_diagnostic.IDE0077.severity = silent
+
+# IDE0078: Use pattern matching
+dotnet_diagnostic.IDE0078.severity = suggestion
+
+# IDE0079: Remove unnecessary suppression
+dotnet_diagnostic.IDE0079.severity = suggestion
+
+# IDE0080: Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0080.severity = warning
+
+# IDE0081: Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0081.severity = none
+
+# IDE0082: 'typeof' can be converted  to 'nameof'
+dotnet_diagnostic.IDE0082.severity = none # TODO: warning
+
+# IDE0083: Use pattern matching
+dotnet_diagnostic.IDE0083.severity = silent
+
+# IDE0084: Use pattern matching (IsNot operator)
+dotnet_diagnostic.IDE0084.severity = none
+
+# IDE0090: Use 'new(...)'
+dotnet_diagnostic.IDE0090.severity = silent
+
+# IDE0100: Remove redundant equality
+dotnet_diagnostic.IDE0100.severity = none # TODO: warning
+
+# IDE0110: Remove unnecessary discard
+dotnet_diagnostic.IDE0110.severity = none # TODO: warning
+
+# IDE0120: Simplify LINQ expression
+dotnet_diagnostic.IDE0120.severity = none
+
+# IDE0130: Namespace does not match folder structure
+dotnet_diagnostic.IDE0130.severity = silent
+
+# IDE0140: Simplify object creation
+dotnet_diagnostic.IDE0140.severity = none
+
+# IDE0150: Prefer 'null' check over type check
+dotnet_diagnostic.IDE0150.severity = silent
+
+# IDE0160: Convert to block scoped namespace
+dotnet_diagnostic.IDE0160.severity = silent
+
+# IDE0161: Convert to file-scoped namespace
+dotnet_diagnostic.IDE0161.severity = silent
+
+# IDE0170: Simplify property pattern
+dotnet_diagnostic.IDE0170.severity = none # TODO: warning
+
+# IDE0180: Use tuple swap
+dotnet_diagnostic.IDE0180.severity = suggestion
+
+# IDE0200: Remove unnecessary lambda expression
+dotnet_diagnostic.IDE0200.severity = none # TODO: warning
+
+# IDE0210: Use top-level statements
+dotnet_diagnostic.IDE0210.severity = silent
+
+# IDE0211: Use program main
+dotnet_diagnostic.IDE0211.severity = silent
+
+# IDE0220: foreach cast
+dotnet_diagnostic.IDE0220.severity = silent
+
+# IDE0230: Use UTF8 string literal
+dotnet_diagnostic.IDE0230.severity = suggestion
+
+# IDE1005: Delegate invocation can be simplified.
+dotnet_diagnostic.IDE1005.severity = warning
+
+# IDE1006: Naming styles
+dotnet_diagnostic.IDE1006.severity = silent
+
+# IDE2000: Allow multiple blank lines
+dotnet_diagnostic.IDE2000.severity = silent
+
+# IDE2001: Embedded statements must be on their own line
+dotnet_diagnostic.IDE2001.severity = silent
+
+# IDE2002: Consecutive braces must not have blank line between them
+dotnet_diagnostic.IDE2002.severity = silent
+
+# IDE2003: Allow statement immediately after block
+dotnet_diagnostic.IDE2003.severity = silent
+
+# IDE2004: Blank line not allowed after constructor initializer colon
+dotnet_diagnostic.IDE2004.severity = silent

--- a/eng/CodeAnalysis.test.globalconfig
+++ b/eng/CodeAnalysis.test.globalconfig
@@ -1,1429 +1,1885 @@
 is_global = true
 
-# Analyzer threw an exception
+# AD0001: Analyzer threw an exception
 dotnet_diagnostic.AD0001.severity = suggestion
 
-# Do not declare static members on generic types
+# CA1000: Do not declare static members on generic types
 dotnet_diagnostic.CA1000.severity = none
 
-# Types that own disposable fields should be disposable
+# CA1001: Types that own disposable fields should be disposable
 dotnet_diagnostic.CA1001.severity = none
 
-# Do not expose generic lists
+# CA1002: Do not expose generic lists
 dotnet_diagnostic.CA1002.severity = none
 
-# Use generic event handler instances
+# CA1003: Use generic event handler instances
 dotnet_diagnostic.CA1003.severity = none
 
-# Avoid excessive parameters on generic types
+# CA1005: Avoid excessive parameters on generic types
 dotnet_diagnostic.CA1005.severity = none
 
-# Enums should have zero value
+# CA1008: Enums should have zero value
 dotnet_diagnostic.CA1008.severity = none
 
-# Generic interface should also be implemented
+# CA1010: Generic interface should also be implemented
 dotnet_diagnostic.CA1010.severity = none
 
-# Abstract types should not have public constructors
+# CA1012: Abstract types should not have public constructors
 dotnet_diagnostic.CA1012.severity = none
 
-# Mark assemblies with CLSCompliant
+# CA1014: Mark assemblies with CLSCompliant
 dotnet_diagnostic.CA1014.severity = none
 
-# Mark assemblies with assembly version
+# CA1016: Mark assemblies with assembly version
 dotnet_diagnostic.CA1016.severity = none
 
-# Mark assemblies with ComVisible
+# CA1017: Mark assemblies with ComVisible
 dotnet_diagnostic.CA1017.severity = none
 
-# Mark attributes with AttributeUsageAttribute
+# CA1018: Mark attributes with AttributeUsageAttribute
 dotnet_diagnostic.CA1018.severity = warning
 
-# Define accessors for attribute arguments
+# CA1019: Define accessors for attribute arguments
 dotnet_diagnostic.CA1019.severity = none
 
-# Avoid out parameters
+# CA1021: Avoid out parameters
 dotnet_diagnostic.CA1021.severity = none
 
-# Use properties where appropriate
+# CA1024: Use properties where appropriate
 dotnet_diagnostic.CA1024.severity = none
 
-# Mark enums with FlagsAttribute
+# CA1027: Mark enums with FlagsAttribute
 dotnet_diagnostic.CA1027.severity = none
 
-# Enum Storage should be Int32
+# CA1028: Enum Storage should be Int32
 dotnet_diagnostic.CA1028.severity = none
 
-# Use events where appropriate
+# CA1030: Use events where appropriate
 dotnet_diagnostic.CA1030.severity = none
 
-# Do not catch general exception types
+# CA1031: Do not catch general exception types
 dotnet_diagnostic.CA1031.severity = none
 
-# Implement standard exception constructors
+# CA1032: Implement standard exception constructors
 dotnet_diagnostic.CA1032.severity = none
 
-# Interface methods should be callable by child types
+# CA1033: Interface methods should be callable by child types
 dotnet_diagnostic.CA1033.severity = none
 
-# Nested types should not be visible
+# CA1034: Nested types should not be visible
 dotnet_diagnostic.CA1034.severity = none
 
-# Override methods on comparable types
+# CA1036: Override methods on comparable types
 dotnet_diagnostic.CA1036.severity = none
 
-# Avoid empty interfaces
+# CA1040: Avoid empty interfaces
 dotnet_diagnostic.CA1040.severity = none
 
-# Provide ObsoleteAttribute message
+# CA1041: Provide ObsoleteAttribute message
 dotnet_diagnostic.CA1041.severity = none
 
-# Use Integral Or String Argument For Indexers
+# CA1043: Use Integral Or String Argument For Indexers
 dotnet_diagnostic.CA1043.severity = none
 
-# Properties should not be write only
+# CA1044: Properties should not be write only
 dotnet_diagnostic.CA1044.severity = none
 
-# Do not pass types by reference
+# CA1045: Do not pass types by reference
 dotnet_diagnostic.CA1045.severity = none
 
-# Do not overload equality operator on reference types
+# CA1046: Do not overload equality operator on reference types
 dotnet_diagnostic.CA1046.severity = none
 
-# Do not declare protected member in sealed type
+# CA1047: Do not declare protected member in sealed type
 dotnet_diagnostic.CA1047.severity = warning
 
-# Declare types in namespaces
+# CA1050: Declare types in namespaces
 dotnet_diagnostic.CA1050.severity = warning
 
-# Do not declare visible instance fields
+# CA1051: Do not declare visible instance fields
 dotnet_diagnostic.CA1051.severity = none
 
-# Static holder types should be Static or NotInheritable
+# CA1052: Static holder types should be Static or NotInheritable
 dotnet_diagnostic.CA1052.severity = none # TODO: warning
 
-# URI-like parameters should not be strings
+# CA1054: URI-like parameters should not be strings
 dotnet_diagnostic.CA1054.severity = none
 
-# URI-like return values should not be strings
+# CA1055: URI-like return values should not be strings
 dotnet_diagnostic.CA1055.severity = none
 
-# URI-like properties should not be strings
+# CA1056: URI-like properties should not be strings
 dotnet_diagnostic.CA1056.severity = none
 
-# Types should not extend certain base types
+# CA1058: Types should not extend certain base types
 dotnet_diagnostic.CA1058.severity = none
 
-# Move pinvokes to native methods class
+# CA1060: Move pinvokes to native methods class
 dotnet_diagnostic.CA1060.severity = none
 
-# Do not hide base class methods
+# CA1061: Do not hide base class methods
 dotnet_diagnostic.CA1061.severity = none
 
-# Validate arguments of public methods
+# CA1062: Validate arguments of public methods
 dotnet_diagnostic.CA1062.severity = none
 
-# Implement IDisposable Correctly
+# CA1063: Implement IDisposable Correctly
 dotnet_diagnostic.CA1063.severity = none
 
-# Exceptions should be public
+# CA1064: Exceptions should be public
 dotnet_diagnostic.CA1064.severity = none
 
-# Do not raise exceptions in unexpected locations
+# CA1065: Do not raise exceptions in unexpected locations
 dotnet_diagnostic.CA1065.severity = none
 
-# Implement IEquatable when overriding Object.Equals
+# CA1066: Implement IEquatable when overriding Object.Equals
 dotnet_diagnostic.CA1066.severity = none # TODO: warning
 
-# Override Object.Equals(object) when implementing IEquatable<T>
+# CA1067: Override Object.Equals(object) when implementing IEquatable<T>
 dotnet_diagnostic.CA1067.severity = warning
 
-# CancellationToken parameters must come last
+# CA1068: CancellationToken parameters must come last
 dotnet_diagnostic.CA1068.severity = none
 
-# Enums values should not be duplicated
+# CA1069: Enums values should not be duplicated
 dotnet_diagnostic.CA1069.severity = none
 
-# Do not declare event fields as virtual
+# CA1070: Do not declare event fields as virtual
 dotnet_diagnostic.CA1070.severity = suggestion
 
-# Avoid using cref tags with a prefix
+# CA1200: Avoid using cref tags with a prefix
 dotnet_diagnostic.CA1200.severity = suggestion
 
-# Do not pass literals as localized parameters
+# CA1303: Do not pass literals as localized parameters
 dotnet_diagnostic.CA1303.severity = none
 
-# Specify CultureInfo
+# CA1304: Specify CultureInfo
 dotnet_diagnostic.CA1304.severity = none
 
-# Specify IFormatProvider
+# CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity = none
 
-# Specify StringComparison for clarity
+# CA1307: Specify StringComparison for clarity
 dotnet_diagnostic.CA1307.severity = none
 
-# Normalize strings to uppercase
+# CA1308: Normalize strings to uppercase
 dotnet_diagnostic.CA1308.severity = none
 
-# Use ordinal string comparison
+# CA1309: Use ordinal string comparison
 dotnet_diagnostic.CA1309.severity = none
 
-# Specify StringComparison for correctness
+# CA1310: Specify StringComparison for correctness
 dotnet_diagnostic.CA1310.severity = suggestion
 
-# P/Invokes should not be visible
+# CA1311: Specify a culture or use an invariant version
+dotnet_diagnostic.CA1311.severity = none
+
+# CA1401: P/Invokes should not be visible
 dotnet_diagnostic.CA1401.severity = warning
 
-# Validate platform compatibility
+# CA1416: Validate platform compatibility
 dotnet_diagnostic.CA1416.severity = none # TODO: warning
 
-# Do not use 'OutAttribute' on string parameters for P/Invokes
+# CA1417: Do not use 'OutAttribute' on string parameters for P/Invokes
 dotnet_diagnostic.CA1417.severity = warning
 
-# Use valid platform string
+# CA1418: Use valid platform string
 dotnet_diagnostic.CA1418.severity = warning
 
-# Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+# CA1419: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
 dotnet_diagnostic.CA1419.severity = warning
 
-# Property, type, or attribute requires runtime marshalling
+# CA1420: Property, type, or attribute requires runtime marshalling
 dotnet_diagnostic.CA1420.severity = warning
 
-# This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+# CA1421: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
 dotnet_diagnostic.CA1421.severity = suggestion
 
-# Avoid excessive inheritance
+# CA1501: Avoid excessive inheritance
 dotnet_diagnostic.CA1501.severity = none
 
-# Avoid excessive complexity
+# CA1502: Avoid excessive complexity
 dotnet_diagnostic.CA1502.severity = none
 
-# Avoid unmaintainable code
+# CA1505: Avoid unmaintainable code
 dotnet_diagnostic.CA1505.severity = none
 
-# Avoid excessive class coupling
+# CA1506: Avoid excessive class coupling
 dotnet_diagnostic.CA1506.severity = none
 
-# Use nameof to express symbol names
+# CA1507: Use nameof to express symbol names
 dotnet_diagnostic.CA1507.severity = none
 
-# Avoid dead conditional code
+# CA1508: Avoid dead conditional code
 dotnet_diagnostic.CA1508.severity = none
 
-# Invalid entry in code metrics rule specification file
+# CA1509: Invalid entry in code metrics rule specification file
 dotnet_diagnostic.CA1509.severity = none
 
-# Do not name enum values 'Reserved'
+# CA1700: Do not name enum values 'Reserved'
 dotnet_diagnostic.CA1700.severity = none
 
-# Identifiers should not contain underscores
+# CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = none
 
-# Identifiers should differ by more than case
+# CA1708: Identifiers should differ by more than case
 dotnet_diagnostic.CA1708.severity = none
 
-# Identifiers should have correct suffix
+# CA1710: Identifiers should have correct suffix
 dotnet_diagnostic.CA1710.severity = none
 
-# Identifiers should not have incorrect suffix
+# CA1711: Identifiers should not have incorrect suffix
 dotnet_diagnostic.CA1711.severity = none
 
-# Do not prefix enum values with type name
+# CA1712: Do not prefix enum values with type name
 dotnet_diagnostic.CA1712.severity = none
 
-# Events should not have 'Before' or 'After' prefix
+# CA1713: Events should not have 'Before' or 'After' prefix
 dotnet_diagnostic.CA1713.severity = none
 
-# Identifiers should have correct prefix
+# CA1715: Identifiers should have correct prefix
 dotnet_diagnostic.CA1715.severity = none
 
-# Identifiers should not match keywords
+# CA1716: Identifiers should not match keywords
 dotnet_diagnostic.CA1716.severity = none
 
-# Identifier contains type name
+# CA1720: Identifier contains type name
 dotnet_diagnostic.CA1720.severity = none
 
-# Property names should not match get methods
+# CA1721: Property names should not match get methods
 dotnet_diagnostic.CA1721.severity = none
 
-# Type names should not match namespaces
+# CA1724: Type names should not match namespaces
 dotnet_diagnostic.CA1724.severity = none
 
-# Parameter names should match base declaration
+# CA1725: Parameter names should match base declaration
 dotnet_diagnostic.CA1725.severity = suggestion
 
-# Use PascalCase for named placeholders
+# CA1727: Use PascalCase for named placeholders
 dotnet_diagnostic.CA1727.severity = suggestion
 
-# Use literals where appropriate
+# CA1802: Use literals where appropriate
 dotnet_diagnostic.CA1802.severity = warning
 
-# Do not initialize unnecessarily
+# CA1805: Do not initialize unnecessarily
 dotnet_diagnostic.CA1805.severity = warning
 
-# Do not ignore method results
+# CA1806: Do not ignore method results
 dotnet_diagnostic.CA1806.severity = none
 
-# Initialize reference type static fields inline
+# CA1810: Initialize reference type static fields inline
 dotnet_diagnostic.CA1810.severity = none # TODO: warning
 
-# Avoid uninstantiated internal classes
+# CA1812: Avoid uninstantiated internal classes
 dotnet_diagnostic.CA1812.severity = none
 
-# Avoid unsealed attributes
+# CA1813: Avoid unsealed attributes
 dotnet_diagnostic.CA1813.severity = none
 
-# Prefer jagged arrays over multidimensional
+# CA1814: Prefer jagged arrays over multidimensional
 dotnet_diagnostic.CA1814.severity = none
 
-# Override equals and operator equals on value types
+# CA1815: Override equals and operator equals on value types
 dotnet_diagnostic.CA1815.severity = none
 
-# Dispose methods should call SuppressFinalize
+# CA1816: Dispose methods should call SuppressFinalize
 dotnet_diagnostic.CA1816.severity = none
 
-# Properties should not return arrays
+# CA1819: Properties should not return arrays
 dotnet_diagnostic.CA1819.severity = none
 
-# Test for empty strings using string length
+# CA1820: Test for empty strings using string length
 dotnet_diagnostic.CA1820.severity = none
 
-# Remove empty Finalizers
+# CA1821: Remove empty Finalizers
 dotnet_diagnostic.CA1821.severity = none # TODO: warning
 
-# Mark members as static
+# CA1822: Mark members as static
 dotnet_diagnostic.CA1822.severity = none # TODO: warning
 
-# Avoid unused private fields
+# CA1823: Avoid unused private fields
 dotnet_diagnostic.CA1823.severity = warning
 
-# Mark assemblies with NeutralResourcesLanguageAttribute
+# CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
 dotnet_diagnostic.CA1824.severity = warning
 
-# Avoid zero-length array allocations
+# CA1825: Avoid zero-length array allocations.
 dotnet_diagnostic.CA1825.severity = warning
 
-# Do not use Enumerable methods on indexable collections
+# CA1826: Do not use Enumerable methods on indexable collections
 dotnet_diagnostic.CA1826.severity = warning
 
-# Do not use Count() or LongCount() when Any() can be used
+# CA1827: Do not use Count() or LongCount() when Any() can be used
 dotnet_diagnostic.CA1827.severity = warning
 
-# Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+# CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
 dotnet_diagnostic.CA1828.severity = warning
 
-# Use Length/Count property instead of Count() when available
+# CA1829: Use Length/Count property instead of Count() when available
 dotnet_diagnostic.CA1829.severity = warning
 
-# Prefer strongly-typed Append and Insert method overloads on StringBuilder
+# CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
 dotnet_diagnostic.CA1830.severity = warning
 
-# Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1831.severity = warning
 
-# Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1832.severity = warning
 
-# Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
 dotnet_diagnostic.CA1833.severity = warning
 
-# Consider using 'StringBuilder.Append(char)' when applicable
+# CA1834: Consider using 'StringBuilder.Append(char)' when applicable
 dotnet_diagnostic.CA1834.severity = warning
 
-# Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+# CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
 dotnet_diagnostic.CA1835.severity = warning
 
-# Prefer IsEmpty over Count
+# CA1836: Prefer IsEmpty over Count
 dotnet_diagnostic.CA1836.severity = warning
 
-# Use 'Environment.ProcessId'
+# CA1837: Use 'Environment.ProcessId'
 dotnet_diagnostic.CA1837.severity = warning
 
-# Avoid 'StringBuilder' parameters for P/Invokes
+# CA1838: Avoid 'StringBuilder' parameters for P/Invokes
 dotnet_diagnostic.CA1838.severity = warning
 
-# Use 'Environment.ProcessPath'
+# CA1839: Use 'Environment.ProcessPath'
 dotnet_diagnostic.CA1839.severity = warning
 
-# Use 'Environment.CurrentManagedThreadId'
+# CA1840: Use 'Environment.CurrentManagedThreadId'
 dotnet_diagnostic.CA1840.severity = warning
 
-# Prefer Dictionary.Contains methods
+# CA1841: Prefer Dictionary.Contains methods
 dotnet_diagnostic.CA1841.severity = warning
 
-# Do not use 'WhenAll' with a single task
+# CA1842: Do not use 'WhenAll' with a single task
 dotnet_diagnostic.CA1842.severity = warning
 
-# Do not use 'WaitAll' with a single task
+# CA1843: Do not use 'WaitAll' with a single task
 dotnet_diagnostic.CA1843.severity = warning
 
-# Provide memory-based overrides of async methods when subclassing 'Stream'
+# CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
 dotnet_diagnostic.CA1844.severity = warning
 
-# Use span-based 'string.Concat'
+# CA1845: Use span-based 'string.Concat'
 dotnet_diagnostic.CA1845.severity = warning
 
-# Prefer 'AsSpan' over 'Substring'
+# CA1846: Prefer 'AsSpan' over 'Substring'
 dotnet_diagnostic.CA1846.severity = warning
 
-# Use char literal for a single character lookup
+# CA1847: Use char literal for a single character lookup
 dotnet_diagnostic.CA1847.severity = warning
 
-# Use the LoggerMessage delegates
+# CA1848: Use the LoggerMessage delegates
 dotnet_diagnostic.CA1848.severity = none
 
-# Call async methods when in an async method
+# CA1849: Call async methods when in an async method
 dotnet_diagnostic.CA1849.severity = suggestion
 
-# Prefer static 'HashData' method over 'ComputeHash'
+# CA1850: Prefer static 'HashData' method over 'ComputeHash'
 dotnet_diagnostic.CA1850.severity = warning
 
-# Possible multiple enumerations of 'IEnumerable' collection
+# CA1851: Possible multiple enumerations of 'IEnumerable' collection
 dotnet_diagnostic.CA1851.severity = suggestion
 
-# Dispose objects before losing scope
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = none
+
+# CA1853: Unnecessary call to 'Dictionary.ContainsKey(key)'
+dotnet_diagnostic.CA1853.severity = none
+
+# CA1854: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+dotnet_diagnostic.CA1854.severity = none
+
+# CA2000: Dispose objects before losing scope
 dotnet_diagnostic.CA2000.severity = none
 
-# Do not lock on objects with weak identity
+# CA2002: Do not lock on objects with weak identity
 dotnet_diagnostic.CA2002.severity = none
 
-# Consider calling ConfigureAwait on the awaited task
+# CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = none # TODO: warning
 
-# Do not create tasks without passing a TaskScheduler
+# CA2008: Do not create tasks without passing a TaskScheduler
 dotnet_diagnostic.CA2008.severity = warning
 
-# Do not call ToImmutableCollection on an ImmutableCollection value
+# CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
 dotnet_diagnostic.CA2009.severity = warning
 
-# Avoid infinite recursion
+# CA2011: Avoid infinite recursion
 dotnet_diagnostic.CA2011.severity = warning
 
-# Use ValueTasks correctly
+# CA2012: Use ValueTasks correctly
 dotnet_diagnostic.CA2012.severity = warning
 
-# Do not use ReferenceEquals with value types
+# CA2013: Do not use ReferenceEquals with value types
 dotnet_diagnostic.CA2013.severity = warning
 
-# Do not use stackalloc in loops
+# CA2014: Do not use stackalloc in loops.
 dotnet_diagnostic.CA2014.severity = none # TODO: warning
 
-# Do not define finalizers for types derived from MemoryManager<T>
+# CA2015: Do not define finalizers for types derived from MemoryManager<T>
 dotnet_diagnostic.CA2015.severity = warning
 
-# Forward the 'CancellationToken' parameter to methods
+# CA2016: Forward the 'CancellationToken' parameter to methods
 dotnet_diagnostic.CA2016.severity = warning
 
-# Parameter count mismatch
+# CA2017: Parameter count mismatch
 dotnet_diagnostic.CA2017.severity = warning
 
-# 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
+# CA2018: 'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument
 dotnet_diagnostic.CA2018.severity = warning
 
-# Improper 'ThreadStatic' field initialization
+# CA2019: Improper 'ThreadStatic' field initialization
 dotnet_diagnostic.CA2019.severity = warning
 
-# Review SQL queries for security vulnerabilities
+# CA2100: Review SQL queries for security vulnerabilities
 dotnet_diagnostic.CA2100.severity = none
 
-# Specify marshaling for P/Invoke string arguments
+# CA2101: Specify marshaling for P/Invoke string arguments
 dotnet_diagnostic.CA2101.severity = none
 
-# Review visible event handlers
+# CA2109: Review visible event handlers
 dotnet_diagnostic.CA2109.severity = none
 
-# Seal methods that satisfy private interfaces
+# CA2119: Seal methods that satisfy private interfaces
 dotnet_diagnostic.CA2119.severity = none
 
-# Do Not Catch Corrupted State Exceptions
+# CA2153: Do Not Catch Corrupted State Exceptions
 dotnet_diagnostic.CA2153.severity = none
 
-# Rethrow to preserve stack details
+# CA2200: Rethrow to preserve stack details
 dotnet_diagnostic.CA2200.severity = warning
 
-# Do not raise reserved exception types
+# CA2201: Do not raise reserved exception types
 dotnet_diagnostic.CA2201.severity = none
 
-# Initialize value type static fields inline
+# CA2207: Initialize value type static fields inline
 dotnet_diagnostic.CA2207.severity = warning
 
-# Instantiate argument exceptions correctly
+# CA2208: Instantiate argument exceptions correctly
 dotnet_diagnostic.CA2208.severity = none # TODO: warning
 
-# Non-constant fields should not be visible
+# CA2211: Non-constant fields should not be visible
 dotnet_diagnostic.CA2211.severity = none
 
-# Disposable fields should be disposed
+# CA2213: Disposable fields should be disposed
 dotnet_diagnostic.CA2213.severity = none
 
-# Do not call overridable methods in constructors
+# CA2214: Do not call overridable methods in constructors
 dotnet_diagnostic.CA2214.severity = none
 
-# Dispose methods should call base class dispose
+# CA2215: Dispose methods should call base class dispose
 dotnet_diagnostic.CA2215.severity = none
 
-# Disposable types should declare finalizer
+# CA2216: Disposable types should declare finalizer
 dotnet_diagnostic.CA2216.severity = none
 
-# Do not mark enums with FlagsAttribute
+# CA2217: Do not mark enums with FlagsAttribute
 dotnet_diagnostic.CA2217.severity = none
 
-# Override GetHashCode on overriding Equals
+# CA2218: Override GetHashCode on overriding Equals
 dotnet_diagnostic.CA2218.severity = none
 
-# Do not raise exceptions in finally clauses
+# CA2219: Do not raise exceptions in finally clauses
 dotnet_diagnostic.CA2219.severity = none
 
-# Override Equals on overloading operator equals
+# CA2224: Override Equals on overloading operator equals
 dotnet_diagnostic.CA2224.severity = none
 
-# Operator overloads have named alternates
+# CA2225: Operator overloads have named alternates
 dotnet_diagnostic.CA2225.severity = none
 
-# Operators should have symmetrical overloads
+# CA2226: Operators should have symmetrical overloads
 dotnet_diagnostic.CA2226.severity = none
 
-# Collection properties should be read only
+# CA2227: Collection properties should be read only
 dotnet_diagnostic.CA2227.severity = none
 
-# Implement serialization constructors
+# CA2229: Implement serialization constructors
 dotnet_diagnostic.CA2229.severity = warning
 
-# Overload operator equals on overriding value type Equals
+# CA2231: Overload operator equals on overriding value type Equals
 dotnet_diagnostic.CA2231.severity = none
 
-# Pass system uri objects instead of strings
+# CA2234: Pass system uri objects instead of strings
 dotnet_diagnostic.CA2234.severity = none
 
-# Mark all non-serializable fields
+# CA2235: Mark all non-serializable fields
 dotnet_diagnostic.CA2235.severity = none
 
-# Mark ISerializable types with serializable
+# CA2237: Mark ISerializable types with serializable
 dotnet_diagnostic.CA2237.severity = none
 
-# Provide correct arguments to formatting methods
+# CA2241: Provide correct arguments to formatting methods
 dotnet_diagnostic.CA2241.severity = warning
 
-# Test for NaN correctly
+# CA2242: Test for NaN correctly
 dotnet_diagnostic.CA2242.severity = warning
 
-# Attribute string literals should parse correctly
+# CA2243: Attribute string literals should parse correctly
 dotnet_diagnostic.CA2243.severity = warning
 
-# Do not duplicate indexed element initializations
+# CA2244: Do not duplicate indexed element initializations
 dotnet_diagnostic.CA2244.severity = warning
 
-# Do not assign a property to itself
+# CA2245: Do not assign a property to itself
 dotnet_diagnostic.CA2245.severity = none # TODO: warning
 
-# Assigning symbol and its member in the same statement
+# CA2246: Assigning symbol and its member in the same statement
 dotnet_diagnostic.CA2246.severity = warning
 
-# Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+# CA2247: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
 dotnet_diagnostic.CA2247.severity = warning
 
-# Provide correct 'enum' argument to 'Enum.HasFlag'
+# CA2248: Provide correct 'enum' argument to 'Enum.HasFlag'
 dotnet_diagnostic.CA2248.severity = warning
 
-# Consider using 'string.Contains' instead of 'string.IndexOf'
+# CA2249: Consider using 'string.Contains' instead of 'string.IndexOf'
 dotnet_diagnostic.CA2249.severity = warning
 
-# Use 'ThrowIfCancellationRequested'
+# CA2250: Use 'ThrowIfCancellationRequested'
 dotnet_diagnostic.CA2250.severity = warning
 
-# Use 'string.Equals'
+# CA2251: Use 'string.Equals'
 dotnet_diagnostic.CA2251.severity = warning
 
-# This API requires opting into preview features
+# CA2252: This API requires opting into preview features
 dotnet_diagnostic.CA2252.severity = error
 
-# Named placeholders should not be numeric values
+# CA2253: Named placeholders should not be numeric values
 dotnet_diagnostic.CA2253.severity = none
 
-# Template should be a static expression
+# CA2254: Template should be a static expression
 dotnet_diagnostic.CA2254.severity = none
 
-# The 'ModuleInitializer' attribute should not be used in libraries
+# CA2255: The 'ModuleInitializer' attribute should not be used in libraries
 dotnet_diagnostic.CA2255.severity = warning
 
-# All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+# CA2256: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
 dotnet_diagnostic.CA2256.severity = warning
 
-# Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+# CA2257: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
 dotnet_diagnostic.CA2257.severity = warning
 
-# Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+# CA2258: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
 dotnet_diagnostic.CA2258.severity = warning
 
-# 'ThreadStatic' only affects static fields
+# CA2259: 'ThreadStatic' only affects static fields
 dotnet_diagnostic.CA2259.severity = warning
 
-# Do not use insecure deserializer BinaryFormatter
+# CA2300: Do not use insecure deserializer BinaryFormatter
 dotnet_diagnostic.CA2300.severity = none
 
-# Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+# CA2301: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
 dotnet_diagnostic.CA2301.severity = none
 
-# Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+# CA2302: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
 dotnet_diagnostic.CA2302.severity = none
 
-# Do not use insecure deserializer LosFormatter
+# CA2305: Do not use insecure deserializer LosFormatter
 dotnet_diagnostic.CA2305.severity = none
 
-# Do not use insecure deserializer NetDataContractSerializer
+# CA2310: Do not use insecure deserializer NetDataContractSerializer
 dotnet_diagnostic.CA2310.severity = none
 
-# Do not deserialize without first setting NetDataContractSerializer.Binder
+# CA2311: Do not deserialize without first setting NetDataContractSerializer.Binder
 dotnet_diagnostic.CA2311.severity = none
 
-# Ensure NetDataContractSerializer.Binder is set before deserializing
+# CA2312: Ensure NetDataContractSerializer.Binder is set before deserializing
 dotnet_diagnostic.CA2312.severity = none
 
-# Do not use insecure deserializer ObjectStateFormatter
+# CA2315: Do not use insecure deserializer ObjectStateFormatter
 dotnet_diagnostic.CA2315.severity = none
 
-# Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+# CA2321: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
 dotnet_diagnostic.CA2321.severity = none
 
-# Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+# CA2322: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
 dotnet_diagnostic.CA2322.severity = none
 
-# Do not use TypeNameHandling values other than None
+# CA2326: Do not use TypeNameHandling values other than None
 dotnet_diagnostic.CA2326.severity = none
 
-# Do not use insecure JsonSerializerSettings
+# CA2327: Do not use insecure JsonSerializerSettings
 dotnet_diagnostic.CA2327.severity = none
 
-# Ensure that JsonSerializerSettings are secure
+# CA2328: Ensure that JsonSerializerSettings are secure
 dotnet_diagnostic.CA2328.severity = none
 
-# Do not deserialize with JsonSerializer using an insecure configuration
+# CA2329: Do not deserialize with JsonSerializer using an insecure configuration
 dotnet_diagnostic.CA2329.severity = none
 
-# Ensure that JsonSerializer has a secure configuration when deserializing
+# CA2330: Ensure that JsonSerializer has a secure configuration when deserializing
 dotnet_diagnostic.CA2330.severity = none
 
-# Do not use DataTable.ReadXml() with untrusted data
+# CA2350: Do not use DataTable.ReadXml() with untrusted data
 dotnet_diagnostic.CA2350.severity = none
 
-# Do not use DataSet.ReadXml() with untrusted data
+# CA2351: Do not use DataSet.ReadXml() with untrusted data
 dotnet_diagnostic.CA2351.severity = none
 
-# Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+# CA2352: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
 dotnet_diagnostic.CA2352.severity = none
 
-# Unsafe DataSet or DataTable in serializable type
+# CA2353: Unsafe DataSet or DataTable in serializable type
 dotnet_diagnostic.CA2353.severity = none
 
-# Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+# CA2354: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
 dotnet_diagnostic.CA2354.severity = none
 
-# Unsafe DataSet or DataTable type found in deserializable object graph
+# CA2355: Unsafe DataSet or DataTable type found in deserializable object graph
 dotnet_diagnostic.CA2355.severity = none
 
-# Unsafe DataSet or DataTable type in web deserializable object graph
+# CA2356: Unsafe DataSet or DataTable type in web deserializable object graph
 dotnet_diagnostic.CA2356.severity = none
 
-# Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+# CA2361: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
 dotnet_diagnostic.CA2361.severity = none
 
-# Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+# CA2362: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
 dotnet_diagnostic.CA2362.severity = none
 
-# Review code for SQL injection vulnerabilities
+# CA3001: Review code for SQL injection vulnerabilities
 dotnet_diagnostic.CA3001.severity = none
 
-# Review code for XSS vulnerabilities
+# CA3002: Review code for XSS vulnerabilities
 dotnet_diagnostic.CA3002.severity = none
 
-# Review code for file path injection vulnerabilities
+# CA3003: Review code for file path injection vulnerabilities
 dotnet_diagnostic.CA3003.severity = none
 
-# Review code for information disclosure vulnerabilities
+# CA3004: Review code for information disclosure vulnerabilities
 dotnet_diagnostic.CA3004.severity = none
 
-# Review code for LDAP injection vulnerabilities
+# CA3005: Review code for LDAP injection vulnerabilities
 dotnet_diagnostic.CA3005.severity = none
 
-# Review code for process command injection vulnerabilities
+# CA3006: Review code for process command injection vulnerabilities
 dotnet_diagnostic.CA3006.severity = none
 
-# Review code for open redirect vulnerabilities
+# CA3007: Review code for open redirect vulnerabilities
 dotnet_diagnostic.CA3007.severity = none
 
-# Review code for XPath injection vulnerabilities
+# CA3008: Review code for XPath injection vulnerabilities
 dotnet_diagnostic.CA3008.severity = none
 
-# Review code for XML injection vulnerabilities
+# CA3009: Review code for XML injection vulnerabilities
 dotnet_diagnostic.CA3009.severity = none
 
-# Review code for XAML injection vulnerabilities
+# CA3010: Review code for XAML injection vulnerabilities
 dotnet_diagnostic.CA3010.severity = none
 
-# Review code for DLL injection vulnerabilities
+# CA3011: Review code for DLL injection vulnerabilities
 dotnet_diagnostic.CA3011.severity = none
 
-# Review code for regex injection vulnerabilities
+# CA3012: Review code for regex injection vulnerabilities
 dotnet_diagnostic.CA3012.severity = none
 
-# Do Not Add Schema By URL
+# CA3061: Do Not Add Schema By URL
 dotnet_diagnostic.CA3061.severity = warning
 
-# Insecure DTD processing in XML
+# CA3075: Insecure DTD processing in XML
 dotnet_diagnostic.CA3075.severity = warning
 
-# Insecure XSLT script processing.
+# CA3076: Insecure XSLT script processing.
 dotnet_diagnostic.CA3076.severity = warning
 
-# Insecure Processing in API Design, XmlDocument and XmlTextReader
+# CA3077: Insecure Processing in API Design, XmlDocument and XmlTextReader
 dotnet_diagnostic.CA3077.severity = warning
 
-# Mark Verb Handlers With Validate Antiforgery Token
+# CA3147: Mark Verb Handlers With Validate Antiforgery Token
 dotnet_diagnostic.CA3147.severity = warning
 
-# Do Not Use Weak Cryptographic Algorithms
+# CA5350: Do Not Use Weak Cryptographic Algorithms
 dotnet_diagnostic.CA5350.severity = warning
 
-# Do Not Use Broken Cryptographic Algorithms
+# CA5351: Do Not Use Broken Cryptographic Algorithms
 dotnet_diagnostic.CA5351.severity = warning
 
-# Review cipher mode usage with cryptography experts
+# CA5358: Review cipher mode usage with cryptography experts
 dotnet_diagnostic.CA5358.severity = none
 
-# Do Not Disable Certificate Validation
+# CA5359: Do Not Disable Certificate Validation
 dotnet_diagnostic.CA5359.severity = warning
 
-# Do Not Call Dangerous Methods In Deserialization
+# CA5360: Do Not Call Dangerous Methods In Deserialization
 dotnet_diagnostic.CA5360.severity = warning
 
-# Do Not Disable SChannel Use of Strong Crypto
+# CA5361: Do Not Disable SChannel Use of Strong Crypto
 dotnet_diagnostic.CA5361.severity = warning
 
-# Potential reference cycle in deserialized object graph
+# CA5362: Potential reference cycle in deserialized object graph
 dotnet_diagnostic.CA5362.severity = none
 
-# Do Not Disable Request Validation
+# CA5363: Do Not Disable Request Validation
 dotnet_diagnostic.CA5363.severity = warning
 
-# Do Not Use Deprecated Security Protocols
+# CA5364: Do Not Use Deprecated Security Protocols
 dotnet_diagnostic.CA5364.severity = warning
 
-# Do Not Disable HTTP Header Checking
+# CA5365: Do Not Disable HTTP Header Checking
 dotnet_diagnostic.CA5365.severity = warning
 
-# Use XmlReader for 'DataSet.ReadXml()'
+# CA5366: Use XmlReader for 'DataSet.ReadXml()'
 dotnet_diagnostic.CA5366.severity = none
 
-# Do Not Serialize Types With Pointer Fields
+# CA5367: Do Not Serialize Types With Pointer Fields
 dotnet_diagnostic.CA5367.severity = none
 
-# Set ViewStateUserKey For Classes Derived From Page
+# CA5368: Set ViewStateUserKey For Classes Derived From Page
 dotnet_diagnostic.CA5368.severity = warning
 
-# Use XmlReader for 'XmlSerializer.Deserialize()'
+# CA5369: Use XmlReader for 'XmlSerializer.Deserialize()'
 dotnet_diagnostic.CA5369.severity = none
 
-# Use XmlReader for XmlValidatingReader constructor
+# CA5370: Use XmlReader for XmlValidatingReader constructor
 dotnet_diagnostic.CA5370.severity = warning
 
-# Use XmlReader for 'XmlSchema.Read()'
+# CA5371: Use XmlReader for 'XmlSchema.Read()'
 dotnet_diagnostic.CA5371.severity = none
 
-# Use XmlReader for XPathDocument constructor
+# CA5372: Use XmlReader for XPathDocument constructor
 dotnet_diagnostic.CA5372.severity = none
 
-# Do not use obsolete key derivation function
+# CA5373: Do not use obsolete key derivation function
 dotnet_diagnostic.CA5373.severity = warning
 
-# Do Not Use XslTransform
+# CA5374: Do Not Use XslTransform
 dotnet_diagnostic.CA5374.severity = warning
 
-# Do Not Use Account Shared Access Signature
+# CA5375: Do Not Use Account Shared Access Signature
 dotnet_diagnostic.CA5375.severity = none
 
-# Use SharedAccessProtocol HttpsOnly
+# CA5376: Use SharedAccessProtocol HttpsOnly
 dotnet_diagnostic.CA5376.severity = warning
 
-# Use Container Level Access Policy
+# CA5377: Use Container Level Access Policy
 dotnet_diagnostic.CA5377.severity = warning
 
-# Do not disable ServicePointManagerSecurityProtocols
+# CA5378: Do not disable ServicePointManagerSecurityProtocols
 dotnet_diagnostic.CA5378.severity = warning
 
-# Ensure Key Derivation Function algorithm is sufficiently strong
+# CA5379: Ensure Key Derivation Function algorithm is sufficiently strong
 dotnet_diagnostic.CA5379.severity = warning
 
-# Do Not Add Certificates To Root Store
+# CA5380: Do Not Add Certificates To Root Store
 dotnet_diagnostic.CA5380.severity = warning
 
-# Ensure Certificates Are Not Added To Root Store
+# CA5381: Ensure Certificates Are Not Added To Root Store
 dotnet_diagnostic.CA5381.severity = warning
 
-# Use Secure Cookies In ASP.NET Core
+# CA5382: Use Secure Cookies In ASP.Net Core
 dotnet_diagnostic.CA5382.severity = none
 
-# Ensure Use Secure Cookies In ASP.NET Core
+# CA5383: Ensure Use Secure Cookies In ASP.NET Core
 dotnet_diagnostic.CA5383.severity = none
 
-# Do Not Use Digital Signature Algorithm (DSA)
+# CA5384: Do Not Use Digital Signature Algorithm (DSA)
 dotnet_diagnostic.CA5384.severity = warning
 
-# Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+# CA5385: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
 dotnet_diagnostic.CA5385.severity = warning
 
-# Avoid hardcoding SecurityProtocolType value
+# CA5386: Avoid hardcoding SecurityProtocolType value
 dotnet_diagnostic.CA5386.severity = none
 
-# Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+# CA5387: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
 dotnet_diagnostic.CA5387.severity = none
 
-# Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+# CA5388: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
 dotnet_diagnostic.CA5388.severity = none
 
-# Do Not Add Archive Item's Path To The Target File System Path
+# CA5389: Do Not Add Archive Item's Path To The Target File System Path
 dotnet_diagnostic.CA5389.severity = none
 
-# Do not hard-code encryption key
+# CA5390: Do not hard-code encryption key
 dotnet_diagnostic.CA5390.severity = none
 
-# Use antiforgery tokens in ASP.NET Core MVC controllers
+# CA5391: Use antiforgery tokens in ASP.NET Core MVC controllers
 dotnet_diagnostic.CA5391.severity = none
 
-# Use DefaultDllImportSearchPaths attribute for P/Invokes
+# CA5392: Use DefaultDllImportSearchPaths attribute for P/Invokes
 dotnet_diagnostic.CA5392.severity = none
 
-# Do not use unsafe DllImportSearchPath value
+# CA5393: Do not use unsafe DllImportSearchPath value
 dotnet_diagnostic.CA5393.severity = none
 
-# Do not use insecure randomness
+# CA5394: Do not use insecure randomness
 dotnet_diagnostic.CA5394.severity = none
 
-# Miss HttpVerb attribute for action methods
+# CA5395: Miss HttpVerb attribute for action methods
 dotnet_diagnostic.CA5395.severity = none
 
-# Set HttpOnly to true for HttpCookie
+# CA5396: Set HttpOnly to true for HttpCookie
 dotnet_diagnostic.CA5396.severity = none
 
-# Do not use deprecated SslProtocols values
+# CA5397: Do not use deprecated SslProtocols values
 dotnet_diagnostic.CA5397.severity = none
 
-# Avoid hardcoded SslProtocols values
+# CA5398: Avoid hardcoded SslProtocols values
 dotnet_diagnostic.CA5398.severity = none
 
-# HttpClients should enable certificate revocation list checks
+# CA5399: HttpClients should enable certificate revocation list checks
 dotnet_diagnostic.CA5399.severity = none
 
-# Ensure HttpClient certificate revocation list check is not disabled
+# CA5400: Ensure HttpClient certificate revocation list check is not disabled
 dotnet_diagnostic.CA5400.severity = none
 
-# Do not use CreateEncryptor with non-default IV
+# CA5401: Do not use CreateEncryptor with non-default IV
 dotnet_diagnostic.CA5401.severity = none
 
-# Use CreateEncryptor with the default IV
+# CA5402: Use CreateEncryptor with the default IV
 dotnet_diagnostic.CA5402.severity = none
 
-# Do not hard-code certificate
+# CA5403: Do not hard-code certificate
 dotnet_diagnostic.CA5403.severity = none
 
-# Do not disable token validation checks
+# CA5404: Do not disable token validation checks
 dotnet_diagnostic.CA5404.severity = none
 
-# Do not always skip token validation in delegates
+# CA5405: Do not always skip token validation in delegates
 dotnet_diagnostic.CA5405.severity = none
 
-# Avoid using accessing Assembly file path when publishing as a single-file
+# IL3000: Avoid using accessing Assembly file path when publishing as a single-file
 dotnet_diagnostic.IL3000.severity = none # TODO: warning
 
-# Avoid using accessing Assembly file path when publishing as a single-file
+# IL3001: Avoid using accessing Assembly file path when publishing as a single-file
 dotnet_diagnostic.IL3001.severity = warning
 
-# Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app
+# IL3002: Using member with RequiresAssemblyFilesAttribute can break functionality when embedded in a single-file app
 dotnet_diagnostic.IL3002.severity = warning
 
 # Public members should not use oblivious types
 dotnet_diagnostic.RS0041.severity = none
 
-# XML comment analysis disabled
+# SA0001: XML comments
 dotnet_diagnostic.SA0001.severity = none
 
 # Invalid settings file
 dotnet_diagnostic.SA0002.severity = none
 
-# Keywords should be spaced correctly
+# SA1000: Spacing around keywords
 dotnet_diagnostic.SA1000.severity = none
 
-# Commas should be spaced correctly
+# SA1001: Commas should not be preceded by whitespace
 dotnet_diagnostic.SA1001.severity = none
 
-# Semicolons should be spaced correctly
+# SA1002: Semicolons should not be preceded by a space
 dotnet_diagnostic.SA1002.severity = none
 
-# Symbols should be spaced correctly
+# SA1003: Operator should not appear at the end of a line
 dotnet_diagnostic.SA1003.severity = none
 
-# Documentation lines should begin with single space
+# SA1004: Documentation line should begin with a space
 dotnet_diagnostic.SA1004.severity = none
 
-# Single line comments should begin with single space
+# SA1005: Single line comment should begin with a space
 dotnet_diagnostic.SA1005.severity = none
 
-# Preprocessor keywords should not be preceded by space
+# SA1006: Preprocessor keywords should not be preceded by space
 dotnet_diagnostic.SA1006.severity = none
 
-# Operator keyword should be followed by space
+# SA1007: Operator keyword should be followed by space
 dotnet_diagnostic.SA1007.severity = none
 
-# Opening parenthesis should be spaced correctly
+# SA1008: Opening parenthesis should not be preceded by a space
 dotnet_diagnostic.SA1008.severity = none
 
-# Closing parenthesis should be spaced correctly
+# SA1009: Closing parenthesis should not be followed by a space
 dotnet_diagnostic.SA1009.severity = none
 
-# Opening square brackets should be spaced correctly
+# SA1010: Opening square brackets should not be preceded by a space
 dotnet_diagnostic.SA1010.severity = none
 
-# Closing square brackets should be spaced correctly
+# SA1011: Closing square bracket should be followed by a space
 dotnet_diagnostic.SA1011.severity = none
 
-# Opening braces should be spaced correctly
+# SA1012: Opening brace should be followed by a space
 dotnet_diagnostic.SA1012.severity = none
 
-# Closing braces should be spaced correctly
+# SA1013: Closing brace should be preceded by a space
 dotnet_diagnostic.SA1013.severity = none
 
-# Opening generic brackets should be spaced correctly
+# SA1014: Opening generic brackets should not be preceded by a space
 dotnet_diagnostic.SA1014.severity = none
 
-# Closing generic brackets should be spaced correctly
+# SA1015: Closing generic bracket should not be followed by a space
 dotnet_diagnostic.SA1015.severity = none
 
-# Opening attribute brackets should be spaced correctly
+# SA1016: Opening attribute brackets should be spaced correctly
 dotnet_diagnostic.SA1016.severity = none
 
-# Closing attribute brackets should be spaced correctly
+# SA1017: Closing attribute brackets should be spaced correctly
 dotnet_diagnostic.SA1017.severity = none
 
-# Nullable type symbols should be spaced correctly
+# SA1018: Nullable type symbol should not be preceded by a space
 dotnet_diagnostic.SA1018.severity = none
 
-# Member access symbols should be spaced correctly
+# SA1019: Member access symbols should be spaced correctly
 dotnet_diagnostic.SA1019.severity = none
 
-# Increment decrement symbols should be spaced correctly
+# SA1020: Increment symbol should not be preceded by a space
 dotnet_diagnostic.SA1020.severity = none
 
-# Negative signs should be spaced correctly
+# SA1021: Negative sign should be preceded by a space
 dotnet_diagnostic.SA1021.severity = none
 
-# Positive signs should be spaced correctly
+# SA1022: Positive signs should be spaced correctly
 dotnet_diagnostic.SA1022.severity = none
 
-# Dereference and access of symbols should be spaced correctly
+# SA1023: Dereference symbol '*' should not be preceded by a space."
 dotnet_diagnostic.SA1023.severity = none
 
-# Colons should be spaced correctly
+# SA1024: Colon should be followed by a space
 dotnet_diagnostic.SA1024.severity = none
 
-# Code should not contain multiple whitespace in a row
+# SA1025: Code should not contain multiple whitespace characters in a row
 dotnet_diagnostic.SA1025.severity = none
 
-# Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+# SA1026: Keyword followed by span or blank line
 dotnet_diagnostic.SA1026.severity = none
 
-# Use tabs correctly
+# SA1027: Tabs and spaces should be used correctly
 dotnet_diagnostic.SA1027.severity = none
 
-# Code should not contain trailing whitespace
+# SA1028: Code should not contain trailing whitespace
 dotnet_diagnostic.SA1028.severity = none
 
-# Do not prefix calls with base unless local implementation exists
+# SA1100: Do not prefix calls with base unless local implementation exists
 dotnet_diagnostic.SA1100.severity = none
 
-# Prefix local calls with this
+# SA1101: Prefix local calls with this
 dotnet_diagnostic.SA1101.severity = none
 
-# Query clause should follow previous clause
+# SA1102: Query clause should follow previous clause
 dotnet_diagnostic.SA1102.severity = none
 
-# Query clauses should be on separate lines or all on one line
+# SA1103: Query clauses should be on separate lines or all on one line
 dotnet_diagnostic.SA1103.severity = none
 
-# Query clause should begin on new line when previous clause spans multiple lines
+# SA1104: Query clause should begin on new line when previous clause spans multiple lines
 dotnet_diagnostic.SA1104.severity = none
 
-# Query clauses spanning multiple lines should begin on own line
+# SA1105: Query clauses spanning multiple lines should begin on own line
 dotnet_diagnostic.SA1105.severity = none
 
-# Code should not contain empty statements
+# SA1106: Code should not contain empty statements
 dotnet_diagnostic.SA1106.severity = none
 
-# Code should not contain multiple statements on one line
+# SA1107: Code should not contain multiple statements on one line
 dotnet_diagnostic.SA1107.severity = none
 
-# Block statements should not contain embedded comments
+# SA1108: Block statements should not contain embedded comments
 dotnet_diagnostic.SA1108.severity = none
 
-# Block statements should not contain embedded regions
+# SA1109: Block statements should not contain embedded regions
 dotnet_diagnostic.SA1109.severity = none
 
-# Opening parenthesis or bracket should be on declaration line
+# SA1110: Opening parenthesis or bracket should be on declaration line
 dotnet_diagnostic.SA1110.severity = none
 
-# Closing parenthesis should be on line of last parameter
+# SA1111: Closing parenthesis should be on line of last parameter
 dotnet_diagnostic.SA1111.severity = none
 
-# Closing parenthesis should be on line of opening parenthesis
+# SA1112: Closing parenthesis should be on line of opening parenthesis
 dotnet_diagnostic.SA1112.severity = none
 
-# Comma should be on the same line as previous parameter
+# SA1113: Comma should be on the same line as previous parameter
 dotnet_diagnostic.SA1113.severity = none
 
-# Parameter list should follow declaration
+# SA1114: Parameter list should follow declaration
 dotnet_diagnostic.SA1114.severity = none
 
-# Parameter should follow comma
+# SA1115: Parameter should begin on the line after the previous parameter
 dotnet_diagnostic.SA1115.severity = none
 
-# Split parameters should start on line after declaration
+# SA1116: Split parameters should start on line after declaration
 dotnet_diagnostic.SA1116.severity = none
 
-# Parameters should be on same line or separate lines
+# SA1117: Parameters should be on same line or separate lines
 dotnet_diagnostic.SA1117.severity = none
 
-# Parameter should not span multiple lines
+# SA1118: Parameter should not span multiple lines
 dotnet_diagnostic.SA1118.severity = none
 
-# Statement should not use unnecessary parenthesis
+# SA1119: Statement should not use unnecessary parenthesis
 dotnet_diagnostic.SA1119.severity = none
 
-# Comments should contain text
+# SA1120: Comments should contain text
 dotnet_diagnostic.SA1120.severity = none
 
-# Use built-in type alias
+# SA1121: Use built-in type alias
 dotnet_diagnostic.SA1121.severity = none
 
-# Use string.Empty for empty strings
+# SA1122: Use string.Empty for empty strings
 dotnet_diagnostic.SA1122.severity = none
 
-# Do not place regions within elements
+# SA1123: Region should not be located within a code element
 dotnet_diagnostic.SA1123.severity = none
 
-# Do not use regions
+# SA1124: Do not use regions
 dotnet_diagnostic.SA1124.severity = none
 
-# Use shorthand for nullable types
+# SA1125: Use shorthand for nullable types
 dotnet_diagnostic.SA1125.severity = none
 
-# Prefix calls correctly
+# SA1126: Prefix calls correctly
 dotnet_diagnostic.SA1126.severity = none
 
-# Generic type constraints should be on their own line
+# SA1127: Generic type constraints should be on their own line
 dotnet_diagnostic.SA1127.severity = none
 
-# Put constructor initializers on their own line
+# SA1128: Put constructor initializers on their own line
 dotnet_diagnostic.SA1128.severity = none
 
-# Do not use default value type constructor
+# SA1129: Do not use default value type constructor
 dotnet_diagnostic.SA1129.severity = none
 
-# Use lambda syntax
+# SA1130: Use lambda syntax
 dotnet_diagnostic.SA1130.severity = none
 
-# Use readable conditions
+# SA1131: Constant values should appear on the right-hand side of comparisons
 dotnet_diagnostic.SA1131.severity = none
 
-# Do not combine fields
+# SA1132: Do not combine fields
 dotnet_diagnostic.SA1132.severity = none
 
-# Do not combine attributes
+# SA1133: Do not combine attributes
 dotnet_diagnostic.SA1133.severity = none
 
-# Attributes should not share line
+# SA1134: Each attribute should be placed on its own line of code
 dotnet_diagnostic.SA1134.severity = none
 
-# Using directives should be qualified
+# SA1135: Using directive should be qualified
 dotnet_diagnostic.SA1135.severity = none
 
-# Enum values should be on separate lines
+# SA1136: Enum values should be on separate lines
 dotnet_diagnostic.SA1136.severity = none
 
-# Elements should have the same indentation
+# SA1137: Elements should have the same indentation
 dotnet_diagnostic.SA1137.severity = none
 
-# Use literal suffix notation instead of casting
+# SA1139: Use literal suffix notation instead of casting
 dotnet_diagnostic.SA1139.severity = none
 
-# Using directives should be placed correctly
+# SA1141: Use tuple syntax
+dotnet_diagnostic.SA1141.severity = none
+
+# SA1142: Refer to tuple elements by name
+dotnet_diagnostic.SA1142.severity = none
+
+# SA1200: Using directive should appear within a namespace declaration
 dotnet_diagnostic.SA1200.severity = none
 
-# Elements should appear in the correct order
+# SA1201: Elements should appear in the correct order
 dotnet_diagnostic.SA1201.severity = none
 
-# Elements should be ordered by access
+# SA1202: Elements should be ordered by access
 dotnet_diagnostic.SA1202.severity = none
 
-# Constants should appear before fields
+# SA1203: Constants should appear before fields
 dotnet_diagnostic.SA1203.severity = none
 
-# Static elements should appear before instance elements
+# SA1204: Static elements should appear before instance elements
 dotnet_diagnostic.SA1204.severity = none
 
-# Partial elements should declare access
+# SA1205: Partial elements should declare an access modifier
 dotnet_diagnostic.SA1205.severity = none
 
-# Declaration keywords should follow order
+# SA1206: Keyword ordering
 dotnet_diagnostic.SA1206.severity = none
 
-# Protected should come before internal
+# SA1207: Protected should come before internal
 dotnet_diagnostic.SA1207.severity = none
 
-# System using directives should be placed before other using directives
+# SA1208: Using directive ordering
 dotnet_diagnostic.SA1208.severity = none
 
-# Using alias directives should be placed after other using directives
+# SA1209: Using alias directives should be placed after all using namespace directives
 dotnet_diagnostic.SA1209.severity = none
 
-# Using directives should be ordered alphabetically by namespace
+# SA1210: Using directives should be ordered alphabetically by the namespaces
 dotnet_diagnostic.SA1210.severity = none
 
-# Using alias directives should be ordered alphabetically by alias name
+# SA1211: Using alias directive ordering
 dotnet_diagnostic.SA1211.severity = none
 
-# Property accessors should follow order
+# SA1212: A get accessor appears after a set accessor within a property or indexer
 dotnet_diagnostic.SA1212.severity = none
 
-# Event accessors should follow order
+# SA1213: Event accessors should follow order
 dotnet_diagnostic.SA1213.severity = none
 
-# Readonly fields should appear before non-readonly fields
+# SA1214: Readonly fields should appear before non-readonly fields
 dotnet_diagnostic.SA1214.severity = none
 
-# Using static directives should be placed at the correct location
+# SA1216: Using static directives should be placed at the correct location
 dotnet_diagnostic.SA1216.severity = none
 
-# Using static directives should be ordered alphabetically
+# SA1217: Using static directives should be ordered alphabetically
 dotnet_diagnostic.SA1217.severity = none
 
-# Element should begin with upper-case letter
+# SA1300: Element should begin with an uppercase letter
 dotnet_diagnostic.SA1300.severity = none
 
-# Element should begin with lower-case letter
+# SA1301: Element should begin with lower-case letter
 dotnet_diagnostic.SA1301.severity = none
 
-# Interface names should begin with I
+# SA1302: Interface names should begin with I
 dotnet_diagnostic.SA1302.severity = none
 
-# Const field names should begin with upper-case letter
+# SA1303: Const field names should begin with upper-case letter
 dotnet_diagnostic.SA1303.severity = none
 
-# Non-private readonly fields should begin with upper-case letter
+# SA1304: Non-private readonly fields should begin with upper-case letter
 dotnet_diagnostic.SA1304.severity = none
 
-# Field names should not use Hungarian notation
+# SA1305: Field names should not use Hungarian notation
 dotnet_diagnostic.SA1305.severity = none
 
-# Field names should begin with lower-case letter
+# SA1306: Field should begin with lower-case letter
 dotnet_diagnostic.SA1306.severity = none
 
-# Accessible fields should begin with upper-case letter
+# SA1307: Field should begin with upper-case letter
 dotnet_diagnostic.SA1307.severity = none
 
-# Variable names should not be prefixed
+# SA1308: Field should not begin with the prefix 's_'
 dotnet_diagnostic.SA1308.severity = none
 
-# Field names should not begin with underscore
+# SA1309: Field names should not begin with underscore
 dotnet_diagnostic.SA1309.severity = none
 
-# Field names should not contain underscore
+# SA1310: Field should not contain an underscore
 dotnet_diagnostic.SA1310.severity = none
 
-# Static readonly fields should begin with upper-case letter
+# SA1311: Static readonly fields should begin with upper-case letter
 dotnet_diagnostic.SA1311.severity = none
 
-# Variable names should begin with lower-case letter
+# SA1312: Variable should begin with lower-case letter
 dotnet_diagnostic.SA1312.severity = none
 
-# Parameter names should begin with lower-case letter
+# SA1313: Parameter should begin with lower-case letter
 dotnet_diagnostic.SA1313.severity = none
 
-# Type parameter names should begin with T
+# SA1314: Type parameter names should begin with T
 dotnet_diagnostic.SA1314.severity = none
 
 # SA1316: Tuple element names should use correct casing
 dotnet_diagnostic.SA1316.severity = none
 
-# Access modifier should be declared
+# SA1400: Member should declare an access modifier
 dotnet_diagnostic.SA1400.severity = none
 
-# Fields should be private
+# SA1401: Fields should be private
 dotnet_diagnostic.SA1401.severity = none
 
-# File may only contain a single type
+# SA1402: File may only contain a single type
 dotnet_diagnostic.SA1402.severity = none
 
-# File may only contain a single namespace
+# SA1403: File may only contain a single namespace
 dotnet_diagnostic.SA1403.severity = none
 
-# Code analysis suppression should have justification
+# SA1404: Code analysis suppression should have justification
 dotnet_diagnostic.SA1404.severity = none
 
-# Debug.Assert should provide message text
+# SA1405: Debug.Assert should provide message text
 dotnet_diagnostic.SA1405.severity = none
 
-# Debug.Fail should provide message text
+# SA1406: Debug.Fail should provide message text
 dotnet_diagnostic.SA1406.severity = none
 
-# Arithmetic expressions should declare precedence
+# SA1407: Arithmetic expressions should declare precedence
 dotnet_diagnostic.SA1407.severity = none
 
-# Conditional expressions should declare precedence
+# SA1408: Conditional expressions should declare precedence
 dotnet_diagnostic.SA1408.severity = warning
 
-# Remove unnecessary code
+# SA1409: Remove unnecessary code
 dotnet_diagnostic.SA1409.severity = none
 
-# Remove delegate parenthesis when possible
+# SA1410: Remove delegate parens when possible
 dotnet_diagnostic.SA1410.severity = none
 
-# Attribute constructor should not use unnecessary parenthesis
+# SA1411: Attribute constructor shouldn't use unnecessary parenthesis
 dotnet_diagnostic.SA1411.severity = none
 
-# Store files as UTF-8 with byte order mark
+# SA1412: Store files as UTF-8 with byte order mark
 dotnet_diagnostic.SA1412.severity = none
 
-# Use trailing comma in multi-line initializers
+# SA1413: Use trailing comma in multi-line initializers
 dotnet_diagnostic.SA1413.severity = none
 
-# Tuple types in signatures should have element names
+# SA1414: Tuple types in signatures should have element names
 dotnet_diagnostic.SA1414.severity = none
 
-# Braces for multi-line statements should not share line
+# SA1500: Braces for multi-line statements should not share line
 dotnet_diagnostic.SA1500.severity = error
 
-# Statement should not be on a single line
+# SA1501: Statement should not be on a single line
 dotnet_diagnostic.SA1501.severity = none
 
-# Element should not be on a single line
+# SA1502: Element should not be on a single line
 dotnet_diagnostic.SA1502.severity = none
 
-# Braces should not be omitted
+# SA1503: Braces should not be omitted
 dotnet_diagnostic.SA1503.severity = none
 
-# All accessors should be single-line or multi-line
+# SA1504: All accessors should be single-line or multi-line
 dotnet_diagnostic.SA1504.severity = none
 
-# Opening braces should not be followed by blank line
+# SA1505: An opening brace should not be followed by a blank line
 dotnet_diagnostic.SA1505.severity = warning
 
-# Element documentation headers should not be followed by blank line
+# SA1506: Element documentation headers should not be followed by blank line
 dotnet_diagnostic.SA1506.severity = none
 
-# Code should not contain multiple blank lines in a row
+# SA1507: Code should not contain multiple blank lines in a row
 dotnet_diagnostic.SA1507.severity = warning
 
-# Closing braces should not be preceded by blank line
+# SA1508: A closing brace should not be preceded by a blank line
 dotnet_diagnostic.SA1508.severity = warning
 
-# Opening braces should not be preceded by blank line
+# SA1509: Opening braces should not be preceded by blank line
 dotnet_diagnostic.SA1509.severity = warning
 
-# Chained statement blocks should not be preceded by blank line
+# SA1510: 'else' statement should not be preceded by a blank line
 dotnet_diagnostic.SA1510.severity = none
 
-# While-do footer should not be preceded by blank line
+# SA1511: While-do footer should not be preceded by blank line
 dotnet_diagnostic.SA1511.severity = none
 
-# Single-line comments should not be followed by blank line
+# SA1512: Single-line comments should not be followed by blank line
 dotnet_diagnostic.SA1512.severity = none
 
-# Closing brace should be followed by blank line
+# SA1513: Closing brace should be followed by blank line
 dotnet_diagnostic.SA1513.severity = error
 
-# Element documentation header should be preceded by blank line
+# SA1514: Element documentation header should be preceded by blank line
 dotnet_diagnostic.SA1514.severity = none
 
-# Single-line comment should be preceded by blank line
+# SA1515: Single-line comment should be preceded by blank line
 dotnet_diagnostic.SA1515.severity = none
 
-# Elements should be separated by blank line
+# SA1516: Elements should be separated by blank line
 dotnet_diagnostic.SA1516.severity = none
 
-# Code should not contain blank lines at start of file
+# SA1517: Code should not contain blank lines at start of file
 dotnet_diagnostic.SA1517.severity = warning
 
-# Use line endings correctly at end of file
+# SA1518: Code should not contain blank lines at the end of the file
 dotnet_diagnostic.SA1518.severity = none
 
-# Braces should not be omitted from multi-line child statement
+# SA1519: Braces should not be omitted from multi-line child statement
 dotnet_diagnostic.SA1519.severity = none
 
-# Use braces consistently
+# SA1520: Use braces consistently
 dotnet_diagnostic.SA1520.severity = none
 
-# Elements should be documented
+# SA1600: Elements should be documented
 dotnet_diagnostic.SA1600.severity = none
 
-# Partial elements should be documented
+# SA1601: Partial elements should be documented
 dotnet_diagnostic.SA1601.severity = none
 
-# Enumeration items should be documented
+# SA1602: Enumeration items should be documented
 dotnet_diagnostic.SA1602.severity = none
 
-# Documentation should contain valid XML
+# SA1603: Documentation should contain valid XML
 dotnet_diagnostic.SA1603.severity = none
 
-# Element documentation should have summary
+# SA1604: Element documentation should have summary
 dotnet_diagnostic.SA1604.severity = none
 
-# Partial element documentation should have summary
+# SA1605: Partial element documentation should have summary
 dotnet_diagnostic.SA1605.severity = none
 
-# Element documentation should have summary text
+# SA1606: Element documentation should have summary text
 dotnet_diagnostic.SA1606.severity = none
 
-# Partial element documentation should have summary text
+# SA1607: Partial element documentation should have summary text
 dotnet_diagnostic.SA1607.severity = none
 
-# Element documentation should not have default summary
+# SA1608: Element documentation should not have default summary
 dotnet_diagnostic.SA1608.severity = none
 
-# Property documentation should have value
+# SA1609: Property documentation should have value
 dotnet_diagnostic.SA1609.severity = none
 
-# Property documentation should have value text
+# SA1610: Property documentation should have value text
 dotnet_diagnostic.SA1610.severity = none
 
-# Element parameters should be documented
+# SA1611: The documentation for parameter 'message' is missing
 dotnet_diagnostic.SA1611.severity = none
 
-# Element parameter documentation should match element parameters
+# SA1612: The parameter documentation is at incorrect position
 dotnet_diagnostic.SA1612.severity = none
 
-# Element parameter documentation should declare parameter name
+# SA1613: Element parameter documentation should declare parameter name
 dotnet_diagnostic.SA1613.severity = none
 
-# Element parameter documentation should have text
+# SA1614: Element parameter documentation should have text
 dotnet_diagnostic.SA1614.severity = none
 
-# Element return value should be documented
+# SA1615: Element return value should be documented
 dotnet_diagnostic.SA1615.severity = none
 
-# Element return value documentation should have text
+# SA1616: Element return value documentation should have text
 dotnet_diagnostic.SA1616.severity = none
 
-# Void return value should not be documented
+# SA1617: Void return value should not be documented
 dotnet_diagnostic.SA1617.severity = none
 
-# Generic type parameters should be documented
+# SA1618: The documentation for type parameter is missing
 dotnet_diagnostic.SA1618.severity = none
 
-# Generic type parameters should be documented partial class
+# SA1619: The documentation for type parameter is missing
 dotnet_diagnostic.SA1619.severity = none
 
-# Generic type parameter documentation should match type parameters
+# SA1620: Generic type parameter documentation should match type parameters
 dotnet_diagnostic.SA1620.severity = none
 
-# Generic type parameter documentation should declare parameter name
+# SA1621: Generic type parameter documentation should declare parameter name
 dotnet_diagnostic.SA1621.severity = none
 
-# Generic type parameter documentation should have text
+# SA1622: Generic type parameter documentation should have text
 dotnet_diagnostic.SA1622.severity = none
 
-# Property summary documentation should match accessors
+# SA1623: Property documentation text
 dotnet_diagnostic.SA1623.severity = none
 
-# Property summary documentation should omit accessor with restricted access
+# SA1624: Because the property only contains a visible get accessor, the documentation summary text should begin with 'Gets'
 dotnet_diagnostic.SA1624.severity = none
 
-# Element documentation should not be copied and pasted
+# SA1625: Element documentation should not be copied and pasted
 dotnet_diagnostic.SA1625.severity = none
 
-# Single-line comments should not use documentation style slashes
+# SA1626: Single-line comments should not use documentation style slashes
 dotnet_diagnostic.SA1626.severity = none
 
-# Documentation text should not be empty
+# SA1627: The documentation text within the \'exception\' tag should not be empty
 dotnet_diagnostic.SA1627.severity = none
 
-# Documentation text should begin with a capital letter
+# SA1628: Documentation text should begin with a capital letter
 dotnet_diagnostic.SA1628.severity = none
 
-# Documentation text should end with a period
+# SA1629: Documentation text should end with a period
 dotnet_diagnostic.SA1629.severity = none
 
-# Documentation text should contain whitespace
+# SA1630: Documentation text should contain whitespace
 dotnet_diagnostic.SA1630.severity = none
 
-# Documentation should meet character percentage
+# SA1631: Documentation should meet character percentage
 dotnet_diagnostic.SA1631.severity = none
 
-# Documentation text should meet minimum character length
+# SA1632: Documentation text should meet minimum character length
 dotnet_diagnostic.SA1632.severity = none
 
-# File should have header
+# SA1633: File should have header
 dotnet_diagnostic.SA1633.severity = none
 
-# File header should show copyright
+# SA1634: File header should show copyright
 dotnet_diagnostic.SA1634.severity = none
 
-# File header should have copyright text
+# SA1635: File header should have copyright text
 dotnet_diagnostic.SA1635.severity = none
 
-# File header copyright text should match
+# SA1636: File header copyright text should match
 dotnet_diagnostic.SA1636.severity = none
 
-# File header should contain file name
+# SA1637: File header should contain file name
 dotnet_diagnostic.SA1637.severity = none
 
-# File header file name documentation should match file name
+# SA1638: File header file name documentation should match file name
 dotnet_diagnostic.SA1638.severity = none
 
-# File header should have summary
+# SA1639: File header should have summary
 dotnet_diagnostic.SA1639.severity = none
 
-# File header should have valid company text
+# SA1640: File header should have valid company text
 dotnet_diagnostic.SA1640.severity = none
 
-# File header company name text should match
+# SA1641: File header company name text should match
 dotnet_diagnostic.SA1641.severity = none
 
-# Constructor summary documentation should begin with standard text
+# SA1642: Constructor summary documentation should begin with standard text
 dotnet_diagnostic.SA1642.severity = none
 
-# Destructor summary documentation should begin with standard text
+# SA1643: Destructor summary documentation should begin with standard text
 dotnet_diagnostic.SA1643.severity = none
 
-# Documentation headers should not contain blank lines
+# SA1644: Documentation headers should not contain blank lines
 dotnet_diagnostic.SA1644.severity = none
 
-# Included documentation file does not exist
+# SA1645: Included documentation file does not exist
 dotnet_diagnostic.SA1645.severity = none
 
-# Included documentation XPath does not exist
+# SA1646: Included documentation XPath does not exist
 dotnet_diagnostic.SA1646.severity = none
 
-# Include node does not contain valid file and path
+# SA1647: Include node does not contain valid file and path
 dotnet_diagnostic.SA1647.severity = none
 
-# Inheritdoc should be used with inheriting class
+# SA1648: Inheritdoc should be used with inheriting class
 dotnet_diagnostic.SA1648.severity = none
 
-# File name should match first type name
+# SA1649: File name should match first type name
 dotnet_diagnostic.SA1649.severity = none
 
-# Element documentation should be spelled correctly
+# SA1650: Element documentation should be spelled correctly
 dotnet_diagnostic.SA1650.severity = none
 
-# Do not use placeholder elements
+# SA1651: Do not use placeholder elements
 dotnet_diagnostic.SA1651.severity = none
 
-# Do not prefix local calls with 'this.'
+# SX1101: Do not prefix local calls with 'this.'
 dotnet_diagnostic.SX1101.severity = none
 
-# Field names should begin with underscore
+# SX1309: Field names should begin with underscore
 dotnet_diagnostic.SX1309.severity = none
 
-# Static field names should begin with underscore
+# SX1309S: Static field names should begin with underscore
 dotnet_diagnostic.SX1309S.severity = none
 
-# Do not use equality check to check for collection size.
+# IDE0001: Simplify name
+dotnet_diagnostic.IDE0001.severity = silent
+
+# IDE0002: Simplify member access
+dotnet_diagnostic.IDE0002.severity = silent
+
+# IDE0003: Remove this or Me qualification
+dotnet_diagnostic.IDE0003.severity = silent
+
+# IDE0004: Remove Unnecessary Cast
+dotnet_diagnostic.IDE0004.severity = silent
+
+# IDE0005: Using directive is unnecessary.
+dotnet_diagnostic.IDE0005.severity = silent
+
+# IDE0007: Use implicit type
+dotnet_diagnostic.IDE0007.severity = silent
+
+# IDE0008: Use explicit type
+dotnet_diagnostic.IDE0008.severity = silent
+
+# IDE0009: Add this or Me qualification
+dotnet_diagnostic.IDE0009.severity = silent
+
+# IDE0010: Add missing cases
+dotnet_diagnostic.IDE0010.severity = silent
+
+# IDE0011: Add braces
+dotnet_diagnostic.IDE0011.severity = silent
+
+# IDE0016: Use 'throw' expression
+dotnet_diagnostic.IDE0016.severity = silent
+
+# IDE0017: Simplify object initialization
+dotnet_diagnostic.IDE0017.severity = silent
+
+# IDE0018: Inline variable declaration
+dotnet_diagnostic.IDE0018.severity = silent
+
+# IDE0019: Use pattern matching to avoid as followed by a null check
+dotnet_diagnostic.IDE0019.severity = silent
+
+# IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
+dotnet_diagnostic.IDE0020.severity = silent
+
+# IDE0021: Use expression body for constructors
+dotnet_diagnostic.IDE0021.severity = silent
+
+# IDE0022: Use expression body for methods
+dotnet_diagnostic.IDE0022.severity = silent
+
+# IDE0023: Use expression body for operators
+dotnet_diagnostic.IDE0023.severity = silent
+
+# IDE0024: Use expression body for operators
+dotnet_diagnostic.IDE0024.severity = silent
+
+# IDE0025: Use expression body for properties
+dotnet_diagnostic.IDE0025.severity = silent
+
+# IDE0026: Use expression body for indexers
+dotnet_diagnostic.IDE0026.severity = silent
+
+# IDE0027: Use expression body for accessors
+dotnet_diagnostic.IDE0027.severity = silent
+
+# IDE0028: Simplify collection initialization
+dotnet_diagnostic.IDE0028.severity = silent
+
+# IDE0029: Use coalesce expression
+dotnet_diagnostic.IDE0029.severity = silent
+
+# IDE0030: Use coalesce expression
+dotnet_diagnostic.IDE0030.severity = silent
+
+# IDE0031: Use null propagation
+dotnet_diagnostic.IDE0031.severity = silent
+
+# IDE0032: Use auto property
+dotnet_diagnostic.IDE0032.severity = silent
+
+# IDE0033: Use explicitly provided tuple name
+dotnet_diagnostic.IDE0033.severity = silent
+
+# IDE0034: Simplify 'default' expression
+dotnet_diagnostic.IDE0034.severity = silent
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = silent
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = silent
+
+# IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = silent
+
+# IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
+dotnet_diagnostic.IDE0038.severity = silent
+
+# IDE0039: Use local function
+dotnet_diagnostic.IDE0039.severity = silent
+
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = silent
+
+# IDE0041: Use 'is null' check
+dotnet_diagnostic.IDE0041.severity = silent
+
+# IDE0042: Deconstruct variable declaration
+dotnet_diagnostic.IDE0042.severity = silent
+
+# IDE0043: Invalid format string
+dotnet_diagnostic.IDE0043.severity = silent
+
+# IDE0044: Add readonly modifier
+dotnet_diagnostic.IDE0044.severity = silent
+
+# IDE0045: Use conditional expression for assignment
+dotnet_diagnostic.IDE0045.severity = silent
+
+# IDE0046: Use conditional expression for return
+dotnet_diagnostic.IDE0046.severity = silent
+
+# IDE0047: Remove unnecessary parentheses
+dotnet_diagnostic.IDE0047.severity = silent
+
+# IDE0048: Add parentheses for clarity
+dotnet_diagnostic.IDE0048.severity = silent
+
+# IDE0049: Use language keywords instead of framework type names for type references
+dotnet_diagnostic.IDE0049.severity = silent
+
+# IDE0051: Remove unused private members
+dotnet_diagnostic.IDE0051.severity = silent
+
+# IDE0052: Remove unread private members
+dotnet_diagnostic.IDE0052.severity = silent
+
+# IDE0053: Use expression body for lambdas
+dotnet_diagnostic.IDE0053.severity = silent
+
+# IDE0054: Use compound assignment
+dotnet_diagnostic.IDE0054.severity = silent
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = silent
+
+# IDE0056: Use index operator
+dotnet_diagnostic.IDE0056.severity = silent
+
+# IDE0057: Use range operator
+dotnet_diagnostic.IDE0057.severity = silent
+
+# IDE0058: Expression value is never used
+dotnet_diagnostic.IDE0058.severity = silent
+
+# IDE0059: Unnecessary assignment of a value
+dotnet_diagnostic.IDE0059.severity = silent
+
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = silent
+
+# IDE0061: Use expression body for local functions
+dotnet_diagnostic.IDE0061.severity = silent
+
+# IDE0062: Make local function 'static'
+dotnet_diagnostic.IDE0062.severity = silent
+
+# IDE0063: Use simple 'using' statement
+dotnet_diagnostic.IDE0063.severity = silent
+
+# IDE0064: Make readonly fields writable
+dotnet_diagnostic.IDE0064.severity = silent
+
+# IDE0065: Misplaced using directive
+dotnet_diagnostic.IDE0065.severity = silent
+
+# IDE0066: Convert switch statement to expression
+dotnet_diagnostic.IDE0066.severity = silent
+
+# IDE0070: Use 'System.HashCode'
+dotnet_diagnostic.IDE0070.severity = silent
+
+# IDE0071: Simplify interpolation
+dotnet_diagnostic.IDE0071.severity = silent
+
+# IDE0072: Add missing cases
+dotnet_diagnostic.IDE0072.severity = silent
+
+# IDE0073: The file header is missing or not located at the top of the file
+dotnet_diagnostic.IDE0073.severity = silent
+
+# IDE0074: Use compound assignment
+dotnet_diagnostic.IDE0074.severity = silent
+
+# IDE0075: Simplify conditional expression
+dotnet_diagnostic.IDE0075.severity = silent
+
+# IDE0076: Invalid global 'SuppressMessageAttribute'
+dotnet_diagnostic.IDE0076.severity = silent
+
+# IDE0077: Avoid legacy format target in 'SuppressMessageAttribute'
+dotnet_diagnostic.IDE0077.severity = silent
+
+# IDE0078: Use pattern matching
+dotnet_diagnostic.IDE0078.severity = silent
+
+# IDE0079: RemoveUnnecessarySuppression
+dotnet_diagnostic.IDE0079.severity = silent
+
+# IDE0080: Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0080.severity = silent
+
+# IDE0081: RemoveUnnecessaryByVal
+dotnet_diagnostic.IDE0081.severity = silent
+
+# IDE0082: 'typeof' can be converted  to 'nameof'
+dotnet_diagnostic.IDE0082.severity = silent
+
+# IDE0083: Use pattern matching
+dotnet_diagnostic.IDE0083.severity = silent
+
+# IDE0084: Use pattern matching (IsNot operator)
+dotnet_diagnostic.IDE0084.severity = silent
+
+# IDE0090: Use 'new(...)'
+dotnet_diagnostic.IDE0090.severity = silent
+
+# IDE0100: Remove redundant equality
+dotnet_diagnostic.IDE0100.severity = silent
+
+# IDE0110: Remove unnecessary discard
+dotnet_diagnostic.IDE0110.severity = silent
+
+# IDE0120: Simplify LINQ expression
+dotnet_diagnostic.IDE0120.severity = silent
+
+# IDE0130: Namespace does not match folder structure
+dotnet_diagnostic.IDE0130.severity = silent
+
+# IDE0140: Simplify object creation
+dotnet_diagnostic.IDE0140.severity = silent
+
+# IDE0150: Prefer 'null' check over type check
+dotnet_diagnostic.IDE0150.severity = silent
+
+# IDE0160: Convert to block scoped namespace
+dotnet_diagnostic.IDE0160.severity = silent
+
+# IDE0161: Convert to file-scoped namespace
+dotnet_diagnostic.IDE0161.severity = silent
+
+# IDE0170: Simplify property pattern
+dotnet_diagnostic.IDE0170.severity = silent
+
+# IDE0180: Use tuple swap
+dotnet_diagnostic.IDE0180.severity = silent
+
+# IDE0200: Remove unnecessary lambda expression
+dotnet_diagnostic.IDE0200.severity = silent
+
+# IDE0210: Use top-level statements
+dotnet_diagnostic.IDE0210.severity = silent
+
+# IDE0211: Use program main
+dotnet_diagnostic.IDE0211.severity = silent
+
+# IDE0220: foreach cast
+dotnet_diagnostic.IDE0220.severity = silent
+
+# IDE0230: Use UTF8 string literal
+dotnet_diagnostic.IDE0230.severity = silent
+
+# IDE1005: Delegate invocation can be simplified.
+dotnet_diagnostic.IDE1005.severity = silent
+
+# IDE1006: Naming Styles
+dotnet_diagnostic.IDE1006.severity = silent
+
+# IDE2000: C#
+dotnet_diagnostic.IDE2000.severity = silent
+
+# IDE2001: Embedded statements must be on their own line
+dotnet_diagnostic.IDE2001.severity = silent
+
+# IDE2002: Consecutive braces must not have blank line between them
+dotnet_diagnostic.IDE2002.severity = silent
+
+# IDE2003: C#
+dotnet_diagnostic.IDE2003.severity = silent
+
+# IDE2004: Blank line not allowed after constructor initializer colon
+dotnet_diagnostic.IDE2004.severity = silent
+
+# xUnit1000: Test classes must be public
+dotnet_diagnostic.xUnit1000.severity = warning
+
+# xUnit1001: Fact methods cannot have parameters
+dotnet_diagnostic.xUnit1001.severity = warning
+
+# xUnit1002: Test methods cannot have multiple Fact or Theory attributes
+dotnet_diagnostic.xUnit1002.severity = warning
+
+# xUnit1003: Theory methods must have test data
+dotnet_diagnostic.xUnit1003.severity = warning
+
+# xUnit1004: Test methods should not be skipped
+dotnet_diagnostic.xUnit1004.severity = none # TODO: warning
+
+# xUnit1005: Fact methods should not have test data
+dotnet_diagnostic.xUnit1005.severity = warning
+
+# xUnit1006: Theory methods should have parameters
+dotnet_diagnostic.xUnit1006.severity = warning
+
+# xUnit1007: ClassData must point at a valid class
+dotnet_diagnostic.xUnit1007.severity = warning
+
+# xUnit1008: Test data attribute should only be used on a Theory
+dotnet_diagnostic.xUnit1008.severity = warning
+
+# xUnit1009: InlineData must match the number of method parameters
+dotnet_diagnostic.xUnit1009.severity = warning
+
+# xUnit1010: The value is not convertible to the method parameter type
+dotnet_diagnostic.xUnit1010.severity = warning
+
+# xUnit1011: There is no matching method parameter
+dotnet_diagnostic.xUnit1011.severity = warning
+
+# xUnit1012: Null should not be used for value type parameters
+dotnet_diagnostic.xUnit1012.severity = warning
+
+# xUnit1013: Public methods should be marked as test
+dotnet_diagnostic.xUnit1013.severity = warning
+
+# xUnit1014: MemberData should use nameof operator for member name
+dotnet_diagnostic.xUnit1014.severity = warning
+
+# xUnit1015: MemberData must reference an existing member
+dotnet_diagnostic.xUnit1015.severity = warning
+
+# xUnit1016: MemberData must reference a public member
+dotnet_diagnostic.xUnit1016.severity = warning
+
+# xUnit1017: MemberData must reference a static member
+dotnet_diagnostic.xUnit1017.severity = warning
+
+# xUnit1018: MemberData must reference a valid member kind
+dotnet_diagnostic.xUnit1018.severity = warning
+
+# xUnit1019: MemberData must reference a member providing a valid data type
+dotnet_diagnostic.xUnit1019.severity = warning
+
+# xUnit1020: MemberData must reference a property with a getter
+dotnet_diagnostic.xUnit1020.severity = warning
+
+# xUnit1021: MemberData should not have parameters if the referenced member is not a method
+dotnet_diagnostic.xUnit1021.severity = warning
+
+# xUnit1022: Theory methods cannot have a parameter array
+dotnet_diagnostic.xUnit1022.severity = warning
+
+# xUnit1023: Theory methods cannot have default parameter values
+dotnet_diagnostic.xUnit1023.severity = warning
+
+# xUnit1024: Test methods cannot have overloads
+dotnet_diagnostic.xUnit1024.severity = warning
+
+# xUnit1025: InlineData should be unique within the Theory it belongs to
+dotnet_diagnostic.xUnit1025.severity = warning
+
+# xUnit1026: Theory methods should use all of their parameters
+dotnet_diagnostic.xUnit1026.severity = warning
+
+# xUnit2000: Constants and literals should be the expected argument
+dotnet_diagnostic.xUnit2000.severity = warning
+
+# xUnit2001: Do not use invalid equality check
+dotnet_diagnostic.xUnit2001.severity = warning
+
+# xUnit2002: Do not use null check on value type
+dotnet_diagnostic.xUnit2002.severity = warning
+
+# xUnit2003: Do not use equality check to test for null value
+dotnet_diagnostic.xUnit2003.severity = warning
+
+# xUnit2004: Do not use equality check to test for boolean conditions
+dotnet_diagnostic.xUnit2004.severity = warning
+
+# xUnit2005: Do not use identity check on value type
+dotnet_diagnostic.xUnit2005.severity = warning
+
+# xUnit2006: Do not use invalid string equality check
+dotnet_diagnostic.xUnit2006.severity = warning
+
+# xUnit2007: Do not use typeof expression to check the type
+dotnet_diagnostic.xUnit2007.severity = warning
+
+# xUnit2008: Do not use boolean check to match on regular expressions
+dotnet_diagnostic.xUnit2008.severity = warning
+
+# xUnit2009: Do not use boolean check to check for substrings
+dotnet_diagnostic.xUnit2009.severity = warning
+
+# xUnit2010: Do not use boolean check to check for string equality
+dotnet_diagnostic.xUnit2010.severity = warning
+
+# xUnit2011: Do not use empty collection check
+dotnet_diagnostic.xUnit2011.severity = warning
+
+# xUnit2012: Do not use Enumerable.Any() to check if a value exists in a collection
+dotnet_diagnostic.xUnit2012.severity = warning
+
+# xUnit2013: Do not use equality check to check for collection size.
 dotnet_diagnostic.xUnit2013.severity = none
+
+# xUnit2014: Do not use throws check to check for asynchronously thrown exception
+dotnet_diagnostic.xUnit2014.severity = none
+
+# xUnit2015: Do not use typeof expression to check the exception type
+dotnet_diagnostic.xUnit2015.severity = warning
+
+# xUnit2016: Keep precision in the allowed range when asserting equality of doubles or decimals
+dotnet_diagnostic.xUnit2016.severity = warning
+
+# xUnit2017: Do not use Contains() to check if a value exists in a collection
+dotnet_diagnostic.xUnit2017.severity = none
+
+# xUnit2018: Do not compare an object's exact type to an abstract class or interface
+dotnet_diagnostic.xUnit2018.severity = warning
+
+# xUnit2019: Do not use obsolete throws check to check for asynchronously thrown exception
+dotnet_diagnostic.xUnit2019.severity = warning
+
+# xUnit3000: Test case classes must derive directly or indirectly from Xunit.LongLivedMarshalByRefObject
+dotnet_diagnostic.xUnit3000.severity = warning
+
+# xUnit3001: Classes that implement Xunit.Abstractions.IXunitSerializable must have a public parameterless constructor
+dotnet_diagnostic.xUnit3001.severity = warning

--- a/eng/CodeStyle.targets
+++ b/eng/CodeStyle.targets
@@ -11,16 +11,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="all" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" PrivateAssets="all" />
+    <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="$(DotNetAnalyzersDocumentationAnalyzersVersion)" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -90,7 +90,10 @@
     <MicrosoftCodeAnalysisCSharpWorkspacesVersion>4.0.0-2.final</MicrosoftCodeAnalysisCSharpWorkspacesVersion>
     <MicrosoftCodeAnalysisVisualBasicWorkspacesVersion>4.0.0-2.final</MicrosoftCodeAnalysisVisualBasicWorkspacesVersion>
     <MicrosoftCodeAnalysisPackagesVersion>1.1.2-beta1.22415.2</MicrosoftCodeAnalysisPackagesVersion>
-    <MicrosoftCodeAnalysisPublicApiAnalyzers>3.3.0-beta1.final</MicrosoftCodeAnalysisPublicApiAnalyzers>
+    <MicrosoftCodeAnalysisPublicApiAnalyzersVersion>3.3.0-beta1.final</MicrosoftCodeAnalysisPublicApiAnalyzersVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0-preview1.22501.1</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <DotNetAnalyzersDocumentationAnalyzersVersion>1.0.0-beta.59</DotNetAnalyzersDocumentationAnalyzersVersion>
+    <StyleCopAnalyzersVersion>1.2.0-beta.354</StyleCopAnalyzersVersion>
   </PropertyGroup>
   <!-- Additional unchanging dependencies -->
   <PropertyGroup>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.WinFormsAppContext.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.WinFormsAppContext.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
         ''' the main form closes and provides for shutting down when the main form closes or the
         ''' last form closes, depending on the mode this application is running in.
         ''' </summary>
-        Private Class WinFormsAppContext
+        Private NotInheritable Class WinFormsAppContext
             Inherits ApplicationContext
 
             Private ReadOnly _app As WindowsFormsApplicationBase

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/ComputerInfo.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/ComputerInfo.vb
@@ -197,7 +197,7 @@ Namespace Microsoft.VisualBasic.Devices
         ''' <summary>
         ''' Calls GlobalMemoryStatusEx and returns the correct value.
         ''' </summary>
-        Private Class InternalMemoryStatus
+        Private NotInheritable Class InternalMemoryStatus
             Friend Sub New()
             End Sub
 

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Network.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Network.vb
@@ -755,7 +755,7 @@ Namespace Microsoft.VisualBasic.Devices
     ''' Temporary class used to provide WebClient with a timeout property.
     ''' </summary>
     ''' <remarks>This class will be deleted when Timeout is added to WebClient</remarks>
-    Friend Class WebClientExtended
+    Friend NotInheritable Class WebClientExtended
         Inherits WebClient
 
         ''' <summary>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/NativeTypes.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/NativeTypes.vb
@@ -12,8 +12,10 @@ Namespace Microsoft.VisualBasic.CompilerServices
     <ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Never)>
     Friend NotInheritable Class NativeTypes
 
+#Disable Warning CA1812 ' Supress warning as this is a type used in PInvoke and shouldn't be changed.
         <StructLayout(LayoutKind.Sequential)>
         Friend NotInheritable Class SECURITY_ATTRIBUTES
+#Enable Warning CA1812
             Implements IDisposable
 
             Friend Sub New()

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
@@ -1131,7 +1131,7 @@ Namespace Microsoft.VisualBasic.Logging
         ''' Wraps a StreamWriter and keeps a reference count. This enables multiple
         ''' FileLogTraceListeners on multiple threads to access the same file.
         ''' </summary>
-        Friend Class ReferencedStream
+        Friend NotInheritable Class ReferencedStream
             Implements IDisposable
 
             ''' <summary>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/Internal/ProgressDialog.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/Internal/ProgressDialog.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualBasic.MyServices.Internal
     ''' <summary>
     '''  A dialog that shows progress used for Network.Download and Network.Upload
     ''' </summary>
-    Friend Class ProgressDialog
+    Friend NotInheritable Class ProgressDialog
         Inherits Form
 
         ''' <summary>

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/Internal/WebClientCopy.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/Internal/WebClientCopy.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.VisualBasic.MyServices.Internal
     ''' <summary>
     '''  Class that controls the thread that does the actual work of downloading or uploading.
     ''' </summary>
-    Friend Class WebClientCopy
+    Friend NotInheritable Class WebClientCopy
 
         ''' <summary>
         ''' Creates an instance of a WebClientCopy, used to download or upload a file

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ContentAlignmentEditor.ContentUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ContentAlignmentEditor.ContentUI.cs
@@ -12,7 +12,7 @@ namespace System.Drawing.Design
     public partial class ContentAlignmentEditor
     {
         /// <summary>
-        ///  Control we use to provide the content alignment UI.
+        /// Control we use to provide the content alignment UI.
         /// </summary>
         private class ContentUI : Control
         {

--- a/src/System.Windows.Forms.PrivateSourceGenerators/src/System/Windows/Forms/SourceGenerators/EnumValidationInfo.cs
+++ b/src/System.Windows.Forms.PrivateSourceGenerators/src/System/Windows/Forms/SourceGenerators/EnumValidationInfo.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace System.Windows.Forms.PrivateSourceGenerators
 {
-    internal class EnumValidationInfo
+    internal sealed class EnumValidationInfo
     {
         public ITypeSymbol EnumType { get; }
         public List<int> Values { get; }

--- a/src/System.Windows.Forms.PrivateSourceGenerators/src/System/Windows/Forms/SourceGenerators/SyntaxReceiver.cs
+++ b/src/System.Windows.Forms.PrivateSourceGenerators/src/System/Windows/Forms/SourceGenerators/SyntaxReceiver.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace System.Windows.Forms.PrivateSourceGenerators
 {
-    internal class SyntaxReceiver : ISyntaxReceiver
+    internal sealed class SyntaxReceiver : ISyntaxReceiver
     {
         public List<SyntaxNode> ArgumentsToValidate { get; } = new();
 


### PR DESCRIPTION
Fixes #7879

Singular warning for CA1812 supressed due to usage in interop.

Synced globalconfig with runtime and added #TODO to items that were warning.
```
Line  182: dotnet_diagnostic.CA1416.severity = none # TODO: warning
Line  260: dotnet_diagnostic.CA1727.severity = suggestion # TODO: warning
Line  273: dotnet_diagnostic.CA1810.severity = none # TODO: warning
Line  297: dotnet_diagnostic.CA1821.severity = none # TODO: warning
Line  394: dotnet_diagnostic.CA1853.severity =  none # TODO: warning
Line  397: dotnet_diagnostic.CA1854.severity =  none # TODO: warning
Line  406: dotnet_diagnostic.CA2007.severity = none # TODO: warning
Line  439: dotnet_diagnostic.CA2019.severity = none # TODO: warning
Line  466: dotnet_diagnostic.CA2208.severity = none # TODO: warning
Line  533: dotnet_diagnostic.CA2245.severity = none # TODO: warning
Line  557: dotnet_diagnostic.CA2253.severity = none # TODO: warning
Line  851: dotnet_diagnostic.IL3000.severity = none # TODO: warning
Line  873: dotnet_diagnostic.SA1001.severity = none # TODO: warning
Line  912: dotnet_diagnostic.SA1014.severity = none # TODO: warning
Line  924: dotnet_diagnostic.SA1018.severity = none # TODO: warning
Line  930: dotnet_diagnostic.SA1020.severity = none # TODO: warning
Line  948: dotnet_diagnostic.SA1026.severity = none # TODO: warning
Line  951: dotnet_diagnostic.SA1027.severity = none # TODO: warning
Line  954: dotnet_diagnostic.SA1028.severity = none # TODO: warning
Line  963: dotnet_diagnostic.SA1102.severity = none # TODO: warning
Line  966: dotnet_diagnostic.SA1105.severity = none # TODO: warning
Line  996: dotnet_diagnostic.SA1113.severity = none # TODO: warning
Line 1002: dotnet_diagnostic.SA1115.severity = none # TODO: warning
Line 1020: dotnet_diagnostic.SA1121.severity = none # TODO: warning
Line 1044: dotnet_diagnostic.SA1129.severity = none # TODO: warning
Line 1074: dotnet_diagnostic.SA1141.severity = none # TODO: warning
Line 1077: dotnet_diagnostic.SA1142.severity = none # TODO: warning
Line 1095: dotnet_diagnostic.SA1205.severity = none # TODO: warning
Line 1116: dotnet_diagnostic.SA1212.severity = none # TODO: warning
Line 1137: dotnet_diagnostic.SA1302.severity = none # TODO: warning
Line 1179: dotnet_diagnostic.SA1400.severity = none # TODO: warning
Line 1191: dotnet_diagnostic.SA1404.severity = none # TODO: warning
Line 1203: dotnet_diagnostic.SA1408.severity = none # TODO: warning
Line 1212: dotnet_diagnostic.SA1411.severity = none # TODO: warning
Line 1278: dotnet_diagnostic.SA1518.severity = none # TODO: warning
Line 1494: dotnet_diagnostic.IDE0020.severity = none # TODO: warning
Line 1521: dotnet_diagnostic.IDE0029.severity = none # TODO: warning
Line 1527: dotnet_diagnostic.IDE0031.severity = none # TODO: warning
Line 1542: dotnet_diagnostic.IDE0036.severity = none # TODO: warning
Line 1593: dotnet_diagnostic.IDE0054.severity = none # TODO: warning
Line 1608: dotnet_diagnostic.IDE0059.severity = none # TODO: warning
Line 1618: dotnet_diagnostic.IDE0062.severity = none # TODO: warning
Line 1627: dotnet_diagnostic.IDE0065.severity = none # TODO: warning
Line 1645: dotnet_diagnostic.IDE0074.severity = none # TODO: warning
Line 1669: dotnet_diagnostic.IDE0082.severity = none # TODO: warning
Line 1681: dotnet_diagnostic.IDE0100.severity = none # TODO: warning
Line 1684: dotnet_diagnostic.IDE0110.severity = none # TODO: warning
Line 1705: dotnet_diagnostic.IDE0170.severity = none # TODO: warning
Line 1711: dotnet_diagnostic.IDE0200.severity = none # TODO: warning
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7881)