### PR TITLE
Start Converting Com Vtbls to Cswin32

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IDropSourceNotifyVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IDropSourceNotifyVtbl.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Windows.Win32.System.Ole;
 
 internal partial class Interop
 {
@@ -13,41 +14,41 @@ internal partial class Interop
         {
             public static IntPtr Create(IntPtr fpQueryInterface, IntPtr fpAddRef, IntPtr fpRelease)
             {
-                IntPtr* vtblRaw = (IntPtr*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IDropSourceNotifyVtbl), IntPtr.Size * 5);
-                vtblRaw[0] = fpQueryInterface;
-                vtblRaw[1] = fpAddRef;
-                vtblRaw[2] = fpRelease;
-                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, HRESULT>)&DragEnterTarget;
-                vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, HRESULT>)&DragLeaveTarget;
+                IDropSourceNotify.Vtbl* vtblRaw = (IDropSourceNotify.Vtbl*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IDropSourceNotifyVtbl), sizeof(IDropSourceNotify.Vtbl));
+                vtblRaw->QueryInterface_1 = (delegate* unmanaged[Stdcall]<IDropSourceNotify*, Guid*, void**, HRESULT>)fpQueryInterface;
+                vtblRaw->AddRef_2 = (delegate* unmanaged[Stdcall]<IDropSourceNotify*, uint>)fpAddRef;
+                vtblRaw->Release_3 = (delegate* unmanaged[Stdcall]<IDropSourceNotify*, uint>)fpRelease;
+                vtblRaw->DragEnterTarget_4 = &DragEnterTarget;
+                vtblRaw->DragLeaveTarget_5 = &DragLeaveTarget;
 
                 return (IntPtr)vtblRaw;
             }
 
-            [UnmanagedCallersOnly]
-            private static HRESULT DragEnterTarget(IntPtr thisPtr, IntPtr hwndTarget)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT DragEnterTarget(IDropSourceNotify* @this, HWND hwndTarget)
             {
                 try
                 {
-                    var instance = ComInterfaceDispatch.GetInstance<Ole32.IDropSourceNotify>((ComInterfaceDispatch*)thisPtr);
+                    var instance = ComInterfaceDispatch.GetInstance<Ole32.IDropSourceNotify>((ComInterfaceDispatch*)@this);
                     return instance.DragEnterTarget(hwndTarget);
                 }
                 catch (Exception ex)
                 {
-                    return (HRESULT)ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static HRESULT DragLeaveTarget(IntPtr thisPtr)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT DragLeaveTarget(IDropSourceNotify* @this)
             {
                 try
                 {
-                    var instance = ComInterfaceDispatch.GetInstance<Ole32.IDropSourceNotify>((ComInterfaceDispatch*)thisPtr);
+                    var instance = ComInterfaceDispatch.GetInstance<Ole32.IDropSourceNotify>((ComInterfaceDispatch*)@this);
                     return instance.DragLeaveTarget();
                 }
                 catch (Exception ex)
                 {
-                    return (HRESULT)ex.HResult;
+                    return ex;
                 }
             }
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumFORMATETCVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumFORMATETCVtbl.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using Com = Windows.Win32.System.Com;
 
 internal partial class Interop
 {
@@ -15,30 +15,30 @@ internal partial class Interop
         {
             public static IntPtr Create(IntPtr fpQueryInterface, IntPtr fpAddRef, IntPtr fpRelease)
             {
-                IntPtr* vtblRaw = (IntPtr*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IEnumFORMATETCVtbl), IntPtr.Size * 7);
-                vtblRaw[0] = fpQueryInterface;
-                vtblRaw[1] = fpAddRef;
-                vtblRaw[2] = fpRelease;
-                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, int, FORMATETC*, int*, int>)&Next;
-                vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, int, int>)&Skip;
-                vtblRaw[5] = (IntPtr)(delegate* unmanaged<IntPtr, int>)&Reset;
-                vtblRaw[6] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr*, int>)&Clone;
+                Com.IEnumFORMATETC.Vtbl* vtblRaw = (Com.IEnumFORMATETC.Vtbl*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IEnumFORMATETCVtbl), sizeof(Com.IEnumFORMATETC.Vtbl));
+                vtblRaw->QueryInterface_1 = (delegate* unmanaged[Stdcall]<Com.IEnumFORMATETC*, Guid*, void**, HRESULT>)fpQueryInterface;
+                vtblRaw->AddRef_2 = (delegate* unmanaged[Stdcall]<Com.IEnumFORMATETC*, uint>)fpAddRef;
+                vtblRaw->Release_3 = (delegate* unmanaged[Stdcall]<Com.IEnumFORMATETC*, uint>)fpRelease;
+                vtblRaw->Next_4 = &Next;
+                vtblRaw->Skip_5 = &Skip;
+                vtblRaw->Reset_6 = &Reset;
+                vtblRaw->Clone_7 = &Clone;
 
                 return (IntPtr)vtblRaw;
             }
 
