### PR TITLE
Enable IDE0065 Misplaced using directive

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1624,7 +1624,7 @@ dotnet_diagnostic.IDE0063.severity = silent
 dotnet_diagnostic.IDE0064.severity = silent
 
 # IDE0065: Misplaced using directive
-dotnet_diagnostic.IDE0065.severity = none # TODO: warning
+dotnet_diagnostic.IDE0065.severity = warning
 
 # IDE0066: Convert switch statement to expression
 dotnet_diagnostic.IDE0066.severity = suggestion

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/TextBoxBaseDesigner.cs
@@ -2,14 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows.Forms.Design.Behavior;
+
 namespace System.Windows.Forms.Design
 {
-    using System;
-    using System.Collections;
-    using System.ComponentModel;
-    using System.Diagnostics;
-    using System.Windows.Forms.Design.Behavior;
-
     /// <summary>
     /// Provides a designer that can design components
     /// that extend TextBoxBase.

--- a/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
+++ b/src/System.Windows.Forms.Design/tests/UnitTests/System/ComponentModel/Design/ByteViewerTests.cs
@@ -6,12 +6,11 @@ using System.Drawing;
 using System.Windows.Forms;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.ComponentModel.Design.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ByteViewerTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelCell.cs
@@ -2,16 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Diagnostics;
+using System.Drawing;
+using System.Globalization;
+using System.Windows.Forms.Layout;
+
 #nullable disable
 
 namespace System.Windows.Forms
 {
-    using System.Collections;
-    using System.Diagnostics;
-    using System.Drawing;
-    using System.Globalization;
-    using System.Windows.Forms.Layout;
-
     ///  this class is a container for toolstrips on a rafting row.
     ///  you can set layout styles on this container all day long and not
     ///  affect the underlying toolstrip's properties.... so if its

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageIndexConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeViewImageIndexConverter.cs
@@ -2,11 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Globalization;
+
 namespace System.Windows.Forms
 {
-    using System.ComponentModel;
-    using System.Globalization;
-
     /// <summary>
     ///  TreeViewImageIndexConverter is a class that can be used to convert
     ///  image index values one data type to another.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Triangle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Triangle.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+using System.Drawing;
+
 namespace System.Windows.Forms
 {
-    using System;
-    using System.Diagnostics;
-    using System.Drawing;
-
     /// <summary>
     ///  This class fully encapsulates the painting logic for a triangle.  (Used by DataGrid)
     /// </summary>

--- a/src/System.Windows.Forms/src/misc/WeakHashtable.cs
+++ b/src/System.Windows.Forms/src/misc/WeakHashtable.cs
@@ -2,11 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+
 namespace System.ComponentModel
 {
-    using System;
-    using System.Collections;
-
     /// <summary>
     ///  This is a hashtable that stores object keys as weak references.
     ///  It monitors memory usage and will periodically scavenge the

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/AxHostTests.cs
@@ -11,12 +11,11 @@ using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads (instantiated via GUID)
     public class AxHostTests : IClassFixture<ThreadExceptionFixture>
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonBaseTests.cs
@@ -12,12 +12,11 @@ using Moq;
 using Xunit;
 using static Interop;
 using static Interop.User32;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ButtonBaseTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ButtonTests.cs
@@ -11,12 +11,11 @@ using Xunit;
 using static Interop;
 using static Interop.UiaCore;
 using static Interop.User32;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ButtonTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/CheckBoxTests.cs
@@ -6,13 +6,12 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using static Interop.UiaCore;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using static Interop.UiaCore;
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class CheckBoxTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ComboBoxTests.cs
@@ -9,12 +9,11 @@ using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static System.Windows.Forms.ComboBox;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ComboBoxTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ContainerControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ContainerControlTests.cs
@@ -8,12 +8,11 @@ using System.Reflection;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ContainerControlTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ControlTests.cs
@@ -6,12 +6,11 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public partial class ControlTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellTests.cs
@@ -9,11 +9,10 @@ using System.Windows.Forms.Automation;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     public class DataGridViewCellTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewHeaderCellTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewHeaderCellTests.cs
@@ -7,11 +7,10 @@ using System.Windows.Forms.VisualStyles;
 using Microsoft.DotNet.RemoteExecutor;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     public class DataGridViewHeaderCellTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTextBoxEditingControlTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class DataGridViewTextBoxEditingControlTests : IClassFixture<ThreadExceptionFixture>
     {
         private static int s_preferredHeight = Control.DefaultFont.Height + SystemInformation.BorderSize.Height * 4 + 3;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataObjectTests.cs
@@ -13,11 +13,10 @@ using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop.User32;
 using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
+using Point = System.Drawing.Point;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-
     // NB: doesn't require thread affinity
     public class DataObjectTests : IClassFixture<ThreadExceptionFixture>
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePickerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DateTimePickerTests.cs
@@ -6,12 +6,11 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class DateTimePickerTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/ComponentEditorFormTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/ComponentEditorFormTests.cs
@@ -6,12 +6,11 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Design.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ComponentEditorFormTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/ComponentEditorPageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/ComponentEditorPageTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Design.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ComponentEditorPageTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/PropertyTabTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Design/PropertyTabTests.cs
@@ -7,11 +7,10 @@ using System.Drawing;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Design.Tests
 {
-    using Size = System.Drawing.Size;
-
     // NB: doesn't require thread affinity
     public class PropertyTabTests : IClassFixture<ThreadExceptionFixture>
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FlowLayoutPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/FlowLayoutPanelTests.cs
@@ -6,12 +6,11 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class FlowLayoutPanelTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/GroupBoxTests.cs
@@ -8,12 +8,11 @@ using System.Windows.Forms.Layout;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class GroupBoxTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/HScrollBarTests.cs
@@ -5,12 +5,11 @@
 using System.ComponentModel;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class HScrollBarTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.ImageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ImageList.ImageCollectionTests.cs
@@ -7,11 +7,10 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     [Collection("Sequential")] // ImageList doesn't appear to behave well under stress in multi-threaded env
     public class ImageCollectionTests : IClassFixture<ThreadExceptionFixture>
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/LabelTests.cs
@@ -6,12 +6,11 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class LabelTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/FlowLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/FlowLayoutTests.cs
@@ -4,11 +4,10 @@
 
 using System.Drawing;
 using Xunit;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Layout.Tests
 {
-    using Size = System.Drawing.Size;
-
     public partial class FlowLayoutTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
@@ -9,12 +9,11 @@ using System.Globalization;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ListControlTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewInsertionMarkTests.cs
@@ -7,11 +7,10 @@ using Microsoft.DotNet.RemoteExecutor;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-
     public class ListViewInsertionMarkTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -11,12 +11,11 @@ using Xunit;
 using static System.Windows.Forms.ListViewItem;
 using static Interop;
 using static Interop.ComCtl32;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ListViewTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiClientTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiClientTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class MdiClientTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MdiControlStripTests.cs
@@ -6,12 +6,11 @@ using System.ComponentModel;
 using System.Drawing;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class MdiControlStripTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MenuStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MenuStripTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class MenuStripTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MessageBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MessageBoxTests.cs
@@ -2,16 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Reflection;
+using System.Windows.Forms.TestUtilities;
+using Xunit;
+using static Interop.User32;
+
 namespace System.Windows.Forms.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.ComponentModel;
-    using System.Reflection;
-    using System.Windows.Forms.TestUtilities;
-    using Xunit;
-    using static Interop.User32;
-
     public class MessageBoxTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendarTests.cs
@@ -9,12 +9,11 @@ using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
 using static Interop.ComCtl32;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     [UseDefaultXunitCulture]
     public class MonthCalendarTests : IClassFixture<ThreadExceptionFixture>
     {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PictureBoxTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class PictureBoxTests : IClassFixture<ThreadExceptionFixture>
     {
         private const string PathImageLocation = "bitmaps/nature24bits.jpg";

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ProgressBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ProgressBarTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ProgressBarTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -11,12 +11,11 @@ using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using System.Runtime.CompilerServices;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public partial class PropertyGridTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RadioButtonTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop.UiaCore;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class RadioButtonTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/RichTextBoxTests.cs
@@ -14,12 +14,11 @@ using Xunit;
 using static Interop;
 using static Interop.Richedit;
 using static Interop.User32;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class RichTextBoxTests : IClassFixture<ThreadExceptionFixture>
     {
         private static int s_preferredHeight = Control.DefaultFont.Height + SystemInformation.BorderSize.Height * 4 + 3;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ScrollBarTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollableControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollableControlTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ScrollableControlTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitterPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitterPanelTests.cs
@@ -6,12 +6,11 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class SplitterPanelTests : IClassFixture<ThreadExceptionFixture>
     {
         public static IEnumerable<object[]> Ctor_SplitContainer_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitterTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/SplitterTests.cs
@@ -6,12 +6,11 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class SplitterTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/StatusStripTests.cs
@@ -6,12 +6,11 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public partial class StatusStripTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.ControlCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.ControlCollectionTests.cs
@@ -7,11 +7,10 @@ using System.Drawing;
 using Moq;
 using Xunit;
 using static Interop;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     public class TabControlControlCollectionTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControl.TabPageCollectionTests.cs
@@ -9,11 +9,10 @@ using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     public class TabControlTabPageCollectionTests : IClassFixture<ThreadExceptionFixture>
     {
         public static IEnumerable<object[]> Add_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabControlTests.cs
@@ -8,12 +8,11 @@ using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class TabControlTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TabPageTests.cs
@@ -11,12 +11,11 @@ using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class TabPageTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/TableLayoutPanelTests.cs
@@ -8,12 +8,11 @@ using System.Windows.Forms.Layout;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class TableLayoutPanelTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripButtonTests.cs
@@ -8,11 +8,10 @@ using System.Runtime.Versioning;
 using System.Windows.Forms.DataBinding.TestUtilities;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     public partial class ToolStripButtonTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripContentPanelTests.cs
@@ -8,12 +8,11 @@ using Moq;
 using Moq.Protected;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ToolStripContentPanelTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripControlHostTests.cs
@@ -9,11 +9,10 @@ using System.Reflection;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     public class ToolStripControlHostTests
     {
         public static IEnumerable<object[]> Ctor_Control_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownItemTests.cs
@@ -6,12 +6,11 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ToolStripItemDropDownTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripDropDownTests.cs
@@ -8,12 +8,11 @@ using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class ToolStripDropDownTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripItemTests.cs
@@ -9,11 +9,10 @@ using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using IComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     public class ToolStripItemTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripRendererTests.cs
@@ -4,11 +4,10 @@
 
 using System.Drawing;
 using Xunit;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     public class ToolStripRendererTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSeparatorTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripSeparatorTests.cs
@@ -7,11 +7,10 @@ using System.Drawing;
 using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     public class ToolStripSeparatorTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -10,12 +10,11 @@ using System.Windows.Forms.TestUtilities;
 using Moq;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public partial class ToolStripTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBaseTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class UpDownBaseTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UserControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UserControlTests.cs
@@ -9,12 +9,11 @@ using Moq;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class UserControlTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/VScrollBarTests.cs
@@ -5,12 +5,11 @@
 using System.ComponentModel;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class VScrollBarTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/WebBrowserTests.cs
@@ -10,12 +10,11 @@ using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
 using static Interop.Mshtml;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads
     public class WebBrowserTests
     {

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxBaseTests.cs
@@ -10,12 +10,11 @@ using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
 using static Interop.User32;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public partial class TextBoxBaseTests : IClassFixture<ThreadExceptionFixture>
     {
         private static int s_preferredHeight = Control.DefaultFont.Height + SystemInformation.BorderSize.Height * 4 + 3;

--- a/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TextBoxTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public partial class TextBoxTests : IClassFixture<ThreadExceptionFixture>
     {
         private static int s_preferredHeight = Control.DefaultFont.Height + SystemInformation.BorderSize.Height * 4 + 3;

--- a/src/System.Windows.Forms/tests/UnitTests/TrackBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/TrackBarTests.cs
@@ -7,12 +7,11 @@ using System.Drawing;
 using System.Windows.Forms.TestUtilities;
 using Xunit;
 using static Interop;
+using Point = System.Drawing.Point;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Point = System.Drawing.Point;
-    using Size = System.Drawing.Size;
-
     public class TrackBarTests : IClassFixture<ThreadExceptionFixture>
     {
         public static readonly int s_dimension = (SystemInformation.HorizontalScrollBarHeight * 8) / 3;

--- a/src/System.Windows.Forms/tests/UnitTests/WebBrowserBaseTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/WebBrowserBaseTests.cs
@@ -6,11 +6,10 @@ using System.ComponentModel;
 using System.Drawing;
 using Moq;
 using Xunit;
+using Size = System.Drawing.Size;
 
 namespace System.Windows.Forms.Tests
 {
-    using Size = System.Drawing.Size;
-
     [Collection("Sequential")] // workaround for WebBrowser control corrupting memory when run on multiple UI threads (instantiated via GUID)
     public class WebBrowserBaseTests
     {


### PR DESCRIPTION
Enables IDE0065 Misplaced using directive
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0065

Related: #7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7922)