### PR TITLE
Fix bug in TabPageCollection.RemoveAt (#7837)

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -11787,9 +11787,10 @@ namespace System.Windows.Forms
         ///  reflect its index.
         /// </summary>
         private void UpdateChildControlIndex(Control control)
-        {            
-            if (// Don't reorder the child control array for tab controls. Implemented as a special case
-                // in order to keep the method private.
+        {
+            // Don't reorder the child control array for tab controls. Implemented as a special case
+            // in order to keep the method private.
+            if (
                 this is TabControl ||
                 // Also short-circuit when the Control class is instantiated directly. This is to provide
                 // consistency with the behavior prior to bug fix https://github.com/dotnet/winforms/issues/7837

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -11790,7 +11790,13 @@ namespace System.Windows.Forms
         {
             // Don't reorder the child control array for tab controls. Implemented as a special case
             // in order to keep the method private.
-            if (GetType().IsAssignableFrom(typeof(TabControl)))
+            if (typeof(TabControl).IsAssignableFrom(GetType()))
+            {
+                return;
+            }
+
+            // The following check is to mitigate a potentially disruptive effect of bug fix #7837 / PR 7911
+            if (GetType() == typeof(Control))
             {
                 return;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -11787,16 +11787,13 @@ namespace System.Windows.Forms
         ///  reflect its index.
         /// </summary>
         private void UpdateChildControlIndex(Control control)
-        {
-            // Don't reorder the child control array for tab controls. Implemented as a special case
-            // in order to keep the method private.
-            if (typeof(TabControl).IsAssignableFrom(GetType()))
-            {
-                return;
-            }
-
-            // The following check is to mitigate a potentially disruptive effect of bug fix #7837 / PR 7911
-            if (GetType() == typeof(Control))
+        {            
+            if (// Don't reorder the child control array for tab controls. Implemented as a special case
+                // in order to keep the method private.
+                this is TabControl ||
+                // Also short-circuit when the Control class is instantiated directly. This is to provide
+                // consistency with the behavior prior to bug fix https://github.com/dotnet/winforms/issues/7837
+                GetType() == typeof(Control))
             {
                 return;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -11790,11 +11790,9 @@ namespace System.Windows.Forms
         {
             // Don't reorder the child control array for tab controls. Implemented as a special case
             // in order to keep the method private.
-            if (
-                this is TabControl ||
-                // Also short-circuit when the Control class is instantiated directly. This is to provide
-                // consistency with the behavior prior to bug fix https://github.com/dotnet/winforms/issues/7837
-                GetType() == typeof(Control))
+            // Also short-circuit when the Control class is instantiated directly. This is to provide
+            // consistency with the behavior prior to bug fix https://github.com/dotnet/winforms/issues/7837
+            if (this is TabControl || GetType() == typeof(Control))
             {
                 return;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
@@ -354,7 +354,13 @@ namespace System.Windows.Forms
                 }
             }
 
-            public void RemoveAt(int index) => _owner.Controls.RemoveAt(index);
+            public void RemoveAt(int index)
+            {
+                // We have to be careful in choosing the correct page to remove.
+                // Calling _owner.Controls.RemoveAt(index) may remove the wrong page
+                // because _owner.Controls may be ordered differently to _owner._tabPages.
+                Remove(this[index]);
+            }
 
             /// <summary>
             ///  Removes the child control with the specified key.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.TabPageCollection.cs
@@ -354,13 +354,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            public void RemoveAt(int index)
-            {
-                // We have to be careful in choosing the correct page to remove.
-                // Calling _owner.Controls.RemoveAt(index) may remove the wrong page
-                // because _owner.Controls may be ordered differently to _owner._tabPages.
-                Remove(this[index]);
-            }
+            public void RemoveAt(int index) => _owner.Controls.RemoveAt(index);
 
             /// <summary>
             ///  Removes the child control with the specified key.

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/TabControlTests.cs
@@ -100,6 +100,7 @@ namespace System.Windows.Forms.UITests
         [WinFormsFact]
         public async Task TabControl_ControlsDoNotReorderWhenSelectedIndexChanges()
         {
+            // Validates the following bug fix: https://github.com/dotnet/winforms/issues/7837
             await RunSingleControlTestAsync(
                 testDriverAsync: async (form, tabControl) =>
                 {
@@ -152,7 +153,7 @@ namespace System.Windows.Forms.UITests
                 });
         }
 
-        // Bug #7837 occured only when TabControl was subclassed.
+        // Bug https://github.com/dotnet/winforms/issues/7837 occured only when TabControl was subclassed.
         class SubclassedTabControl : TabControl { }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7837


## Proposed changes

- Fix logic in TabPageCollection.RemoveAt to avoid removing incorrect TabPage when TabControl.Controls collection is out of sync with TabControls._tabPages. This can happen when Control.WmWindowPosChanged calls _parent.UpdateChildControlIndex, which calls Controls.SetChildIndex.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- None

## Regression? 

- No

## Risk

- Low

<!-- end TELL-MODE -->


## Test methodology <!-- How did you ensure quality? -->

- Adhoc testing. There's just one of code, and the new implementation calls only public methods.




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7911)