-            [UnmanagedCallersOnly]
-            private static int Next(IntPtr thisPtr, int celt, FORMATETC* rgelt, int* pceltFetched)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Next(Com.IEnumFORMATETC* @this, uint celt, Com.FORMATETC* rgelt, uint* pceltFetched)
             {
                 try
                 {
-                    IEnumFORMATETC instance = ComInterfaceDispatch.GetInstance<IEnumFORMATETC>((ComInterfaceDispatch*)thisPtr);
+                    IEnumFORMATETC instance = ComInterfaceDispatch.GetInstance<IEnumFORMATETC>((ComInterfaceDispatch*)@this);
                     FORMATETC[] elt = new FORMATETC[celt];
                     int[] celtFetched = new int[1];
 
                     // Eliminate null bang after https://github.com/dotnet/runtime/pull/68537 lands, or 
                     // IEnumFORMATETC annotations would be corrected.
-                    var result = instance.Next(celt, elt, pceltFetched is null ? null! : celtFetched);
+                    var result = instance.Next((int)celt, elt, pceltFetched is null ? null! : celtFetched);
                     for (var i = 0; i < celt; i++)
                     {
                         rgelt[i] = elt[i];
@@ -46,63 +46,59 @@ internal partial class Interop
 
                     if (pceltFetched is not null)
                     {
-                        *pceltFetched = celtFetched[0];
+                        *pceltFetched = (uint)celtFetched[0];
                     }
 
-                    return result;
+                    return (HRESULT)result;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Skip(IntPtr thisPtr, int celt)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Skip(Com.IEnumFORMATETC* @this, uint celt)
             {
-                IEnumFORMATETC instance = ComInterfaceDispatch.GetInstance<IEnumFORMATETC>((ComInterfaceDispatch*)thisPtr);
+                IEnumFORMATETC instance = ComInterfaceDispatch.GetInstance<IEnumFORMATETC>((ComInterfaceDispatch*)@this);
                 try
                 {
-                    return instance.Skip(celt);
+                    return (HRESULT)instance.Skip((int)celt);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Reset(IntPtr thisPtr)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Reset(Com.IEnumFORMATETC* @this)
             {
                 try
                 {
-                    IEnumFORMATETC instance = ComInterfaceDispatch.GetInstance<IEnumFORMATETC>((ComInterfaceDispatch*)thisPtr);
+                    IEnumFORMATETC instance = ComInterfaceDispatch.GetInstance<IEnumFORMATETC>((ComInterfaceDispatch*)@this);
                     instance.Reset();
-                    return S_OK;
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Clone(IntPtr thisPtr, IntPtr* ppenum)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Clone(Com.IEnumFORMATETC* @this, Com.IEnumFORMATETC** ppenum)
             {
                 try
                 {
-                    IEnumFORMATETC instance = ComInterfaceDispatch.GetInstance<IEnumFORMATETC>((ComInterfaceDispatch*)thisPtr);
+                    IEnumFORMATETC instance = ComInterfaceDispatch.GetInstance<IEnumFORMATETC>((ComInterfaceDispatch*)@this);
                     instance.Clone(out var cloned);
-                    *ppenum = WinFormsComWrappers.Instance.GetComPointer(cloned, IID.IEnumFORMATETC);
-                    return S_OK;
+                    *ppenum = (Com.IEnumFORMATETC*)WinFormsComWrappers.Instance.GetComPointer(cloned, IID.IEnumFORMATETC);
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumStringVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumStringVtbl.cs
@@ -2,10 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using Com = Windows.Win32.System.Com;
 
 internal partial class Interop
 {
@@ -15,85 +15,81 @@ internal partial class Interop
         {
             public static IntPtr Create(IntPtr fpQueryInterface, IntPtr fpAddRef, IntPtr fpRelease)
             {
-                IntPtr* vtblRaw = (IntPtr*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IEnumStringVtbl), IntPtr.Size * 7);
-                vtblRaw[0] = fpQueryInterface;
-                vtblRaw[1] = fpAddRef;
-                vtblRaw[2] = fpRelease;
-                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, int, IntPtr*, int*, int>)&Next;
-                vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, int, int>)&Skip;
-                vtblRaw[5] = (IntPtr)(delegate* unmanaged<IntPtr, int>)&Reset;
-                vtblRaw[6] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr*, int>)&Clone;
+                Com.IEnumString.Vtbl* vtblRaw = (Com.IEnumString.Vtbl*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IEnumStringVtbl), sizeof(Com.IEnumString.Vtbl));
+                vtblRaw->QueryInterface_1 = (delegate* unmanaged[Stdcall]<Com.IEnumString*, Guid*, void**, HRESULT>)fpQueryInterface;
+                vtblRaw->AddRef_2 = (delegate* unmanaged[Stdcall]<Com.IEnumString*, uint>)fpAddRef;
+                vtblRaw->Release_3 = (delegate* unmanaged[Stdcall]<Com.IEnumString*, uint>)fpRelease;
+                vtblRaw->Next_4 = &Next;
+                vtblRaw->Skip_5 = &Skip;
+                vtblRaw->Reset_6 = &Reset;
+                vtblRaw->Clone_7 = &Clone;
 
                 return (IntPtr)vtblRaw;
             }
 
-            [UnmanagedCallersOnly]
-            private static int Next(IntPtr thisPtr, int celt, IntPtr* rgelt, int* pceltFetched)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Next(Com.IEnumString* @this, uint celt, PWSTR* rgelt, uint* pceltFetched)
             {
                 try
                 {
-                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
+                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)@this);
                     string[] elt = new string[celt];
-                    var result = instance.Next(celt, elt, (IntPtr)pceltFetched);
+                    var result = instance.Next((int)celt, elt, (nint)pceltFetched);
                     for (var i = 0; i < *pceltFetched; i++)
                     {
-                        rgelt[i] = Marshal.StringToCoTaskMemUni(elt[i]);
+                        rgelt[i] = (char*)Marshal.StringToCoTaskMemUni(elt[i]);
                     }
 
-                    return result;
+                    return (HRESULT)result;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Skip(IntPtr thisPtr, int celt)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Skip(Com.IEnumString* @this, uint celt)
             {
                 try
                 {
-                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
-                    return instance.Skip(celt);
+                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)@this);
+                    return (HRESULT)instance.Skip((int)celt);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Reset(IntPtr thisPtr)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Reset(Com.IEnumString* @this)
             {
                 try
                 {
-                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
+                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)@this);
                     instance.Reset();
-                    return S_OK;
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Clone(IntPtr thisPtr, IntPtr* ppenum)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Clone(Com.IEnumString* @this, Com.IEnumString** ppenum)
             {
                 try
                 {
-                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)thisPtr);
+                    IEnumString instance = ComInterfaceDispatch.GetInstance<IEnumString>((ComInterfaceDispatch*)@this);
                     instance.Clone(out var cloned);
-                    *ppenum = WinFormsComWrappers.Instance.GetOrCreateComInterfaceForObject(cloned, CreateComInterfaceFlags.None);
-                    return S_OK;
+                    *ppenum = (Com.IEnumString*)WinFormsComWrappers.Instance.GetOrCreateComInterfaceForObject(cloned, CreateComInterfaceFlags.None);
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IFileDialogEventsVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IFileDialogEventsVtbl.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Shell = Windows.Win32.UI.Shell;
 
 internal partial class Interop
 {
@@ -14,133 +14,126 @@ internal partial class Interop
         {
             public static IntPtr Create(IntPtr fpQueryInterface, IntPtr fpAddRef, IntPtr fpRelease)
             {
-                IntPtr* vtblRaw = (IntPtr*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IFileDialogEventsVtbl), IntPtr.Size * 10);
-                vtblRaw[0] = fpQueryInterface;
-                vtblRaw[1] = fpAddRef;
-                vtblRaw[2] = fpRelease;
-                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, int>)&OnFileOk;
-                vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, int>)&OnFolderChanging;
-                vtblRaw[5] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, int>)&OnFolderChange;
-                vtblRaw[6] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, int>)&OnSelectionChange;
-                vtblRaw[7] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, Shell32.FDESVR*, int>)&OnShareViolation;
-                vtblRaw[8] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, int>)&OnTypeChange;
-                vtblRaw[9] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, Shell32.FDEOR*, int>)&OnOverwrite;
+                IFileDialogEvents.Vtbl* vtblRaw = (IFileDialogEvents.Vtbl*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IFileDialogEventsVtbl), sizeof(IFileDialogEvents.Vtbl));
+                vtblRaw->QueryInterface_1 = (delegate* unmanaged[Stdcall]<IFileDialogEvents*, Guid*, void**, HRESULT>)fpQueryInterface;
+                vtblRaw->AddRef_2 = (delegate* unmanaged[Stdcall]<IFileDialogEvents*, uint>)fpAddRef;
+                vtblRaw->Release_3 = (delegate* unmanaged[Stdcall]<IFileDialogEvents*, uint>)fpRelease;
+                vtblRaw->OnFileOk_4 = &OnFileOk;
+                vtblRaw->OnFolderChanging_5 = &OnFolderChanging;
+                vtblRaw->OnFolderChange_6 = &OnFolderChange;
+                vtblRaw->OnSelectionChange_7 = &OnSelectionChange;
+                vtblRaw->OnShareViolation_8 = &OnShareViolation;
+                vtblRaw->OnTypeChange_9 = &OnTypeChange;
+                vtblRaw->OnOverwrite_10 = &OnOverwrite;
 
                 return (IntPtr)vtblRaw;
             }
 
