### PR TITLE
Enable and refactor to fix IDE0031 Use null propagation

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1524,7 +1524,7 @@ dotnet_diagnostic.IDE0029.severity = warning
 dotnet_diagnostic.IDE0030.severity = warning
 
 # IDE0031: Use null propagation
-dotnet_diagnostic.IDE0031.severity = none # TODO: warning
+dotnet_diagnostic.IDE0031.severity = warning
 
 # IDE0032: Use auto property
 dotnet_diagnostic.IDE0032.severity = silent

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -258,9 +258,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                     _processingUnhandledExceptionEvent = True
 
                     For Each handler As UnhandledExceptionEventHandler In _unhandledExceptionHandlers
-                        If handler IsNot Nothing Then
-                            handler.Invoke(sender, e)
-                        End If
+                        handler?.Invoke(sender, e)
                     Next
 
                     ' Now that we are out of the unhandled exception handler, treat exceptions normally again.
@@ -747,9 +745,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 ' Dispose on the Splash screen. (we're just swapping the order of the two If blocks.)
                 ' This is to fix the issue where the main form doesn't come to the front after the
                 ' Splash screen disappears.
-                If MainForm IsNot Nothing Then
-                    MainForm.Activate()
-                End If
+                MainForm?.Activate()
 
                 If _splashScreen IsNot Nothing AndAlso Not _splashScreen.IsDisposed Then
                     Dim disposeSplashDelegate As New DisposeDelegate(AddressOf _splashScreen.Dispose)

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Audio.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Devices/Audio.vb
@@ -118,9 +118,7 @@ Namespace Microsoft.VisualBasic
                 Debug.Assert([Enum].IsDefined(GetType(AudioPlayMode), mode), "Enum value is out of range")
 
                 ' Stopping the sound ensures it's safe to dispose it. This could happen when we change the value of m_Sound below
-                If _sound IsNot Nothing Then
-                    _sound.Stop()
-                End If
+                _sound?.Stop()
 
                 _sound = sound
 

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/VBInputBox.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Helpers/VBInputBox.vb
@@ -35,9 +35,7 @@ Namespace Microsoft.VisualBasic.CompilerServices
 
         Protected Overloads Overrides Sub Dispose(disposing As Boolean)
             If disposing Then
-                If Not (components Is Nothing) Then
-                    components.Dispose()
-                End If
+                components?.Dispose()
             End If
             MyBase.Dispose(disposing)
         End Sub

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/Logging/FileLogTraceListener.vb
@@ -584,9 +584,7 @@ Namespace Microsoft.VisualBasic.Logging
         ''' Flushes the underlying stream
         ''' </summary>
         Public Overrides Sub Flush()
