### PR TITLE
Upgrade Cswin32 Version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,6 +22,7 @@
     <MicrosoftNETCoreRuntimeCoreCLRPackageVersion>5.0.0-preview.7.20320.5</MicrosoftNETCoreRuntimeCoreCLRPackageVersion>
     <MicrosoftNETCoreILDAsmPackageVersion>8.0.0-alpha.1.22504.14</MicrosoftNETCoreILDAsmPackageVersion>
     <SystemDiagnosticsPerformanceCounterPackageVersion>8.0.0-alpha.1.22504.14</SystemDiagnosticsPerformanceCounterPackageVersion>
+    <SystemRuntimeCompilerServicesUnsafePackageVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageVersion>
     <SystemSecurityCryptographyPkcsPackageVersion>8.0.0-alpha.1.22504.14</SystemSecurityCryptographyPkcsPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>8.0.0-alpha.1.22504.14</SystemSecurityCryptographyProtectedDataPackageVersion>
     <SystemTextEncodingsWebPackageVersion>8.0.0-alpha.1.22504.14</SystemTextEncodingsWebPackageVersion>
@@ -45,7 +46,7 @@
       Microsoft.NET.Sdk.IL.targets requires definition of MicrosoftNETCoreILAsmVersion
     -->
     <MicrosoftNETCoreILAsmVersion>$(MicrosoftNETCoreILAsmPackageVersion)</MicrosoftNETCoreILAsmVersion>
-    <MicrosoftWindowsCsWin32PackageVersion>0.2.63-beta</MicrosoftWindowsCsWin32PackageVersion>
+    <MicrosoftWindowsCsWin32PackageVersion>0.2.79-beta</MicrosoftWindowsCsWin32PackageVersion>
   </PropertyGroup>
   <!-- Docs / Intellisense -->
   <PropertyGroup>

--- a/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
+++ b/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/LOGFONTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/LOGFONTW.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 
 namespace Windows.Win32.Graphics.Gdi
@@ -14,7 +15,8 @@ namespace Windows.Win32.Graphics.Gdi
         // We should never reference lfFaceName directly and use this property instead.
         public ReadOnlySpan<char> FaceName
         {
-            get => new Span<char>(lfFaceName.ToArray()).SliceAtFirstNull();
+            [UnscopedRef]
+            get => lfFaceName.AsSpan().SliceAtFirstNull();
             set => SpanHelpers.CopyAndTerminate(value, lfFaceName.AsSpan());
         }
 

--- a/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
+++ b/src/System.Windows.Forms.Primitives/tests/TestUtilities/Metafiles/EmfRecord.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms.Metafiles
         }
 
         public ENHANCED_METAFILE_RECORD_TYPE Type => _lpmr->iType;
-        public ReadOnlySpan<uint> Params => new(_lpmr->dParm.ToArray());
+        public ReadOnlySpan<uint> Params => _lpmr->dParm.AsReadOnlySpan();
         public ReadOnlySpan<HGDIOBJ> Handles => new(_lpht, _nHandles);
 
         public ENHMETAHEADER* HeaderRecord => Type == ENHANCED_METAFILE_RECORD_TYPE.EMR_HEADER ? (ENHMETAHEADER*)_lpmr : null;

--- a/src/System.Windows.Forms/src/System.Windows.Forms.csproj
+++ b/src/System.Windows.Forms/src/System.Windows.Forms.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="System.Drawing.Common" Version="$(SystemDrawingCommonPackageVersion)" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="System.Windows.Extensions" Version="$(SystemWindowsExtensionsPackageVersion)" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemRuntimeCompilerServicesUnsafePackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As well as fixups and upgrade `System.Runtime.CompilerServices.Unsafe` to version Cswin32 is using

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7900)