-            [UnmanagedCallersOnly]
-            public static int OnFileOk(IntPtr thisPtr, IntPtr pfd)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            public static HRESULT OnFileOk(IFileDialogEvents* @this, IFileDialog* pfd)
             {
                 try
                 {
-                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
-                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    return (int)instance.OnFileOk(fd);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)@this);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance((nint)pfd, CreateObjectFlags.Unwrap);
+                    return instance.OnFileOk(fd);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            public static int OnFolderChanging(IntPtr thisPtr, IntPtr pfd, IntPtr psiFolder)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            public static HRESULT OnFolderChanging(IFileDialogEvents* @this, IFileDialog* pfd, Shell.IShellItem* psiFolder)
             {
                 try
                 {
-                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
-                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    Shell32.IShellItem siFolder = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance(psiFolder, CreateObjectFlags.Unwrap);
-                    return (int)instance.OnFolderChanging(fd, siFolder);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)@this);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance((nint)pfd, CreateObjectFlags.Unwrap);
+                    Shell32.IShellItem siFolder = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance((nint)psiFolder, CreateObjectFlags.Unwrap);
+                    return instance.OnFolderChanging(fd, siFolder);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            public static int OnFolderChange(IntPtr thisPtr, IntPtr pfd)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            public static HRESULT OnFolderChange(IFileDialogEvents* @this, IFileDialog* pfd)
             {
                 try
                 {
-                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
-                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    return (int)instance.OnFolderChange(fd);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)@this);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance((nint)pfd, CreateObjectFlags.Unwrap);
+                    return instance.OnFolderChange(fd);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            public static int OnSelectionChange(IntPtr thisPtr, IntPtr pfd)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            public static HRESULT OnSelectionChange(IFileDialogEvents* @this, IFileDialog* pfd)
             {
                 try
                 {
-                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
-                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    return (int)instance.OnSelectionChange(fd);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)@this);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance((nint)pfd, CreateObjectFlags.Unwrap);
+                    return instance.OnSelectionChange(fd);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            public static int OnShareViolation(IntPtr thisPtr, IntPtr pfd, IntPtr psi, Shell32.FDESVR* pResponse)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            public static HRESULT OnShareViolation(IFileDialogEvents* @this, IFileDialog* pfd, Shell.IShellItem* psi, FDE_SHAREVIOLATION_RESPONSE* pResponse)
             {
                 try
                 {
-                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
-                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    Shell32.IShellItem si = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance(psi, CreateObjectFlags.Unwrap);
-                    return (int)instance.OnShareViolation(fd, si, pResponse);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)@this);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance((nint)pfd, CreateObjectFlags.Unwrap);
+                    Shell32.IShellItem si = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance((nint)psi, CreateObjectFlags.Unwrap);
+                    return instance.OnShareViolation(fd, si, (Shell32.FDESVR*)pResponse);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            public static int OnTypeChange(IntPtr thisPtr, IntPtr pfd)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            public static HRESULT OnTypeChange(IFileDialogEvents* @this, IFileDialog* pfd)
             {
                 try
                 {
-                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
-                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    return (int)instance.OnTypeChange(fd);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)@this);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance((nint)pfd, CreateObjectFlags.Unwrap);
+                    return instance.OnTypeChange(fd);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            public static int OnOverwrite(IntPtr thisPtr, IntPtr pfd, IntPtr psi, Shell32.FDEOR* pResponse)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            public static HRESULT OnOverwrite(IFileDialogEvents* @this, IFileDialog* pfd, Shell.IShellItem* psi, FDE_OVERWRITE_RESPONSE* pResponse)
             {
                 try
                 {
-                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)thisPtr);
-                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance(pfd, CreateObjectFlags.Unwrap);
-                    Shell32.IShellItem si = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance(psi, CreateObjectFlags.Unwrap);
-                    return (int)instance.OnOverwrite(fd, si, pResponse);
+                    Shell32.IFileDialogEvents instance = ComInterfaceDispatch.GetInstance<Shell32.IFileDialogEvents>((ComInterfaceDispatch*)@this);
+                    Shell32.IFileDialog fd = (Shell32.IFileDialog)Instance.GetOrCreateObjectForComInstance((nint)pfd, CreateObjectFlags.Unwrap);
+                    Shell32.IShellItem si = (Shell32.IShellItem)Instance.GetOrCreateObjectForComInstance((nint)psi, CreateObjectFlags.Unwrap);
+                    return instance.OnOverwrite(fd, si, (Shell32.FDEOR*)pResponse);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IStreamVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IStreamVtbl.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Windows.Win32.System.Com;
 
 internal partial class Interop
 {
@@ -14,204 +14,193 @@ internal partial class Interop
         {
             public static IntPtr Create(IntPtr fpQueryInterface, IntPtr fpAddRef, IntPtr fpRelease)
             {
-                IntPtr* vtblRaw = (IntPtr*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IStreamVtbl), IntPtr.Size * 14);
-                vtblRaw[0] = fpQueryInterface;
-                vtblRaw[1] = fpAddRef;
-                vtblRaw[2] = fpRelease;
-                vtblRaw[3] = (IntPtr)(delegate* unmanaged<IntPtr, byte*, uint, uint*, int>)&Read;
-                vtblRaw[4] = (IntPtr)(delegate* unmanaged<IntPtr, byte*, uint, uint*, int>)&Write;
-                vtblRaw[5] = (IntPtr)(delegate* unmanaged<IntPtr, long, SeekOrigin, ulong*, int>)&Seek;
-                vtblRaw[6] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, int>)&SetSize;
-                vtblRaw[7] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, ulong, ulong*, ulong*, int>)&CopyTo;
-                vtblRaw[8] = (IntPtr)(delegate* unmanaged<IntPtr, uint, int>)&Commit;
-                vtblRaw[9] = (IntPtr)(delegate* unmanaged<IntPtr, int>)&Revert;
-                vtblRaw[10] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, ulong, uint, int>)&LockRegion;
-                vtblRaw[11] = (IntPtr)(delegate* unmanaged<IntPtr, ulong, ulong, uint, int>)&UnlockRegion;
-                vtblRaw[12] = (IntPtr)(delegate* unmanaged<IntPtr, Interop.Ole32.STATSTG*, Interop.Ole32.STATFLAG, int>)&Stat;
-                vtblRaw[13] = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr*, int>)&Clone;
+                IStream.Vtbl* vtblRaw = (IStream.Vtbl*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IStreamVtbl), sizeof(IStream.Vtbl));
+                vtblRaw->QueryInterface_1 = (delegate* unmanaged[Stdcall]<IStream*, Guid*, void**, HRESULT>)fpQueryInterface;
+                vtblRaw->AddRef_2 = (delegate* unmanaged[Stdcall]<IStream*, uint>)fpAddRef;
+                vtblRaw->Release_3 = (delegate* unmanaged[Stdcall]<IStream*, uint>)fpRelease;
+                vtblRaw->Read_4 = &Read;
+                vtblRaw->Write_5 = &Write;
+                vtblRaw->Seek_6 = &Seek;
+                vtblRaw->SetSize_7 = &SetSize;
+                vtblRaw->CopyTo_8 = &CopyTo;
+                vtblRaw->Commit_9 = &Commit;
+                vtblRaw->Revert_10 = &Revert;
+                vtblRaw->LockRegion_11 = &LockRegion;
+                vtblRaw->UnlockRegion_12 = &UnlockRegion;
+                vtblRaw->Stat_13 = &Stat;
+                vtblRaw->Clone_14 = &Clone;
 
                 return (IntPtr)vtblRaw;
             }
 
