### PR TITLE
Use native tools present on the machine rather than bootstraped tools in CI build

### DIFF
--- a/Restore.cmd
+++ b/Restore.cmd
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -NativeToolsOnMachine -restore %*"

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore -build -bl %*"
+powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -NativeToolsOnMachine -restore -build -bl %*"
 exit /b %ErrorLevel%

--- a/global.json
+++ b/global.json
@@ -21,6 +21,6 @@
     "Microsoft.NET.Sdk.IL": "7.0.0-rtm.22504.4"
   },
   "native-tools": {
-    "cmake": "3.21.0"
+    "cmake": "3"
   }
 }


### PR DESCRIPTION
This is a fix for the build errors, e.g.:
![image](https://user-images.githubusercontent.com/4403806/193995304-72512bc6-d44c-4416-ad6e-ab1a12c1777b.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7886)