### PR TITLE
Clean up PInvoke Definitions

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.BitBlt.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.BitBlt.cs
@@ -7,7 +7,7 @@ namespace Windows.Win32
     internal static partial class PInvoke
     {
         public static BOOL BitBlt<T>(
-            in T hdc,
+            T hdc,
             int x,
             int y,
             int cx,
@@ -27,7 +27,7 @@ namespace Windows.Win32
                 x1,
                 y1,
                 rop);
-            GC.KeepAlive(hdc.Handle);
+            GC.KeepAlive(hdc.Wrapper);
             return result;
         }
 
@@ -37,7 +37,7 @@ namespace Windows.Win32
             int y,
             int cx,
             int cy,
-            in T hdcSrc,
+            T hdcSrc,
             int x1,
             int y1,
             ROP_CODE rop) where T : IHandle<HDC>
@@ -52,7 +52,7 @@ namespace Windows.Win32
                 x1,
                 y1,
                 rop);
-            GC.KeepAlive(hdcSrc.Handle);
+            GC.KeepAlive(hdcSrc.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CloseHandle.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CloseHandle.cs
@@ -6,10 +6,10 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL CloseHandle(IHandle handle)
+        public static BOOL CloseHandle<T>(T handle) where T : IHandle<HANDLE>
         {
-            BOOL result = CloseHandle((HANDLE)handle.Handle);
-            GC.KeepAlive(handle);
+            BOOL result = CloseHandle(handle.Handle);
+            GC.KeepAlive(handle.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CreateBitmapScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CreateBitmapScope.cs
@@ -31,7 +31,7 @@ namespace Windows.Win32
             }
 
             /// <summary>
-            ///  Creates a bitmap compatible with the given <see cref="HDC"/> via <see cref="CreateCompatibleBitmap(Windows.Win32.Graphics.Gdi.HDC, int, int)"/>
+            ///  Creates a bitmap compatible with the given <see cref="HDC"/> via <see cref="CreateCompatibleBitmap(HDC, int, int)"/>
             /// </summary>
             public CreateBitmapScope(HDC hdc, int cx, int cy)
             {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CreateBrushScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CreateBrushScope.cs
@@ -35,7 +35,7 @@ namespace Windows.Win32
             {
                 HBRUSH = color.IsSystemColor
                     ? User32.GetSysColorBrush(color)
-                    : CreateSolidBrush((COLORREF)(uint)ColorTranslator.ToWin32(color));
+                    : CreateSolidBrush(color);
                 ValidateBrushHandle();
             }
 

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CreateDcScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CreateDcScope.cs
@@ -37,21 +37,16 @@ namespace Windows.Win32
                 HDC = CreateCompatibleDC(hdc);
             }
 
-            public unsafe CreateDcScope(
+            public CreateDcScope(
                 string lpszDriverName,
                 string? lpszDeviceName = null,
                 string? lpszOutput = null,
                 DEVMODEW lpInitData = default,
                 bool informationOnly = true)
             {
-                fixed (char* pDriver = lpszDriverName)
-                fixed (char* pDevice = lpszDeviceName)
-                fixed (char* pOutput = lpszOutput)
-                {
-                    HDC = informationOnly
-                        ? CreateICW(pDriver, pDevice, pOutput, &lpInitData)
-                        : CreateDCW(pDriver, pDevice, pOutput, &lpInitData);
-                }
+                HDC = informationOnly
+                    ? CreateICW(lpszDriverName, lpszDeviceName, lpszOutput, lpInitData)
+                    : CreateDCW(lpszDriverName, lpszDeviceName, lpszOutput, lpInitData);
             }
 
             public static implicit operator HDC(in CreateDcScope scope) => scope.HDC;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CreatePenScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.CreatePenScope.cs
@@ -33,7 +33,7 @@ namespace Windows.Win32
                 HPEN = CreatePen(
                     width > 1 ? (PEN_STYLE.PS_GEOMETRIC | PEN_STYLE.PS_SOLID) : default,
                     width,
-                    (COLORREF)(uint)ColorTranslator.ToWin32(color));
+                    color);
             }
 
             public static implicit operator HPEN(in CreatePenScope scope) => scope.HPEN;

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.DragAcceptFiles.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.DragAcceptFiles.cs
@@ -6,10 +6,10 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static void DragAcceptFiles(IHandle hWnd, BOOL fAccept)
+        public static void DragAcceptFiles<T>(T hWnd, BOOL fAccept) where T : IHandle<HWND>
         {
-            DragAcceptFiles((HWND)hWnd.Handle, fAccept);
-            GC.KeepAlive(hWnd);
+            DragAcceptFiles(hWnd.Handle, fAccept);
+            GC.KeepAlive(hWnd.Wrapper);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetAncestor.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetAncestor.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static HWND GetAncestor<T>(in T hwnd, GET_ANCESTOR_FLAGS flags) where T : IHandle<HWND>
+        public static HWND GetAncestor<T>(T hwnd, GET_ANCESTOR_FLAGS flags) where T : IHandle<HWND>
         {
             HWND result = GetAncestor(hwnd.Handle, flags);
             GC.KeepAlive(hwnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetParent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetParent.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static HWND GetParent<T>(in T hwnd) where T : IHandle<HWND>
+        public static HWND GetParent<T>(T hwnd) where T : IHandle<HWND>
         {
             HWND result = GetParent(hwnd.Handle);
             GC.KeepAlive(hwnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetSystemMenu.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetSystemMenu.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static HMENU GetSystemMenu<T>(in T hwnd, BOOL bRevert) where T : IHandle<HWND>
+        public static HMENU GetSystemMenu<T>(T hwnd, BOOL bRevert) where T : IHandle<HWND>
         {
             HMENU result = GetSystemMenu(hwnd.Handle, bRevert);
             GC.KeepAlive(hwnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetTextExtentPoint32.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetTextExtentPoint32.cs
@@ -8,14 +8,11 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {   
-        public static unsafe BOOL GetTextExtentPoint32W<T>(in T hdc, string lpString, int c, Size size) where T : IHandle<HDC>
+        public static BOOL GetTextExtentPoint32W<T>(T hdc, string lpString, int c, out Size size) where T : IHandle<HDC>
         {
-            fixed (char* pString = lpString)
-            {
-                BOOL result = GetTextExtentPoint32W(hdc.Handle, pString, c, (SIZE*)(void*)&size);
-                GC.KeepAlive(hdc.Wrapper);
-                return result;
-            }
+            BOOL result = GetTextExtentPoint32W(hdc.Handle, lpString, c, out size);
+            GC.KeepAlive(hdc.Wrapper);
+            return result;
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetTextExtentPoint32.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetTextExtentPoint32.cs
@@ -7,12 +7,15 @@ using System.Drawing;
 namespace Windows.Win32
 {
     internal static partial class PInvoke
-    {   
-        public static BOOL GetTextExtentPoint32W<T>(T hdc, string lpString, int c, out Size size) where T : IHandle<HDC>
+    {
+        public static unsafe BOOL GetTextExtentPoint32W<T>(T hdc, string lpString, int c, Size size) where T : IHandle<HDC>
         {
-            BOOL result = GetTextExtentPoint32W(hdc.Handle, lpString, c, out size);
-            GC.KeepAlive(hdc.Wrapper);
-            return result;
+            fixed (char* pString = lpString)
+            {
+                BOOL result = GetTextExtentPoint32W(hdc.Handle, pString, c, (SIZE*)(void*)&size);
+                GC.KeepAlive(hdc.Wrapper);
+                return result;
+            }
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetThemeFont.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetThemeFont.cs
@@ -8,7 +8,7 @@ namespace Windows.Win32
     {
         public static unsafe HRESULT GetThemeFont(IHandle hTheme, HDC hdc, int iPartId, int iStateId, int iPropId, out LOGFONTW pFont)
         {
-            HRESULT result = (HRESULT)GetThemeFont(hTheme.Handle, hdc, iPartId, iStateId, iPropId, out pFont).Value;
+            HRESULT result = GetThemeFont(hTheme.Handle, hdc, iPartId, iStateId, iPropId, out pFont);
             GC.KeepAlive(hTheme);
             return result;
         }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindow.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static HWND GetWindow<T>(in T hWnd, GET_WINDOW_CMD uCmd) where T : IHandle<HWND>
+        public static HWND GetWindow<T>(T hWnd, GET_WINDOW_CMD uCmd) where T : IHandle<HWND>
         {
             HWND result = GetWindow(hWnd.Handle, uCmd);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowLong.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowLong.cs
@@ -15,7 +15,7 @@ namespace Windows.Win32
         [DllImport(Libraries.User32, SetLastError = true)]
         private static extern nint GetWindowLongPtrW(HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex);
 
-        public static nint GetWindowLong<T>(in T hWnd, WINDOW_LONG_PTR_INDEX nIndex)
+        public static nint GetWindowLong<T>(T hWnd, WINDOW_LONG_PTR_INDEX nIndex)
             where T : IHandle<HWND>
         {
             nint result = Environment.Is64BitProcess

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetWindowRect.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL GetWindowRect<T>(in T hWnd, out RECT lpRect) where T : IHandle<HWND>
+        public static BOOL GetWindowRect<T>(T hWnd, out RECT lpRect) where T : IHandle<HWND>
         {
             BOOL result = GetWindowRect(hWnd.Handle, out lpRect);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImageList.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImageList.cs
@@ -8,21 +8,21 @@ namespace Windows.Win32
     {
         public static class ImageList
         {
-            public static int Add<T>(in T himl, HBITMAP hbmImage, HBITMAP hbmMask) where T : IHandle<HIMAGELIST>
+            public static int Add<T>(T himl, HBITMAP hbmImage, HBITMAP hbmMask) where T : IHandle<HIMAGELIST>
             {
                 int result = ImageList_Add(himl.Handle, hbmImage, hbmMask);
                 GC.KeepAlive(himl.Wrapper);
                 return result;
             }
 
-            public static bool Destroy<T>(in T himl) where T: IHandle<HIMAGELIST>
+            public static bool Destroy<T>(T himl) where T: IHandle<HIMAGELIST>
             {
                 bool result = ImageList_Destroy(himl.Handle);
                 GC.KeepAlive(himl.Wrapper);
                 return result;
             }
 
-            public static bool Draw<T>(in T himl, int i, HDC hdcDst, int x, int y, IMAGE_LIST_DRAW_STYLE fStyle)
+            public static bool Draw<T>(T himl, int i, HDC hdcDst, int x, int y, IMAGE_LIST_DRAW_STYLE fStyle)
                 where T : IHandle<HIMAGELIST>
             {
                 BOOL result = ImageList_Draw(himl.Handle, i, hdcDst, x, y, fStyle);
@@ -31,9 +31,9 @@ namespace Windows.Win32
             }
 
             public static bool DrawEx<THIML, THDC>(
-                in THIML himl,
+                THIML himl,
                 int i,
-                in THDC hdcDst,
+                THDC hdcDst,
                 int x,
                 int y,
                 int dx,
@@ -48,7 +48,7 @@ namespace Windows.Win32
                 return result;
             }
 
-            public static unsafe bool GetIconSize<T>(in T himl, out int x, out int y) where T : IHandle<HIMAGELIST>
+            public static unsafe bool GetIconSize<T>(T himl, out int x, out int y) where T : IHandle<HIMAGELIST>
             {
                 fixed (int* px = &x)
                 fixed (int* py = &y)
@@ -59,28 +59,28 @@ namespace Windows.Win32
                 }
             }
 
-            public static int GetImageCount<T>(in T himl) where T : IHandle<HIMAGELIST>
+            public static int GetImageCount<T>(T himl) where T : IHandle<HIMAGELIST>
             {
                 int result = ImageList_GetImageCount(himl.Handle);
                 GC.KeepAlive(himl.Wrapper);
                 return result;
             }
 
-            public static bool GetImageInfo<T>(in T himl, int i, out IMAGEINFO pImageInfo) where T : IHandle<HIMAGELIST>
+            public static bool GetImageInfo<T>(T himl, int i, out IMAGEINFO pImageInfo) where T : IHandle<HIMAGELIST>
             {
                 bool result = ImageList_GetImageInfo(himl.Handle, i, out pImageInfo);
                 GC.KeepAlive(himl.Wrapper);
                 return result;
             }
 
-            public static bool Remove<T>(in T himl, int i) where T : IHandle<HIMAGELIST>
+            public static bool Remove<T>(T himl, int i) where T : IHandle<HIMAGELIST>
             {
                 bool result = ImageList_Remove(himl.Handle, i);
                 GC.KeepAlive(himl.Wrapper);
                 return result;
             }
 
-            public static bool Replace<T>(in T himl, int i, HBITMAP hbmImage, HBITMAP hbmMask) where T : IHandle<HIMAGELIST>
+            public static bool Replace<T>(T himl, int i, HBITMAP hbmImage, HBITMAP hbmMask) where T : IHandle<HIMAGELIST>
             {
                 bool result = ImageList_Replace(himl.Handle, i, hbmImage, hbmMask);
                 GC.KeepAlive(himl.Wrapper);
@@ -88,9 +88,9 @@ namespace Windows.Win32
             }
 
             public static int ReplaceIcon<THIML, THICON>(
-                in THIML himl,
+                THIML himl,
                 int i,
-                in THICON hicon) where THIML : IHandle<HIMAGELIST> where THICON : IHandle<HICON>
+                THICON hicon) where THIML : IHandle<HIMAGELIST> where THICON : IHandle<HICON>
             {
                 int result = ImageList_ReplaceIcon(himl.Handle, i, hicon.Handle);
                 GC.KeepAlive(himl.Wrapper);
@@ -98,7 +98,7 @@ namespace Windows.Win32
                 return result;
             }
 
-            public static COLORREF SetBkColor<T>(in T himl, COLORREF clrBk) where T : IHandle<HIMAGELIST>
+            public static COLORREF SetBkColor<T>(T himl, COLORREF clrBk) where T : IHandle<HIMAGELIST>
             {
                 COLORREF result = ImageList_SetBkColor(himl.Handle, clrBk);
                 GC.KeepAlive(himl.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmGetContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmGetContext.cs
@@ -8,7 +8,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static HIMC ImmGetContext<T>(in T hWnd) where T : IHandle<HWND>
+        public static HIMC ImmGetContext<T>(T hWnd) where T : IHandle<HWND>
         {
             HIMC result = ImmGetContext(hWnd.Handle);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmReleaseContext.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ImmReleaseContext.cs
@@ -8,7 +8,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL ImmReleaseContext<T>(in T hWnd, HIMC hIMC) where T : IHandle<HWND>
+        public static BOOL ImmReleaseContext<T>(T hWnd, HIMC hIMC) where T : IHandle<HWND>
         {
             BOOL result = ImmReleaseContext(hWnd.Handle, hIMC);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IntersectClipRect.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IntersectClipRect.cs
@@ -2,16 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using static Interop;
-
 namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static RegionType IntersectClipRect(IHandle hdc, int left, int top, int right, int bottom)
+        public static GDI_REGION_TYPE IntersectClipRect<T>(T hdc, int left, int top, int right, int bottom) where T : IHandle<HDC>
         {
-            RegionType result = (RegionType)IntersectClipRect((HDC)hdc.Handle, left, top, right, bottom);
-            GC.KeepAlive(hdc);
+            GDI_REGION_TYPE result = IntersectClipRect(hdc.Handle, left, top, right, bottom);
+            GC.KeepAlive(hdc.Wrapper);
             return result;
         }
     }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsChild.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsChild.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL IsChild<TParent, TChild>(in TParent hWndParent, TChild hWnd)
+        public static BOOL IsChild<TParent, TChild>(TParent hWndParent, TChild hWnd)
             where TParent : IHandle<HWND>
             where TChild : IHandle<HWND>
         {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindow.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL IsWindow<T>(in T hWnd) where T : IHandle<HWND>
+        public static BOOL IsWindow<T>(T hWnd) where T : IHandle<HWND>
         {
             BOOL result = IsWindow(hWnd.Handle);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindowVisible.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.IsWindowVisible.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL IsWindowVisible<T>(in T hWnd) where T : IHandle<HWND>
+        public static BOOL IsWindowVisible<T>(T hWnd) where T : IHandle<HWND>
         {
             BOOL result = IsWindowVisible(hWnd.Handle);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.LoadLibrary.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.LoadLibrary.cs
@@ -11,7 +11,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public unsafe static IntPtr LoadComctl32(string startupPath)
+        public static HINSTANCE LoadComctl32(string startupPath)
         {
             // NOTE: we don't look for the loaded module!
 
@@ -23,8 +23,8 @@ namespace Windows.Win32
                 if (Path.IsPathFullyQualified(customPath))
                 {
                     // OS will validate the path for us
-                    HINSTANCE result = LoadLibraryEx(customPath, (HANDLE)0, 0);
-                    if (result != 0)
+                    HINSTANCE result = LoadLibraryEx(customPath, HANDLE.Null, 0);
+                    if (!result.IsNull)
                     {
                         return result;
                     }
@@ -41,17 +41,17 @@ namespace Windows.Win32
         /// </summary>
         /// <param name="libraryName">The assembly name to load.</param>
         /// <returns>A handle to the loaded module, if successful; <see cref="IntPtr.Zero"/> otherwise.</returns>
-        public unsafe static nint LoadLibraryFromSystemPathIfAvailable(string libraryName)
+        public static HINSTANCE LoadLibraryFromSystemPathIfAvailable(string libraryName)
         {
-            if (GetModuleHandle(Libraries.Kernel32) == 0)
+            if (GetModuleHandle(Libraries.Kernel32).IsNull)
             {
-                return 0;
+                return HINSTANCE.Null;
             }
 
             // LOAD_LIBRARY_SEARCH_SYSTEM32 was introduced in KB2533623. Check for its presence
             // to preserve compat with Windows 7 SP1 without this patch.
-            HINSTANCE result = LoadLibraryEx(libraryName, (HANDLE)0, LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_SEARCH_SYSTEM32);
-            if (result != 0)
+            HINSTANCE result = LoadLibraryEx(libraryName, HANDLE.Null, LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_SEARCH_SYSTEM32);
+            if (!result.IsNull)
             {
                 return result;
             }
@@ -59,10 +59,10 @@ namespace Windows.Win32
             // Load without this flag.
             if (Marshal.GetLastWin32Error() != ERROR.INVALID_PARAMETER)
             {
-                return (HINSTANCE)0;
+                return HINSTANCE.Null;
             }
 
-            return LoadLibraryEx(libraryName, (HANDLE)0, 0);
+            return LoadLibraryEx(libraryName, HANDLE.Null, 0);
         }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MapWindowPoints.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.MapWindowPoints.cs
@@ -8,7 +8,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public unsafe static int MapWindowPoints<TFrom, TTo>(in TFrom hWndFrom, in TTo hWndTo, ref RECT lpRect)
+        public unsafe static int MapWindowPoints<TFrom, TTo>(TFrom hWndFrom, TTo hWndTo, ref RECT lpRect)
             where TFrom : IHandle<HWND>
             where TTo : IHandle<HWND>
         {
@@ -21,7 +21,7 @@ namespace Windows.Win32
             }
         }
 
-        public unsafe static int MapWindowPoints<TFrom, TTo>(in TFrom hWndFrom, in TTo hWndTo, ref Point lpPoint)
+        public unsafe static int MapWindowPoints<TFrom, TTo>(TFrom hWndFrom, TTo hWndTo, ref Point lpPoint)
             where TFrom : IHandle<HWND>
             where TTo : IHandle<HWND>
         {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.PostMessage.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.PostMessage.cs
@@ -9,7 +9,7 @@ namespace Windows.Win32
     internal static partial class PInvoke
     {
         public static BOOL PostMessage(
-           in IHandle<HWND> hWnd,
+           IHandle<HWND> hWnd,
            WM Msg,
            WPARAM wParam = default,
            LPARAM lParam = default)

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.RevokeDragDrop.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.RevokeDragDrop.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static HRESULT RevokeDragDrop<T>(in T hwnd) where T : IHandle<HWND>
+        public static HRESULT RevokeDragDrop<T>(T hwnd) where T : IHandle<HWND>
         {
             HRESULT result = RevokeDragDrop(hwnd.Handle);
             GC.KeepAlive(hwnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SHAutoComplete.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SHAutoComplete.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static HRESULT SHAutoComplete<T>(in T hwndEdit, SHELL_AUTOCOMPLETE_FLAGS flags) where T : IHandle<HWND>
+        public static HRESULT SHAutoComplete<T>(T hwndEdit, SHELL_AUTOCOMPLETE_FLAGS flags) where T : IHandle<HWND>
         {
             HRESULT result = SHAutoComplete(hwndEdit.Handle, flags);
             GC.KeepAlive(hwndEdit.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetActiveWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetActiveWindow.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static HWND SetActiveWindow<T>(in T hWnd) where T : IHandle<HWND>
+        public static HWND SetActiveWindow<T>(T hWnd) where T : IHandle<HWND>
         {
             HWND result = SetActiveWindow(hWnd.Handle);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetBackgroundColorScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetBackgroundColorScope.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Drawing;
-
 namespace Windows.Win32
 {
     internal static partial class PInvoke
@@ -27,13 +25,12 @@ namespace Windows.Win32
             ///  Sets text color <paramref name="color"/> in the given <paramref name="hdc"/> using
             ///  <see cref="SetBkColor(HDC, COLORREF)"/>.
             /// </summary>
-            public SetBackgroundColorScope(HDC hdc, Color color)
+            public SetBackgroundColorScope(HDC hdc, COLORREF color)
             {
-                COLORREF colorref = (COLORREF)(uint)ColorTranslator.ToWin32(color);
-                _previousColor = SetBkColor(hdc, colorref);
+                _previousColor = SetBkColor(hdc, color);
 
                 // If we didn't actually change the color, don't keep the HDC so we skip putting back the same state.
-                _hdc = colorref == _previousColor ? default : hdc;
+                _hdc = color == _previousColor ? default : hdc;
             }
 
             public void Dispose()

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetFocus.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetFocus.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static HWND SetFocus<T>(in T hWnd) where T : IHandle<HWND>
+        public static HWND SetFocus<T>(T hWnd) where T : IHandle<HWND>
         {
             HWND result = SetFocus(hWnd.Handle);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetParent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetParent.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static HWND SetParent<TChild, TParent>(in TChild hWndChild, in TParent hWndNewParent)
+        public static HWND SetParent<TChild, TParent>(TChild hWndChild, TParent hWndNewParent)
             where TChild : IHandle<HWND>
             where TParent : IHandle<HWND>
         {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetTextColorScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetTextColorScope.cs
@@ -4,7 +4,6 @@
 
 #if DEBUG
 #endif
-using System.Drawing;
 
 namespace Windows.Win32
 {
@@ -33,13 +32,12 @@ namespace Windows.Win32
             ///  Sets text color <paramref name="color"/> in the given <paramref name="hdc"/> using
             ///  <see cref="SetTextColor(HDC, COLORREF)"/>.
             /// </summary>
-            public SetTextColorScope(HDC hdc, Color color)
+            public SetTextColorScope(HDC hdc, COLORREF color)
             {
-                COLORREF colorref = (COLORREF)(uint)ColorTranslator.ToWin32(color);
-                _previousColor = SetTextColor(hdc, colorref);
+                _previousColor = SetTextColor(hdc, color);
 
                 // If we didn't actually change the color, don't keep the HDC so we skip putting back the same state.
-                _hdc = colorref == _previousColor ? default : hdc;
+                _hdc = color == _previousColor ? default : hdc;
             }
 
             public void Dispose()

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetWindowLong.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetWindowLong.cs
@@ -15,7 +15,7 @@ namespace Windows.Win32
         [DllImport(Libraries.User32, SetLastError = true)]
         private static extern nint SetWindowLongPtrW(HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex, nint dwNewLong);
 
-        public static nint SetWindowLong<T>(in T hWnd, WINDOW_LONG_PTR_INDEX nIndex, nint newValue)
+        public static nint SetWindowLong<T>(T hWnd, WINDOW_LONG_PTR_INDEX nIndex, nint newValue)
             where T : IHandle<HWND>
         {
             nint result = Environment.Is64BitProcess
@@ -25,7 +25,7 @@ namespace Windows.Win32
             return result;
         }
 
-        public static nint SetWindowLong<THwnd, TNewValue>(in THwnd hWnd, WINDOW_LONG_PTR_INDEX nIndex, TNewValue newValue)
+        public static nint SetWindowLong<THwnd, TNewValue>(THwnd hWnd, WINDOW_LONG_PTR_INDEX nIndex, TNewValue newValue)
             where THwnd : IHandle<HWND>
             where TNewValue : IHandle<HWND>
         {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetWindowPos.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SetWindowPos.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL SetWindowPos<T1, T2>(in T1 hWnd, in T2 hWndInsertAfter, int X, int Y, int cx, int cy, SET_WINDOW_POS_FLAGS uFlags)
+        public static BOOL SetWindowPos<T1, T2>(T1 hWnd, T2 hWndInsertAfter, int X, int Y, int cx, int cy, SET_WINDOW_POS_FLAGS uFlags)
             where T1 : IHandle<HWND>
             where T2 : IHandle<HWND>
         {

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ShowWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.ShowWindow.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL ShowWindow<T>(in T hWnd, SHOW_WINDOW_CMD nCmdShow) where T : IHandle<HWND>
+        public static BOOL ShowWindow<T>(T hWnd, SHOW_WINDOW_CMD nCmdShow) where T : IHandle<HWND>
         {
             BOOL result = ShowWindow(hWnd.Handle, nCmdShow);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UpdateWindow.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.UpdateWindow.cs
@@ -6,7 +6,7 @@ namespace Windows.Win32
 {
     internal static partial class PInvoke
     {
-        public static BOOL UpdateWindow<T>(in T hWnd) where T : IHandle<HWND>
+        public static BOOL UpdateWindow<T>(T hWnd) where T : IHandle<HWND>
         {
             BOOL result = UpdateWindow(hWnd.Handle);
             GC.KeepAlive(hWnd.Wrapper);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms
         ///  TLS is really just an unfortunate artifact of using Win 32.  We want the world to be free
         ///  threaded.
         /// </summary>
-        internal sealed class ThreadContext : MarshalByRefObject, IMsoComponent, IHandle
+        internal sealed class ThreadContext : MarshalByRefObject, IMsoComponent, IHandle<HANDLE>
         {
             private const int STATE_OLEINITIALIZED = 0x00000001;
             private const int STATE_EXTERNALOLEINIT = 0x00000002;
@@ -55,7 +55,7 @@ namespace System.Windows.Forms
             private List<IMessageFilter> _messageFilters;
             private List<IMessageFilter> _messageFilterSnapshot;
             private int _inProcessFilters;
-            private IntPtr _handle;
+            private HANDLE _handle;
             private readonly uint _id;
             private int _messageLoopCount;
             private int _threadState;
@@ -518,10 +518,10 @@ namespace System.Windows.Forms
                                 finally
                                 {
                                     // We can always clean up this handle, though
-                                    if (_handle != IntPtr.Zero)
+                                    if (!_handle.IsNull)
                                     {
                                         PInvoke.CloseHandle(this);
-                                        _handle = IntPtr.Zero;
+                                        _handle = HANDLE.Null;
                                     }
 
                                     try
@@ -708,10 +708,10 @@ namespace System.Windows.Forms
             {
                 // Don't call OleUninitialize as the finalizer is called on the wrong thread.
                 // We can always clean up this handle, though.
-                if (_handle != IntPtr.Zero)
+                if (!_handle.IsNull)
                 {
-                    PInvoke.CloseHandle((HANDLE)_handle);
-                    _handle = IntPtr.Zero;
+                    PInvoke.CloseHandle(_handle);
+                    _handle = HANDLE.Null;
                 }
             }
 
@@ -777,7 +777,9 @@ namespace System.Windows.Forms
             /// <summary>
             ///  Retrieves the handle to this thread.
             /// </summary>
-            public nint Handle => _handle;
+            public HANDLE Handle => _handle;
+
+            HANDLE IHandle<HANDLE>.Handle => Handle;
 
             /// <summary>
             ///  Retrieves the ID of this thread.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -3933,7 +3933,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            nint threadHandle = ((IHandle)ctx).Handle;
+            HANDLE threadHandle = ctx.Handle;
             bool processed = false;
             // setting default exitcode to 0, though it won't be accessed in current code below due to short-circuit logic in condition (returnValue will be false when exitCode is undefined)
             uint exitCode = 0;
@@ -3943,7 +3943,7 @@ namespace System.Windows.Forms
                 //Get the thread's exit code, if we found the thread as expected
                 if (threadHandle != 0)
                 {
-                    returnValue = PInvoke.GetExitCodeThread((HANDLE)threadHandle, &exitCode);
+                    returnValue = PInvoke.GetExitCodeThread(threadHandle, &exitCode);
                 }
 
                 //If we didn't find the thread, or if GetExitCodeThread failed, we don't know the thread's state:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Cursor.cs
@@ -246,7 +246,7 @@ namespace System.Windows.Forms
             targetRect.X += (int)graphics.Transform.OffsetX;
             targetRect.Y += (int)graphics.Transform.OffsetY;
 
-            IntPtr dc = graphics.GetHdc();
+            HDC dc = (HDC)graphics.GetHdc();
 
             // want finally clause to release dc
             try
@@ -328,9 +328,9 @@ namespace System.Windows.Forms
                 // The ROP is SRCCOPY, so we can be simple here and take
                 // advantage of clipping regions.  Drawing the cursor
                 // is merely a matter of offsetting and clipping.
-                PInvoke.IntersectClipRect(this, targetX, targetY, targetX + clipWidth, targetY + clipHeight);
+                PInvoke.IntersectClipRect(new HandleRef<HDC>(this, dc), targetX, targetY, targetX + clipWidth, targetY + clipHeight);
                 User32.DrawIconEx(
-                    (HDC)dc,
+                    dc,
                     targetX - imageX,
                     targetY - imageY,
                     this,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -3814,9 +3814,10 @@ namespace System.Windows.Forms.PropertyGridInternal
                     {
                         for (int i = 0; i < rgItems.Length; i++)
                         {
+                            Size textSize = default;
                             string value = gridEntry.GetPropertyTextValue(rgItems[i]);
                             DropDownListBox.Items.Add(value);
-                            PInvoke.GetTextExtentPoint32W(hdc.HDC, value, value.Length, out Size textSize);
+                            PInvoke.GetTextExtentPoint32W(hdc.HDC, value, value.Length, textSize);
                             maxWidth = Math.Max(textSize.Width, maxWidth);
                         }
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -3812,14 +3812,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                     selectionIndex = GetCurrentValueIndex(gridEntry);
                     if (rgItems is not null && rgItems.Length > 0)
                     {
-                        string value;
-                        Size textSize = default;
-
                         for (int i = 0; i < rgItems.Length; i++)
                         {
-                            value = gridEntry.GetPropertyTextValue(rgItems[i]);
+                            string value = gridEntry.GetPropertyTextValue(rgItems[i]);
                             DropDownListBox.Items.Add(value);
-                            PInvoke.GetTextExtentPoint32W(hdc.HDC, value, value.Length, textSize);
+                            PInvoke.GetTextExtentPoint32W(hdc.HDC, value, value.Length, out Size textSize);
                             maxWidth = Math.Max(textSize.Width, maxWidth);
                         }
                     }


### PR DESCRIPTION
- Removed `in` from PInvoke method signatures with generics. Using sharplab.io, found that `in` is causing some extra work to be done to make copies of the parameter
- Some other minor code clean up


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7892)