-            [UnmanagedCallersOnly]
-            private static int Read(IntPtr thisPtr, byte* pv, uint cb, uint* pcbRead)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Read(IStream* @this, void* pv, uint cb, uint* pcbRead)
             {
                 try
                 {
-                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    instance.Read(pv, cb, pcbRead);
-                    return S_OK;
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)@this);
+                    instance.Read((byte*)pv, cb, pcbRead);
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Write(IntPtr thisPtr, byte* pv, uint cb, uint* pcbWritten)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Write(IStream* @this, void* pv, uint cb, uint* pcbWritten)
             {
                 try
                 {
-                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    instance.Write(pv, cb, pcbWritten);
-                    return S_OK;
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)@this);
+                    instance.Write((byte*)pv, cb, pcbWritten);
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Seek(IntPtr thisPtr, long dlibMove, SeekOrigin dwOrigin, ulong* plibNewPosition)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Seek(IStream* @this, long dlibMove, SeekOrigin dwOrigin, ulong* plibNewPosition)
             {
                 try
                 {
-                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)@this);
                     instance.Seek(dlibMove, dwOrigin, plibNewPosition);
-                    return S_OK;
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int SetSize(IntPtr thisPtr, ulong libNewSize)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT SetSize(IStream* @this, ulong libNewSize)
             {
                 try
                 {
-                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)@this);
                     instance.SetSize(libNewSize);
