### PR TITLE
Fixing the AutomationId property for AccessibleObject of options in ContentUI and DockUI forms

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ContentAlignmentEditor.ContentUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ContentAlignmentEditor.ContentUI.cs
@@ -117,46 +117,55 @@ namespace System.Drawing.Design
 
                 _topLeft.TabIndex = 8;
                 _topLeft.Text = string.Empty;
+                _topLeft.Name = "_topLeft";
                 _topLeft.Appearance = Appearance.Button;
                 _topLeft.AccessibleName = SR.ContentAlignmentEditorTopLeftAccName;
 
                 _topCenter.TabIndex = 0;
                 _topCenter.Text = string.Empty;
+                _topCenter.Name = "_topCenter";
                 _topCenter.Appearance = Appearance.Button;
                 _topCenter.AccessibleName = SR.ContentAlignmentEditorTopCenterAccName;
 
                 _topRight.TabIndex = 1;
                 _topRight.Text = string.Empty;
+                _topRight.Name = "_topRight";
                 _topRight.Appearance = Appearance.Button;
                 _topRight.AccessibleName = SR.ContentAlignmentEditorTopRightAccName;
 
                 _middleLeft.TabIndex = 2;
                 _middleLeft.Text = string.Empty;
+                _middleLeft.Name = "_middleLeft";
                 _middleLeft.Appearance = Appearance.Button;
                 _middleLeft.AccessibleName = SR.ContentAlignmentEditorMiddleLeftAccName;
 
                 _middleCenter.TabIndex = 3;
                 _middleCenter.Text = string.Empty;
+                _middleCenter.Name = "_middleCenter";
                 _middleCenter.Appearance = Appearance.Button;
                 _middleCenter.AccessibleName = SR.ContentAlignmentEditorMiddleCenterAccName;
 
                 _middleRight.TabIndex = 4;
                 _middleRight.Text = string.Empty;
+                _middleRight.Name = "_middleRight";
                 _middleRight.Appearance = Appearance.Button;
                 _middleRight.AccessibleName = SR.ContentAlignmentEditorMiddleRightAccName;
 
                 _bottomLeft.TabIndex = 5;
                 _bottomLeft.Text = string.Empty;
+                _bottomLeft.Name = "_bottomLeft";
                 _bottomLeft.Appearance = Appearance.Button;
                 _bottomLeft.AccessibleName = SR.ContentAlignmentEditorBottomLeftAccName;
 
                 _bottomCenter.TabIndex = 6;
                 _bottomCenter.Text = string.Empty;
+                _bottomCenter.Name = "_bottomCenter";
                 _bottomCenter.Appearance = Appearance.Button;
                 _bottomCenter.AccessibleName = SR.ContentAlignmentEditorBottomCenterAccName;
 
                 _bottomRight.TabIndex = 7;
                 _bottomRight.Text = string.Empty;
+                _bottomRight.Name = "_bottomRight";
                 _bottomRight.Appearance = Appearance.Button;
                 _bottomRight.AccessibleName = SR.ContentAlignmentEditorBottomRightAccName;
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DockEditor.DockUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DockEditor.DockUI.cs
@@ -143,6 +143,7 @@ namespace System.Windows.Forms.Design
 
                 _none.Dock = DockStyle.Bottom;
                 _none.Size = new Size(s_noneWidth, s_noneHeight);
+                _none.Name = "_none";
                 _none.Text = DockStyle.None.ToString();
                 _none.TabIndex = 0;
                 _none.TabStop = true;
@@ -160,6 +161,7 @@ namespace System.Windows.Forms.Design
                 _right.Size = s_buttonSize;
                 _right.TabIndex = 4;
                 _right.TabStop = true;
+                _right.Name = "_right";
                 _right.Text = " "; // Needs at least one character so focus rect will show.
                 _right.Appearance = Appearance.Button;
                 _right.AccessibleName = SR.DockEditorRightAccName;
@@ -168,6 +170,7 @@ namespace System.Windows.Forms.Design
                 _left.Size = s_buttonSize;
                 _left.TabIndex = 2;
                 _left.TabStop = true;
+                _left.Name = "_left";
                 _left.Text = " ";
                 _left.Appearance = Appearance.Button;
                 _left.AccessibleName = SR.DockEditorLeftAccName;
@@ -176,6 +179,7 @@ namespace System.Windows.Forms.Design
                 _top.Size = s_buttonSize;
                 _top.TabIndex = 1;
                 _top.TabStop = true;
+                _top.Name = "_top";
                 _top.Text = " ";
                 _top.Appearance = Appearance.Button;
                 _top.AccessibleName = SR.DockEditorTopAccName;
@@ -184,6 +188,7 @@ namespace System.Windows.Forms.Design
                 _bottom.Size = s_buttonSize;
                 _bottom.TabIndex = 5;
                 _bottom.TabStop = true;
+                _bottom.Name = "_bottom";
                 _bottom.Text = " ";
                 _bottom.Appearance = Appearance.Button;
                 _bottom.AccessibleName = SR.DockEditorBottomAccName;
@@ -192,6 +197,7 @@ namespace System.Windows.Forms.Design
                 _fill.Size = s_buttonSize;
                 _fill.TabIndex = 3;
                 _fill.TabStop = true;
+                _fill.Name = "_fill";
                 _fill.Text = " ";
                 _fill.Appearance = Appearance.Button;
                 _fill.AccessibleName = SR.DockEditorFillAccName;


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7830 


## Proposed changes

- Added `Name` to buttons in `DockUI` and `ContentUI`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The `AutomationId` property will be filled.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Screenshot 2022-10-05 150607](https://user-images.githubusercontent.com/109065597/194053377-7e55c9e5-d3fe-4c83-9d24-e92039a4ceea.png)
_ContentUI_
![Screenshot 2022-10-05 150630](https://user-images.githubusercontent.com/109065597/194053428-bb987430-cfcc-465d-89ad-7bc1d8396d3e.png)
_DockUI_

### After

![Screenshot 2022-10-05 145718](https://user-images.githubusercontent.com/109065597/194053536-6764eb2d-4da6-433a-8c83-9faded88dfee.png)
_ContentUI_
![Screenshot 2022-10-05 145751](https://user-images.githubusercontent.com/109065597/194053521-400b50cf-24b2-4ae5-b45d-6b9fe5b922cf.png)
_DockUI_


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Inspect

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK:
 Version:   8.0.100-alpha.1.22423.9
 Commit:    b9635390c8

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7890)