-            If _stream IsNot Nothing Then
-                _stream.Flush()
-            End If
+            _stream?.Flush()
         End Sub
 
         ''' <summary>
@@ -894,9 +892,7 @@ Namespace Microsoft.VisualBasic.Logging
                         Return Reader.CurrentEncoding
                     End If
                 Finally
-                    If Reader IsNot Nothing Then
-                        Reader.Close()
-                    End If
+                    Reader?.Close()
                 End Try
             End If
 
@@ -1226,9 +1222,7 @@ Namespace Microsoft.VisualBasic.Logging
             Private Overloads Sub Dispose(disposing As Boolean)
                 If disposing Then
                     If Not _disposed Then
-                        If _stream IsNot Nothing Then
-                            _stream.Close()
-                        End If
+                        _stream?.Close()
                         _disposed = True
                     End If
                 End If

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/Internal/ProgressDialog.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/MyServices/Internal/ProgressDialog.vb
@@ -214,9 +214,7 @@ Namespace Microsoft.VisualBasic.MyServices.Internal
         'Form overrides dispose to clean up the component list.
         Protected Overloads Overrides Sub Dispose(disposing As Boolean)
             If disposing Then
-                If Not (_components Is Nothing) Then
-                    _components.Dispose()
-                End If
+                _components?.Dispose()
                 If _formClosableSemaphore IsNot Nothing Then
                     _formClosableSemaphore.Dispose()
                     _formClosableSemaphore = Nothing

--- a/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/ApplicationServices/SingleInstanceTests.cs
+++ b/src/Microsoft.VisualBasic/tests/UnitTests/Microsoft/VisualBasic/ApplicationServices/SingleInstanceTests.cs
@@ -349,10 +349,7 @@ namespace Microsoft.VisualBasic.ApplicationServices.Tests
             }
             finally
             {
-                if (pipeClient != null)
-                {
-                    pipeClient.Dispose();
-                }
+                pipeClient?.Dispose();
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CodeMarkers.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CodeMarkers.cs
@@ -277,10 +277,7 @@ namespace System.ComponentModel.Design
             byte[] bufferWithCorrelation = new byte[s_correlationMarkBytes.Length + correlationIdBytes.Length + (buffer is not null ? buffer.Length : 0)];
             s_correlationMarkBytes.CopyTo(bufferWithCorrelation, 0);
             correlationIdBytes.CopyTo(bufferWithCorrelation, s_correlationMarkBytes.Length);
-            if (buffer is not null)
-            {
-                buffer.CopyTo(bufferWithCorrelation, s_correlationMarkBytes.Length + correlationIdBytes.Length);
-            }
+            buffer?.CopyTo(bufferWithCorrelation, s_correlationMarkBytes.Length + correlationIdBytes.Length);
 
             return bufferWithCorrelation;
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/CollectionEditor.CollectionEditorCollectionForm.cs
@@ -271,10 +271,7 @@ namespace System.ComponentModel.Design
                         _createdItems.Clear();
                     }
 
-                    if (_removedItems is not null)
-                    {
-                        _removedItems.Clear();
-                    }
+                    _removedItems?.Clear();
 
                     // Restore the original contents. Because objects get parented during CreateAndAddInstance, the underlying collection
                     // gets changed during add, but not other operations. Not all consumers of this dialog can roll back every single change,

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurface.cs
@@ -382,10 +382,7 @@ namespace System.ComponentModel.Design
                 {
                     try
                     {
-                        if (_host is not null)
-                        {
-                            _host.DisposeHost();
-                        }
+                        _host?.DisposeHost();
                     }
                     finally
                     {
@@ -409,10 +406,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         public void Flush()
         {
-            if (_host is not null)
-            {
-                _host.Flush();
-            }
+            _host?.Flush();
 
             Flushed?.Invoke(this, EventArgs.Empty);
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignSurfaceManager.cs
@@ -303,10 +303,7 @@ namespace System.ComponentModel.Design
             // the ones providing the event service, then whoever is providing
             // it will be responsible for updating it when new designers are created.
             DesignerEventService eventService = GetService(typeof(IDesignerEventService)) as DesignerEventService;
-            if (eventService is not null)
-            {
-                eventService.OnCreateDesigner(surface);
-            }
+            eventService?.OnCreateDesigner(surface);
 
             return surface;
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionPanel.EditorPropertyLine.cs
@@ -792,18 +792,12 @@ namespace System.ComponentModel.Design
                                     }
                                     finally
                                     {
-                                        if (attrs is not null)
-                                        {
-                                            attrs.Dispose();
-                                        }
+                                        attrs?.Dispose();
                                     }
                                 }
                                 finally
                                 {
-                                    if (icon is not null)
-                                    {
-                                        icon.Dispose();
-                                    }
+                                    icon?.Dispose();
                                 }
                             }
                             catch

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionService.cs
@@ -259,10 +259,7 @@ namespace System.ComponentModel.Design
                                 if (verb == sender)
                                 {
                                     DesignerActionUIService dapUISvc = (DesignerActionUIService)sc.GetService(typeof(DesignerActionUIService));
-                                    if (dapUISvc is not null)
-                                    {
-                                        dapUISvc.Refresh(comp); // we need to refresh, a verb on the current panel has changed its state
-                                    }
+                                    dapUISvc?.Refresh(comp); // we need to refresh, a verb on the current panel has changed its state
                                 }
                             }
                         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUI.cs
@@ -130,10 +130,7 @@ namespace System.ComponentModel.Design
                 if (_cmdShowDesignerActions is not null)
                 {
                     IMenuCommandService mcs = (IMenuCommandService)_serviceProvider.GetService(typeof(IMenuCommandService));
-                    if (mcs is not null)
-                    {
-                        mcs.RemoveCommand(_cmdShowDesignerActions);
-                    }
+                    mcs?.RemoveCommand(_cmdShowDesignerActions);
                 }
             }
 
@@ -568,10 +565,7 @@ namespace System.ComponentModel.Design
                     host.TransactionClosed -= new DesignerTransactionCloseEventHandler(InvalidateGlyphOnLastTransaction);
                 }
 
-                if (_relatedGlyphTransaction is not null)
-                {
-                    _relatedGlyphTransaction.InvalidateOwnerLocation();
-                }
+                _relatedGlyphTransaction?.InvalidateOwnerLocation();
 
                 _relatedGlyphTransaction = null;
             }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerActionUIService.cs
@@ -34,10 +34,7 @@ namespace System.ComponentModel.Design
             if (_serviceProvider is not null)
             {
                 IDesignerHost host = (IDesignerHost)_serviceProvider.GetService(typeof(IDesignerHost));
-                if (host is not null)
-                {
-                    host.RemoveService(typeof(DesignerActionUIService));
-                }
+                host?.RemoveService(typeof(DesignerActionUIService));
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerEventService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerEventService.cs
@@ -186,10 +186,7 @@ namespace System.ComponentModel.Design
                 }
             }
 
-            if (_designerList is not null)
-            {
-                _designerList.Remove(host);
-            }
+            _designerList?.Remove(host);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -394,10 +394,7 @@ namespace System.ComponentModel.Design
             }
             else
             {
-                if (nameCreate is not null)
-                {
-                    nameCreate.ValidateName(name);
-                }
+                nameCreate?.ValidateName(name);
             }
 
             return new Site(component, this, name, this);
@@ -472,10 +469,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         internal void Flush()
         {
-            if (_loader is not null)
-            {
-                _loader.Flush();
-            }
+            _loader?.Flush();
         }
 
         /// <summary>
@@ -706,10 +700,7 @@ namespace System.ComponentModel.Design
             }
 
             ISelectionService selectionService = (ISelectionService)GetService(typeof(ISelectionService));
-            if (selectionService is not null)
-            {
-                selectionService.SetSelectedComponents(null, SelectionTypes.Replace);
-            }
+            selectionService?.SetSelectedComponents(null, SelectionTypes.Replace);
 
             // Now remove all the designers and their components.  We save the root for last.  Note that we eat any exceptions that components or their designers generate.  A bad component or designer should not prevent an unload from happening.  We do all of this in a transaction to help reduce the number of events we generate.
             _state[s_stateUnloading] = true;
@@ -1251,10 +1242,7 @@ namespace System.ComponentModel.Design
                         errorCollection = errorList;
                         successful = false;
 
-                        if (_surface is not null)
-                        {
-                            _surface.OnLoaded(successful, errorCollection);
-                        }
+                        _surface?.OnLoaded(successful, errorCollection);
 
                         // We re-throw.  If this was a synchronous load this will error back to BeginLoad (and, as a side effect, may call us again).  For asynchronous loads we need to throw so the caller knows what happened.
                         throw;

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ReferenceService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ReferenceService.cs
@@ -140,10 +140,7 @@ namespace System.ComponentModel.Design
             if (!(compAdded.Site is INestedSite))
             {
                 _addedComponents.Add(compAdded);
-                if (_removedComponents is not null)
-                {
-                    _removedComponents.Remove(compAdded);
-                }
+                _removedComponents?.Remove(compAdded);
             }
         }
 
@@ -161,10 +158,7 @@ namespace System.ComponentModel.Design
             if (!(compRemoved.Site is INestedSite))
             {
                 _removedComponents.Add(compRemoved);
-                if (_addedComponents is not null)
-                {
-                    _addedComponents.Remove(compRemoved);
-                }
+                _addedComponents?.Remove(compRemoved);
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -176,10 +176,7 @@ namespace System.ComponentModel.Design
         /// </summary>
         internal void RemoveSelection(object sel)
         {
-            if (_selection is not null)
-            {
-                _selection.Remove(sel);
-            }
+            _selection?.Remove(sel);
         }
 
         private void ApplicationIdle(object source, EventArgs args)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomComponentSerializationService.cs
@@ -793,10 +793,7 @@ namespace System.ComponentModel.Design.Serialization
                             foreach (DictionaryEntry de in (IDictionary)state)
                             {
                                 PropertyDescriptor prop = props[(string)de.Key];
-                                if (prop is not null)
-                                {
-                                    prop.SetValue(comp, de.Value);
-                                }
+                                prop?.SetValue(comp, de.Value);
                             }
                         }
                     }
@@ -1051,10 +1048,7 @@ namespace System.ComponentModel.Design.Serialization
                                 {
                                     PropertyDescriptor prop = eventProps[eventName];
 
-                                    if (prop is not null)
-                                    {
-                                        prop.SetValue(comp, null);
-                                    }
+                                    prop?.SetValue(comp, null);
                                 }
                             }
                         }
@@ -1069,10 +1063,7 @@ namespace System.ComponentModel.Design.Serialization
                     {
                         MemberAttributes modifierValue = (MemberAttributes)state;
                         PropertyDescriptor modifierProp = TypeDescriptor.GetProperties(comp)["Modifiers"];
-                        if (modifierProp is not null)
-                        {
-                            modifierProp.SetValue(comp, modifierValue);
-                        }
+                        modifierProp?.SetValue(comp, modifierValue);
                     }
                 }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersExtenderProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomDesignerLoader.ModifiersExtenderProvider.cs
@@ -172,10 +172,7 @@ namespace System.ComponentModel.Design.Serialization
                 IDictionaryService dictionary = (IDictionaryService)site.GetService(typeof(IDictionaryService));
                 bool oldValue = GetGenerateMember(comp);
 
-                if (dictionary is not null)
-                {
-                    dictionary.SetValue("GenerateMember", generate);
-                }
+                dictionary?.SetValue("GenerateMember", generate);
 
                 // If the old value was true and the new value is false, we've got
                 // to remove the existing member declaration for this
@@ -219,10 +216,7 @@ namespace System.ComponentModel.Design.Serialization
 
                 IDictionaryService dictionary = (IDictionaryService)site.GetService(typeof(IDictionaryService));
 
-                if (dictionary is not null)
-                {
-                    dictionary.SetValue("Modifiers", modifiers);
-                }
+                dictionary?.SetValue("Modifiers", modifiers);
             }
         }
     }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomLocalizationProvider.cs
@@ -431,10 +431,7 @@ namespace System.ComponentModel.Design.Serialization
                         {
                             IUIService uis = (IUIService)_serviceProvider.GetService(typeof(IUIService));
 
-                            if (uis is not null)
-                            {
-                                uis.ShowMessage(SR.LocalizationProviderManualReload);
-                            }
+                            uis?.ShowMessage(SR.LocalizationProviderManualReload);
                         }
                     }
                 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -505,10 +505,7 @@ namespace System.ComponentModel.Design.Serialization
         {
             public void Dispose()
             {
-                if (traceScope is not null)
-                {
-                    traceScope.Pop();
-                }
+                traceScope?.Pop();
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CollectionCodeDomSerializer.cs
@@ -102,11 +102,8 @@ namespace System.ComponentModel.Design.Serialization
                         originalValues[value] = count;
                     }
                 }
-                else if (result is not null)
-                {
-                    // this one isn't in the old list, so add it to our  result list.
-                    result.Add(value);
-                }
+                else                     // this one isn't in the old list, so add it to our  result list.
+                    result?.Add(value);
 
                 // this item isn't in the list and we haven't yet created our array list so just keep on going.
             }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCache.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ComponentCache.cs
@@ -135,10 +135,7 @@ namespace System.ComponentModel.Design.Serialization
         private void OnComponentRename(object source, ComponentRenameEventArgs args)
         {
             // we might have a symbolic rename that has side effects beyond our control, so we don't have a choice but to clear the whole cache when a component gets renamed...
-            if (_cache is not null)
-            {
-                _cache.Clear();
-            }
+            _cache?.Clear();
         }
 
         private void OnComponentChanging(object source, ComponentChangingEventArgs ce)

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/DesignerSerializationManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/DesignerSerializationManager.cs
@@ -860,10 +860,7 @@ namespace System.ComponentModel.Design.Serialization
         /// </summary>
         void IDesignerSerializationManager.RemoveSerializationProvider(IDesignerSerializationProvider provider)
         {
-            if (designerSerializationProviders is not null)
-            {
-                designerSerializationProviders.Remove(provider);
-            }
+            designerSerializationProviders?.Remove(provider);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/ResourceCodeDomSerializer.cs
@@ -671,17 +671,11 @@ namespace System.ComponentModel.Design.Serialization
 
                 // .NET Framework 4.0 (Dev10 #425129): Control location moves due to incorrect anchor info when resource files are reloaded.
                 Windows.Forms.Control control = value as Windows.Forms.Control;
-                if (control is not null)
-                {
-                    control.SuspendLayout();
-                }
+                control?.SuspendLayout();
 
                 base.ApplyResources(value, objectName, culture);
 
-                if (control is not null)
-                {
-                    control.ResumeLayout(false);
-                }
+                control?.ResumeLayout(false);
             }
 
             /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/UndoEngine.cs
@@ -675,10 +675,7 @@ namespace System.ComponentModel.Design
                     AddEvent(new AddRemoveUndoEvent(UndoEngine, e.Component, true));
                 }
 
-                if (_ignoreAddingList is not null)
-                {
-                    _ignoreAddingList.Remove(e.Component);
-                }
+                _ignoreAddingList?.Remove(e.Component);
 
                 if (_ignoreAddedList is null)
                 {
@@ -975,10 +972,7 @@ namespace System.ComponentModel.Design
                 }
                 finally
                 {
-                    if (transaction is not null)
-                    {
-                        transaction.Commit();
-                    }
+                    transaction?.Commit();
 
                     UndoEngine._executingUnit = savedUnit;
                     if (savedUnit is null)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Adorner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/Adorner.cs
@@ -76,10 +76,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public void Invalidate(Rectangle rectangle)
         {
-            if (_behaviorService != null)
-            {
-                _behaviorService.Invalidate(rectangle);
-            }
+            _behaviorService?.Invalidate(rectangle);
         }
 
         /// <summary>
@@ -87,10 +84,7 @@ namespace System.Windows.Forms.Design.Behavior
         /// </summary>
         public void Invalidate(Region region)
         {
-            if (_behaviorService != null)
-            {
-                _behaviorService.Invalidate(region);
-            }
+            _behaviorService?.Invalidate(region);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.cs
@@ -184,10 +184,7 @@ namespace System.Windows.Forms.Design.Behavior
         {
             // Remove adorner window from overlay service
             IOverlayService os = (IOverlayService)_serviceProvider.GetService(typeof(IOverlayService));
-            if (os != null)
-            {
-                os.RemoveOverlay(_adornerWindow);
-            }
+            os?.RemoveOverlay(_adornerWindow);
 
             MenuCommandHandler menuCommandHandler = null;
             if (_serviceProvider.GetService(typeof(IMenuCommandService)) is IMenuCommandService menuCommandService)
@@ -263,10 +260,7 @@ namespace System.Windows.Forms.Design.Behavior
                 // It's possible we did not receive an EndDrag, and therefore we weren't able to cleanup the drag.
                 // We will do that here. Scenarios where this happens: dragging from designer to recycle-bin,
                 // or over the taskbar.
-                if (dropSourceBehavior != null)
-                {
-                    dropSourceBehavior.CleanupDrag();
-                }
+                dropSourceBehavior?.CleanupDrag();
             }
 
             return res;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DragAssistanceManager.cs
@@ -1065,15 +1065,9 @@ namespace System.Windows.Forms.Design.Behavior
                 _edgePen.Dispose();
             }
 
-            if (_baselinePen != null)
-            {
-                _baselinePen.Dispose();
-            }
+            _baselinePen?.Dispose();
 
-            if (_backgroundImage != null)
-            {
-                _backgroundImage.Dispose();
-            }
+            _backgroundImage?.Dispose();
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/DropSourceBehavior.cs
@@ -199,20 +199,11 @@ namespace System.Windows.Forms.Design.Behavior
                 Rectangle rect = dragImageRect;
                 rect.Location = MapPointFromSourceToTarget(rect.Location);
 
-                if (graphicsTarget != null)
-                {
-                    graphicsTarget.SetClip(rect);
-                }
+                graphicsTarget?.SetClip(rect);
 
-                if (behaviorServiceTarget != null)
-                {
-                    behaviorServiceTarget.Invalidate(rect);
-                }
+                behaviorServiceTarget?.Invalidate(rect);
 
-                if (graphicsTarget != null)
-                {
-                    graphicsTarget.ResetClip();
-                }
+                graphicsTarget?.ResetClip();
             }
         }
 
@@ -249,11 +240,8 @@ namespace System.Windows.Forms.Design.Behavior
                 // Hook the control to its new designerHost
                 SetDesignerHost(currentControl);
                 currentControl.Parent = dragTarget;
-                if (propLoc != null)
-                {
-                    //Make sure and set the Visible property to the correct value
-                    propLoc.SetValue(currentControl, visibleState);
-                }
+                //Make sure and set the Visible property to the correct value
+                propLoc?.SetValue(currentControl, visibleState);
             }
             else if (!localDrag && currentControl.Parent.Equals(dragSource))
             {
@@ -341,10 +329,7 @@ namespace System.Windows.Forms.Design.Behavior
             IComponentChangeService componentChangeSvcSource = (IComponentChangeService)serviceProviderSource.GetService(typeof(IComponentChangeService));
             IComponentChangeService componentChangeSvcTarget = (IComponentChangeService)serviceProviderTarget.GetService(typeof(IComponentChangeService));
 
-            if (dragAssistanceManager != null)
-            {
-                dragAssistanceManager.OnMouseUp();
-            }
+            dragAssistanceManager?.OnMouseUp();
 
             // If we are dropping between hosts, we want to set the selection in the new host to be the components that we are dropping. ... or if we are copying
             ISelectionService selSvc = null;
@@ -469,10 +454,7 @@ namespace System.Windows.Forms.Design.Behavior
                         // everything is fine, carry on...
                         SetLocationPropertyAndChildIndex(primaryComponentIndex, dragTarget, initialDropPoint,
                                                             shareParent ? dragComponents[primaryComponentIndex].zorderIndex : 0, allowSetChildIndexOnDrop);
-                        if (selSvc != null)
-                        {
-                            selSvc.SetSelectedComponents(new object[] { dragComponents[primaryComponentIndex].dragComponent }, SelectionTypes.Primary | SelectionTypes.Replace);
-                        }
+                        selSvc?.SetSelectedComponents(new object[] { dragComponents[primaryComponentIndex].dragComponent }, SelectionTypes.Primary | SelectionTypes.Replace);
 
                         for (int i = 0; i < dragComponents.Length; i++)
                         {
@@ -487,10 +469,7 @@ namespace System.Windows.Forms.Design.Behavior
                                                             initialDropPoint.Y + dragComponents[i].positionOffset.Y);
                             SetLocationPropertyAndChildIndex(i, dragTarget, dropPoint,
                                                                 shareParent ? dragComponents[i].zorderIndex : 0, allowSetChildIndexOnDrop);
-                            if (selSvc != null)
-                            {
-                                selSvc.SetSelectedComponents(new object[] { dragComponents[i].dragComponent }, SelectionTypes.Add);
-                            }
+                            selSvc?.SetSelectedComponents(new object[] { dragComponents[i].dragComponent }, SelectionTypes.Add);
                         }
 
                         if ((!localDrag || performCopy) && componentChangeSvcSource != null && componentChangeSvcTarget != null)
@@ -556,15 +535,9 @@ namespace System.Windows.Forms.Design.Behavior
 
                     finally
                     {
-                        if (transSource != null)
-                        {
-                            transSource.Cancel();
-                        }
+                        transSource?.Cancel();
 
-                        if (transTarget != null)
-                        {
-                            transTarget.Cancel();
-                        }
+                        transTarget?.Cancel();
                     }
                 }
             }
@@ -581,12 +554,9 @@ namespace System.Windows.Forms.Design.Behavior
 
                 // Even though we call CleanupDrag(false) twice (see above), this method guards against doing the wrong thing.
                 CleanupDrag(false);
-                if (statusCommandUITarget != null)
-                {
-                    // if selSvs is not null, then we either did a copy, or moved between forms, so use it to set the right info
-                    statusCommandUITarget.SetStatusInformation(selSvc is null ? dragComponents[primaryComponentIndex].dragComponent as Component :
-                                                                                selSvc.PrimarySelection as Component);
-                }
+                // if selSvs is not null, then we either did a copy, or moved between forms, so use it to set the right info
+                statusCommandUITarget?.SetStatusInformation(selSvc is null ? dragComponents[primaryComponentIndex].dragComponent as Component :
+                                                                            selSvc.PrimarySelection as Component);
             }
 
             // clear the last feedback loc
@@ -610,10 +580,7 @@ namespace System.Windows.Forms.Design.Behavior
                     clearDragImageRect = dragImageRect;
                 }
 
-                if (dragAssistanceManager != null)
-                {
-                    dragAssistanceManager.EraseSnapLines();
-                }
+                dragAssistanceManager?.EraseSnapLines();
 
                 return;
             }
@@ -702,10 +669,7 @@ namespace System.Windows.Forms.Design.Behavior
                                 controlRect.Location = behaviorServiceTarget.MapAdornerWindowPoint(IntPtr.Zero, controlRect.Location);
                                 if (i == 0)
                                 {
-                                    if (dragImageRegion != null)
-                                    {
-                                        dragImageRegion.Dispose();
-                                    }
+                                    dragImageRegion?.Dispose();
 
                                     dragImageRegion = new Region(controlRect);
                                 }
@@ -716,10 +680,7 @@ namespace System.Windows.Forms.Design.Behavior
                             }
                         }
 
-                        if (graphicsTarget != null)
-                        {
-                            graphicsTarget.Dispose();
-                        }
+                        graphicsTarget?.Dispose();
 
                         graphicsTarget = behaviorServiceTarget.AdornerWindowGraphics;
 
@@ -739,11 +700,8 @@ namespace System.Windows.Forms.Design.Behavior
                 // Create new dragassistancemanager if needed
                 if (createNewDragAssistance && behaviorServiceTarget.UseSnapLines)
                 {
-                    if (dragAssistanceManager != null)
-                    {
-                        //erase any snaplines (if we had any)
-                        dragAssistanceManager.EraseSnapLines();
-                    }
+                    //erase any snaplines (if we had any)
+                    dragAssistanceManager?.EraseSnapLines();
 
                     dragAssistanceManager = new DragAssistanceManager(serviceProviderTarget, graphicsTarget, dragObjects, null, lastEffect == DragDropEffects.Copy);
                 }
@@ -832,10 +790,7 @@ namespace System.Windows.Forms.Design.Behavior
                         dropPoint.Offset(-c.Width, 0);
                     }
 
-                    if (statusCommandUITarget != null)
-                    {
-                        statusCommandUITarget.SetStatusInformation(c, dropPoint);
-                    }
+                    statusCommandUITarget?.SetStatusInformation(c, dropPoint);
                 }
 
                 // allow any snaplines to be drawn above our drag images as long as the alt key is not pressed and the mouse is over the root comp
@@ -1137,10 +1092,7 @@ namespace System.Windows.Forms.Design.Behavior
                 ShowHideDragControls(true);
                 try
                 {
-                    if (suspendedParent != null)
-                    {
-                        suspendedParent.ResumeLayout();
-                    }
+                    suspendedParent?.ResumeLayout();
                 }
 
                 finally
@@ -1155,10 +1107,7 @@ namespace System.Windows.Forms.Design.Behavior
                     }
 
                     // Layout may have caused controls to resize, which would mean their BodyGlyphs are wrong.  We need to sync these.
-                    if (behaviorServiceSource != null)
-                    {
-                        behaviorServiceSource.SyncSelection();
-                    }
+                    behaviorServiceSource?.SyncSelection();
 
                     if (dragImageRegion != null)
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/SelectionManager.cs
@@ -335,10 +335,7 @@ namespace System.Windows.Forms.Design.Behavior
             }
 
             //remove the associated designeractionpanel
-            if (_designerActionUI != null)
-            {
-                _designerActionUI.RemoveActionGlyph(ce.Component);
-            }
+            _designerActionUI?.RemoveActionGlyph(ce.Component);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ToolboxItemSnapLineBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/ToolboxItemSnapLineBehavior.cs
@@ -361,10 +361,7 @@ namespace System.Windows.Forms.Design.Behavior
                     {
                         Point adornerServiceOrigin = behaviorService.MapAdornerWindowPoint(baseControl.Handle, new Point(0, 0));
                         Rectangle statusRect = new Rectangle(newRectangle.X - adornerServiceOrigin.X, newRectangle.Y - adornerServiceOrigin.Y, 0, 0);
-                        if (statusCommandUI != null)
-                        {
-                            statusCommandUI.SetStatusInformation(statusRect);
-                        }
+                        statusCommandUI?.SetStatusInformation(statusRect);
                     }
                 }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ChangeToolStripParentVerb.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ChangeToolStripParentVerb.cs
@@ -117,10 +117,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (changeParent != null)
-                {
-                    changeParent.Commit();
-                }
+                changeParent?.Commit();
 
                 Cursor.Current = current;
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CollectionEditVerbManager.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CollectionEditVerbManager.cs
@@ -190,10 +190,7 @@ namespace System.Windows.Forms.Design
         private void OnEditItems(object sender, EventArgs e)
         {
             DesignerActionUIService actionUIService = (DesignerActionUIService)((IServiceProvider)this).GetService(typeof(DesignerActionUIService));
-            if (actionUIService != null)
-            {
-                actionUIService.HideUI(_designer.Component);
-            }
+            actionUIService?.HideUI(_designer.Component);
 
             object propertyValue = _targetProperty.GetValue(_designer.Component);
             if (propertyValue is null)
@@ -203,10 +200,7 @@ namespace System.Windows.Forms.Design
 
             CollectionEditor itemsEditor = TypeDescriptor.GetEditor(propertyValue, typeof(UITypeEditor)) as CollectionEditor;
             Debug.Assert(itemsEditor != null, "Didn't get a collection editor for type '" + _targetProperty.PropertyType.FullName + "'");
-            if (itemsEditor != null)
-            {
-                itemsEditor.EditValue(this, this, propertyValue);
-            }
+            itemsEditor?.EditValue(this, this, propertyValue);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComboBoxDesigner.cs
@@ -90,10 +90,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         private void OnControlPropertyChanged(object sender, EventArgs e)
         {
-            if (BehaviorService != null)
-            {
-                BehaviorService.SyncSelection();
-            }
+            BehaviorService?.SyncSelection();
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/CommandSet.cs
@@ -231,10 +231,7 @@ namespace System.Windows.Forms.Design
             //
             IDictionaryService ds = site.GetService(typeof(IDictionaryService)) as IDictionaryService;
             Debug.Assert(ds != null, "No dictionary service");
-            if (ds != null)
-            {
-                ds.SetValue(typeof(CommandID), new CommandID(new Guid("BA09E2AF-9DF2-4068-B2F0-4C7E5CC19E2F"), 0));
-            }
+            ds?.SetValue(typeof(CommandID), new CommandID(new Guid("BA09E2AF-9DF2-4068-B2F0-4C7E5CC19E2F"), 0));
         }
 
         /// <summary>
@@ -450,10 +447,7 @@ namespace System.Windows.Forms.Design
         {
             if (dragManager != null)
             {
-                if (snapLineTimer != null)
-                {
-                    snapLineTimer.Stop();
-                }
+                snapLineTimer?.Stop();
 
                 dragManager.EraseSnapLines();
                 dragManager.OnMouseUp();
@@ -816,10 +810,7 @@ namespace System.Windows.Forms.Design
                     {
                         IDesigner designer = host.GetDesigner(pri);
 
-                        if (designer != null)
-                        {
-                            designer.DoDefaultAction();
-                        }
+                        designer?.DoDefaultAction();
                     }
                 }
             }
@@ -1064,10 +1055,7 @@ namespace System.Windows.Forms.Design
                             }
                             finally
                             {
-                                if (trans != null)
-                                {
-                                    trans.Commit();
-                                }
+                                trans?.Commit();
 
                                 if (dragManager != null)
                                 {
@@ -1249,10 +1237,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (trans != null)
-                    {
-                        trans.Commit();
-                    }
+                    trans?.Commit();
                 }
             }
             finally
@@ -1378,10 +1363,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (trans != null)
-                    {
-                        trans.Commit();
-                    }
+                    trans?.Commit();
                 }
             }
             finally
@@ -1569,10 +1551,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (trans != null)
-                    {
-                        trans.Commit();
-                    }
+                    trans?.Commit();
                 }
             }
             finally
@@ -1767,14 +1746,10 @@ namespace System.Windows.Forms.Design
                             }
                             finally
                             {
-                                if (trans != null)
-                                    trans.Commit();
+                                trans?.Commit();
                                 foreach (ParentControlDesigner des in designerList)
                                 {
-                                    if (des != null)
-                                    {
-                                        des.ResumeChangingEvents();
-                                    }
+                                    des?.ResumeChangingEvents();
                                 }
                             }
 
@@ -2010,17 +1985,11 @@ namespace System.Windows.Forms.Design
                         }
                         finally
                         {
-                            if (trans != null)
-                            {
-                                trans.Commit();
-                            }
+                            trans?.Commit();
 
                             foreach (ParentControlDesigner des in designerList)
                             {
-                                if (des != null)
-                                {
-                                    des.ResumeChangingEvents();
-                                }
+                                des?.ResumeChangingEvents();
                             }
                         }
 
@@ -2470,10 +2439,7 @@ namespace System.Windows.Forms.Design
                             if (parentControlDesigner != null && parentControlDesigner.AllowSetChildIndexOnDrop)
                             {
                                 MenuCommand btf = MenuService.FindCommand(StandardCommands.BringToFront);
-                                if (btf != null)
-                                {
-                                    btf.Invoke();
-                                }
+                                btf?.Invoke();
                             }
 
                             trans.Commit();
@@ -2490,10 +2456,7 @@ namespace System.Windows.Forms.Design
                 Cursor.Current = oldCursor;
                 foreach (ParentControlDesigner des in designerList)
                 {
-                    if (des != null)
-                    {
-                        des.ResumeChangingEvents();
-                    }
+                    des?.ResumeChangingEvents();
                 }
             }
         }
@@ -2582,8 +2545,7 @@ namespace System.Windows.Forms.Design
                     }
                     finally
                     {
-                        if (trans != null)
-                            trans.Commit();
+                        trans?.Commit();
                     }
                 }
             }
@@ -2696,10 +2658,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (trans != null)
-                    {
-                        trans.Commit();
-                    }
+                    trans?.Commit();
                 }
             }
             finally
@@ -2792,10 +2751,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (trans != null)
-                {
-                    trans.Commit();
-                }
+                trans?.Commit();
 
                 Cursor.Current = oldCursor;
             }
@@ -2857,8 +2813,7 @@ namespace System.Windows.Forms.Design
                     }
                     finally
                     {
-                        if (trans != null)
-                            trans.Commit();
+                        trans?.Commit();
                     }
                 }
             }
@@ -3252,10 +3207,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (trans != null)
-                {
-                    trans.Commit();
-                }
+                trans?.Commit();
 
                 Cursor.Current = oldCursor;
             }
@@ -3831,10 +3783,7 @@ namespace System.Windows.Forms.Design
             // Now, for each control, update the offset.
             //
 
-            if (parentControl != null)
-            {
-                parentControl.SuspendLayout();
-            }
+            parentControl?.SuspendLayout();
 
             try
             {
@@ -3847,10 +3796,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (parentControl != null)
-                {
-                    parentControl.ResumeLayout();
-                }
+                parentControl?.ResumeLayout();
             }
         }
 
@@ -4047,10 +3993,7 @@ namespace System.Windows.Forms.Design
                 }
                 catch (Exception e)
                 {
-                    if (uiService != null)
-                    {
-                        uiService.ShowError(e, string.Format(SR.CommandSetError, e.Message));
-                    }
+                    uiService?.ShowError(e, string.Format(SR.CommandSetError, e.Message));
 
                     if (ClientUtils.IsCriticalException(e))
                     {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -87,10 +87,7 @@ namespace System.Windows.Forms.Design
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
             IExtenderProviderService es = (IExtenderProviderService)GetService(typeof(IExtenderProviderService));
             Debug.Assert(es != null, "Component tray wants an extender provider service, but there isn't one.");
-            if (es != null)
-            {
-                es.AddExtenderProvider(this);
-            }
+            es?.AddExtenderProvider(this);
 
             if (GetService(typeof(IEventHandlerService)) is null)
             {
@@ -299,17 +296,11 @@ namespace System.Windows.Forms.Design
             {
                 t = host.CreateTransaction(SR.TrayShowLargeIcons);
                 PropertyDescriptor trayIconProp = TypeDescriptor.GetProperties(mainDesigner.Component)["TrayLargeIcon"];
-                if (trayIconProp != null)
-                {
-                    trayIconProp.SetValue(mainDesigner.Component, !ShowLargeIcons);
-                }
+                trayIconProp?.SetValue(mainDesigner.Component, !ShowLargeIcons);
             }
             finally
             {
-                if (t != null)
-                {
-                    t.Commit();
-                }
+                t?.Commit();
             }
         }
 
@@ -324,10 +315,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (t != null)
-                {
-                    t.Commit();
-                }
+                t?.Commit();
             }
         }
 
@@ -393,10 +381,7 @@ namespace System.Windows.Forms.Design
                     prevCtl = ctl;
                 }
 
-                if (selectionUISvc != null)
-                {
-                    selectionUISvc.SyncSelection();
-                }
+                selectionUISvc?.SyncSelection();
             }
             finally
             {
@@ -414,17 +399,11 @@ namespace System.Windows.Forms.Design
                 t = host.CreateTransaction(SR.TrayAutoArrange);
 
                 PropertyDescriptor trayAAProp = TypeDescriptor.GetProperties(mainDesigner.Component)["TrayAutoArrange"];
-                if (trayAAProp != null)
-                {
-                    trayAAProp.SetValue(mainDesigner.Component, !AutoArrange);
-                }
+                trayAAProp?.SetValue(mainDesigner.Component, !AutoArrange);
             }
             finally
             {
-                if (t != null)
-                {
-                    t.Commit();
-                }
+                t?.Commit();
             }
         }
 
@@ -738,19 +717,13 @@ namespace System.Windows.Forms.Design
                     PositionControl(trayctl);
                 }
 
-                if (selectionUISvc != null)
-                {
-                    selectionUISvc.AssignSelectionUIHandler(component, this);
-                }
+                selectionUISvc?.AssignSelectionUIHandler(component, this);
 
                 InheritanceAttribute attr = trayctl.InheritanceAttribute;
                 if (attr.InheritanceLevel != InheritanceLevel.NotInherited)
                 {
                     InheritanceUI iui = InheritanceUI;
-                    if (iui != null)
-                    {
-                        iui.AddInheritedControl(trayctl, attr.InheritanceLevel);
-                    }
+                    iui?.AddInheritedControl(trayctl, attr.InheritanceLevel);
                 }
             }
             finally
@@ -875,10 +848,7 @@ namespace System.Windows.Forms.Design
             {
                 IExtenderProviderService es = (IExtenderProviderService)GetService(typeof(IExtenderProviderService));
                 Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (es != null), "IExtenderProviderService not found");
-                if (es != null)
-                {
-                    es.RemoveExtenderProvider(this);
-                }
+                es?.RemoveExtenderProvider(this);
 
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
                 if (eventHandlerService != null)
@@ -1065,10 +1035,7 @@ namespace System.Windows.Forms.Design
                 OnLostCapture();
                 IEventBindingService eps = (IEventBindingService)GetService(typeof(IEventBindingService));
                 Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (eps != null), "IEventBindingService not found");
-                if (eps != null)
-                {
-                    eps.ShowCode();
-                }
+                eps?.ShowCode();
             }
         }
 
@@ -1297,10 +1264,7 @@ namespace System.Windows.Forms.Design
                     {
                         ISelectionService ss = (ISelectionService)GetService(typeof(ISelectionService));
                         Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ss != null), "ISelectionService not found");
-                        if (ss != null)
-                        {
-                            ss.SetSelectedComponents(new object[] { mainDesigner.Component });
-                        }
+                        ss?.SetSelectedComponents(new object[] { mainDesigner.Component });
                     }
                     catch (Exception ex)
                     {
@@ -1392,10 +1356,7 @@ namespace System.Windows.Forms.Design
                 {
                     ISelectionService ss = (ISelectionService)GetService(typeof(ISelectionService));
                     Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ss != null), "ISelectionService not found");
-                    if (ss != null)
-                    {
-                        ss.SetSelectedComponents(comps);
-                    }
+                    ss?.SetSelectedComponents(comps);
                 }
                 catch (Exception ex)
                 {
@@ -1514,18 +1475,12 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (selectionBorderBrush != null)
-                    {
-                        selectionBorderBrush.Dispose();
-                    }
+                    selectionBorderBrush?.Dispose();
                 }
             }
 
             //paint any glyphs
-            if (glyphManager != null)
-            {
-                glyphManager.OnPaintGlyphs(pe);
-            }
+            glyphManager?.OnPaintGlyphs(pe);
         }
 
         /// <summary>
@@ -1656,10 +1611,7 @@ namespace System.Windows.Forms.Design
                     // When we scroll, we reposition a control without causing a property change event.
                     // Therefore, we must tell the selection UI service to sync itself.
                     base.WndProc(ref m);
-                    if (selectionUISvc != null)
-                    {
-                        selectionUISvc.SyncSelection();
-                    }
+                    selectionUISvc?.SyncSelection();
 
                     return;
                 case User32.WM.STYLECHANGED:
@@ -2002,10 +1954,7 @@ namespace System.Windows.Forms.Design
                     name = site.Name;
                     IDictionaryService ds = (IDictionaryService)site.GetService(typeof(IDictionaryService));
                     Debug.Assert(ds != null, "ComponentTray relies on IDictionaryService, which is not available.");
-                    if (ds != null)
-                    {
-                        ds.SetValue(GetType(), this);
-                    }
+                    ds?.SetValue(GetType(), this);
                 }
 
                 if (name is null)
@@ -2074,16 +2023,10 @@ namespace System.Windows.Forms.Design
 
                 finally
                 {
-                    if (gr != null)
-                    {
-                        gr.Dispose();
-                    }
+                    gr?.Dispose();
                 }
 
-                if (_tray.glyphManager != null)
-                {
-                    _tray.glyphManager.UpdateLocation(this);
-                }
+                _tray.glyphManager?.UpdateLocation(this);
             }
 
             protected override AccessibleObject CreateAccessibilityInstance() => new TrayControlAccessibleObject(this, _tray);
@@ -2107,10 +2050,7 @@ namespace System.Windows.Forms.Design
 
                         IDictionaryService ds = (IDictionaryService)site.GetService(typeof(IDictionaryService));
                         Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (ds != null), "IDictionaryService not found");
-                        if (ds != null)
-                        {
-                            ds.SetValue(typeof(TrayControl), null);
-                        }
+                        ds?.SetValue(typeof(TrayControl), null);
                     }
                 }
 
@@ -2202,10 +2142,7 @@ namespace System.Windows.Forms.Design
                     if (_ctrlSelect)
                     {
                         ISelectionService sel = (ISelectionService)_tray.GetService(typeof(ISelectionService));
-                        if (sel != null)
-                        {
-                            sel.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
-                        }
+                        sel?.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
 
                         _ctrlSelect = false;
                     }
@@ -2247,10 +2184,7 @@ namespace System.Windows.Forms.Design
                             ISelectionService sel = (ISelectionService)_tray.GetService(typeof(ISelectionService));
                             // Make sure the component is selected
                             Debug.Assert(!CompModSwitches.CommonDesignerServices.Enabled || (sel != null), "ISelectionService not found");
-                            if (sel != null)
-                            {
-                                sel.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
-                            }
+                            sel?.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
                         }
                     }
                 }
@@ -2293,10 +2227,7 @@ namespace System.Windows.Forms.Design
                 {
                     // Make sure the component is selected
                     ISelectionService sel = (ISelectionService)_tray.GetService(typeof(ISelectionService));
-                    if (sel != null)
-                    {
-                        sel.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
-                    }
+                    sel?.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
 
                     // Notify the selection service that all the components are in the "mouse down" mode.
                     if (_tray.selectionUISvc != null && _tray.selectionUISvc.BeginDrag(SelectionRules.Visible | SelectionRules.Moveable, _mouseDragLast.X, _mouseDragLast.Y))
@@ -2397,15 +2328,9 @@ namespace System.Windows.Forms.Design
 
                 finally
                 {
-                    if (format != null)
-                    {
-                        format.Dispose();
-                    }
+                    format?.Dispose();
 
-                    if (foreBrush != null)
-                    {
-                        foreBrush.Dispose();
-                    }
+                    foreBrush?.Dispose();
                 }
 
                 // If this component is being inherited, paint it as such
@@ -2433,10 +2358,7 @@ namespace System.Windows.Forms.Design
             /// </summary>
             protected override void OnLocationChanged(EventArgs e)
             {
-                if (_tray.glyphManager != null)
-                {
-                    _tray.glyphManager.UpdateLocation(this);
-                }
+                _tray.glyphManager?.UpdateLocation(this);
             }
 
             /// <summary>
@@ -2568,10 +2490,7 @@ namespace System.Windows.Forms.Design
                 // If we couldn't find a property for this event, or if the property is read only, then abort and just show the code.
                 if (defaultPropEvent is null || defaultPropEvent.IsReadOnly)
                 {
-                    if (eps != null)
-                    {
-                        eps.ShowCode();
-                    }
+                    eps?.ShowCode();
 
                     return;
                 }
@@ -2605,10 +2524,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (trans != null)
-                    {
-                        trans.Commit();
-                    }
+                    trans?.Commit();
                 }
             }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ContextMenuStripActionList.cs
@@ -36,10 +36,7 @@ namespace System.Windows.Forms.Design
         {
             PropertyDescriptor changingProperty = TypeDescriptor.GetProperties(_toolStripDropDown)[propertyName];
             Debug.Assert(changingProperty != null, "Could not find given property in control.");
-            if (changingProperty != null)
-            {
-                changingProperty.SetValue(_toolStripDropDown, value);
-            }
+            changingProperty?.SetValue(_toolStripDropDown, value);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlCommandSet.cs
@@ -821,10 +821,7 @@ namespace System.Windows.Forms.Design
 
                             finally
                             {
-                                if (trans != null)
-                                {
-                                    trans.Commit();
-                                }
+                                trans?.Commit();
 
                                 if (dragManager != null)
                                 {
@@ -917,8 +914,7 @@ namespace System.Windows.Forms.Design
                         }
                         finally
                         {
-                            if (trans != null)
-                                trans.Commit();
+                            trans?.Commit();
                         }
                     }
                 }
@@ -1083,8 +1079,7 @@ namespace System.Windows.Forms.Design
                                             if (ex == CheckoutException.Canceled)
                                             {
                                                 // If the user canceled the check out then cancel the transaction
-                                                if (trans != null)
-                                                    trans.Cancel();
+                                                trans?.Cancel();
                                                 return;
                                             }
 
@@ -1113,18 +1108,12 @@ namespace System.Windows.Forms.Design
                                 // we do this backwards to maintain zorder
                                 Control otherControl = selectedComponents[len - i - 1] as Control;
 
-                                if (otherControl != null)
-                                {
-                                    otherControl.BringToFront();
-                                }
+                                otherControl?.BringToFront();
                             }
                             else if (cmdID == StandardCommands.SendToBack)
                             {
                                 Control control = selectedComponents[i] as Control;
-                                if (control != null)
-                                {
-                                    control.SendToBack();
-                                }
+                                control?.SendToBack();
                             }
                         }
                     }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -502,10 +502,7 @@ namespace System.Windows.Forms.Design
                     UnhookChildControls(Control);
                 }
 
-                if (DesignerTarget != null)
-                {
-                    DesignerTarget.Dispose();
-                }
+                DesignerTarget?.Dispose();
 
                 _downPos = Point.Empty;
 
@@ -682,11 +679,8 @@ namespace System.Windows.Forms.Design
 
         private void OnDragEnter(object s, DragEventArgs e)
         {
-            if (BehaviorService != null)
-            {
-                // Tell the BehaviorService to monitor mouse messages so it can send appropriate drag notifications.
-                BehaviorService.StartDragNotification();
-            }
+            // Tell the BehaviorService to monitor mouse messages so it can send appropriate drag notifications.
+            BehaviorService?.StartDragNotification();
 
             OnDragEnter(e);
         }
@@ -695,11 +689,8 @@ namespace System.Windows.Forms.Design
 
         private void OnDragDrop(object s, DragEventArgs e)
         {
-            if (BehaviorService != null)
-            {
-                // This will cause the Behavior Service to return from 'drag mode'
-                BehaviorService.EndDragNotification();
-            }
+            // This will cause the Behavior Service to return from 'drag mode'
+            BehaviorService?.EndDragNotification();
 
             OnDragDrop(e);
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignBindingValueUIHandler.cs
@@ -67,10 +67,7 @@ namespace System.Windows.Forms.Design
 
         public void Dispose()
         {
-            if (dataBitmap != null)
-            {
-                dataBitmap.Dispose();
-            }
+            dataBitmap?.Dispose();
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerFrame.cs
@@ -192,10 +192,7 @@ namespace System.Windows.Forms.Design
             Size selectionSize = DesignerUtils.GetAdornmentDimensions(AdornmentType.Maximum);
             _designerRegion.AutoScrollMargin = selectionSize;
             _designer.Location = new Point(selectionSize.Width, selectionSize.Height);
-            if (BehaviorService != null)
-            {
-                BehaviorService.SyncSelection();
-            }
+            BehaviorService?.SyncSelection();
         }
 
         /// <summary>
@@ -447,10 +444,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 // We've reparented everything, which means that our selection UI is probably out of sync.  Ask it to sync.
-                if (BehaviorService != null)
-                {
-                    BehaviorService.SyncSelection();
-                }
+                BehaviorService?.SyncSelection();
             }
 
             /// <summary>
@@ -612,10 +606,7 @@ namespace System.Windows.Forms.Design
                 else if ((m.Msg == (int)User32.WM.MOUSEWHEEL))
                 {
                     _messageMouseWheelProcessed = false;
-                    if (BehaviorService != null)
-                    {
-                        BehaviorService.SyncSelection();
-                    }
+                    BehaviorService?.SyncSelection();
                 }
             }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerVerbToolStripMenuItem.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DesignerVerbToolStripMenuItem.cs
@@ -32,10 +32,7 @@ namespace System.Windows.Forms.Design
 
         protected override void OnClick(EventArgs e)
         {
-            if (_verb != null)
-            {
-                _verb.Invoke();
-            }
+            _verb?.Invoke();
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/DocumentDesigner.cs
@@ -491,10 +491,7 @@ namespace System.Windows.Forms.Design
                     if (host != null)
                     {
                         ISplitWindowService sws = (ISplitWindowService)GetService(typeof(ISplitWindowService));
-                        if (sws != null)
-                        {
-                            sws.RemoveSplitWindow(componentTray);
-                        }
+                        sws?.RemoveSplitWindow(componentTray);
                     }
 
                     componentTray.Dispose();
@@ -550,10 +547,7 @@ namespace System.Windows.Forms.Design
                     designerExtenders = null;
                 }
 
-                if (axTools != null)
-                {
-                    axTools.Clear();
-                }
+                axTools?.Clear();
 
                 if (host != null)
                 {
@@ -899,11 +893,9 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (key != null)
-                    key.Close();
+                key?.Close();
 
-                if (designtimeKey != null)
-                    designtimeKey.Close();
+                designtimeKey?.Close();
             }
         }
 
@@ -1057,10 +1049,7 @@ namespace System.Windows.Forms.Design
                     {
                         sws.RemoveSplitWindow(componentTray);
                         IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                        if (host != null)
-                        {
-                            host.RemoveService(typeof(ComponentTray));
-                        }
+                        host?.RemoveService(typeof(ComponentTray));
 
                         componentTray.Dispose();
                         componentTray = null;
@@ -1485,10 +1474,7 @@ namespace System.Windows.Forms.Design
             }
 
             IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-            if (host != null)
-            {
-                host.Activate();
-            }
+            host?.Activate();
 
             // Just find the currently selected frame designer and ask it to create the tool.
             //
@@ -1499,10 +1485,7 @@ namespace System.Windows.Forms.Design
                 {
                     InvokeCreateTool(designer, tool);
                     IToolboxService toolboxService = (IToolboxService)GetService(typeof(IToolboxService));
-                    if (toolboxService != null)
-                    {
-                        toolboxService.SelectedToolboxItemUsed();
-                    }
+                    toolboxService?.SelectedToolboxItemUsed();
                 }
             }
             catch (Exception e)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EditorServiceContext.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/EditorServiceContext.cs
@@ -180,10 +180,7 @@ namespace System.Windows.Forms.Design
             CollectionEditor itemsEditor = TypeDescriptor.GetEditor(propertyValue, typeof(UITypeEditor)) as CollectionEditor;
 
             Debug.Assert(itemsEditor != null, "Didn't get a collection editor for type '" + _targetProperty.PropertyType.FullName + "'");
-            if (itemsEditor != null)
-            {
-                itemsEditor.EditValue(this, this, propertyValue);
-            }
+            itemsEditor?.EditValue(this, this, propertyValue);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatControl.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatControl.cs
@@ -448,10 +448,7 @@ namespace System.Windows.Forms.Design
                 ctl = ctl.Parent;
             }
 
-            if (fsd != null)
-            {
-                fsd.FormatControlFinishedLoading();
-            }
+            fsd?.FormatControlFinishedLoading();
         }
 
         private class DateTimeFormatsListBoxItem

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatStringDialog.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/FormatStringDialog.cs
@@ -113,7 +113,7 @@ namespace System.Windows.Forms.Design
         {
             // make a reasonable guess what user control should be shown
             string formatString = _dgvCellStyle != null ? _dgvCellStyle.Format : _listControl.FormatString;
-            object nullValue = _dgvCellStyle != null ? _dgvCellStyle.NullValue : null;
+            object nullValue = _dgvCellStyle?.NullValue;
             string formatType = string.Empty;
 
             if (!string.IsNullOrEmpty(formatString))

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InheritanceUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/InheritanceUI.cs
@@ -93,10 +93,7 @@ namespace System.Windows.Forms.Design
 
         public void Dispose()
         {
-            if (_tooltip != null)
-            {
-                _tooltip.Dispose();
-            }
+            _tooltip?.Dispose();
         }
 
         /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.ComponentDataObject.cs
@@ -267,10 +267,7 @@ namespace System.Windows.Forms.Design
                                 }
                             }
 
-                            if (host != null)
-                            {
-                                host.DestroyComponent(removeComp);
-                            }
+                            host?.DestroyComponent(removeComp);
                         }
 
                         components = null;
@@ -311,10 +308,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (trans != null)
-                    {
-                        trans.Commit();
-                    }
+                    trans?.Commit();
                 }
             }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
@@ -241,10 +241,7 @@ namespace System.Windows.Forms.Design
                         if (host != null && CurrentlyLocalizing(host.RootComponent))
                         {
                             IUIService uiService = (IUIService)GetService(typeof(IUIService));
-                            if (uiService != null)
-                            {
-                                uiService.ShowMessage(SR.LocalizingCannotAdd);
-                            }
+                            uiService?.ShowMessage(SR.LocalizingCannotAdd);
 
                             comps = Array.Empty<IComponent>();
                             return comps;
@@ -287,10 +284,7 @@ namespace System.Windows.Forms.Design
                     catch (ArgumentException argumentEx)
                     {
                         IUIService uiService = (IUIService)GetService(typeof(IUIService));
-                        if (uiService != null)
-                        {
-                            uiService.ShowError(argumentEx);
-                        }
+                        uiService?.ShowError(argumentEx);
                     }
                     catch (Exception ex)
                     {
@@ -337,10 +331,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (trans != null)
-                {
-                    trans.Commit();
-                }
+                trans?.Commit();
 
                 Cursor.Current = oldCursor;
             }
@@ -349,10 +340,7 @@ namespace System.Windows.Forms.Design
             //
             if (selSvc != null && comps.Length > 0)
             {
-                if (host != null)
-                {
-                    host.Activate();
-                }
+                host?.Activate();
 
                 ArrayList selectComps = new ArrayList(comps);
 
@@ -632,10 +620,7 @@ namespace System.Windows.Forms.Design
             try
             {
                 effect = c.DoDragDrop(data, allowedEffects);
-                if (trans != null)
-                {
-                    trans.Commit();
-                }
+                trans?.Commit();
             }
             finally
             {
@@ -969,10 +954,7 @@ namespace System.Windows.Forms.Design
                                 }
                             }
 
-                            if (host != null)
-                            {
-                                host.Activate();
-                            }
+                            host?.Activate();
 
                             // select the newly added components
                             ISelectionService selService = (ISelectionService)GetService(typeof(ISelectionService));
@@ -982,8 +964,7 @@ namespace System.Windows.Forms.Design
                         }
                         finally
                         {
-                            if (trans != null)
-                                trans.Commit();
+                            trans?.Commit();
                         }
                     }
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -217,10 +217,7 @@ namespace System.Windows.Forms.Design
 
                     //invalidate the control to remove or draw the grid based on the new value
                     Control control = Control;
-                    if (control != null)
-                    {
-                        control.Invalidate(true);
-                    }
+                    control?.Invalidate(true);
 
                     //now, notify all child parent control designers that we have changed our setting
                     // 'cause they might to change along with us, unless the user has explicitly set
@@ -232,10 +229,7 @@ namespace System.Windows.Forms.Design
                         foreach (Control child in Control.Controls)
                         {
                             ParentControlDesigner designer = host.GetDesigner(child) as ParentControlDesigner;
-                            if (designer != null)
-                            {
-                                designer.DrawGridOfParentChanged(_drawGrid);
-                            }
+                            designer?.DrawGridOfParentChanged(_drawGrid);
                         }
                     }
                 }
@@ -316,10 +310,7 @@ namespace System.Windows.Forms.Design
 
                 //invalidate the control
                 Control control = Control;
-                if (control != null)
-                {
-                    control.Invalidate(true);
-                }
+                control?.Invalidate(true);
 
                 //now, notify all child parent control designers that we have changed our setting
                 // 'cause they might to change along with us, unless the user has explicitly set
@@ -330,10 +321,7 @@ namespace System.Windows.Forms.Design
                     foreach (Control child in Control.Controls)
                     {
                         ParentControlDesigner designer = host.GetDesigner(child) as ParentControlDesigner;
-                        if (designer != null)
-                        {
-                            designer.GridSizeOfParentChanged(_gridSize);
-                        }
+                        designer?.GridSizeOfParentChanged(_gridSize);
                     }
                 }
             }
@@ -491,10 +479,7 @@ namespace System.Windows.Forms.Design
                         foreach (Control child in Control.Controls)
                         {
                             ParentControlDesigner designer = host.GetDesigner(child) as ParentControlDesigner;
-                            if (designer != null)
-                            {
-                                designer.GridSnapOfParentChanged(_gridSnap);
-                            }
+                            designer?.GridSnapOfParentChanged(_gridSnap);
                         }
                     }
                 }
@@ -660,10 +645,7 @@ namespace System.Windows.Forms.Design
                 //
                 //
                 PropertyDescriptor controlsProp = TypeDescriptor.GetProperties(Control)["Controls"];
-                if (_changeService != null)
-                {
-                    _changeService.OnComponentChanging(Control, controlsProp);
-                }
+                _changeService?.OnComponentChanging(Control, controlsProp);
 
                 AddChildControl(newChild);
 
@@ -674,10 +656,7 @@ namespace System.Windows.Forms.Design
                 if (props != null)
                 {
                     PropertyDescriptor prop = props["Size"];
-                    if (prop != null)
-                    {
-                        prop.SetValue(newChild, new Size(bounds.Width, bounds.Height));
-                    }
+                    prop?.SetValue(newChild, new Size(bounds.Width, bounds.Height));
 
                     //VSWhidbey# 364133 - ControlDesigner shadows the Location property. If the control is parented
                     //and the parent is a scrollable control, then it expects the Location to be in displayrectangle coordinates.
@@ -695,16 +674,10 @@ namespace System.Windows.Forms.Design
                     }
 
                     prop = props["Location"];
-                    if (prop != null)
-                    {
-                        prop.SetValue(newChild, pt);
-                    }
+                    prop?.SetValue(newChild, pt);
                 }
 
-                if (_changeService != null)
-                {
-                    _changeService.OnComponentChanged(Control, controlsProp, Control.Controls, Control.Controls);
-                }
+                _changeService?.OnComponentChanged(Control, controlsProp, Control.Controls, Control.Controls);
 
                 newChild.Update();
             }
@@ -754,10 +727,7 @@ namespace System.Windows.Forms.Design
                         continue;
                     }
 
-                    if (childContainer != null)
-                    {
-                        childContainer.Remove(children[i]);
-                    }
+                    childContainer?.Remove(children[i]);
 
                     if (name != null)
                     {
@@ -782,10 +752,7 @@ namespace System.Windows.Forms.Design
                     }
 
                     IComponentInitializer init = host.GetDesigner(component) as IComponentInitializer;
-                    if (init != null)
-                    {
-                        init.InitializeExistingComponent(null);
-                    }
+                    init?.InitializeExistingComponent(null);
 
                     // recurse;
                     AddChildComponents(children[i], container, host);
@@ -1519,10 +1486,7 @@ namespace System.Windows.Forms.Design
         protected override void OnDragComplete(DragEventArgs de)
         {
             DropSourceBehavior.BehaviorDataObject data = de.Data as DropSourceBehavior.BehaviorDataObject;
-            if (data != null)
-            {
-                data.CleanupDrag();
-            }
+            data?.CleanupDrag();
         }
 
         /// <summary>
@@ -1574,22 +1538,16 @@ namespace System.Windows.Forms.Design
             if (_mouseDragTool != null)
             {
                 IDesignerHost host = (IDesignerHost)GetService(typeof(IDesignerHost));
-                if (host != null)
-                {
-                    host.Activate();
-                }
+                host?.Activate();
 
                 try
                 {
                     //There may be a wizard displaying as a result of CreateTool.
                     //we do not want the behavior service thinking there he is dragging while this wizard is up
                     //it causes the cursor to constantly flicker to the toolbox cursor.
-                    if (BehaviorService != null)
-                    {
-                        //this will cause the BehSvc to return from 'drag mode'
-                        //
-                        BehaviorService.EndDragNotification();
-                    }
+                    //this will cause the BehSvc to return from 'drag mode'
+                    //
+                    BehaviorService?.EndDragNotification();
 
                     CreateTool(_mouseDragTool, new Point(de.X, de.Y));
                 }
@@ -1785,19 +1743,13 @@ namespace System.Windows.Forms.Design
                 // This must be called last. Tell the behavior that we are beginning a drag.
                 // Yeah, this is OnDragEnter, but to the behavior this is as if we are starting a drag.
                 // VSWhidbey 487816
-                if (_toolboxItemSnapLineBehavior != null)
-                {
-                    _toolboxItemSnapLineBehavior.OnBeginDrag();
-                }
+                _toolboxItemSnapLineBehavior?.OnBeginDrag();
             }
         }
 
         private void PerformDragEnter(DragEventArgs de, IDesignerHost host)
         {
-            if (host != null)
-            {
-                host.Activate();
-            }
+            host?.Activate();
 
             Debug.Assert(0 != (de.AllowedEffect & (DragDropEffects.Move | DragDropEffects.Copy)), "DragDropEffect.Move | .Copy isn't allowed?");
             if ((de.AllowedEffect & DragDropEffects.Move) != 0)
@@ -1819,10 +1771,7 @@ namespace System.Windows.Forms.Design
             // Also, select this parent control to indicate it will be the drop target.
             //
             ISelectionService sel = (ISelectionService)GetService(typeof(ISelectionService));
-            if (sel != null)
-            {
-                sel.SetSelectedComponents(new object[] { Component }, SelectionTypes.Replace);
-            }
+            sel?.SetSelectedComponents(new object[] { Component }, SelectionTypes.Replace);
         }
 
         /// <summary>
@@ -1937,10 +1886,7 @@ namespace System.Windows.Forms.Design
             // Select the given object.
             ISelectionService selsvc = (ISelectionService)GetService(typeof(ISelectionService));
 
-            if (selsvc != null)
-            {
-                selsvc.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
-            }
+            selsvc?.SetSelectedComponents(new object[] { Component }, SelectionTypes.Primary);
 
             // Get the event handler service.  We push a handler to handle the escape
             // key.
@@ -2047,10 +1993,7 @@ namespace System.Windows.Forms.Design
                     try
                     {
                         CreateTool(tool, baseVar);
-                        if (_toolboxService != null)
-                        {
-                            _toolboxService.SelectedToolboxItemUsed();
-                        }
+                        _toolboxService?.SelectedToolboxItemUsed();
                     }
                     catch (Exception e)
                     {
@@ -2095,10 +2038,7 @@ namespace System.Windows.Forms.Design
                     }
 
                     CreateTool(tool, offset);
-                    if (_toolboxService != null)
-                    {
-                        _toolboxService.SelectedToolboxItemUsed();
-                    }
+                    _toolboxService?.SelectedToolboxItemUsed();
                 }
                 catch (Exception e)
                 {
@@ -2424,10 +2364,7 @@ namespace System.Windows.Forms.Design
                     //fire comp changing on parent and control
                     if (oldParent != null)
                     {
-                        if (changeService != null)
-                        {
-                            changeService.OnComponentChanging(oldParent, controlsProp);
-                        }
+                        changeService?.OnComponentChanging(oldParent, controlsProp);
 
                         //remove control from the old parent
                         oldParent.Controls.Remove(control);
@@ -2463,10 +2400,7 @@ namespace System.Windows.Forms.Design
                     }
                 }
 
-                if (changeService != null)
-                {
-                    changeService.OnComponentChanged(newParent, controlsProp);
-                }
+                changeService?.OnComponentChanged(newParent, controlsProp);
 
                 //commit the transaction
                 dt.Commit();
@@ -2539,10 +2473,7 @@ namespace System.Windows.Forms.Design
             _parentCanSetGridSize = true;
             //invalidate the control
             Control control = Control;
-            if (control != null)
-            {
-                control.Invalidate(true);
-            }
+            control?.Invalidate(true);
         }
 
         private void ResetDrawGrid()
@@ -2551,10 +2482,7 @@ namespace System.Windows.Forms.Design
             _parentCanSetDrawGrid = true;
             //invalidate the control
             Control control = Control;
-            if (control != null)
-            {
-                control.Invalidate(true);
-            }
+            control?.Invalidate(true);
         }
 
         private void ResetSnapToGrid()
@@ -2645,10 +2573,7 @@ namespace System.Windows.Forms.Design
                     {
                         // move it back.
                         container.Remove(component);
-                        if (oldContainer != null)
-                        {
-                            oldContainer.Add(component);
-                        }
+                        oldContainer?.Add(component);
                     }
                     else
                     {
@@ -2686,16 +2611,10 @@ namespace System.Windows.Forms.Design
                         if (c.Parent != null)
                         {
                             Control cParent = c.Parent;
-                            if (_changeService != null)
-                            {
-                                _changeService.OnComponentChanging(cParent, controlsProp);
-                            }
+                            _changeService?.OnComponentChanging(cParent, controlsProp);
 
                             cParent.Controls.Remove(c);
-                            if (_changeService != null)
-                            {
-                                _changeService.OnComponentChanged(cParent, controlsProp, cParent.Controls, cParent.Controls);
-                            }
+                            _changeService?.OnComponentChanged(cParent, controlsProp, cParent.Controls, cParent.Controls);
                         }
 
                         if (_suspendChanging == 0 && _changeService != null)
@@ -2708,10 +2627,7 @@ namespace System.Windows.Forms.Design
                         // z-order, but do we need that?
                         //
                         //parent.Controls.SetChildIndex(c, 0);
-                        if (_changeService != null)
-                        {
-                            _changeService.OnComponentChanged(parent, controlsProp, parent.Controls, parent.Controls);
-                        }
+                        _changeService?.OnComponentChanged(parent, controlsProp, parent.Controls, parent.Controls);
                     }
                     else
                     {
@@ -2732,10 +2648,7 @@ namespace System.Windows.Forms.Design
                 // handled properly.  if we respected the boolean before, the ui selection handlers
                 // would cache designers, handlers, etc. and cause problems.
                 IComponentInitializer init = localDesignerHost.GetDesigner(component) as IComponentInitializer;
-                if (init != null)
-                {
-                    init.InitializeExistingComponent(null);
-                }
+                init?.InitializeExistingComponent(null);
 
                 AddChildComponents(component, container, localDesignerHost);
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PbrsForward.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/PbrsForward.cs
@@ -213,10 +213,7 @@ namespace System.Windows.Forms.Design
                     break;
             }
 
-            if (oldTarget != null)
-            {
-                oldTarget.OnMessage(ref m);
-            }
+            oldTarget?.OnMessage(ref m);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ScrollableControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ScrollableControlDesigner.cs
@@ -62,10 +62,7 @@ namespace System.Windows.Forms.Design
                         selManager = GetService(typeof(SelectionManager)) as SelectionManager;
                     }
 
-                    if (selManager != null)
-                    {
-                        selManager.Refresh();
-                    }
+                    selManager?.Refresh();
 
                     // Now we must paint our adornments, since the scroll does not
                     // trigger a paint event

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIHandler.cs
@@ -103,10 +103,7 @@ namespace System.Windows.Forms.Design
                 // Suspend parent layout so that we don't continuously re-arrange components
                 // while we move.
                 //
-                if (parent != null)
-                {
-                    parent.SuspendLayout();
-                }
+                parent?.SuspendLayout();
 
                 b.X = bounds[i].X;
                 b.Y = bounds[i].Y;
@@ -121,10 +118,7 @@ namespace System.Windows.Forms.Design
             for (int i = 0; i < controls.Length; i++)
             {
                 Control parent = controls[i].Parent;
-                if (parent != null)
-                {
-                    parent.ResumeLayout();
-                }
+                parent?.ResumeLayout();
             }
         }
 
@@ -277,10 +271,7 @@ namespace System.Windows.Forms.Design
                 // Suspend parent layout so that we don't continuously re-arrange components
                 // while we move.
                 //
-                if (parent != null)
-                {
-                    parent.SuspendLayout();
-                }
+                parent?.SuspendLayout();
 
                 BoundsInfo ctlBounds = bounds[i];
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
@@ -438,10 +438,7 @@ namespace System.Windows.Forms.Design
         protected override void OnDragEnter(DragEventArgs devent)
         {
             base.OnDragEnter(devent);
-            if (_dragHandler != null)
-            {
-                _dragHandler.OleDragEnter(devent);
-            }
+            _dragHandler?.OleDragEnter(devent);
         }
 
         /// <summary>
@@ -450,10 +447,7 @@ namespace System.Windows.Forms.Design
         protected override void OnDragOver(DragEventArgs devent)
         {
             base.OnDragOver(devent);
-            if (_dragHandler != null)
-            {
-                _dragHandler.OleDragOver(devent);
-            }
+            _dragHandler?.OleDragOver(devent);
         }
 
         /// <summary>
@@ -462,10 +456,7 @@ namespace System.Windows.Forms.Design
         protected override void OnDragLeave(EventArgs e)
         {
             base.OnDragLeave(e);
-            if (_dragHandler != null)
-            {
-                _dragHandler.OleDragLeave();
-            }
+            _dragHandler?.OleDragLeave();
         }
 
         /// <summary>
@@ -474,10 +465,7 @@ namespace System.Windows.Forms.Design
         protected override void OnDragDrop(DragEventArgs devent)
         {
             base.OnDragDrop(devent);
-            if (_dragHandler != null)
-            {
-                _dragHandler.OleDragDrop(devent);
-            }
+            _dragHandler?.OleDragDrop(devent);
         }
 
         /// <summary>
@@ -493,10 +481,7 @@ namespace System.Windows.Forms.Design
                 if (selComp != null)
                 {
                     ISelectionUIHandler handler = GetHandler(selComp);
-                    if (handler != null)
-                    {
-                        handler.OnSelectionDoubleClick((IComponent)selComp);
-                    }
+                    handler?.OnSelectionDoubleClick((IComponent)selComp);
                 }
             }
         }
@@ -1147,10 +1132,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (trans != null)
-                {
-                    trans.Commit();
-                }
+                trans?.Commit();
 
                 // Reset the selection.  This will re-display our selection.
                 Visible = _savedVisible;
@@ -1265,19 +1247,13 @@ namespace System.Windows.Forms.Design
                 SelectionUIItem existingItem = (SelectionUIItem)_selectionItems[component];
                 if (!(existingItem is ContainerSelectionUIItem))
                 {
-                    if (existingItem != null)
-                    {
-                        existingItem.Dispose();
-                    }
+                    existingItem?.Dispose();
 
                     SelectionUIItem item = new ContainerSelectionUIItem(this, component);
                     _selectionItems[component] = item;
                     // Now update our region and invalidate
                     UpdateWindowRegion();
-                    if (existingItem != null)
-                    {
-                        existingItem.Invalidate();
-                    }
+                    existingItem?.Invalidate();
 
                     item.Invalidate();
                 }
@@ -1288,10 +1264,7 @@ namespace System.Windows.Forms.Design
                 if (existingItem is null || existingItem is ContainerSelectionUIItem)
                 {
                     _selectionItems.Remove(component);
-                    if (existingItem != null)
-                    {
-                        existingItem.Dispose();
-                    }
+                    existingItem?.Dispose();
 
                     UpdateWindowRegion();
                     existingItem.Invalidate();

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardMenuStripVerb.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StandardMenuStripVerb.cs
@@ -40,10 +40,7 @@ namespace System.Windows.Forms.Design
         public void InsertItems()
         {
             DesignerActionUIService actionUIService = (DesignerActionUIService)_host.GetService(typeof(DesignerActionUIService));
-            if (actionUIService != null)
-            {
-                actionUIService.HideUI(_designer.Component);
-            }
+            actionUIService?.HideUI(_designer.Component);
 
             Cursor current = Cursor.Current;
             try
@@ -178,10 +175,7 @@ namespace System.Windows.Forms.Design
                             {
                                 PropertyDescriptor imageProperty = TypeDescriptor.GetProperties(item)["Image"];
                                 Debug.Assert(imageProperty != null, "Could not find 'Image' property in ToolStripItem.");
-                                if (imageProperty != null)
-                                {
-                                    imageProperty.SetValue(item, image);
-                                }
+                                imageProperty?.SetValue(item, image);
 
                                 item.ImageTransparentColor = Color.Magenta;
                             }
@@ -247,17 +241,11 @@ namespace System.Windows.Forms.Design
                 tool.ResumeLayout();
                 // Select the Main Menu...
                 ISelectionService selSvc = (ISelectionService)_provider.GetService(typeof(ISelectionService));
-                if (selSvc != null)
-                {
-                    selSvc.SetSelectedComponents(new object[] { _designer.Component });
-                }
+                selSvc?.SetSelectedComponents(new object[] { _designer.Component });
 
                 //Refresh the Glyph
                 DesignerActionUIService actionUIService = (DesignerActionUIService)_provider.GetService(typeof(DesignerActionUIService));
-                if (actionUIService != null)
-                {
-                    actionUIService.Refresh(_designer.Component);
-                }
+                actionUIService?.Refresh(_designer.Component);
 
                 // this will invalidate the Selection Glyphs.
                 SelectionManager selMgr = (SelectionManager)_provider.GetService(typeof(SelectionManager));
@@ -333,17 +321,11 @@ namespace System.Windows.Forms.Design
 
                         PropertyDescriptor displayStyleProperty = TypeDescriptor.GetProperties(item)["DisplayStyle"];
                         Debug.Assert(displayStyleProperty != null, "Could not find 'Text' property in ToolStripItem.");
-                        if (displayStyleProperty != null)
-                        {
-                            displayStyleProperty.SetValue(item, ToolStripItemDisplayStyle.Image);
-                        }
+                        displayStyleProperty?.SetValue(item, ToolStripItemDisplayStyle.Image);
 
                         PropertyDescriptor textProperty = TypeDescriptor.GetProperties(item)["Text"];
                         Debug.Assert(textProperty != null, "Could not find 'Text' property in ToolStripItem.");
-                        if (textProperty != null)
-                        {
-                            textProperty.SetValue(item, itemText);
-                        }
+                        textProperty?.SetValue(item, itemText);
 
                         Bitmap image = null;
                         try
@@ -359,10 +341,7 @@ namespace System.Windows.Forms.Design
                         {
                             PropertyDescriptor imageProperty = TypeDescriptor.GetProperties(item)["Image"];
                             Debug.Assert(imageProperty != null, "Could not find 'Image' property in ToolStripItem.");
-                            if (imageProperty != null)
-                            {
-                                imageProperty.SetValue(item, image);
-                            }
+                            imageProperty?.SetValue(item, image);
 
                             item.ImageTransparentColor = Color.Magenta;
                         }
@@ -405,17 +384,11 @@ namespace System.Windows.Forms.Design
                 tool.ResumeLayout();
                 // Select the Main Menu...
                 ISelectionService selSvc = (ISelectionService)_provider.GetService(typeof(ISelectionService));
-                if (selSvc != null)
-                {
-                    selSvc.SetSelectedComponents(new object[] { _designer.Component });
-                }
+                selSvc?.SetSelectedComponents(new object[] { _designer.Component });
 
                 //Refresh the Glyph
                 DesignerActionUIService actionUIService = (DesignerActionUIService)_provider.GetService(typeof(DesignerActionUIService));
-                if (actionUIService != null)
-                {
-                    actionUIService.Refresh(_designer.Component);
-                }
+                actionUIService?.Refresh(_designer.Component);
 
                 // this will invalidate the Selection Glyphs.
                 SelectionManager selMgr = (SelectionManager)_provider.GetService(typeof(SelectionManager));

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StatusCommandUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/StatusCommandUI.cs
@@ -88,10 +88,7 @@ namespace System.Windows.Forms.Design
                 bounds.Y = location.Y;
             }
 
-            if (StatusRectCommand is not null)
-            {
-                StatusRectCommand.Invoke(bounds);
-            }
+            StatusRectCommand?.Invoke(bounds);
         }
 
         /// <summary>
@@ -118,10 +115,7 @@ namespace System.Windows.Forms.Design
                 }
             }
 
-            if (StatusRectCommand is not null)
-            {
-                StatusRectCommand.Invoke(bounds);
-            }
+            StatusRectCommand?.Invoke(bounds);
         }
 
         /// <summary>
@@ -129,10 +123,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public void SetStatusInformation(Rectangle bounds)
         {
-            if (StatusRectCommand is not null)
-            {
-                StatusRectCommand.Invoke(bounds);
-            }
+            StatusRectCommand?.Invoke(bounds);
         }
     }
 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TabOrder.cs
@@ -92,18 +92,12 @@ namespace System.Windows.Forms.Design
             //
             IOverlayService os = (IOverlayService)host.GetService(typeof(IOverlayService));
             Debug.Assert(os != null, "No overlay service -- tab order UI cannot be shown");
-            if (os != null)
-            {
-                os.PushOverlay(this);
-            }
+            os?.PushOverlay(this);
 
             // Push a help keyword so the help system knows we're in place.
             //
             IHelpService hs = (IHelpService)host.GetService(typeof(IHelpService));
-            if (hs != null)
-            {
-                hs.AddContextAttribute("Keyword", "TabOrderView", HelpKeywordType.FilterKeyword);
-            }
+            hs?.AddContextAttribute("Keyword", "TabOrderView", HelpKeywordType.FilterKeyword);
 
             commands = new MenuCommand[]
             {
@@ -151,10 +145,7 @@ namespace System.Windows.Forms.Design
             // above array of menu commands, so this must come after we initialize the array.
             //
             IEventHandlerService ehs = (IEventHandlerService)host.GetService(typeof(IEventHandlerService));
-            if (ehs != null)
-            {
-                ehs.PushHandler(this);
-            }
+            ehs?.PushHandler(this);
 
             // We sync add, remove and change events so we remain in sync with any nastiness that the
             // form may pull on us.
@@ -184,16 +175,10 @@ namespace System.Windows.Forms.Design
                 if (host != null)
                 {
                     IOverlayService os = (IOverlayService)host.GetService(typeof(IOverlayService));
-                    if (os != null)
-                    {
-                        os.RemoveOverlay(this);
-                    }
+                    os?.RemoveOverlay(this);
 
                     IEventHandlerService ehs = (IEventHandlerService)host.GetService(typeof(IEventHandlerService));
-                    if (ehs != null)
-                    {
-                        ehs.PopHandler(this);
-                    }
+                    ehs?.PopHandler(this);
 
                     IMenuCommandService mcs = (IMenuCommandService)host.GetService(typeof(IMenuCommandService));
                     if (mcs != null)
@@ -216,10 +201,7 @@ namespace System.Windows.Forms.Design
                     }
 
                     IHelpService hs = (IHelpService)host.GetService(typeof(IHelpService));
-                    if (hs != null)
-                    {
-                        hs.RemoveContextAttribute("Keyword", "TabOrderView");
-                    }
+                    hs?.RemoveContextAttribute("Keyword", "TabOrderView");
 
                     host = null;
                 }
@@ -518,15 +500,9 @@ namespace System.Windows.Forms.Design
             tabControls = null;
             tabGlyphs = null;
 
-            if (tabComplete != null)
-            {
-                tabComplete.Clear();
-            }
+            tabComplete?.Clear();
 
-            if (tabNext != null)
-            {
-                tabNext.Clear();
-            }
+            tabNext?.Clear();
 
             if (region != null)
             {
@@ -565,10 +541,7 @@ namespace System.Windows.Forms.Design
             {
                 MenuCommand mc = mcs.FindCommand(StandardCommands.TabOrder);
                 Debug.Assert(mc != null, "No tab order menu command, can't get out of tab order UI");
-                if (mc != null)
-                {
-                    mc.Invoke();
-                }
+                mc?.Invoke();
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TableLayoutPanelCodeDomSerializer.cs
@@ -54,7 +54,7 @@ namespace System.Windows.Forms.Design
                     if (IsLocalizable(host))
                     {
                         PropertyDescriptor lsProp = TypeDescriptor.GetProperties(tlp)[LayoutSettingsPropName];
-                        object val = (lsProp != null) ? lsProp.GetValue(tlp) : null;
+                        object val = lsProp?.GetValue(tlp);
 
                         if (val != null)
                         {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TemplateNodeCustomMenuItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TemplateNodeCustomMenuItemCollection.cs
@@ -104,27 +104,18 @@ namespace System.Windows.Forms.Design
 
                     PropertyDescriptor dispProperty = TypeDescriptor.GetProperties(component)["DisplayStyle"];
                     Debug.Assert(dispProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
-                    if (dispProperty != null)
-                    {
-                        dispProperty.SetValue(component, ToolStripItemDisplayStyle.Image);
-                    }
+                    dispProperty?.SetValue(component, ToolStripItemDisplayStyle.Image);
 
                     PropertyDescriptor imageTransProperty = TypeDescriptor.GetProperties(component)["ImageTransparentColor"];
                     Debug.Assert(imageTransProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
-                    if (imageTransProperty != null)
-                    {
-                        imageTransProperty.SetValue(component, Color.Magenta);
-                    }
+                    imageTransProperty?.SetValue(component, Color.Magenta);
                 }
 
                 Debug.Assert(dummyIndex != -1, "Why is the index of the Item negative?");
                 parent.Items.Insert(dummyIndex, (ToolStripItem)component);
                 // set the selection to our new item.. since we destroyed Original component.. we have to ask SelectionService from new Component
                 ISelectionService selSvc = (ISelectionService)_serviceProvider.GetService(typeof(ISelectionService));
-                if (selSvc != null)
-                {
-                    selSvc.SetSelectedComponents(new object[] { component }, SelectionTypes.Replace);
-                }
+                selSvc?.SetSelectedComponents(new object[] { component }, SelectionTypes.Replace);
             }
             catch (Exception ex)
             {
@@ -141,10 +132,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (newItemTransaction != null)
-                {
-                    newItemTransaction.Commit();
-                }
+                newItemTransaction?.Commit();
 
                 // turn off Adding/Added events listened to by the ToolStripDesigner...
                 ToolStripDesigner.s_autoAddNewItems = true;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripActionList.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripActionList.cs
@@ -80,10 +80,7 @@ namespace System.Windows.Forms.Design
         {
             PropertyDescriptor changingProperty = TypeDescriptor.GetProperties(_toolStrip)[propertyName];
             Debug.Assert(changingProperty != null, "Could not find given property in control.");
-            if (changingProperty != null)
-            {
-                changingProperty.SetValue(_toolStrip, value);
-            }
+            changingProperty?.SetValue(_toolStrip, value);
         }
 
         /// <summary>
@@ -141,10 +138,7 @@ namespace System.Windows.Forms.Design
         {
             // Hide the Panel...
             DesignerActionUIService actionUIService = (DesignerActionUIService)_toolStrip.Site.GetService(typeof(DesignerActionUIService));
-            if (actionUIService != null)
-            {
-                actionUIService.HideUI(_toolStrip);
-            }
+            actionUIService?.HideUI(_toolStrip);
 
             _changeParentVerb.ChangeParent();
         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripAdornerWindowService.cs
@@ -34,10 +34,7 @@ namespace System.Windows.Forms.Design
 
             //use the adornerWindow as an overlay
             _overlayService = (IOverlayService)serviceProvider.GetService(typeof(IOverlayService));
-            if (_overlayService != null)
-            {
-                _overlayService.InsertOverlay(_toolStripAdornerWindow, indexToInsert);
-            }
+            _overlayService?.InsertOverlay(_toolStripAdornerWindow, indexToInsert);
 
             _dropDownAdorner = new Adorner();
             int count = _behaviorService.Adorners.Count;
@@ -75,10 +72,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public void Dispose()
         {
-            if (_overlayService != null)
-            {
-                _overlayService.RemoveOverlay(_toolStripAdornerWindow);
-            }
+            _overlayService?.RemoveOverlay(_toolStripAdornerWindow);
 
             _toolStripAdornerWindow.Dispose();
             if (_behaviorService != null)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -502,10 +502,7 @@ namespace System.Windows.Forms.Design
                     //Set the glyph for the item .. so that we can remove it later....
                     dropDownItemDesigner.bodyGlyph = bodyGlyphForddItem;
                     //Add ItemGlyph to the Collection
-                    if (_toolStripAdornerWindowService != null)
-                    {
-                        _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Add(bodyGlyphForddItem);
-                    }
+                    _toolStripAdornerWindowService?.DropDownAdorner.Glyphs.Add(bodyGlyphForddItem);
                 }
             }
         }
@@ -637,17 +634,11 @@ namespace System.Windows.Forms.Design
 
                         PropertyDescriptor dispProperty = TypeDescriptor.GetProperties(item)["DisplayStyle"];
                         Debug.Assert(dispProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
-                        if (dispProperty != null)
-                        {
-                            dispProperty.SetValue(item, ToolStripItemDisplayStyle.Image);
-                        }
+                        dispProperty?.SetValue(item, ToolStripItemDisplayStyle.Image);
 
                         PropertyDescriptor imageTransProperty = TypeDescriptor.GetProperties(item)["ImageTransparentColor"];
                         Debug.Assert(imageTransProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
-                        if (imageTransProperty != null)
-                        {
-                            imageTransProperty.SetValue(item, Color.Magenta);
-                        }
+                        imageTransProperty?.SetValue(item, Color.Magenta);
                     }
                 }
 
@@ -727,15 +718,9 @@ namespace System.Windows.Forms.Design
                     _pendingTransaction.Cancel();
                     _pendingTransaction = null;
 
-                    if (outerTransaction != null)
-                    {
-                        outerTransaction.Cancel();
-                    }
+                    outerTransaction?.Cancel();
                 }
-                else if (outerTransaction != null)
-                {
-                    outerTransaction.Commit();
-                }
+                else outerTransaction?.Commit();
 
                 _addingItem = false;
             }
@@ -761,10 +746,7 @@ namespace System.Windows.Forms.Design
 
         internal void CancelPendingMenuItemTransaction()
         {
-            if (_insertMenuItemTransaction != null)
-            {
-                _insertMenuItemTransaction.Cancel();
-            }
+            _insertMenuItemTransaction?.Cancel();
         }
 
         /// <summary>
@@ -1372,10 +1354,7 @@ namespace System.Windows.Forms.Design
                     if (comp is ToolStripItem item && item.Visible)
                     {
                         ToolStripItemDesigner itemDesigner = (ToolStripItemDesigner)_host.GetDesigner(item);
-                        if (itemDesigner != null)
-                        {
-                            itemDesigner.GetGlyphs(ref glyphs, StandardBehavior);
-                        }
+                        itemDesigner?.GetGlyphs(ref glyphs, StandardBehavior);
                     }
                 }
             }
@@ -1495,10 +1474,7 @@ namespace System.Windows.Forms.Design
             {
                 // smoke the dock property whenever we add a toolstrip to a toolstrip panel.
                 PropertyDescriptor dockProp = TypeDescriptor.GetProperties(ToolStrip)["Dock"];
-                if (dockProp != null)
-                {
-                    dockProp.SetValue(ToolStrip, DockStyle.None);
-                }
+                dockProp?.SetValue(ToolStrip, DockStyle.None);
             }
 
             // Set up parenting and all the base functionality.
@@ -1526,17 +1502,11 @@ namespace System.Windows.Forms.Design
                 {
                     PropertyDescriptor controlsProp = TypeDescriptor.GetProperties(parentPanel)["Controls"];
 
-                    if (_componentChangeSvc != null)
-                    {
-                        _componentChangeSvc.OnComponentChanging(parentPanel, controlsProp);
-                    }
+                    _componentChangeSvc?.OnComponentChanging(parentPanel, controlsProp);
 
                     parentPanel.Join(ToolStrip, parentPanel.Rows.Length);
 
-                    if (_componentChangeSvc != null)
-                    {
-                        _componentChangeSvc.OnComponentChanged(parentPanel, controlsProp, parentPanel.Controls, parentPanel.Controls);
-                    }
+                    _componentChangeSvc?.OnComponentChanged(parentPanel, controlsProp, parentPanel.Controls, parentPanel.Controls);
 
                     //Try to fire ComponentChange on the Location Property for ToolStrip.
                     PropertyDescriptor locationProp = TypeDescriptor.GetProperties(ToolStrip)["Location"];
@@ -1942,10 +1912,7 @@ namespace System.Windows.Forms.Design
                     SelectionService.SetSelectedComponents(new IComponent[] { primaryItem }, SelectionTypes.Primary | SelectionTypes.Replace);
                 }
 
-                if (changeService != null)
-                {
-                    changeService.OnComponentChanged(parentToolStrip, TypeDescriptor.GetProperties(parentToolStrip)["Items"]);
-                }
+                changeService?.OnComponentChanged(parentToolStrip, TypeDescriptor.GetProperties(parentToolStrip)["Items"]);
 
                 // Fire extra changing/changed events so that the order is "restored" after undo/redo
                 if (copy)
@@ -1971,10 +1938,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (changeParent != null)
-                {
-                    changeParent.Commit();
-                }
+                changeParent?.Commit();
             }
         }
 
@@ -2448,10 +2412,7 @@ namespace System.Windows.Forms.Design
             if (ToolStrip is MenuStrip)
             {
                 // The TemplateNode should no longer be selected.
-                if (KeyboardHandlingService != null)
-                {
-                    KeyboardHandlingService.ResetActiveTemplateNodeSelectionState();
-                }
+                KeyboardHandlingService?.ResetActiveTemplateNodeSelectionState();
 
                 try
                 {
@@ -2479,10 +2440,7 @@ namespace System.Windows.Forms.Design
                     Debug.Assert(NewItemTransaction is null, "NewItemTransaction should have been nulled out and cancelled by now.");
                     GetService<IUIService>().ShowError(ex.Message);
 
-                    if (KeyboardHandlingService != null)
-                    {
-                        KeyboardHandlingService.ResetActiveTemplateNodeSelectionState();
-                    }
+                    KeyboardHandlingService?.ResetActiveTemplateNodeSelectionState();
                 }
             }
         }
@@ -2500,10 +2458,7 @@ namespace System.Windows.Forms.Design
 
                 // Get the itemDesigner...
                 ToolStripItemDesigner itemDesigner = (ToolStripItemDesigner)_host.GetDesigner(item);
-                if (itemDesigner != null)
-                {
-                    itemDesigner.SetItemVisible(toolStripSelected, this);
-                }
+                itemDesigner?.SetItemVisible(toolStripSelected, this);
             }
 
             if (FireSyncSelection)

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
@@ -519,15 +519,9 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (invalidateRegion != null)
-                {
-                    invalidateRegion.Dispose();
-                }
+                invalidateRegion?.Dispose();
 
-                if (itemRegion != null)
-                {
-                    itemRegion.Dispose();
-                }
+                itemRegion?.Dispose();
             }
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDropDownDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDropDownDesigner.cs
@@ -147,10 +147,7 @@ namespace System.Windows.Forms.Design
                         }
 
                         ToolStripMenuItemDesigner itemDesigner = (ToolStripMenuItemDesigner)host.GetDesigner(menuItem);
-                        if (itemDesigner != null)
-                        {
-                            itemDesigner.InitializeDropDown();
-                        }
+                        itemDesigner?.InitializeDropDown();
                     }
                 }
             }
@@ -208,10 +205,7 @@ namespace System.Windows.Forms.Design
                 if (selComp is ToolStripItem item)
                 {
                     ToolStripItemDesigner itemDesigner = (ToolStripItemDesigner)host.GetDesigner(item);
-                    if (itemDesigner != null)
-                    {
-                        itemDesigner.GetGlyphs(ref glyphs, new ResizeBehavior(item.Site));
-                    }
+                    itemDesigner?.GetGlyphs(ref glyphs, new ResizeBehavior(item.Site));
                 }
             }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripInSituService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripInSituService.cs
@@ -28,10 +28,7 @@ namespace System.Windows.Forms.Design
             _sp = provider;
             _designerHost = (IDesignerHost)provider.GetService(typeof(IDesignerHost));
             Debug.Assert(_designerHost != null, "ToolStripKeyboardHandlingService relies on the selection service, which is unavailable.");
-            if (_designerHost != null)
-            {
-                _designerHost.AddService(typeof(ISupportInSituService), this);
-            }
+            _designerHost?.AddService(typeof(ISupportInSituService), this);
 
             _componentChangeSvc = (IComponentChangeService)_designerHost.GetService(typeof(IComponentChangeService));
             Debug.Assert(_componentChangeSvc != null, "ToolStripKeyboardHandlingService relies on the componentChange service, which is unavailable.");

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemBehavior.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemBehavior.cs
@@ -426,10 +426,7 @@ namespace System.Windows.Forms.Design
                             {
                                 //Invalidate glyph only if we are in ShiftState...
                                 ToolStripDesigner.s_shiftState = false;
-                                if (bSvc != null)
-                                {
-                                    bSvc.Invalidate(glyphItem.Owner.Bounds);
-                                }
+                                bSvc?.Invalidate(glyphItem.Owner.Bounds);
                             }
 
                             selSvc.SetSelectedComponents(new IComponent[] { glyphItem }, SelectionTypes.Auto);
@@ -799,10 +796,7 @@ namespace System.Windows.Forms.Design
 
                         // Refresh on SelectionManager...
                         BehaviorService bSvc = GetBehaviorService(currentDropItem);
-                        if (bSvc != null)
-                        {
-                            bSvc.SyncSelection();
-                        }
+                        bSvc?.SyncSelection();
                     }
                     catch (Exception ex)
                     {
@@ -819,10 +813,7 @@ namespace System.Windows.Forms.Design
                     }
                     finally
                     {
-                        if (designerTransaction != null)
-                        {
-                            designerTransaction.Commit();
-                        }
+                        designerTransaction?.Commit();
                     }
                 }
             }
@@ -947,10 +938,7 @@ namespace System.Windows.Forms.Design
                 ToolStripItem item = sender as ToolStripItem;
                 SetParentDesignerValuesForDragDrop(item, false, Point.Empty);
                 ISelectionService selSvc = GetSelectionService(item);
-                if (selSvc != null)
-                {
-                    selSvc.SetSelectedComponents(new IComponent[] { item }, SelectionTypes.Auto);
-                }
+                selSvc?.SetSelectedComponents(new IComponent[] { item }, SelectionTypes.Auto);
 
                 ToolStripDesigner.s_dragItem = null;
             }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemCustomMenuItemCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemCustomMenuItemCollection.cs
@@ -222,10 +222,7 @@ namespace System.Windows.Forms.Design
 
         private void OnEditItemsMenuItemClick(object sender, EventArgs e)
         {
-            if (verbManager != null)
-            {
-                verbManager.EditItemsVerb.Invoke();
-            }
+            verbManager?.EditItemsVerb.Invoke();
         }
 
         private void OnImageToolStripMenuItemClick(object sender, EventArgs e)
@@ -397,10 +394,7 @@ namespace System.Windows.Forms.Design
                 parent.Items.Insert(dummyIndex, (ToolStripItem)component);
                 // set the selection to our new item.. since we destroyed Original component.. we have to ask SelectionService from new Component
                 ISelectionService selSvc = (ISelectionService)serviceProvider.GetService(typeof(ISelectionService));
-                if (selSvc != null)
-                {
-                    selSvc.SetSelectedComponents(new object[] { component }, SelectionTypes.Replace);
-                }
+                selSvc?.SetSelectedComponents(new object[] { component }, SelectionTypes.Replace);
             }
             catch (Exception ex)
             {
@@ -423,10 +417,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (newItemTransaction != null)
-                {
-                    newItemTransaction.Commit();
-                }
+                newItemTransaction?.Commit();
             }
         }
 
@@ -453,10 +444,7 @@ namespace System.Windows.Forms.Design
                 parent.Items.Insert(dummyIndex, (ToolStripItem)component);
                 // set the selection to our new item.. since we destroyed Original component.. we have to ask SelectionService from new Component
                 ISelectionService selSvc = (ISelectionService)serviceProvider.GetService(typeof(ISelectionService));
-                if (selSvc != null)
-                {
-                    selSvc.SetSelectedComponents(new object[] { component }, SelectionTypes.Replace);
-                }
+                selSvc?.SetSelectedComponents(new object[] { component }, SelectionTypes.Replace);
             }
             catch (Exception ex)
             {
@@ -468,10 +456,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (newItemTransaction != null)
-                {
-                    newItemTransaction.Commit();
-                }
+                newItemTransaction?.Commit();
             }
         }
 
@@ -498,10 +483,7 @@ namespace System.Windows.Forms.Design
                 parent.Items.Insert(dummyIndex, (ToolStripItem)component);
                 // set the selection to our new item.. since we destroyed Original component.. we have to ask SelectionService from new Component
                 ISelectionService selSvc = (ISelectionService)serviceProvider.GetService(typeof(ISelectionService));
-                if (selSvc != null)
-                {
-                    selSvc.SetSelectedComponents(new object[] { component }, SelectionTypes.Replace);
-                }
+                selSvc?.SetSelectedComponents(new object[] { component }, SelectionTypes.Replace);
             }
             catch (Exception ex)
             {
@@ -513,10 +495,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (newItemTransaction != null)
-                {
-                    newItemTransaction.Commit();
-                }
+                newItemTransaction?.Commit();
             }
         }
 
@@ -565,10 +544,7 @@ namespace System.Windows.Forms.Design
                 parent.Items.Insert(dummyIndex, (ToolStripItem)component);
                 // set the selection to our new item.. since we destroyed Original component.. we have to ask SelectionService from new Component
                 ISelectionService selSvc = (ISelectionService)serviceProvider.GetService(typeof(ISelectionService));
-                if (selSvc != null)
-                {
-                    selSvc.SetSelectedComponents(new object[] { component }, SelectionTypes.Replace);
-                }
+                selSvc?.SetSelectedComponents(new object[] { component }, SelectionTypes.Replace);
             }
             catch (Exception ex)
             {
@@ -586,10 +562,7 @@ namespace System.Windows.Forms.Design
 
             finally
             {
-                if (newItemTransaction != null)
-                {
-                    newItemTransaction.Commit();
-                }
+                newItemTransaction?.Commit();
             }
         }
 
@@ -633,10 +606,7 @@ namespace System.Windows.Forms.Design
             Debug.Assert(changingProperty != null, "Could not find given property in control.");
             try
             {
-                if (changingProperty != null)
-                {
-                    changingProperty.SetValue(target, value);
-                }
+                changingProperty?.SetValue(target, value);
             }
             catch (InvalidOperationException ex)
             {

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripItemDesigner.cs
@@ -103,10 +103,7 @@ namespace System.Windows.Forms.Design
                 }
 
                 // Refresh the list on every show..
-                if (toolStripItemCustomMenuItemCollection != null)
-                {
-                    toolStripItemCustomMenuItemCollection.RefreshItems();
-                }
+                toolStripItemCustomMenuItemCollection?.RefreshItems();
 
                 toolStripContextMenu.Populated = false;
                 return toolStripContextMenu;
@@ -353,10 +350,7 @@ namespace System.Windows.Forms.Design
                 commit = false;
 
                 // Select the MenuStrip
-                if (_selectionService != null)
-                {
-                    _selectionService.SetSelectedComponents(new object[] { immediateParent });
-                }
+                _selectionService?.SetSelectedComponents(new object[] { immediateParent });
             }
 
             if (commit)
@@ -404,10 +398,7 @@ namespace System.Windows.Forms.Design
                             designerTransaction = null;
                         }
 
-                        if (selectionManager != null)
-                        {
-                            selectionManager.Refresh();
-                        }
+                        selectionManager?.Refresh();
 
                         if (ClientUtils.IsCriticalException(e))
                         {
@@ -416,10 +407,7 @@ namespace System.Windows.Forms.Design
                     }
                     finally
                     {
-                        if (designerTransaction != null)
-                        {
-                            designerTransaction.Commit();
-                        }
+                        designerTransaction?.Commit();
                     }
                 }
 
@@ -464,10 +452,7 @@ namespace System.Windows.Forms.Design
             }
 
             // used the SelectionManager to Add the glyphs.
-            if (selectionManager != null)
-            {
-                selectionManager.Refresh();
-            }
+            selectionManager?.Refresh();
         }
 
         /// <summary>
@@ -862,17 +847,11 @@ namespace System.Windows.Forms.Design
 
                     PropertyDescriptor dispProperty = TypeDescriptor.GetProperties(newItem)["DisplayStyle"];
                     Debug.Assert(dispProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
-                    if (dispProperty != null)
-                    {
-                        dispProperty.SetValue(newItem, ToolStripItemDisplayStyle.Image);
-                    }
+                    dispProperty?.SetValue(newItem, ToolStripItemDisplayStyle.Image);
 
                     PropertyDescriptor imageTransProperty = TypeDescriptor.GetProperties(newItem)["ImageTransparentColor"];
                     Debug.Assert(imageTransProperty != null, "Could not find 'DisplayStyle' property in ToolStripItem.");
-                    if (imageTransProperty != null)
-                    {
-                        imageTransProperty.SetValue(newItem, Color.Magenta);
-                    }
+                    imageTransProperty?.SetValue(newItem, Color.Magenta);
                 }
 
                 parent.Items.Insert(dummyIndex, newItem);
@@ -908,17 +887,11 @@ namespace System.Windows.Forms.Design
                     }
 
                     BehaviorService windowService = (BehaviorService)newItem.Site.GetService(typeof(BehaviorService));
-                    if (windowService != null)
-                    {
-                        windowService.Invalidate();
-                    }
+                    windowService?.Invalidate();
 
                     // set the selection to our new item.. since we destroyed Original component.. we have to ask SelectionService from new Component
                     ISelectionService selSvc = (ISelectionService)newItem.Site.GetService(typeof(ISelectionService));
-                    if (selSvc != null)
-                    {
-                        selSvc.SetSelectedComponents(new object[] { newItem }, SelectionTypes.Replace);
-                    }
+                    selSvc?.SetSelectedComponents(new object[] { newItem }, SelectionTypes.Replace);
                 }
 
                 return newItem;
@@ -935,10 +908,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (designerTransaction != null)
-                {
-                    designerTransaction.Commit();
-                }
+                designerTransaction?.Commit();
             }
 
             return newItem;
@@ -1031,10 +1001,7 @@ namespace System.Windows.Forms.Design
                         if (parentDropDown.OwnerItem is ToolStripDropDownItem parentItem)
                         {
                             ToolStripMenuItemDesigner parentItemDesigner = (ToolStripMenuItemDesigner)designerHost.GetDesigner(parentItem);
-                            if (parentItemDesigner != null)
-                            {
-                                parentItemDesigner.InitializeDropDown();
-                            }
+                            parentItemDesigner?.InitializeDropDown();
 
                             needRefresh = true;
                         }
@@ -1042,10 +1009,7 @@ namespace System.Windows.Forms.Design
                         {
                             // For ContextMenuStrip, we need use different ways to show the menu.
                             ToolStripDropDownDesigner parentDropDownDesigner = (ToolStripDropDownDesigner)designerHost.GetDesigner(parentDropDown);
-                            if (parentDropDownDesigner != null)
-                            {
-                                parentDropDownDesigner.ShowMenu(currentSelection);
-                            }
+                            parentDropDownDesigner?.ShowMenu(currentSelection);
 
                             needRefresh = true;
                         }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripKeyboardHandlingService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripKeyboardHandlingService.cs
@@ -59,10 +59,7 @@ namespace System.Windows.Forms.Design
 
             _designerHost = (IDesignerHost)_provider.GetService(typeof(IDesignerHost));
             Debug.Assert(_designerHost != null, "ToolStripKeyboardHandlingService relies on the selection service, which is unavailable.");
-            if (_designerHost != null)
-            {
-                _designerHost.AddService(typeof(ToolStripKeyboardHandlingService), this);
-            }
+            _designerHost?.AddService(typeof(ToolStripKeyboardHandlingService), this);
 
             _componentChangeSvc = (IComponentChangeService)_designerHost.GetService(typeof(IComponentChangeService));
             Debug.Assert(_componentChangeSvc != null, "ToolStripKeyboardHandlingService relies on the componentChange service, which is unavailable.");
@@ -602,26 +599,17 @@ namespace System.Windows.Forms.Design
                     parent = item.GetCurrentParent();
                 }
 
-                if (parent != null)
-                {
-                    parent.SuspendLayout();
-                }
+                parent?.SuspendLayout();
 
                 // INVOKE THE OldCommand
-                if (_oldCommandPaste != null)
-                {
-                    _oldCommandPaste.Invoke();
-                }
+                _oldCommandPaste?.Invoke();
 
                 if (parent != null)
                 {
                     parent.ResumeLayout();
                     // Since the Glyphs don't get correct bounds as the ToolStrip Layout is suspended .. force Glyph Updates.
                     BehaviorService behaviorService = (BehaviorService)_provider.GetService(typeof(BehaviorService));
-                    if (behaviorService != null)
-                    {
-                        behaviorService.SyncSelection();
-                    }
+                    behaviorService?.SyncSelection();
 
                     // For ContextMenuStrip; since its not a control .. we don't get called on GetGlyphs directly through the BehaviorService So we need this internal call to push the glyphs on the SelectionManager
                     if (host.GetDesigner(item) is ToolStripItemDesigner designer)
@@ -773,10 +761,7 @@ namespace System.Windows.Forms.Design
 
                     SelectItems(parent);
                     BehaviorService behaviorService = (BehaviorService)_provider.GetService(typeof(BehaviorService));
-                    if (behaviorService != null)
-                    {
-                        behaviorService.Invalidate();
-                    }
+                    behaviorService?.Invalidate();
 
                     return;
                 }
@@ -1147,10 +1132,7 @@ namespace System.Windows.Forms.Design
                 if (behaviorService != null)
                 {
                     DesignerActionUI designerUI = behaviorService.DesignerActionUI;
-                    if (designerUI != null)
-                    {
-                        designerUI.HideDesignerActionPanel();
-                    }
+                    designerUI?.HideDesignerActionPanel();
                 }
 
                 AddCommands();
@@ -1773,10 +1755,7 @@ namespace System.Windows.Forms.Design
                     else if (toolStripItem.IsOnDropDown && toolStripItem.Placement == ToolStripItemPlacement.Overflow)
                     {
                         ToolStrip owner = toolStripItem.Owner;
-                        if (owner != null)
-                        {
-                            owner.OverflowButton.HideDropDown();
-                        }
+                        owner?.OverflowButton.HideDropDown();
 
                         next = toolStripItem.Owner;
                     }
@@ -2157,10 +2136,7 @@ namespace System.Windows.Forms.Design
                     {
                         SelectedDesignerControl = null;
 
-                        if (overFlowButton != null)
-                        {
-                            overFlowButton.ShowDropDown();
-                        }
+                        overFlowButton?.ShowDropDown();
 
                         object newSelection = GetNextItem(overFlowButton.DropDown, null, ArrowDirection.Down);
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripMenuItemDesigner.cs
@@ -384,10 +384,7 @@ namespace System.Windows.Forms.Design
                     //Set the glyph for the item .. so that we can remove it later....
                     dropDownItemDesigner.bodyGlyph = bodyGlyphForddItem;
                     //Add ItemGlyph to the Collection
-                    if (_toolStripAdornerWindowService != null)
-                    {
-                        _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Insert(0, bodyGlyphForddItem);
-                    }
+                    _toolStripAdornerWindowService?.DropDownAdorner.Glyphs.Insert(0, bodyGlyphForddItem);
                 }
             }
         }
@@ -549,10 +546,7 @@ namespace System.Windows.Forms.Design
                             }
                             finally
                             {
-                                if (designerTransaction != null)
-                                {
-                                    designerTransaction.Commit();
-                                }
+                                designerTransaction?.Commit();
                             }
                         }
                     }
@@ -916,10 +910,7 @@ namespace System.Windows.Forms.Design
             }
             finally
             {
-                if (outerTransaction != null)
-                {
-                    outerTransaction.Commit();
-                }
+                outerTransaction?.Commit();
 
                 // turn on Adding/Added events listened to by the ToolStripDesigner...
                 ToolStripDesigner.s_autoAddNewItems = true;
@@ -977,10 +968,7 @@ namespace System.Windows.Forms.Design
                 if (currentItem != null)
                 {
                     ToolStripMenuItemDesigner itemDesigner = (ToolStripMenuItemDesigner)_designerHost.GetDesigner(currentItem);
-                    if (itemDesigner != null)
-                    {
-                        itemDesigner.Commit();
-                    }
+                    itemDesigner?.Commit();
                 }
             }
         }
@@ -1133,10 +1121,7 @@ namespace System.Windows.Forms.Design
                     rootControlGlyph = new ToolStripDropDownGlyph(rootControl.Bounds, new DropDownBehavior(designer, this));
                 }
 
-                if (_toolStripAdornerWindowService != null)
-                {
-                    _toolStripAdornerWindowService.DropDownAdorner.Glyphs.Add(rootControlGlyph);
-                }
+                _toolStripAdornerWindowService?.DropDownAdorner.Glyphs.Add(rootControlGlyph);
             }
         }
 
@@ -1165,10 +1150,7 @@ namespace System.Windows.Forms.Design
                     //Get Designer ... and call Remove on that Designer.
                     RemoveTypeHereNode(ddi);
                 }
-                else if (_toolStripAdornerWindowService != null)
-                {
-                    _toolStripAdornerWindowService.Invalidate(ddi.DropDown.Bounds);
-                }
+                else _toolStripAdornerWindowService?.Invalidate(ddi.DropDown.Bounds);
             }
         }
 
@@ -1371,10 +1353,7 @@ namespace System.Windows.Forms.Design
             toolItem.Visible = false;
             MenuItem.DropDown.ResumeLayout();
             // Try Focusing the TextBox....
-            if (commitedTemplateNode != null)
-            {
-                commitedTemplateNode.FocusEditor(toolItem);
-            }
+            commitedTemplateNode?.FocusEditor(toolItem);
 
             ToolStripDropDownItem dropDownItem = toolItem as ToolStripDropDownItem;
             if (!(dropDownItem.Owner is ToolStripDropDownMenu) && dropDownItem != null && dropDownItem.Bounds.Width < commitedEditorNode.Bounds.Width)
@@ -1662,10 +1641,7 @@ namespace System.Windows.Forms.Design
             ToolStripAdornerWindowService toolStripService = _toolStripAdornerWindowService;
             ToolStripItem newItem = base.MorphCurrentItem(t);
             // We loose the ToolStripWindowService after Morphing... so use the cached one.
-            if (toolStripService != null)
-            {
-                toolStripService.Invalidate(boundstoInvalidate);
-            }
+            toolStripService?.Invalidate(boundstoInvalidate);
 
             return newItem;
         }
@@ -1775,10 +1751,7 @@ namespace System.Windows.Forms.Design
                     // If the Item is added through Undo/Redo ONLY then select the item
                     if (undoingCalled)
                     {
-                        if (_selectionService != null)
-                        {
-                            _selectionService.SetSelectedComponents(new IComponent[] { newItem }, SelectionTypes.Replace);
-                        }
+                        _selectionService?.SetSelectedComponents(new IComponent[] { newItem }, SelectionTypes.Replace);
                     }
 
                     ResetGlyphs(MenuItem);
@@ -2338,10 +2311,7 @@ namespace System.Windows.Forms.Design
                 typeHereNode = null;
             }
 
-            if (_toolStripAdornerWindowService != null)
-            {
-                _toolStripAdornerWindowService.Invalidate(bounds);
-            }
+            _toolStripAdornerWindowService?.Invalidate(bounds);
         }
 
         /// <summary>
@@ -2578,10 +2548,7 @@ namespace System.Windows.Forms.Design
                 {
                     // ContextMenuStrip does not have an owner item, and need be shown with different method
                     ToolStripDropDownDesigner dropDownDesigner = (ToolStripDropDownDesigner)_designerHost.GetDesigner(currentDropDown);
-                    if (dropDownDesigner != null)
-                    {
-                        dropDownDesigner.ShowMenu(null);
-                    }
+                    dropDownDesigner?.ShowMenu(null);
                 }
             }
         }
@@ -2800,10 +2767,7 @@ namespace System.Windows.Forms.Design
 
                             // Refresh the BehaviorService.
                             BehaviorService bSvc = (BehaviorService)primaryItem.Site.GetService(typeof(BehaviorService));
-                            if (bSvc != null)
-                            {
-                                bSvc.SyncSelection();
-                            }
+                            bSvc?.SyncSelection();
                         }
                         catch
                         {
@@ -2815,10 +2779,7 @@ namespace System.Windows.Forms.Design
                         }
                         finally
                         {
-                            if (changeParent != null)
-                            {
-                                changeParent.Commit();
-                            }
+                            changeParent?.Commit();
                         }
                     }
                 }

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripTemplateNode.cs
@@ -193,10 +193,7 @@ namespace System.Windows.Forms.Design
 
                         // Listen to command and key events
                         IEventHandlerService ehs = (IEventHandlerService)_component.Site.GetService(typeof(IEventHandlerService));
-                        if (ehs != null)
-                        {
-                            ehs.PushHandler(this);
-                        }
+                        ehs?.PushHandler(this);
                     }
                     else
                     {
@@ -227,10 +224,7 @@ namespace System.Windows.Forms.Design
 
                         // Stop listening to command and key events
                         IEventHandlerService ehs = (IEventHandlerService)_component.Site.GetService(typeof(IEventHandlerService));
-                        if (ehs != null)
-                        {
-                            ehs.PopHandler(this);
-                        }
+                        ehs?.PopHandler(this);
                     }
                 }
             }
@@ -836,10 +830,7 @@ namespace System.Windows.Forms.Design
                         Region rgn = new Region(invalidateBounds);
                         invalidateBounds.Inflate(-GLYPHINSET, -GLYPHINSET);
                         rgn.Exclude(invalidateBounds);
-                        if (BehaviorService != null)
-                        {
-                            BehaviorService.Invalidate(rgn);
-                        }
+                        BehaviorService?.Invalidate(rgn);
 
                         rgn.Dispose();
                     }
@@ -855,10 +846,7 @@ namespace System.Windows.Forms.Design
             if (!_inSituMode)
             {
                 // Listen For Commands....
-                if (_miniToolStrip.Parent != null)
-                {
-                    _miniToolStrip.Parent.SuspendLayout();
-                }
+                _miniToolStrip.Parent?.SuspendLayout();
 
                 try
                 {
@@ -919,10 +907,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (_miniToolStrip.Parent != null)
-                    {
-                        _miniToolStrip.Parent.ResumeLayout();
-                    }
+                    _miniToolStrip.Parent?.ResumeLayout();
                 }
             }
         }
@@ -935,10 +920,7 @@ namespace System.Windows.Forms.Design
             // put the ToolStripTemplateNode back into "non edit state"
             if (_centerTextBox != null && _inSituMode)
             {
-                if (_miniToolStrip.Parent != null)
-                {
-                    _miniToolStrip.Parent.SuspendLayout();
-                }
+                _miniToolStrip.Parent?.SuspendLayout();
 
                 try
                 {
@@ -965,10 +947,7 @@ namespace System.Windows.Forms.Design
                 }
                 finally
                 {
-                    if (_miniToolStrip.Parent != null)
-                    {
-                        _miniToolStrip.Parent.ResumeLayout();
-                    }
+                    _miniToolStrip.Parent?.ResumeLayout();
 
                     // POP of the Handler !!!
                     Active = false;
@@ -1078,10 +1057,7 @@ namespace System.Windows.Forms.Design
             {
                 case Keys.Up:
                     Commit(false, true);
-                    if (KeyboardService != null)
-                    {
-                        KeyboardService.ProcessUpDown(false);
-                    }
+                    KeyboardService?.ProcessUpDown(false);
 
                     break;
                 case Keys.Down:
@@ -1640,10 +1616,7 @@ namespace System.Windows.Forms.Design
             private void CommitAndSelectNext(bool forward)
             {
                 owner.Commit(false, true);
-                if (owner.KeyboardService != null)
-                {
-                    owner.KeyboardService.ProcessKeySelect(!forward, null);
-                }
+                owner.KeyboardService?.ProcessKeySelect(!forward, null);
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -425,10 +425,7 @@ namespace System.Windows.Forms
                 try
                 {
                     IMsoComponentManager cm = ComponentManager;
-                    if (cm is not null)
-                    {
-                        cm.OnComponentEnterState(_componentID, msocstate.Modal, msoccontext.All, 0, null, 0);
-                    }
+                    cm?.OnComponentEnterState(_componentID, msocstate.Modal, msoccontext.All, 0, null, 0);
                 }
                 finally
                 {
@@ -654,10 +651,7 @@ namespace System.Windows.Forms
                 {
                     // If We started the ModalMessageLoop .. this will call us back on the IMSOComponent.OnStateEnter and not do anything ...
                     IMsoComponentManager cm = ComponentManager;
-                    if (cm is not null)
-                    {
-                        cm.FOnComponentExitState(_componentID, msocstate.Modal, msoccontext.All, 0, null);
-                    }
+                    cm?.FOnComponentExitState(_componentID, msocstate.Modal, msoccontext.All, 0, null);
                 }
                 finally
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadWindows.cs
@@ -79,10 +79,7 @@ namespace System.Windows.Forms
                     if (PInvoke.IsWindow(hWnd))
                     {
                         Control c = Control.FromHandle(hWnd);
-                        if (c is not null)
-                        {
-                            c.Dispose();
-                        }
+                        c?.Dispose();
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.cs
@@ -1114,10 +1114,7 @@ namespace System.Windows.Forms
         internal static void UnparkHandle(IHandle<HWND> handle, DPI_AWARENESS_CONTEXT context)
         {
             ThreadContext threadContext = GetContextForHandle(handle);
-            if (threadContext is not null)
-            {
-                threadContext.GetParkingWindow(context).UnparkHandle(handle);
-            }
+            threadContext?.GetParkingWindow(context).UnparkHandle(handle);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyTypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyTypeEditor.cs
@@ -37,10 +37,7 @@ namespace System.Windows.Forms
                 catch (Exception ex)
                 {
                     IUIService? uiSvc = (IUIService?)provider?.GetService(typeof(IUIService));
-                    if (uiSvc is not null)
-                    {
-                        uiSvc.ShowError(ex, SR.ErrorTypeConverterFailed);
-                    }
+                    uiSvc?.ShowError(ex, SR.ErrorTypeConverterFailed);
                 }
 
                 return value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -2820,10 +2820,7 @@ namespace System.Windows.Forms
                         }
                         else
                         {
-                            if (axPropDesc is not null)
-                            {
-                                axPropDesc.UpdateAttributes();
-                            }
+                            axPropDesc?.UpdateAttributes();
 
                             returnProperties.Add(propDesc);
                         }
@@ -3336,10 +3333,7 @@ namespace System.Windows.Forms
                     ((Ole32.IPropertyNotifySink)_oleSite).OnChanged(Ole32.DispatchID.UNKNOWN);
                 }
 
-                if (trans is not null)
-                {
-                    trans.Commit();
-                }
+                trans?.Commit();
 
                 if (uuids.pElems is not null)
                 {
@@ -3729,15 +3723,9 @@ namespace System.Windows.Forms
             if (disposing)
             {
                 TransitionDownTo(OC_PASSIVE);
-                if (_newParent is not null)
-                {
-                    _newParent.Dispose();
-                }
+                _newParent?.Dispose();
 
-                if (_oleSite is not null)
-                {
-                    _oleSite.Dispose();
-                }
+                _oleSite?.Dispose();
             }
 
             base.Dispose(disposing);
@@ -3750,10 +3738,7 @@ namespace System.Windows.Forms
 
         private void DisposeAxControl()
         {
-            if (GetParentContainer() is not null)
-            {
-                GetParentContainer().RemoveControl(this);
-            }
+            GetParentContainer()?.RemoveControl(this);
 
             TransitionDownTo(OC_RUNNING);
             if (GetOcState() == OC_RUNNING)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingContext.cs
@@ -401,10 +401,7 @@ namespace System.Windows.Forms
             ArgumentNullException.ThrowIfNull(binding);
 
             BindingManagerBase oldManager = binding.BindingManagerBase;
-            if (oldManager is not null)
-            {
-                oldManager.Bindings.Remove(binding);
-            }
+            oldManager?.Bindings.Remove(binding);
 
             if (newBindingContext is not null)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonBase.cs
@@ -964,10 +964,7 @@ namespace System.Windows.Forms
         protected override void OnMouseLeave(EventArgs eventargs)
         {
             SetFlag(FlagMouseOver, false);
-            if (_textToolTip is not null)
-            {
-                _textToolTip.Hide(this);
-            }
+            _textToolTip?.Hide(this);
 
             Invalidate();
             // call base last, so if it invokes any listeners that disable the button, we

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -836,10 +836,7 @@ namespace System.Windows.Forms
             {
                 AccessibleObject? checkedItem = AccessibilityObject.GetChild(ice.Index);
 
-                if (checkedItem is not null)
-                {
-                    checkedItem.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.ToggleToggleStatePropertyId, ice.CurrentValue, ice.NewValue);
-                }
+                checkedItem?.RaiseAutomationPropertyChangedEvent(UiaCore.UIA.ToggleToggleStatePropertyId, ice.CurrentValue, ice.NewValue);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ColumnHeader.cs
@@ -323,10 +323,7 @@ namespace System.Windows.Forms
                     _text = value;
                 }
 
-                if (ListView is not null)
-                {
-                    ListView.SetColumnInfo(LVCF.TEXT, this);
-                }
+                ListView?.SetColumnInfo(LVCF.TEXT, this);
             }
         }
 
@@ -423,10 +420,7 @@ namespace System.Windows.Forms
             set
             {
                 _width = value;
-                if (ListView is not null)
-                {
-                    ListView.SetColumnWidth(Index, ColumnHeaderAutoResizeStyle.None);
-                }
+                ListView?.SetColumnWidth(Index, ColumnHeaderAutoResizeStyle.None);
             }
         }
 
@@ -437,10 +431,7 @@ namespace System.Windows.Forms
                 throw new InvalidEnumArgumentException(nameof(headerAutoResize), (int)headerAutoResize, typeof(ColumnHeaderAutoResizeStyle));
             }
 
-            if (ListView is not null)
-            {
-                ListView.AutoResizeColumn(Index, headerAutoResize);
-            }
+            ListView?.AutoResizeColumn(Index, headerAutoResize);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -1992,10 +1992,7 @@ namespace System.Windows.Forms
                 //childwindow could be null if the handle was recreated while within a message handler
                 // and then whoever recreated the handle allowed the message to continue to be processed
                 //we cannot really be sure the new child will properly handle this window message, so we eat it.
-                if (childWindow is not null)
-                {
-                    childWindow.DefWndProc(ref m);
-                }
+                childWindow?.DefWndProc(ref m);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedUITypeEditor.cs
@@ -79,10 +79,7 @@ namespace System.Drawing.Design
         /// </summary>
         public override void PaintValue(PaintValueEventArgs e)
         {
-            if (_innerEditor is not null)
-            {
-                _innerEditor.PaintValue(e);
-            }
+            _innerEditor?.PaintValue(e);
 
             base.PaintValue(e);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyPageUITypeConverter.cs
@@ -57,10 +57,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             catch (Exception ex)
             {
                 IUIService? uiSvc = (IUIService?)provider?.GetService(typeof(IUIService));
-                if (uiSvc is not null)
-                {
-                    uiSvc.ShowError(ex, SR.ErrorTypeConverterFailed);
-                }
+                uiSvc?.ShowError(ex, SR.ErrorTypeConverterFailed);
             }
 
             return value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -495,10 +495,7 @@ namespace System.Windows.Forms
                 if (cc is not null && cc.ActiveControl == this)
                 {
                     Form? f = FindForm();
-                    if (f is not null)
-                    {
-                        f.SelectNextControl(this, true, true, true, true);
-                    }
+                    f?.SelectNextControl(this, true, true, true, true);
                 }
             }
 
@@ -568,10 +565,7 @@ namespace System.Windows.Forms
                 if (_activeControl == value)
                 {
                     Form? form = FindForm();
-                    if (form is not null)
-                    {
-                        form.UpdateDefaultButton();
-                    }
+                    form?.UpdateDefaultButton();
                 }
             }
             else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -276,10 +276,7 @@ namespace System.Windows.Forms
                      dwSaveOption == OLECLOSE.PROMPTSAVE) &&
                     _activeXState[s_isDirty])
                 {
-                    if (_clientSite is not null)
-                    {
-                        _clientSite.SaveObject();
-                    }
+                    _clientSite?.SaveObject();
 
                     SendOnSave();
                 }
@@ -928,10 +925,7 @@ namespace System.Windows.Forms
                     // set ourselves up in the host.
                     Debug.Assert(_inPlaceFrame is not null, "Setting us to visible should have created the in place frame");
                     _inPlaceFrame.SetActiveObject(_control, null);
-                    if (_inPlaceUiWindow is not null)
-                    {
-                        _inPlaceUiWindow.SetActiveObject(_control, null);
-                    }
+                    _inPlaceUiWindow?.SetActiveObject(_control, null);
 
                     // we have to explicitly say we don't wany any border space.
                     HRESULT hr = _inPlaceFrame.SetBorderSpace(null);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ControlCollection.cs
@@ -70,10 +70,7 @@ namespace System.Windows.Forms
                 }
 
                 // Remove the new control from its old parent (if any)
-                if (value._parent is not null)
-                {
-                    value._parent.Controls.Remove(value);
-                }
+                value._parent?.Controls.Remove(value);
 
                 // Add the control
                 InnerList.Add(value);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ThreadMethodEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ThreadMethodEntry.cs
@@ -45,10 +45,7 @@ namespace System.Windows.Forms
 
             ~ThreadMethodEntry()
             {
-                if (_resetEvent is not null)
-                {
-                    _resetEvent.Close();
-                }
+                _resetEvent?.Close();
             }
 
             public object? AsyncState
@@ -106,10 +103,7 @@ namespace System.Windows.Forms
                 lock (_invokeSyncObject)
                 {
                     IsCompleted = true;
-                    if (_resetEvent is not null)
-                    {
-                        _resetEvent.Set();
-                    }
+                    _resetEvent?.Set();
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -360,12 +360,12 @@ namespace System.Windows.Forms
         /*
         example usage
 
-        #if DEBUG
+#if DEBUG
                 int dbgLayoutCheck = LayoutSuspendCount;
-        #endif
-        #if DEBUG
+#endif
+#if DEBUG
                 AssertLayoutSuspendCount(dbgLayoutCheck);
-        #endif
+#endif
         */
 #endif
 
@@ -920,7 +920,7 @@ namespace System.Windows.Forms
                 {
                     return Properties.GetObject(s_dataContextProperty);
                 }
-                
+
                 return ParentInternal?.DataContext;
             }
             set
@@ -929,7 +929,7 @@ namespace System.Windows.Forms
                 {
                     return;
                 }
-                
+
                 // When DataContext was different than its parent before, but now it is about to become the same,
                 // we're removing it altogether, so it can inherit the value from its parent.
                 if (Properties.ContainsObject(s_dataContextProperty) && Equals(ParentInternal?.DataContext, value))
@@ -1136,10 +1136,7 @@ namespace System.Windows.Forms
         public void ResetBindings()
         {
             ControlBindingsCollection? bindings = (ControlBindingsCollection?)Properties.GetObject(s_bindingsProperty);
-            if (bindings is not null)
-            {
-                bindings.Clear();
-            }
+            bindings?.Clear();
         }
 
         /// <summary>
@@ -3059,10 +3056,8 @@ namespace System.Windows.Forms
                 {
                     value.Controls.Add(this);
                 }
-                else if (_parent is not null)
-                {
-                    _parent.Controls.Remove(this);
-                }
+                else
+                    _parent?.Controls.Remove(this);
             }
         }
 
@@ -3123,10 +3118,7 @@ namespace System.Windows.Forms
             get => _reflectParent;
             set
             {
-                if (value is not null)
-                {
-                    value.AddReflectChild();
-                }
+                value?.AddReflectChild();
 
                 Control? existing = _reflectParent as Control;
                 _reflectParent = value;
@@ -4716,10 +4708,7 @@ namespace System.Windows.Forms
             }
 
             SetState(States.CheckedHost, false);
-            if (ParentInternal is not null)
-            {
-                ParentInternal.LayoutEngine.InitLayout(this, BoundsSpecified.All);
-            }
+            ParentInternal?.LayoutEngine.InitLayout(this, BoundsSpecified.All);
         }
 
         [SRCategory(nameof(SR.CatPropertyChanged))]
@@ -4899,10 +4888,7 @@ namespace System.Windows.Forms
                 ActiveXOnFocus(true);
             }
 
-            if (_parent is not null)
-            {
-                _parent.ChildGotFocus(child);
-            }
+            _parent?.ChildGotFocus(child);
         }
 
         /// <summary>
@@ -5258,10 +5244,7 @@ namespace System.Windows.Forms
                         DestroyHandle();
                     }
 
-                    if (_parent is not null)
-                    {
-                        _parent.Controls.Remove(this);
-                    }
+                    _parent?.Controls.Remove(this);
 
                     ControlCollection? controlsCollection = (ControlCollection?)Properties.GetObject(s_controlsCollectionProperty);
 
@@ -5293,10 +5276,7 @@ namespace System.Windows.Forms
             {
                 // This same post is done in NativeWindow's finalize method, so if you change
                 // it, change it there too.
-                if (_window is not null)
-                {
-                    _window.ForceExitMessageLoop();
-                }
+                _window?.ForceExitMessageLoop();
 
                 base.Dispose(disposing);
             }
@@ -7220,10 +7200,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected void InvokeOnClick(Control toInvoke, EventArgs e)
         {
-            if (toInvoke is not null)
-            {
-                toInvoke.OnClick(e);
-            }
+            toInvoke?.OnClick(e);
         }
 
         protected virtual void OnAutoSizeChanged(EventArgs e)
@@ -7362,10 +7339,7 @@ namespace System.Windows.Forms
         /// </summary>
         internal virtual void OnChildLayoutResuming(Control child, bool performLayout)
         {
-            if (ParentInternal is not null)
-            {
-                ParentInternal.OnChildLayoutResuming(child, performLayout);
-            }
+            ParentInternal?.OnChildLayoutResuming(child, performLayout);
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
@@ -8295,10 +8269,7 @@ namespace System.Windows.Forms
                 ActiveXOnFocus(true);
             }
 
-            if (_parent is not null)
-            {
-                _parent.ChildGotFocus(this);
-            }
+            _parent?.ChildGotFocus(this);
 
             ((EventHandler)Events[s_gotFocusEvent])?.Invoke(this, e);
         }
@@ -10944,14 +10915,9 @@ namespace System.Windows.Forms
             // to update the layout engine's state with the new control bounds.
 #if DEBUG
             int suspendCount = -44371;      // Arbitrary negative prime to surface bugs.
+            suspendCount = ParentInternal is not null ? ParentInternal.LayoutSuspendCount : suspendCount;
 #endif
-            if (ParentInternal is not null)
-            {
-#if DEBUG
-                suspendCount = ParentInternal.LayoutSuspendCount;
-#endif
-                ParentInternal.SuspendLayout();
-            }
+            ParentInternal?.SuspendLayout();
 
             try
             {
@@ -10989,7 +10955,7 @@ namespace System.Windows.Forms
 
                             // Give a chance for derived controls to do what they want, just before we resize.
                             OnBoundsUpdate(x, y, width, height);
-                            
+
                             PInvoke.SetWindowPos(this, HWND.Null, x, y, width, height, flags);
 
                             // NOTE: SetWindowPos causes a WM_WINDOWPOSCHANGED which is processed
@@ -11112,10 +11078,7 @@ namespace System.Windows.Forms
                                 throw new Win32Exception(Marshal.GetLastWin32Error(), SR.Win32SetParentFailed);
                             }
 
-                            if (_parent is not null)
-                            {
-                                _parent.UpdateChildZOrder(this);
-                            }
+                            _parent?.UpdateChildZOrder(this);
 
                             Application.UnparkHandle(this, _window.DpiAwarenessContext);
                         }
@@ -11847,10 +11810,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected void UpdateZOrder()
         {
-            if (_parent is not null)
-            {
-                _parent.UpdateChildZOrder(this);
-            }
+            _parent?.UpdateChildZOrder(this);
         }
 
         /// <summary>
@@ -12278,10 +12238,7 @@ namespace System.Windows.Forms
         {
             DefWndProc(ref m);
 
-            if (_parent is not null)
-            {
-                _parent.UpdateChildZOrder(this);
-            }
+            _parent?.UpdateChildZOrder(this);
 
             UpdateBounds();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -13765,10 +13765,7 @@ namespace System.Windows.Forms
             _dataGridViewState2[State2_RaiseSelectionChanged] = _selectedBandIndexes.Count > 0 ||
                                                                                 _individualSelectedCells.Count > 0;
             _selectedBandIndexes.Clear();
-            if (_selectedBandSnapshotIndexes is not null)
-            {
-                _selectedBandSnapshotIndexes.Clear();
-            }
+            _selectedBandSnapshotIndexes?.Clear();
 
             _individualSelectedCells.Clear();
             _individualReadOnlyCells.Clear();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCell.cs
@@ -159,10 +159,7 @@ namespace System.Windows.Forms
                         value.Disposed += disposedHandler;
                     }
 
-                    if (DataGridView is not null)
-                    {
-                        DataGridView.OnCellContextMenuStripChanged(this);
-                    }
+                    DataGridView?.OnCellContextMenuStripChanged(this);
                 }
             }
         }
@@ -704,10 +701,7 @@ namespace System.Windows.Forms
                     State &= ~DataGridViewElementStates.Selected;
                 }
 
-                if (DataGridView is not null)
-                {
-                    DataGridView.OnDataGridViewElementStateChanged(this, -1, DataGridViewElementStates.Selected);
-                }
+                DataGridView?.OnDataGridViewElementStateChanged(this, -1, DataGridViewElementStates.Selected);
             }
         }
 
@@ -769,10 +763,7 @@ namespace System.Windows.Forms
 
                 if (value is not null || Properties.ContainsObject(s_propCellStyle))
                 {
-                    if (value is not null)
-                    {
-                        value.AddScope(DataGridView, DataGridViewCellStyleScopes.Cell);
-                    }
+                    value?.AddScope(DataGridView, DataGridViewCellStyleScopes.Cell);
 
                     Properties.SetObject(s_propCellStyle, value);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellCollection.cs
@@ -134,10 +134,7 @@ namespace System.Windows.Forms
                     throw new InvalidOperationException(SR.DataGridViewCellCollection_CellAlreadyBelongsToDataGridViewRow);
                 }
 
-                if (_owner.DataGridView is not null)
-                {
-                    _owner.DataGridView.OnReplacingCell(_owner, index);
-                }
+                _owner.DataGridView?.OnReplacingCell(_owner, index);
 
                 DataGridViewCell oldDataGridViewCell = (DataGridViewCell)_items[index];
                 _items[index] = dataGridViewCell;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewColumn.cs
@@ -200,10 +200,7 @@ namespace System.Windows.Forms
                 if (value != _dataPropertyName)
                 {
                     _dataPropertyName = value;
-                    if (DataGridView is not null)
-                    {
-                        DataGridView.OnColumnDataPropertyNameChanged(this);
-                    }
+                    DataGridView?.OnColumnDataPropertyNameChanged(this);
                 }
             }
         }
@@ -812,10 +809,7 @@ namespace System.Windows.Forms
                         _flags = (byte)(_flags & ~ProgrammaticSort);
                     }
 
-                    if (DataGridView is not null)
-                    {
-                        DataGridView.OnColumnSortModeChanged(this);
-                    }
+                    DataGridView?.OnColumnSortModeChanged(this);
                 }
             }
         }
@@ -836,10 +830,7 @@ namespace System.Windows.Forms
                 {
                     HeaderCell.ToolTipText = value;
 
-                    if (DataGridView is not null)
-                    {
-                        DataGridView.OnColumnToolTipTextChanged(this);
-                    }
+                    DataGridView?.OnColumnToolTipTextChanged(this);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageColumn.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageColumn.cs
@@ -119,10 +119,7 @@ namespace System.Windows.Forms
             set
             {
                 _icon = value;
-                if (DataGridView is not null)
-                {
-                    DataGridView.OnColumnCommonChange(Index);
-                }
+                DataGridView?.OnColumnCommonChange(Index);
             }
         }
 
@@ -138,10 +135,7 @@ namespace System.Windows.Forms
             set
             {
                 _image = value;
-                if (DataGridView is not null)
-                {
-                    DataGridView.OnColumnCommonChange(Index);
-                }
+                DataGridView?.OnColumnCommonChange(Index);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewRowCollection.cs
@@ -217,10 +217,7 @@ namespace System.Windows.Forms
                         // Simply update the index and return the current row without cloning it.
                         dataGridViewRow.Index = 0;
                         dataGridViewRow.State = SharedRowState(0);
-                        if (DataGridView is not null)
-                        {
-                            DataGridView.OnRowUnshared(dataGridViewRow);
-                        }
+                        DataGridView?.OnRowUnshared(dataGridViewRow);
 
                         return dataGridViewRow;
                     }
@@ -246,10 +243,7 @@ namespace System.Windows.Forms
                         newDataGridViewRow.HeaderCell.OwningRow = newDataGridViewRow;
                     }
 
-                    if (DataGridView is not null)
-                    {
-                        DataGridView.OnRowUnshared(newDataGridViewRow);
-                    }
+                    DataGridView?.OnRowUnshared(newDataGridViewRow);
 
                     return newDataGridViewRow;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.ControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.ControlCollection.cs
@@ -54,10 +54,7 @@ namespace System.Windows.Forms
 
                 base.Add(value);
 
-                if (_owner._ctlClient is not null)
-                {
-                    _owner._ctlClient.SendToBack();
-                }
+                _owner._ctlClient?.SendToBack();
             }
 
             /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -1817,17 +1817,11 @@ namespace System.Windows.Forms
 
                 Properties.SetObject(PropOwner, null);
 
-                if (ownerOld is not null)
-                {
-                    ownerOld.RemoveOwnedForm(this);
-                }
+                ownerOld?.RemoveOwnedForm(this);
 
                 Properties.SetObject(PropOwner, value);
 
-                if (value is not null)
-                {
-                    value.AddOwnedForm(this);
-                }
+                value?.AddOwnedForm(this);
 
                 UpdateHandleWithOwner();
             }
@@ -3166,10 +3160,7 @@ namespace System.Windows.Forms
             // child is created maximized, the menu ends up with two sets of
             // MDI child ornaments.
             Form? form = (Form?)Properties.GetObject(PropFormMdiParent);
-            if (form is not null)
-            {
-                form.SuspendUpdateMenuHandles();
-            }
+            form?.SuspendUpdateMenuHandles();
 
             try
             {
@@ -3248,10 +3239,7 @@ namespace System.Windows.Forms
             }
             finally
             {
-                if (form is not null)
-                {
-                    form.ResumeUpdateMenuHandles();
-                }
+                form?.ResumeUpdateMenuHandles();
 
                 // We need to reset the styles in case Windows tries to set us up
                 // with "correct" styles
@@ -4901,10 +4889,7 @@ namespace System.Windows.Forms
 
                 foreach (Control control in Controls)
                 {
-                    if (control is not null)
-                    {
-                        control.Scale(x, y);
-                    }
+                    control?.Scale(x, y);
                 }
             }
             finally
@@ -5084,16 +5069,10 @@ namespace System.Windows.Forms
 
             if (defaultButton != button)
             {
-                if (defaultButton is not null)
-                {
-                    defaultButton.NotifyDefault(false);
-                }
+                defaultButton?.NotifyDefault(false);
 
                 Properties.SetObject(PropDefaultButton, button);
-                if (button is not null)
-                {
-                    button.NotifyDefault(true);
-                }
+                button?.NotifyDefault(true);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.HTMLDocumentEvents2.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.HTMLDocumentEvents2.cs
@@ -195,10 +195,7 @@ namespace System.Windows.Forms
 
             private void FireEvent(object key, EventArgs e)
             {
-                if (_parent is not null)
-                {
-                    _parent.DocumentShim.FireEvent(key, e);
-                }
+                _parent?.DocumentShim.FireEvent(key, e);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
@@ -486,19 +486,13 @@ namespace System.Windows.Forms
         public void AttachEventHandler(string eventName, EventHandler eventHandler)
         {
             HtmlDocumentShim shim = DocumentShim;
-            if (shim is not null)
-            {
-                shim.AttachEventHandler(eventName, eventHandler);
-            }
+            shim?.AttachEventHandler(eventName, eventHandler);
         }
 
         public void DetachEventHandler(string eventName, EventHandler eventHandler)
         {
             HtmlDocumentShim shim = DocumentShim;
-            if (shim is not null)
-            {
-                shim.DetachEventHandler(eventName, eventHandler);
-            }
+            shim?.DetachEventHandler(eventName, eventHandler);
         }
 
         public event HtmlElementEventHandler Click

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.HTMLElementEvents2.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.HTMLElementEvents2.cs
@@ -370,10 +370,7 @@ namespace System.Windows.Forms
 
             private void FireEvent(object key, EventArgs e)
             {
-                if (_parent is not null)
-                {
-                    _parent.ElementShim.FireEvent(key, e);
-                }
+                _parent?.ElementShim.FireEvent(key, e);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.HTMLWindowEvents2.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.HTMLWindowEvents2.cs
@@ -78,18 +78,12 @@ namespace System.Windows.Forms
             {
                 HtmlElementEventArgs e = new(_parent.ShimManager, evtObj);
                 FireEvent(HtmlWindow.s_eventUnload, e);
-                if (_parent is not null)
-                {
-                    _parent.WindowShim.OnWindowUnload();
-                }
+                _parent?.WindowShim.OnWindowUnload();
             }
 
             private void FireEvent(object key, EventArgs e)
             {
-                if (_parent is not null)
-                {
-                    _parent.WindowShim.FireEvent(key, e);
-                }
+                _parent?.WindowShim.FireEvent(key, e);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.HtmlWindowShim.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlWindow.HtmlWindowShim.cs
@@ -94,10 +94,7 @@ namespace System.Windows.Forms
 
             public void OnWindowUnload()
             {
-                if (_htmlWindow is not null)
-                {
-                    _htmlWindow.ShimManager.OnWindowUnloaded(_htmlWindow);
-                }
+                _htmlWindow?.ShimManager.OnWindowUnloaded(_htmlWindow);
             }
 
             protected override void Dispose(bool disposing)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ImageList.ImageCollection.cs
@@ -423,10 +423,7 @@ namespace System.Windows.Forms
             public void Clear()
             {
                 AssertInvariant();
-                if (_owner._originals is not null)
-                {
-                    _owner._originals.Clear();
-                }
+                _owner._originals?.Clear();
 
                 _imageInfoCollection.Clear();
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/KeyboardToolTipStateMachine.cs
@@ -297,10 +297,7 @@ namespace System.Windows.Forms
             if (_currentState == SmState.Shown && _currentTool is not null)
             {
                 ToolTip? currentToolTip = _toolToTip[_currentTool];
-                if (currentToolTip is not null)
-                {
-                    currentToolTip.HideToolTip(_currentTool);
-                }
+                currentToolTip?.HideToolTip(_currentTool);
             }
 
             ResetTimer();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/LayoutTransaction.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/LayoutTransaction.cs
@@ -62,6 +62,7 @@ namespace System.Windows.Forms.Layout
 
         public void Dispose()
         {
+#pragma warning disable IDE0031
             if (_controlToLayout is not null)
             {
                 _controlToLayout.ResumeLayout(_resumeLayout);
@@ -70,6 +71,7 @@ namespace System.Windows.Forms.Layout
                 Debug.Assert(_controlToLayout.LayoutSuspendCount == _layoutSuspendCount, "Suspend/Resume layout mismatch!");
 #endif
             }
+#pragma warning restore IDE0031
         }
 
         // This overload should be used when a property has changed that affects preferred size,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.ContainerInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.ContainerInfo.cs
@@ -204,10 +204,7 @@ namespace System.Windows.Forms.Layout
                 set
                 {
                     _rowStyles = value;
-                    if (_rowStyles is not null)
-                    {
-                        _rowStyles.EnsureOwnership(_container);
-                    }
+                    _rowStyles?.EnsureOwnership(_container);
                 }
             }
 
@@ -225,10 +222,7 @@ namespace System.Windows.Forms.Layout
                 set
                 {
                     _colStyles = value;
-                    if (_colStyles is not null)
-                    {
-                        _colStyles.EnsureOwnership(_container);
-                    }
+                    _colStyles?.EnsureOwnership(_container);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/LinkLabel.cs
@@ -728,10 +728,7 @@ namespace System.Windows.Forms
                 {
                     alwaysUnderlined.Dispose();
 
-                    if (created is not null)
-                    {
-                        created.Dispose();
-                    }
+                    created?.Dispose();
                 }
 
                 _textLayoutValid = true;
@@ -863,10 +860,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void InvalidateLinkFonts()
         {
-            if (_linkFont is not null)
-            {
-                _linkFont.Dispose();
-            }
+            _linkFont?.Dispose();
 
             if (_hoverLinkFont is not null && _hoverLinkFont != _linkFont)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.ObjectCollection.cs
@@ -136,11 +136,8 @@ namespace System.Windows.Forms
                         {
                             _owner.NativeInsert(index, item);
                             _owner.UpdateMaxItemWidth(item, false);
-                            if (_owner._selectedItems is not null)
-                            {
-                                // Sorting may throw the LB contents and the selectedItem array out of synch.
-                                _owner._selectedItems.Dirty();
-                            }
+                            // Sorting may throw the LB contents and the selectedItem array out of synch.
+                            _owner._selectedItems?.Dirty();
                         }
                     }
                     else

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.SelectedIndexCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.SelectedIndexCollection.cs
@@ -180,10 +180,7 @@ namespace System.Windows.Forms
 
             public void Clear()
             {
-                if (_owner is not null)
-                {
-                    _owner.ClearSelected();
-                }
+                _owner?.ClearSelected();
             }
 
             public void Add(int index)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.SelectedObjectCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.SelectedObjectCollection.cs
@@ -250,10 +250,7 @@ namespace System.Windows.Forms
 
             public void Clear()
             {
-                if (_owner is not null)
-                {
-                    _owner.ClearSelected();
-                }
+                _owner?.ClearSelected();
             }
 
             public void Add(object value)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -1836,10 +1836,7 @@ namespace System.Windows.Forms
 
                     if (_selectionMode != SelectionMode.None)
                     {
-                        if (_selectedItems is not null)
-                        {
-                            _selectedItems.PushSelectionIntoNativeListBox(i);
-                        }
+                        _selectedItems?.PushSelectionIntoNativeListBox(i);
                     }
                 }
             }
@@ -2394,10 +2391,7 @@ namespace System.Windows.Forms
             switch ((User32.LBN)m.WParamInternal.HIWORD)
             {
                 case User32.LBN.SELCHANGE:
-                    if (_selectedItems is not null)
-                    {
-                        _selectedItems.Dirty();
-                    }
+                    _selectedItems?.Dirty();
 
                     OnSelectedIndexChanged(EventArgs.Empty);
                     break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewNativeItemCollection.cs
@@ -299,10 +299,7 @@ namespace System.Windows.Forms
                     for (int i = 0; i < count; i++)
                     {
                         ListViewItem item = _owner.Items[i];
-                        if (item is not null)
-                        {
-                            item.UnHost(i, true);
-                        }
+                        item?.UnHost(i, true);
                     }
 
                     Debug.Assert(_owner._listViewItems is not null, "listItemsArray is null, but the handle isn't created");

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -2981,10 +2981,7 @@ namespace System.Windows.Forms
                         }
                         else
                         {
-                            if (_odCacheFontHandleWrapper is not null)
-                            {
-                                _odCacheFontHandleWrapper.Dispose();
-                            }
+                            _odCacheFontHandleWrapper?.Dispose();
 
                             _odCacheFontHandleWrapper = new FontHandleWrapper(subItemFont);
                             PInvoke.SelectObject(nmcd->nmcd.hdc, _odCacheFontHandleWrapper.Handle);
@@ -4129,10 +4126,7 @@ namespace System.Windows.Forms
 
                 ArrayList? itemList = (ArrayList?)Properties.GetObject(PropDelayedUpdateItems);
                 Debug.Assert(itemList is not null, "In Begin/EndUpdate with no delayed array!");
-                if (itemList is not null)
-                {
-                    itemList.AddRange(items);
-                }
+                itemList?.AddRange(items);
 
                 // add the list view item to the list view
                 // this way we can retrieve the item's index inside BeginUpdate/EndUpdate

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MenuTimer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MenuTimer.cs
@@ -159,10 +159,7 @@ namespace System.Windows.Forms
                 // we're about to fall off the edge of the toolstrip, something should be selected
                 // at all times while we're InTransition mode - otherwise it looks really funny
                 // to have an auto expanded item
-                if (CurrentItem is not null)
-                {
-                    CurrentItem.Select();
-                }
+                CurrentItem?.Select();
             }
             else
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -627,10 +627,7 @@ namespace System.Windows.Forms
         {
             AsyncOperation temp = _currentAsyncLoadOperation;
             _currentAsyncLoadOperation = null;
-            if (temp is not null)
-            {
-                temp.PostOperationCompleted(_loadCompletedDelegate, new AsyncCompletedEventArgs(error, cancelled, null));
-            }
+            temp?.PostOperationCompleted(_loadCompletedDelegate, new AsyncCompletedEventArgs(error, cancelled, null));
         }
 
         private void LoadCompletedDelegate(object arg)
@@ -732,21 +729,15 @@ namespace System.Windows.Forms
                     if (_contentLength != -1)
                     {
                         int progress = (int)(100 * (((float)_totalBytesRead) / ((float)_contentLength)));
-                        if (_currentAsyncLoadOperation is not null)
-                        {
-                            _currentAsyncLoadOperation.Post(_loadProgressDelegate,
+                        _currentAsyncLoadOperation?.Post(_loadProgressDelegate,
                                     new ProgressChangedEventArgs(progress, null));
-                        }
                     }
                 }
                 else
                 {
                     _tempDownloadStream.Seek(0, SeekOrigin.Begin);
-                    if (_currentAsyncLoadOperation is not null)
-                    {
-                        _currentAsyncLoadOperation.Post(_loadProgressDelegate,
+                    _currentAsyncLoadOperation?.Post(_loadProgressDelegate,
                                     new ProgressChangedEventArgs(100, null));
-                    }
 
                     PostCompleted(null, false);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintControllerWithStatusDialog.cs
@@ -67,10 +67,7 @@ namespace System.Windows.Forms
             }
             catch
             {
-                if (_backgroundThread is not null)
-                {
-                    _backgroundThread.Stop();
-                }
+                _backgroundThread?.Stop();
 
                 throw;
             }
@@ -90,10 +87,7 @@ namespace System.Windows.Forms
         {
             base.OnStartPage(document, e);
 
-            if (_backgroundThread is not null)
-            {
-                _backgroundThread.UpdateLabel();
-            }
+            _backgroundThread?.UpdateLabel();
 
             Graphics? result = _underlyingController.OnStartPage(document, e);
             if (_backgroundThread is not null && _backgroundThread._canceled)
@@ -131,10 +125,7 @@ namespace System.Windows.Forms
                 e.Cancel = true;
             }
 
-            if (_backgroundThread is not null)
-            {
-                _backgroundThread.Stop();
-            }
+            _backgroundThread?.Stop();
 
             base.OnEndPrint(document, e);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintDialog.cs
@@ -564,10 +564,7 @@ namespace System.Windows.Forms
             settings.SetHdevmode(hDevMode);
             settings.SetHdevnames(hDevNames);
 
-            if (pageSettings is not null)
-            {
-                pageSettings.SetHdevmode(hDevMode);
-            }
+            pageSettings?.SetHdevmode(hDevMode);
 
             //Check for Copies == 1 since we might get the Right number of Copies from hdevMode.dmCopies...
             if (settings.Copies == 1)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
@@ -1464,10 +1464,7 @@ namespace System.Windows.Forms
 
         void OnprintToolStripButtonClick(object? sender, EventArgs e)
         {
-            if (_previewControl.Document is not null)
-            {
-                _previewControl.Document.Print();
-            }
+            _previewControl.Document?.Print();
         }
 
         void OnzoomToolStripSplitButtonClick(object? sender, EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -2389,10 +2389,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             if (e.KeyCode == Keys.Return)
             {
                 OnListClick(null, null);
-                if (_selectedGridEntry is not null)
-                {
-                    _selectedGridEntry.OnValueReturnKey();
-                }
+                _selectedGridEntry?.OnValueReturnKey();
             }
 
             OnKeyDown(sender, e);
@@ -5223,10 +5220,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 _dropDownHolder.FocusComponent();
                 return;
             }
-            else if (_currentEditor is not null)
-            {
-                _currentEditor.Focus();
-            }
+            else _currentEditor?.Focus();
 
             return;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.DockPaddingEdgesConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollableControl.DockPaddingEdgesConverter.cs
@@ -206,10 +206,7 @@ namespace System.Windows.Forms
 
             internal void Scale(float dx, float dy)
             {
-                if (_owner is not null)
-                {
-                    _owner.Padding.Scale(dx, dy);
-                }
+                _owner?.Padding.Scale(dx, dy);
             }
 
             public override string ToString() => $"{{Left={Left},Top={Top},Right={Right},Bottom={Bottom}}}";

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1380,10 +1380,7 @@ namespace System.Windows.Forms
         protected override void OnEnter(EventArgs e)
         {
             base.OnEnter(e);
-            if (SelectedTab is not null)
-            {
-                SelectedTab.FireEnter(e);
-            }
+            SelectedTab?.FireEnter(e);
         }
 
         /// <summary>
@@ -1402,10 +1399,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected override void OnLeave(EventArgs e)
         {
-            if (SelectedTab is not null)
-            {
-                SelectedTab.FireLeave(e);
-            }
+            SelectedTab?.FireLeave(e);
 
             base.OnLeave(e);
         }
@@ -1516,10 +1510,7 @@ namespace System.Windows.Forms
             ((TabControlEventHandler)Events[s_selectedEvent])?.Invoke(this, e);
 
             // Raise the enter event for this tab.
-            if (SelectedTab is not null)
-            {
-                SelectedTab.FireEnter(EventArgs.Empty);
-            }
+            SelectedTab?.FireEnter(EventArgs.Empty);
         }
 
         /// <summary>
@@ -1916,10 +1907,7 @@ namespace System.Windows.Forms
                                             c = (IContainerControl)c.ActiveControl;
                                         }
 
-                                        if (c.ActiveControl is not null)
-                                        {
-                                            c.ActiveControl.Focus();
-                                        }
+                                        c.ActiveControl?.Focus();
                                     }
                                 }
                             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ThreadExceptionDialog.cs
@@ -363,17 +363,11 @@ namespace System.Windows.Forms
 
         private void ThreadExceptionDialog_DpiChanged(object? sender, DpiChangedEventArgs e)
         {
-            if (_expandImage is not null)
-            {
-                _expandImage.Dispose();
-            }
+            _expandImage?.Dispose();
 
             _expandImage = DpiHelper.GetBitmapFromIcon(GetType(), DownBitmapName);
 
-            if (_collapseImage is not null)
-            {
-                _collapseImage.Dispose();
-            }
+            _collapseImage?.Dispose();
 
             _collapseImage = DpiHelper.GetBitmapFromIcon(GetType(), UpBitmapName);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2005,10 +2005,7 @@ namespace System.Windows.Forms
             }
             finally
             {
-                if (region is not null)
-                {
-                    region.Dispose();
-                }
+                region?.Dispose();
             }
 
             // fire accessibility
@@ -2041,10 +2038,7 @@ namespace System.Windows.Forms
             if (IsSelectionSuspended)
             {
                 SetToolStripState(STATE_LASTMOUSEDOWNEDITEMCAPTURE, false);
-                if (lastItem is not null)
-                {
-                    lastItem.Invalidate();
-                }
+                lastItem?.Invalidate();
             }
         }
 
@@ -2060,10 +2054,7 @@ namespace System.Windows.Forms
                 try
                 {
                     SuspendLayout();
-                    if (overflow is not null)
-                    {
-                        overflow.SuspendLayout();
-                    }
+                    overflow?.SuspendLayout();
 
                     // if there's a problem in config, don't be a leaker.
                     SetToolStripState(STATE_DISPOSINGITEMS, true);
@@ -2076,21 +2067,12 @@ namespace System.Windows.Forms
                         toolStripPanelCell.Dispose();
                     }
 
-                    if (_cachedItemHdcInfo is not null)
-                    {
-                        _cachedItemHdcInfo.Dispose();
-                    }
+                    _cachedItemHdcInfo?.Dispose();
 
-                    if (_mouseHoverTimer is not null)
-                    {
-                        _mouseHoverTimer.Dispose();
-                    }
+                    _mouseHoverTimer?.Dispose();
 
                     ToolTip toolTip = (ToolTip)Properties.GetObject(ToolStrip.s_propToolTip);
-                    if (toolTip is not null)
-                    {
-                        toolTip.Dispose();
-                    }
+                    toolTip?.Dispose();
 
                     if (!Items.IsReadOnly)
                     {
@@ -2104,15 +2086,9 @@ namespace System.Windows.Forms
                     }
 
                     // clean up items not in the Items list
-                    if (_toolStripGrip is not null)
-                    {
-                        _toolStripGrip.Dispose();
-                    }
+                    _toolStripGrip?.Dispose();
 
-                    if (_toolStripOverflowButton is not null)
-                    {
-                        _toolStripOverflowButton.Dispose();
-                    }
+                    _toolStripOverflowButton?.Dispose();
 
                     // remove the restore focus filter
                     if (_restoreFocusFilter is not null)
@@ -2143,10 +2119,7 @@ namespace System.Windows.Forms
                 finally
                 {
                     ResumeLayout(false);
-                    if (overflow is not null)
-                    {
-                        overflow.ResumeLayout(false);
-                    }
+                    overflow?.ResumeLayout(false);
 
                     SetToolStripState(STATE_DISPOSINGITEMS, false);
                 }
@@ -3485,11 +3458,8 @@ namespace System.Windows.Forms
 
         protected override void OnHandleDestroyed(EventArgs e)
         {
-            if (DropTargetManager is not null)
-            {
-                // Make sure we unregister ourselves as a drop target
-                DropTargetManager.EnsureUnRegistered();
-            }
+            // Make sure we unregister ourselves as a drop target
+            DropTargetManager?.EnsureUnRegistered();
 
             base.OnHandleDestroyed(e);
         }
@@ -3571,10 +3541,7 @@ namespace System.Windows.Forms
             OnLayoutCompleted(EventArgs.Empty);
             Invalidate();
 
-            if (overflow is not null)
-            {
-                overflow.ResumeLayout();
-            }
+            overflow?.ResumeLayout();
         }
 
         protected virtual void OnLayoutCompleted(EventArgs e)
@@ -3903,10 +3870,7 @@ namespace System.Windows.Forms
                     }
                     finally
                     {
-                        if (itemGraphics is not null)
-                        {
-                            itemGraphics.Dispose();
-                        }
+                        itemGraphics?.Dispose();
                     }
                 }
             }
@@ -3941,15 +3905,9 @@ namespace System.Windows.Forms
                     Items[i].OnParentRightToLeftChanged(e);
                 }
 
-                if (_toolStripOverflowButton is not null)
-                {
-                    _toolStripOverflowButton.OnParentRightToLeftChanged(e);
-                }
+                _toolStripOverflowButton?.OnParentRightToLeftChanged(e);
 
-                if (_toolStripGrip is not null)
-                {
-                    _toolStripGrip.OnParentRightToLeftChanged(e);
-                }
+                _toolStripGrip?.OnParentRightToLeftChanged(e);
             }
         }
 
@@ -4065,10 +4023,7 @@ namespace System.Windows.Forms
                     ResetScaling(deviceDpiNew);
 
                     // We need to scale the one Grip per ToolStrip as well (if present).
-                    if (_toolStripGrip is not null)
-                    {
-                        _toolStripGrip.ToolStrip_RescaleConstants(deviceDpiOld, deviceDpiNew);
-                    }
+                    _toolStripGrip?.ToolStrip_RescaleConstants(deviceDpiOld, deviceDpiNew);
 
                     // ToolStripItems are components and have Font property. Components do not receive WM_DPICHANGED messages, nor they have
                     // parent-child relationship with owners and, thus, do not get scaled by parent/Container. For these reasons, they need the font
@@ -4457,10 +4412,7 @@ namespace System.Windows.Forms
 
                 _lastMouseDownedItem = null;
 
-                if (lastInfo is not null)
-                {
-                    lastInfo.Dispose();
-                }
+                lastInfo?.Dispose();
             }
 
             base.SetVisibleCore(visible);
@@ -5028,10 +4980,7 @@ namespace System.Windows.Forms
                 // that point our handle is not actually destroyed so
                 // destroying our parent actually causes a recursive
                 // WM_DESTROY.
-                if (_dropDownOwnerWindow is not null)
-                {
-                    _dropDownOwnerWindow.DestroyHandle();
-                }
+                _dropDownOwnerWindow?.DestroyHandle();
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -699,10 +699,7 @@ namespace System.Windows.Forms
                 // politely remove ourselves from the control collection
                 ReadOnlyControlCollection oldControlCollection
                                 = GetControlCollection(Control.ParentInternal as ToolStrip);
-                if (oldControlCollection is not null)
-                {
-                    oldControlCollection.RemoveInternal(Control);
-                }
+                oldControlCollection?.RemoveInternal(Control);
             }
             else
             {
@@ -818,10 +815,7 @@ namespace System.Windows.Forms
         private void SyncControlParent()
         {
             ReadOnlyControlCollection newControls = GetControlCollection(ParentInternal);
-            if (newControls is not null)
-            {
-                newControls.AddInternal(Control);
-            }
+            newControls?.AddInternal(Control);
         }
 
         protected virtual void OnHostedControlResize(EventArgs e)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDown.cs
@@ -1670,10 +1670,7 @@ namespace System.Windows.Forms
 
                 foreach (Control control in Controls)
                 {
-                    if (control is not null)
-                    {
-                        control.Scale(dx, dy);
-                    }
+                    control?.Scale(dx, dy);
                 }
             }
             finally

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropDownItem.cs
@@ -422,10 +422,7 @@ namespace System.Windows.Forms
         protected override void OnFontChanged(EventArgs e)
         {
             base.OnFontChanged(e);
-            if (dropDown is not null)
-            {
-                dropDown.OnOwnerItemFontChanged(EventArgs.Empty);
-            }
+            dropDown?.OnOwnerItemFontChanged(EventArgs.Empty);
         }
 
         protected override void OnBoundsChanged()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripGrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripGrip.cs
@@ -143,10 +143,7 @@ namespace System.Windows.Forms
         protected override void OnPaint(PaintEventArgs e)
         {
             // all the grip painting should be on the ToolStrip itself.
-            if (ParentInternal is not null)
-            {
-                ParentInternal.OnPaintGrip(e);
-            }
+            ParentInternal?.OnPaintGrip(e);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.ToolStripItemAccessibleObject.cs
@@ -196,10 +196,7 @@ namespace System.Windows.Forms
 
             public override void DoDefaultAction()
             {
-                if (Owner is not null)
-                {
-                    Owner.PerformClick();
-                }
+                Owner?.PerformClick();
             }
 
             public override int GetHelpTopic(out string? fileName)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -889,10 +889,7 @@ namespace System.Windows.Forms
 
         private void EnsureParentDropTargetRegistered()
         {
-            if (ParentInternal is not null)
-            {
-                ParentInternal.DropTargetManager.EnsureRegistered();
-            }
+            ParentInternal?.DropTargetManager.EnsureRegistered();
         }
 
         /// <summary>
@@ -1481,15 +1478,9 @@ namespace System.Windows.Forms
             {
                 if (_owner != value)
                 {
-                    if (_owner is not null)
-                    {
-                        _owner.Items.Remove(this);
-                    }
+                    _owner?.Items.Remove(this);
 
-                    if (value is not null)
-                    {
-                        value.Items.Add(this);
-                    }
+                    value?.Items.Add(this);
                 }
             }
         }
@@ -3649,10 +3640,7 @@ namespace System.Windows.Forms
                 if (Available)
                 {
                     Invalidate();
-                    if (ParentInternal is not null)
-                    {
-                        ParentInternal.NotifySelectionChange(this);
-                    }
+                    ParentInternal?.NotifySelectionChange(this);
 
                     KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(this);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItemCollection.cs
@@ -181,10 +181,7 @@ namespace System.Windows.Forms
             {
                 _owner.SuspendLayout();
                 overflow = _owner.GetOverflow();
-                if (overflow is not null)
-                {
-                    overflow.SuspendLayout();
-                }
+                overflow?.SuspendLayout();
             }
 
             try
@@ -196,10 +193,7 @@ namespace System.Windows.Forms
             }
             finally
             {
-                if (overflow is not null)
-                {
-                    overflow.ResumeLayout(false);
-                }
+                overflow?.ResumeLayout(false);
 
                 if (_owner is not null && !_owner.IsDisposingItems)
                 {
@@ -514,16 +508,10 @@ namespace System.Windows.Forms
             {
                 if (item is not null)
                 {
-                    if (item.Owner is not null)
-                    {
-                        item.Owner.Items.Remove(item);
-                    }
+                    item.Owner?.Items.Remove(item);
 
                     item.SetOwner(_owner);
-                    if (item.Renderer is not null)
-                    {
-                        item.Renderer.InitializeItem(item);
-                    }
+                    item.Renderer?.InitializeItem(item);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripLabel.cs
@@ -228,10 +228,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void InvalidateLinkFonts()
         {
-            if (_linkFont is not null)
-            {
-                _linkFont.Dispose();
-            }
+            _linkFont?.Dispose();
 
             if (_hoverLinkFont is not null && _hoverLinkFont != _linkFont)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.ModalMenuFilter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.ModalMenuFilter.cs
@@ -315,10 +315,7 @@ namespace System.Windows.Forms
                     ExitMenuMode();
 
                     // Make sure we roll selection off  the toplevel toolstrip.
-                    if (activeToolStripDropDown.OwnerItem is not null)
-                    {
-                        activeToolStripDropDown.OwnerItem.Unselect();
-                    }
+                    activeToolStripDropDown.OwnerItem?.Unselect();
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -1062,10 +1062,7 @@ namespace System.Windows.Forms
             Keys shortcut = ShortcutKeys;
             if (shortcut != Keys.None)
             {
-                if (_lastOwner is not null)
-                {
-                    _lastOwner.Shortcuts.Remove(shortcut);
-                }
+                _lastOwner?.Shortcuts.Remove(shortcut);
 
                 if (Owner is not null)
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.ToolStripPanelRowCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.ToolStripPanelRowCollection.cs
@@ -56,10 +56,7 @@ namespace System.Windows.Forms
                 ArgumentNullException.ThrowIfNull(value);
 
                 ToolStripPanel currentOwner = _owner;
-                if (currentOwner is not null)
-                {
-                    currentOwner.SuspendLayout();
-                }
+                currentOwner?.SuspendLayout();
 
                 try
                 {
@@ -70,10 +67,7 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-                    if (currentOwner is not null)
-                    {
-                        currentOwner.ResumeLayout();
-                    }
+                    currentOwner?.ResumeLayout();
                 }
             }
 
@@ -82,10 +76,7 @@ namespace System.Windows.Forms
                 ArgumentNullException.ThrowIfNull(value);
 
                 ToolStripPanel currentOwner = _owner;
-                if (currentOwner is not null)
-                {
-                    currentOwner.SuspendLayout();
-                }
+                currentOwner?.SuspendLayout();
 
                 try
                 {
@@ -97,10 +88,7 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-                    if (currentOwner is not null)
-                    {
-                        currentOwner.ResumeLayout();
-                    }
+                    currentOwner?.ResumeLayout();
                 }
             }
 
@@ -111,10 +99,7 @@ namespace System.Windows.Forms
 
             public virtual void Clear()
             {
-                if (_owner is not null)
-                {
-                    _owner.SuspendLayout();
-                }
+                _owner?.SuspendLayout();
 
                 try
                 {
@@ -125,10 +110,7 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-                    if (_owner is not null)
-                    {
-                        _owner.ResumeLayout();
-                    }
+                    _owner?.ResumeLayout();
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.cs
@@ -737,10 +737,7 @@ namespace System.Windows.Forms
 #endif
             FeedbackRectangle? oldFeedback = feedbackRect;
             feedbackRect = null;
-            if (oldFeedback is not null)
-            {
-                oldFeedback.Dispose();
-            }
+            oldFeedback?.Dispose();
         }
 
         private static FeedbackRectangle? CurrentFeedbackRect
@@ -1006,10 +1003,7 @@ namespace System.Windows.Forms
                 if (changedRow)
                 {
                     Debug.WriteLineIf(s_toolStripPanelDebug.TraceVerbose, string.Format(CultureInfo.CurrentCulture, "\tCalling JoinRow."));
-                    if (currentToolStripPanelRow is not null)
-                    {
-                        currentToolStripPanelRow.LeaveRow(toolStripToDrag);
-                    }
+                    currentToolStripPanelRow?.LeaveRow(toolStripToDrag);
 
                     row.JoinRow(toolStripToDrag, clientLocation);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.cs
@@ -98,10 +98,7 @@ namespace System.Windows.Forms
 
                 ToolStripPanel currentOwner = ToolStripPanel;
 
-                if (currentOwner is not null)
-                {
-                    currentOwner.SuspendLayout();
-                }
+                currentOwner?.SuspendLayout();
 
                 try
                 {
@@ -112,10 +109,7 @@ namespace System.Windows.Forms
                 }
                 finally
                 {
-                    if (currentOwner is not null)
-                    {
-                        currentOwner.ResumeLayout();
-                    }
+                    currentOwner?.ResumeLayout();
                 }
             }
 
@@ -273,10 +267,7 @@ namespace System.Windows.Forms
                     }
                     finally
                     {
-                        if (layoutTransaction is not null)
-                        {
-                            layoutTransaction.Dispose();
-                        }
+                        layoutTransaction?.Dispose();
                     }
                 }
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitStackDragDropHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitStackDragDropHandler.cs
@@ -61,10 +61,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    if (_owner is not null)
-                    {
-                        _owner.ClearInsertionMark();
-                    }
+                    _owner?.ClearInsertionMark();
 
                     e.Effect = DragDropEffects.None;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowser.cs
@@ -1085,10 +1085,7 @@ namespace System.Windows.Forms
         {
             if (disposing)
             {
-                if (htmlShimManager is not null)
-                {
-                    htmlShimManager.Dispose();
-                }
+                htmlShimManager?.Dispose();
 
                 DetachSink();
                 ActiveXSite.Dispose();
@@ -1390,10 +1387,7 @@ namespace System.Windows.Forms
 
                 if (ClientRectangle.Contains(client))
                 {
-                    if (contextMenuStrip is not null)
-                    {
-                        contextMenuStrip.ShowInternal(this, client, keyboardActivated);
-                    }
+                    contextMenuStrip?.ShowInternal(this, client, keyboardActivated);
 
                     return true;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -474,10 +474,7 @@ namespace System.Windows.Forms
                     // up to InPlaceActivate that the ActiveX control grabs our handle).
                     TransitionDownTo(WebBrowserHelper.AXState.Running);
 
-                    if (axWindow is not null)
-                    {
-                        axWindow.ReleaseHandle();
-                    }
+                    axWindow?.ReleaseHandle();
 
                     OnHandleDestroyed(EventArgs.Empty);
                     break;
@@ -835,10 +832,7 @@ namespace System.Windows.Forms
         {
             PInvoke.SetParent(hwnd, this);
 
-            if (axWindow is not null)
-            {
-                axWindow.ReleaseHandle();
-            }
+            axWindow?.ReleaseHandle();
 
             axWindow = new WebBrowserBaseNativeWindow(this);
             axWindow.AssignHandle(hwnd, false);
@@ -991,10 +985,7 @@ namespace System.Windows.Forms
                 //
                 // Remove ourselves from our parent container...
                 WebBrowserContainer parentContainer = GetParentContainer();
-                if (parentContainer is not null)
-                {
-                    parentContainer.RemoveControl(this);
-                }
+                parentContainer?.RemoveControl(this);
 
                 //
                 // Now inform the ActiveX control that it's been un-sited.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
@@ -459,10 +459,7 @@ namespace System.Windows.Forms
             {
                 siteActive = null;
                 ContainerControl parentContainer = parent.FindContainerControlInternal();
-                if (parentContainer is not null)
-                {
-                    parentContainer.SetActiveControl(null);
-                }
+                parentContainer?.SetActiveControl(null);
             }
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DemoConsole/MainForm.cs
@@ -258,15 +258,13 @@ namespace TestConsole
         private void undoToolStripMenuItem_Click(object sender, EventArgs e)
         {
             IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
-            if (null != isurf)
-                isurf.GetUndoEngineExt().Undo();
+            isurf?.GetUndoEngineExt().Undo();
         }
 
         private void redoToolStripMenuItem_Click(object sender, EventArgs e)
         {
             IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
-            if (null != isurf)
-                isurf.GetUndoEngineExt().Redo();
+            isurf?.GetUndoEngineExt().Redo();
         }
 
         private void OnAbout(object sender, EventArgs e)
@@ -278,8 +276,7 @@ namespace TestConsole
         {
             //- find out the DesignSurfaceExt control hosted by the TabPage
             IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
-            if (null != isurf)
-                isurf.SwitchTabOrder();
+            isurf?.SwitchTabOrder();
         }
 
         private void MainForm_Load(object sender, EventArgs e)
@@ -300,8 +297,7 @@ namespace TestConsole
         private void OnMenuClick(object sender, EventArgs e)
         {
             IDesignSurfaceExt isurf = _listOfDesignSurface[tabControl1.SelectedIndex];
-            if (null != isurf)
-                isurf.DoAction((sender as ToolStripMenuItem).Text);
+            isurf?.DoAction((sender as ToolStripMenuItem).Text);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/DesignSurface/DesignSurfaceExt/DesignSurfaceExt.cs
@@ -123,8 +123,7 @@ namespace DesignSurfaceExt
                     PropertyDescriptorCollection pdc = TypeDescriptor.GetProperties(ctrl);
                     //- Sets a PropertyDescriptor to the specific property.
                     PropertyDescriptor pdS = pdc.Find("Size", false);
-                    if (null != pdS)
-                        pdS.SetValue(ihost.RootComponent, controlSize);
+                    pdS?.SetValue(ihost.RootComponent, controlSize);
                 }
                 else if (hostType == typeof(UserControl))
                 {
@@ -134,8 +133,7 @@ namespace DesignSurfaceExt
                     PropertyDescriptorCollection pdc = TypeDescriptor.GetProperties(ctrl);
                     //- Sets a PropertyDescriptor to the specific property.
                     PropertyDescriptor pdS = pdc.Find("Size", false);
-                    if (null != pdS)
-                        pdS.SetValue(ihost.RootComponent, controlSize);
+                    pdS?.SetValue(ihost.RootComponent, controlSize);
                 }
                 else if (hostType == typeof(Component))
                 {
@@ -173,11 +171,9 @@ namespace DesignSurfaceExt
                 PropertyDescriptorCollection pdc = TypeDescriptor.GetProperties(newComp);
                 //- Sets a PropertyDescriptor to the specific property.
                 PropertyDescriptor pdS = pdc.Find("Size", false);
-                if (null != pdS)
-                    pdS.SetValue(newComp, controlSize);
+                pdS?.SetValue(newComp, controlSize);
                 PropertyDescriptor pdL = pdc.Find("Location", false);
-                if (null != pdL)
-                    pdL.SetValue(newComp, controlLocation);
+                pdL?.SetValue(newComp, controlLocation);
                 //-
                 //-
                 //- step.4

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/DragDropTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/DragDropTests.cs
@@ -815,11 +815,9 @@ public class DragDropTests : ControlTestBase
                         }
 
                         // Dispose of the cursors since they are no longer needed.
-                        if (MyNormalCursor != null)
-                            MyNormalCursor.Dispose();
+                        MyNormalCursor?.Dispose();
 
-                        if (MyNoDropCursor != null)
-                            MyNoDropCursor.Dispose();
+                        MyNoDropCursor?.Dispose();
                     }
                 }
             }


### PR DESCRIPTION
Used the build in Analyzer's code fix.
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0031

The analyzer currently is broken and doesn't take into account `#if DEBUG` statements. 
Issue: https://github.com/dotnet/roslyn-analyzers/issues/6197

Related: #7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7902)