-                    return S_OK;
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int CopyTo(IntPtr thisPtr, IntPtr pstm, ulong cb, ulong* pcbRead, ulong* pcbWritten)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT CopyTo(IStream* @this, IStream* pstm, ulong cb, ulong* pcbRead, ulong* pcbWritten)
             {
                 try
                 {
-                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)@this);
                     Interop.Ole32.IStream pstmStream = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)pstm);
 
                     instance.CopyTo(pstmStream, cb, pcbRead, pcbWritten);
-                    return S_OK;
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Commit(IntPtr thisPtr, uint grfCommitFlags)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Commit(IStream* @this, STGC grfCommitFlags)
             {
                 try
                 {
-                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)@this);
                     instance.Commit((Interop.Ole32.STGC)grfCommitFlags);
-                    return S_OK;
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Revert(IntPtr thisPtr)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Revert(IStream* thisPtr)
             {
                 try
                 {
                     Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
                     instance.Revert();
-                    return S_OK;
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int LockRegion(IntPtr thisPtr, ulong libOffset, ulong cb, uint dwLockType)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT LockRegion(IStream* @this, ulong libOffset, ulong cb, LOCKTYPE dwLockType)
             {
                 try
                 {
-                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    return (int)instance.LockRegion(libOffset, cb, dwLockType);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)@this);
+                    return instance.LockRegion(libOffset, cb, (uint)dwLockType);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int UnlockRegion(IntPtr thisPtr, ulong libOffset, ulong cb, uint dwLockType)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT UnlockRegion(IStream* @this, ulong libOffset, ulong cb, uint dwLockType)
             {
                 try
                 {
-                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    return (int)instance.UnlockRegion(libOffset, cb, dwLockType);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)@this);
+                    return instance.UnlockRegion(libOffset, cb, dwLockType);
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Stat(IntPtr thisPtr, Interop.Ole32.STATSTG* pstatstg, Interop.Ole32.STATFLAG grfStatFlag)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Stat(IStream* @this, STATSTG* pstatstg, STATFLAG grfStatFlag)
             {
                 try
                 {
-                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
-                    instance.Stat(out *pstatstg, grfStatFlag);
-                    return S_OK;
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)@this);
+                    instance.Stat(out *((Ole32.STATSTG*)pstatstg), (Ole32.STATFLAG)grfStatFlag);
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
 
-            [UnmanagedCallersOnly]
-            private static int Clone(IntPtr thisPtr, IntPtr* ppstm)
+            [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
+            private static HRESULT Clone(IStream* @this, IStream** ppstm)
             {
                 if (ppstm is null)
                 {
-                    return (int)HRESULT.STG_E_INVALIDPOINTER;
+                    return HRESULT.STG_E_INVALIDPOINTER;
                 }
 
                 try
                 {
-                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)thisPtr);
+                    Interop.Ole32.IStream instance = ComInterfaceDispatch.GetInstance<Interop.Ole32.IStream>((ComInterfaceDispatch*)@this);
 
-                    *ppstm = Instance.GetOrCreateComInterfaceForObject(instance.Clone(), CreateComInterfaceFlags.None);
-                    return S_OK;
+                    *ppstm = (IStream*)Instance.GetOrCreateComInterfaceForObject(instance.Clone(), CreateComInterfaceFlags.None);
+                    return HRESULT.S_OK;
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine(ex);
-                    return ex.HResult;
+                    return ex;
                 }
             }
         }

--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -219,6 +219,11 @@ ICM_MODE
 ICON_*
 IDC_*
 IDI_*
+IDropSource
+IDropSourceNotify
+IEnumString
+IEnumFORMATETC
+IFileDialogEvents
 ImageList_Add
 ImageList_Create
 ImageList_Draw
@@ -250,6 +255,7 @@ IsChild
 IsProcessDPIAware
 IsThemeBackgroundPartiallyTransparent
 IsThemePartDefined
+IStream
 IsValidDpiAwarenessContext
 IsWindow
 IsWindowVisible

--- a/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
+++ b/src/System.Windows.Forms.Primitives/src/System.Windows.Forms.Primitives.csproj
@@ -13,6 +13,10 @@
     -->
     <NoWarn>$(NoWarn);CS8981</NoWarn>
     <!--
+      We don't care about CLS compliance since everything here is internal and we want to match native types.
+    -->
+    <NoWarn>$(NoWarn);CS3016</NoWarn>
+    <!--
       IL Trim warnings which should be removed in order to make WinForms trimmable
       See https://github.com/dotnet/winforms/issues/4649
     -->

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/FileDialogCustomPlacesCollection.cs
@@ -3,15 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.ObjectModel;
-using static Interop.Shell32;
+using static Interop;
 
 namespace System.Windows.Forms
 {
     public class FileDialogCustomPlacesCollection : Collection<FileDialogCustomPlace>
     {
-        internal void Apply(IFileDialog dialog)
+        internal void Apply(Shell32.IFileDialog dialog)
         {
-            // Walk backwards
             for (int i = Items.Count - 1; i >= 0; --i)
             {
                 FileDialogCustomPlace customPlace = Items[i];

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/HRESULT.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Foundation/HRESULT.cs
@@ -2,11 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace Windows.Win32.Foundation
 {
     internal readonly partial struct HRESULT
     {
         public static HRESULT HRESULT_FROM_WIN32(WIN32_ERROR error)
             => new(((int)error & 0x0000FFFF) | unchecked((int)0x80070000));
+
+        public static implicit operator HRESULT(Exception ex)
+        {
+            Debug.WriteLine(ex);
+            return (HRESULT)ex.HResult;
+        }
     }
 }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/FORMATETC.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/System/Com/FORMATETC.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using ComType = System.Runtime.InteropServices.ComTypes;
+
+namespace Windows.Win32.System.Com
+{
+    internal partial struct FORMATETC
+    {
+        public static unsafe implicit operator FORMATETC(ComType.FORMATETC formatetc) =>
+            new()
+            {
+                cfFormat = (ushort)formatetc.cfFormat,
+                ptd = (DVTARGETDEVICE*)formatetc.ptd,
+                dwAspect = (uint)formatetc.dwAspect,
+                lindex = formatetc.lindex,
+                tymed = (uint)formatetc.tymed
+            };
+    }
+}

--- a/src/System.Windows.Forms/src/GlobalUsings.cs
+++ b/src/System.Windows.Forms/src/GlobalUsings.cs
@@ -12,3 +12,4 @@ global using Windows.Win32.UI.Shell;
 global using Windows.Win32.UI.Shell.Common;
 global using Windows.Win32.UI.WindowsAndMessaging;
 global using IShellItem = Interop.Shell32.IShellItem;
+global using IFileDialog = Interop.Shell32.IFileDialog;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.VistaDialogEvents.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.VistaDialogEvents.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using static Interop.Shell32;
+using IFileDialogEvents = Interop.Shell32.IFileDialogEvents;
 
 namespace System.Windows.Forms
 {


### PR DESCRIPTION
- Convert `IStreamVtbl`,`IFileDialogEventsVtbl`,`IEnumStringVtbl`,`IEnumFORMATETCVtble`,
`IDropSourceVtbl`,`IDropSourceNotifyVtbl`
- Add implicit operators for `Exception` > `HRESULT` and  `ComType.FORMATETC` > `FORMATETC`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7906)