### PR TITLE
Added unit tests for "AccessibleObject.FragmentNavigate" method in DataGridViewCell-related classes

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
@@ -1013,17 +1013,26 @@ namespace System.Windows.Forms.Tests
             Assert.False(dataGridView.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected(bool createControl)
         {
-            using DataGridView dataGridView = CreateDataGridView(columnCount: 1);
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
-            DataGridViewRow row = dataGridView.Rows[0];
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 1, createControl);
 
+            DataGridViewRow row = dataGridView.Rows[0];
             AccessibleObject accessibleObject = row.Cells[0].AccessibilityObject;
 
-            Assert.Equal(row.AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-            Assert.True(dataGridView.IsHandleCreated);
+            if (createControl)
+            {
+                Assert.Equal(row.AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            }
+            else
+            {
+                Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            }
+
+            Assert.Equal(createControl, dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1040,7 +1049,6 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
         {
             using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
@@ -1054,8 +1062,24 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+        }
 
-            Assert.True(dataGridView.IsHandleCreated);
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsNull_IfHandleIsNotCreated()
+        {
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 2, createControl: false);
+
+            DataGridViewRow row = dataGridView.Rows[0];
+            AccessibleObject cell1 = row.Cells[0].AccessibilityObject;
+            AccessibleObject cell2 = row.Cells[1].AccessibilityObject;
+
+            Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.False(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1063,7 +1087,6 @@ namespace System.Windows.Forms.Tests
         {
             using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.RowHeadersVisible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
             AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
@@ -1076,8 +1099,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1085,7 +1106,6 @@ namespace System.Windows.Forms.Tests
         {
             using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.Columns[0].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
             AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
@@ -1098,8 +1118,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(rowHeader, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1107,7 +1125,6 @@ namespace System.Windows.Forms.Tests
         {
             using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.Columns[1].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
@@ -1120,8 +1137,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell1, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1129,7 +1144,6 @@ namespace System.Windows.Forms.Tests
         {
             using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.Columns[2].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
@@ -1142,8 +1156,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1152,7 +1164,6 @@ namespace System.Windows.Forms.Tests
             using DataGridView dataGridView = CreateDataGridView(columnCount: 4);
             dataGridView.RowHeadersVisible = false;
             dataGridView.Columns[0].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
             AccessibleObject cell3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
@@ -1165,8 +1176,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell3, cell4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1175,7 +1184,6 @@ namespace System.Windows.Forms.Tests
             using DataGridView dataGridView = CreateDataGridView(columnCount: 4);
             dataGridView.RowHeadersVisible = false;
             dataGridView.Columns[1].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
             AccessibleObject cell3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
@@ -1188,8 +1196,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell3, cell4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(cell1, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1198,7 +1204,6 @@ namespace System.Windows.Forms.Tests
             using DataGridView dataGridView = CreateDataGridView(columnCount: 4);
             dataGridView.RowHeadersVisible = false;
             dataGridView.Columns[3].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
             AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
@@ -1211,8 +1216,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1222,7 +1225,6 @@ namespace System.Windows.Forms.Tests
             dataGridView.Columns[0].DisplayIndex = 2;
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
@@ -1238,8 +1240,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1250,7 +1250,6 @@ namespace System.Windows.Forms.Tests
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[0].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
@@ -1263,8 +1262,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1275,7 +1272,6 @@ namespace System.Windows.Forms.Tests
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[1].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
@@ -1288,8 +1284,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell1, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1300,7 +1294,6 @@ namespace System.Windows.Forms.Tests
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[2].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
             AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
@@ -1313,8 +1306,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(rowHeader, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1325,7 +1316,6 @@ namespace System.Windows.Forms.Tests
             dataGridView.Columns[0].DisplayIndex = 2;
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
             AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
@@ -1338,8 +1328,6 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1351,7 +1339,6 @@ namespace System.Windows.Forms.Tests
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[0].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
             AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
@@ -1361,8 +1348,6 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1374,7 +1359,6 @@ namespace System.Windows.Forms.Tests
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[1].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
             AccessibleObject cell3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
@@ -1384,8 +1368,6 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(cell1, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1397,7 +1379,6 @@ namespace System.Windows.Forms.Tests
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[2].Visible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
             AccessibleObject cell3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
@@ -1407,15 +1388,14 @@ namespace System.Windows.Forms.Tests
 
             Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
             Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewCellAccessibleObject_FragmentNavigate_Child_ReturnsNull()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Child_ReturnsNull(bool createControl)
         {
-            using DataGridView dataGridView = CreateDataGridView(columnCount: 2);
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 2, createControl);
 
             AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
             AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
@@ -1426,7 +1406,7 @@ namespace System.Windows.Forms.Tests
             Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
             Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
 
-            Assert.True(dataGridView.IsHandleCreated);
+            Assert.Equal(createControl, dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -1434,23 +1414,25 @@ namespace System.Windows.Forms.Tests
         {
             using DataGridView dataGridView = CreateDataGridView(columnCount: 1);
             dataGridView.RowHeadersVisible = false;
-            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
             AccessibleObject cell = dataGridView.Rows[0].Cells[0].AccessibilityObject;
 
             Assert.Null(cell.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
             Assert.Null(cell.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
-
-            Assert.True(dataGridView.IsHandleCreated);
         }
 
-        private DataGridView CreateDataGridView(int columnCount)
+        private DataGridView CreateDataGridView(int columnCount, bool createControl = true)
         {
             DataGridView dataGridView = new();
 
             for (int i = 0; i < columnCount; i++)
             {
                 dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            }
+
+            if (createControl)
+            {
+                dataGridView.CreateControl();
             }
 
             return dataGridView;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
@@ -1016,22 +1016,21 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
         {
-            using DataGridView dataGridView = new();
-            dataGridView.Columns.Add("Column 1", "Header text 1");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 1);
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+            DataGridViewRow row = dataGridView.Rows[0];
 
-            var cellAccessibleObject = dataGridView.Rows[0].Cells[0].AccessibilityObject;
-            var rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+            AccessibleObject accessibleObject = row.Cells[0].AccessibilityObject;
 
-            Assert.Equal(rowAccessibleObject, cellAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.Equal(row.AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
             Assert.True(dataGridView.IsHandleCreated);
         }
 
         [WinFormsFact]
-        public void DataGridViewCellAccessibleObject_FragmentNavigate_Parent_IsNull_IfOwningRowIsNull()
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Parent_ReturnsNull_IfOwningRowIsNull()
         {
-            using var owner = new SubDataGridViewCell();
-            var accessibleObject = new DataGridViewCellAccessibleObject(owner);
+            using SubDataGridViewCell owner = new();
+            DataGridViewCellAccessibleObject accessibleObject = new(owner);
 
             Assert.Null(accessibleObject.Owner.OwningRow);
             Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
@@ -1040,24 +1039,21 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
         {
-            using DataGridView dataGridView = new();
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell2, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1065,23 +1061,21 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfRowHeadersHidden()
         {
-            using DataGridView dataGridView = new() { RowHeadersVisible = false };
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
+            dataGridView.RowHeadersVisible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell2, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1089,24 +1083,21 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfFirstColumnHidden()
         {
-            using DataGridView dataGridView = new();
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.Columns[0].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject2, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell2, rowHeader.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeader, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1114,24 +1105,21 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfSecondColumnHidden()
         {
-            using DataGridView dataGridView = new();
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.Columns[1].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject1, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell1, rowHeader.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1139,24 +1127,21 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfLastColumnHidden()
         {
-            using DataGridView dataGridView = new();
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.Columns[2].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject1, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell1, rowHeader.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell2, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1164,25 +1149,22 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfRowHeadersAndFirstColumnHidden()
         {
-            using DataGridView dataGridView = new() { RowHeadersVisible = false };
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
-            dataGridView.Columns.Add("Column 4", "Header text 4");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 4);
+            dataGridView.RowHeadersVisible = false;
             dataGridView.Columns[0].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
-            AccessibleObject cellAccessibleObject4 = dataGridView.Rows[0].Cells[3].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cell4 = dataGridView.Rows[0].Cells[3].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject4, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell4, cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell3, cell4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1190,25 +1172,22 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfRowHeadersAndSecondColumnHidden()
         {
-            using DataGridView dataGridView = new() { RowHeadersVisible = false };
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
-            dataGridView.Columns.Add("Column 4", "Header text 4");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 4);
+            dataGridView.RowHeadersVisible = false;
             dataGridView.Columns[1].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
-            AccessibleObject cellAccessibleObject4 = dataGridView.Rows[0].Cells[3].AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cell4 = dataGridView.Rows[0].Cells[3].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject4, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell4, cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell3, cell4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1216,25 +1195,22 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfRowHeadersAndLastColumnHidden()
         {
-            using DataGridView dataGridView = new() { RowHeadersVisible = false };
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
-            dataGridView.Columns.Add("Column 4", "Header text 4");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 4);
+            dataGridView.RowHeadersVisible = false;
             dataGridView.Columns[3].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell2, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1242,29 +1218,26 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrder()
         {
-            using DataGridView dataGridView = new();
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.Columns[0].DisplayIndex = 2;
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject1, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell1, rowHeader.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell2, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1272,27 +1245,24 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndFirstColumnHidden()
         {
-            using DataGridView dataGridView = new();
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.Columns[0].DisplayIndex = 2;
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[0].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject1, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell1, rowHeader.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell2, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1300,27 +1270,24 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndSecondColumnHidden()
         {
-            using DataGridView dataGridView = new();
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.Columns[0].DisplayIndex = 2;
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[1].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject1, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell1, rowHeader.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeader, cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1328,27 +1295,24 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndLastColumnHidden()
         {
-            using DataGridView dataGridView = new();
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
             dataGridView.Columns[0].DisplayIndex = 2;
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[2].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject rowHeader = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject2, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell2, rowHeader.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeader, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeader.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1356,26 +1320,24 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndRowHeadersHidden()
         {
-            using DataGridView dataGridView = new() { RowHeadersVisible = false };
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
+            dataGridView.RowHeadersVisible = false;
             dataGridView.Columns[0].DisplayIndex = 2;
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell2, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1383,24 +1345,22 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndFirstColumnAndRowHeadersHidden()
         {
-            using DataGridView dataGridView = new() { RowHeadersVisible = false };
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
+            dataGridView.RowHeadersVisible = false;
             dataGridView.Columns[0].DisplayIndex = 2;
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[0].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell2, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1408,24 +1368,22 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndSecondColumnAndRowHeadersHidden()
         {
-            using DataGridView dataGridView = new() { RowHeadersVisible = false };
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
+            dataGridView.RowHeadersVisible = false;
             dataGridView.Columns[0].DisplayIndex = 2;
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[1].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject1, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell1, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1433,24 +1391,22 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndLastColumnAndRowHeadersHidden()
         {
-            using DataGridView dataGridView = new() { RowHeadersVisible = false };
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
-            dataGridView.Columns.Add("Column 3", "Header text 3");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 3);
+            dataGridView.RowHeadersVisible = false;
             dataGridView.Columns[0].DisplayIndex = 2;
             dataGridView.Columns[1].DisplayIndex = 1;
             dataGridView.Columns[2].DisplayIndex = 0;
             dataGridView.Columns[2].Visible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
-            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
 
-            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cell3, cell2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cell3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
 
-            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.Null(cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cell2, cell3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1458,19 +1414,17 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Child_ReturnsNull()
         {
-            using DataGridView dataGridView = new();
-            dataGridView.Columns.Add("Column 1", "Header text 1");
-            dataGridView.Columns.Add("Column 2", "Header text 2");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 2);
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
-            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cell1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
 
-            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(cell1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
 
-            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(cell2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
 
             Assert.True(dataGridView.IsHandleCreated);
         }
@@ -1478,16 +1432,28 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewCellAccessibleObject_FragmentNavigate_Child_ReturnsNull_IfRowHeadersHidden()
         {
-            using DataGridView dataGridView = new() { RowHeadersVisible = false };
-            dataGridView.Columns.Add("Column 1", "Header text 1");
+            using DataGridView dataGridView = CreateDataGridView(columnCount: 1);
+            dataGridView.RowHeadersVisible = false;
             dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
 
-            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cell = dataGridView.Rows[0].Cells[0].AccessibilityObject;
 
-            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
-            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.Null(cell.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(cell.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
 
             Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        private DataGridView CreateDataGridView(int columnCount)
+        {
+            DataGridView dataGridView = new();
+
+            for (int i = 0; i < columnCount; i++)
+            {
+                dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            }
+
+            return dataGridView;
         }
 
         private class SubDataGridViewCell : DataGridViewCell

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewCellAccessibleObjectTests.cs
@@ -1013,6 +1013,483 @@ namespace System.Windows.Forms.Tests
             Assert.False(dataGridView.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            var cellAccessibleObject = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            var rowAccessibleObject = dataGridView.Rows[0].AccessibilityObject;
+
+            Assert.Equal(rowAccessibleObject, cellAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Parent_IsNull_IfOwningRowIsNull()
+        {
+            using var owner = new SubDataGridViewCell();
+            var accessibleObject = new DataGridViewCellAccessibleObject(owner);
+
+            Assert.Null(accessibleObject.Owner.OwningRow);
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject2, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject1, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[2].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject1, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfRowHeadersAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns.Add("Column 4", "Header text 4");
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cellAccessibleObject4 = dataGridView.Rows[0].Cells[3].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject4, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfRowHeadersAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns.Add("Column 4", "Header text 4");
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cellAccessibleObject4 = dataGridView.Rows[0].Cells[3].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject4, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfRowHeadersAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns.Add("Column 4", "Header text 4");
+            dataGridView.Columns[3].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject1, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndFirstColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject1, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndSecondColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject1, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndLastColumnHidden()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject rowHeaderAccessibleObject = dataGridView.Rows[0].HeaderCell.AccessibilityObject;
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject2, rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(rowHeaderAccessibleObject, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(rowHeaderAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndFirstColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[0].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndSecondColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[1].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject cellAccessibleObject1 = dataGridView.Rows[0].Cells[2].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject1, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cellAccessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfCustomOrderAndLastColumnAndRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.Columns.Add("Column 3", "Header text 3");
+            dataGridView.Columns[0].DisplayIndex = 2;
+            dataGridView.Columns[1].DisplayIndex = 1;
+            dataGridView.Columns[2].DisplayIndex = 0;
+            dataGridView.Columns[2].Visible = false;
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject cellAccessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+            AccessibleObject cellAccessibleObject3 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Equal(cellAccessibleObject3, cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(cellAccessibleObject2, cellAccessibleObject3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(cellAccessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Child_ReturnsNull()
+        {
+            using DataGridView dataGridView = new();
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.Columns.Add("Column 2", "Header text 2");
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+            AccessibleObject accessibleObject2 = dataGridView.Rows[0].Cells[1].AccessibilityObject;
+
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject2.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewCellAccessibleObject_FragmentNavigate_Child_ReturnsNull_IfRowHeadersHidden()
+        {
+            using DataGridView dataGridView = new() { RowHeadersVisible = false };
+            dataGridView.Columns.Add("Column 1", "Header text 1");
+            dataGridView.CreateControl(); // DataGridViewCellAccessibleObject.FragmentNavigate method needs Handle no provide non-empty results
+
+            AccessibleObject accessibleObject1 = dataGridView.Rows[0].Cells[0].AccessibilityObject;
+
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject1.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.True(dataGridView.IsHandleCreated);
+        }
+
         private class SubDataGridViewCell : DataGridViewCell
         {
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeaderCellAccessibleObjectTests.cs
@@ -167,5 +167,84 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(row.Cells[0].AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
             Assert.False(control.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Columns[0].Visible = false;
+            DataGridViewRow row = control.Rows[0];
+
+            AccessibleObject accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+            AccessibleObject expected = row.Cells[1].AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Columns[0].DisplayIndex = 1;
+            control.Columns[1].DisplayIndex = 0;
+            DataGridViewRow row = control.Rows[0];
+
+            AccessibleObject accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+            AccessibleObject expected = row.Cells[1].AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrderAndFirstDisplayedColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Columns[0].DisplayIndex = 1;
+            control.Columns[1].DisplayIndex = 0;
+            control.Columns[1].Visible = false;
+            DataGridViewRow row = control.Rows[0];
+
+            AccessibleObject accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+            AccessibleObject expected = row.Cells[0].AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_Child_ReturnsNull()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewRow row = control.Rows[0];
+
+            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            DataGridViewRow row = control.Rows[0];
+
+            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeaderCellAccessibleObjectTests.cs
@@ -133,17 +133,20 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected(bool createControl)
         {
-            using DataGridView control = CreateDataGridView(columnCount: 1);
+            using DataGridView control = CreateDataGridView(columnCount: 1, createControl);
             DataGridViewRow row = control.Rows[0];
 
             var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
             AccessibleObject expected = row.AccessibilityObject;
 
             Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
         [WinFormsFact]
@@ -155,23 +158,28 @@ namespace System.Windows.Forms.Tests
             Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
         }
 
-        [WinFormsFact]
-        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected(bool createControl)
         {
-            using DataGridView control = CreateDataGridView(columnCount: 1);
+            using DataGridView control = CreateDataGridView(columnCount: 1, createControl);
             DataGridViewRow row = control.Rows[0];
 
             AccessibleObject accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
             AccessibleObject expected = row.Cells[0].AccessibilityObject;
 
             Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfFirstColumnHidden()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfFirstColumnHidden(bool createControl)
         {
-            using DataGridView control = CreateDataGridView(columnCount: 2);
+            using DataGridView control = CreateDataGridView(columnCount: 2, createControl);
             control.Columns[0].Visible = false;
             DataGridViewRow row = control.Rows[0];
 
@@ -179,13 +187,16 @@ namespace System.Windows.Forms.Tests
             AccessibleObject expected = row.Cells[1].AccessibilityObject;
 
             Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrder()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrder(bool createControl)
         {
-            using DataGridView control = CreateDataGridView(columnCount: 2);
+            using DataGridView control = CreateDataGridView(columnCount: 2, createControl);
             control.Columns[0].DisplayIndex = 1;
             control.Columns[1].DisplayIndex = 0;
             DataGridViewRow row = control.Rows[0];
@@ -194,13 +205,16 @@ namespace System.Windows.Forms.Tests
             AccessibleObject expected = row.Cells[1].AccessibilityObject;
 
             Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrderAndFirstDisplayedColumnHidden()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrderAndFirstDisplayedColumnHidden(bool createControl)
         {
-            using DataGridView control = CreateDataGridView(columnCount: 2);
+            using DataGridView control = CreateDataGridView(columnCount: 2, createControl);
             control.Columns[0].DisplayIndex = 1;
             control.Columns[1].DisplayIndex = 0;
             control.Columns[1].Visible = false;
@@ -210,25 +224,31 @@ namespace System.Windows.Forms.Tests
             AccessibleObject expected = row.Cells[0].AccessibilityObject;
 
             Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected(bool createControl)
         {
-            using DataGridView control = CreateDataGridView(columnCount: 1);
+            using DataGridView control = CreateDataGridView(columnCount: 1, createControl);
             DataGridViewRow row = control.Rows[0];
 
             var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
 
             Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_Child_ReturnsNull()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_Child_ReturnsNull(bool createControl)
         {
-            using DataGridView control = CreateDataGridView(columnCount: 1);
+            using DataGridView control = CreateDataGridView(columnCount: 1, createControl);
             DataGridViewRow row = control.Rows[0];
 
             var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
@@ -236,16 +256,21 @@ namespace System.Windows.Forms.Tests
             Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
             Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
 
-            Assert.False(control.IsHandleCreated);
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        private DataGridView CreateDataGridView(int columnCount)
+        private DataGridView CreateDataGridView(int columnCount, bool createControl)
         {
             DataGridView dataGridView = new();
 
             for (int i = 0; i < columnCount; i++)
             {
                 dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            }
+
+            if (createControl)
+            {
+                dataGridView.CreateControl();
             }
 
             return dataGridView;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewRowHeaderCellAccessibleObjectTests.cs
@@ -134,7 +134,20 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_IsNull_IfOwningRowIsNull()
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using DataGridView control = CreateDataGridView(columnCount: 1);
+            DataGridViewRow row = control.Rows[0];
+
+            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+            AccessibleObject expected = row.AccessibilityObject;
+
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_Parent_ReturnsNull_IfOwningRowIsNull()
         {
             DataGridViewRowHeaderCellAccessibleObject accessibleObject = new(new());
 
@@ -143,37 +156,22 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
-        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
-        {
-            using DataGridView control = new();
-            control.Columns.Add("Column 1", "Header text 1");
-            DataGridViewRow row = control.Rows[0];
-
-            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
-
-            Assert.Equal(row.AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-            Assert.False(control.IsHandleCreated);
-        }
-
-        [WinFormsFact]
         public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected()
         {
-            using DataGridView control = new();
-            control.Columns.Add("Column 1", "Header text 1");
+            using DataGridView control = CreateDataGridView(columnCount: 1);
             DataGridViewRow row = control.Rows[0];
 
-            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+            AccessibleObject accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+            AccessibleObject expected = row.Cells[0].AccessibilityObject;
 
-            Assert.Equal(row.Cells[0].AccessibilityObject, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(expected, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
             Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsFact]
         public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfFirstColumnHidden()
         {
-            using DataGridView control = new();
-            control.Columns.Add("Column 1", "Header text 1");
-            control.Columns.Add("Column 2", "Header text 2");
+            using DataGridView control = CreateDataGridView(columnCount: 2);
             control.Columns[0].Visible = false;
             DataGridViewRow row = control.Rows[0];
 
@@ -187,9 +185,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrder()
         {
-            using DataGridView control = new();
-            control.Columns.Add("Column 1", "Header text 1");
-            control.Columns.Add("Column 2", "Header text 2");
+            using DataGridView control = CreateDataGridView(columnCount: 2);
             control.Columns[0].DisplayIndex = 1;
             control.Columns[1].DisplayIndex = 0;
             DataGridViewRow row = control.Rows[0];
@@ -204,9 +200,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrderAndFirstDisplayedColumnHidden()
         {
-            using DataGridView control = new();
-            control.Columns.Add("Column 1", "Header text 1");
-            control.Columns.Add("Column 2", "Header text 2");
+            using DataGridView control = CreateDataGridView(columnCount: 2);
             control.Columns[0].DisplayIndex = 1;
             control.Columns[1].DisplayIndex = 0;
             control.Columns[1].Visible = false;
@@ -220,10 +214,21 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        {
+            using DataGridView control = CreateDataGridView(columnCount: 1);
+            DataGridViewRow row = control.Rows[0];
+
+            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
         public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_Child_ReturnsNull()
         {
-            using DataGridView control = new();
-            control.Columns.Add("Column 1", "Header text 1");
+            using DataGridView control = CreateDataGridView(columnCount: 1);
             DataGridViewRow row = control.Rows[0];
 
             var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
@@ -234,17 +239,16 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewRowHeaderCellAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        private DataGridView CreateDataGridView(int columnCount)
         {
-            using DataGridView control = new();
-            control.Columns.Add("Column 1", "Header text 1");
-            DataGridViewRow row = control.Rows[0];
+            DataGridView dataGridView = new();
 
-            var accessibleObject = (DataGridViewRowHeaderCellAccessibleObject)row.HeaderCell.AccessibilityObject;
+            for (int i = 0; i < columnCount; i++)
+            {
+                dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            }
 
-            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.False(control.IsHandleCreated);
+            return dataGridView;
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopLeftHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopLeftHeaderCellAccessibleObjectTests.cs
@@ -194,5 +194,73 @@ namespace System.Windows.Forms.Tests
             Assert.Null(cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
             Assert.False(control.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfFirstColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Columns[0].Visible = false;
+
+            using DataGridViewTopLeftHeaderCell cell = new();
+            control.TopLeftHeaderCell = cell;
+
+            AccessibleObject expected = control.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(expected, cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrder()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 2", "Header text 2");
+            control.Columns[0].DisplayIndex = 1;
+            control.Columns[1].DisplayIndex = 0;
+
+            using DataGridViewTopLeftHeaderCell cell = new();
+            control.TopLeftHeaderCell = cell;
+
+            AccessibleObject expected = control.Columns[1].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(expected, cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrderAndFirstDisplayedColumnHidden()
+        {
+            using DataGridView control = new();
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns[0].DisplayIndex = 1;
+            control.Columns[1].DisplayIndex = 0;
+            control.Columns[1].Visible = false;
+
+            using DataGridViewTopLeftHeaderCell cell = new();
+            control.TopLeftHeaderCell = cell;
+
+            AccessibleObject expected = control.Columns[0].HeaderCell.AccessibilityObject;
+
+            Assert.Equal(expected, cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_Child_ReturnsNull()
+        {
+            using DataGridView control = new();
+
+            using DataGridViewTopLeftHeaderCell cell = new();
+            control.TopLeftHeaderCell = cell;
+
+            Assert.Null(cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.False(control.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopLeftHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopLeftHeaderCellAccessibleObjectTests.cs
@@ -145,61 +145,74 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected(bool createControl)
         {
-            using DataGridView control = new();
+            using DataGridView control = CreateDataGridView(columnCount: 0, createControl);
             using DataGridViewTopLeftHeaderCell cell = new();
 
             control.TopLeftHeaderCell = cell;
             AccessibleObject expected = control.AccessibilityObject.GetChild(0);
 
             Assert.Equal(expected, cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected(bool createControl)
         {
-            using DataGridView control = new();
+            using DataGridView control = CreateDataGridView(columnCount: 0, createControl);
             using DataGridViewTopLeftHeaderCell cell = new();
 
             control.TopLeftHeaderCell = cell;
 
             Assert.Null(cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected(bool createControl)
         {
-            using DataGridView control = new();
+            using DataGridView control = CreateDataGridView(columnCount: 0, createControl);
             using DataGridViewTopLeftHeaderCell cell = new();
 
             control.TopLeftHeaderCell = cell;
             AccessibleObject expected = control.AccessibilityObject.GetChild(0)?.GetChild(1);
 
             Assert.Equal(expected, cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsNull_IfDataGridViewHasNoVisibleCollumns()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsNull_IfDataGridViewHasNoVisibleCollumns(bool createControl)
         {
-            using DataGridView control = new();
+            using DataGridView control = CreateDataGridView(columnCount: 0, createControl);
             using DataGridViewTopLeftHeaderCell cell = new();
 
             control.TopLeftHeaderCell = cell;
 
             Assert.Null(cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfFirstColumnHidden()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfFirstColumnHidden(bool createControl)
         {
-            using DataGridView control = new();
-            control.Columns.AddRange(new DataGridViewTextBoxColumn(), new DataGridViewTextBoxColumn());
+            using DataGridView control = CreateDataGridView(columnCount: 2, createControl);
             control.Columns[0].Visible = false;
 
             using DataGridViewTopLeftHeaderCell cell = new();
@@ -208,14 +221,16 @@ namespace System.Windows.Forms.Tests
             AccessibleObject expected = control.Columns[1].HeaderCell.AccessibilityObject;
 
             Assert.Equal(expected, cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrder()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrder(bool createControl)
         {
-            using DataGridView control = new();
-            control.Columns.AddRange(new DataGridViewTextBoxColumn(), new DataGridViewTextBoxColumn());
+            using DataGridView control = CreateDataGridView(columnCount: 2, createControl);
             control.Columns[0].DisplayIndex = 1;
             control.Columns[1].DisplayIndex = 0;
 
@@ -225,14 +240,16 @@ namespace System.Windows.Forms.Tests
             AccessibleObject expected = control.Columns[1].HeaderCell.AccessibilityObject;
 
             Assert.Equal(expected, cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrderAndFirstDisplayedColumnHidden()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrderAndFirstDisplayedColumnHidden(bool createControl)
         {
-            using DataGridView control = new();
-            control.Columns.AddRange(new DataGridViewTextBoxColumn(), new DataGridViewTextBoxColumn());
+            using DataGridView control = CreateDataGridView(columnCount: 2, createControl);
             control.Columns[0].DisplayIndex = 1;
             control.Columns[1].DisplayIndex = 0;
             control.Columns[1].Visible = false;
@@ -243,13 +260,16 @@ namespace System.Windows.Forms.Tests
             AccessibleObject expected = control.Columns[0].HeaderCell.AccessibilityObject;
 
             Assert.Equal(expected, cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
-            Assert.False(control.IsHandleCreated);
+
+            Assert.Equal(createControl, control.IsHandleCreated);
         }
 
-        [WinFormsFact]
-        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_Child_ReturnsNull()
+        [WinFormsTheory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_Child_ReturnsNull(bool createControl)
         {
-            using DataGridView control = new();
+            using DataGridView control = CreateDataGridView(columnCount: 0, createControl);
 
             using DataGridViewTopLeftHeaderCell cell = new();
             control.TopLeftHeaderCell = cell;
@@ -257,7 +277,24 @@ namespace System.Windows.Forms.Tests
             Assert.Null(cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
             Assert.Null(cell.AccessibilityObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
 
-            Assert.False(control.IsHandleCreated);
+            Assert.Equal(createControl, control.IsHandleCreated);
+        }
+
+        private DataGridView CreateDataGridView(int columnCount, bool createControl = true)
+        {
+            DataGridView dataGridView = new();
+
+            for (int i = 0; i < columnCount; i++)
+            {
+                dataGridView.Columns.Add(new DataGridViewTextBoxColumn());
+            }
+
+            if (createControl)
+            {
+                dataGridView.CreateControl();
+            }
+
+            return dataGridView;
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopLeftHeaderCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DataGridViewTopLeftHeaderCellAccessibleObjectTests.cs
@@ -199,8 +199,7 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfFirstColumnHidden()
         {
             using DataGridView control = new();
-            control.Columns.Add("Column 1", "Header text 1");
-            control.Columns.Add("Column 2", "Header text 2");
+            control.Columns.AddRange(new DataGridViewTextBoxColumn(), new DataGridViewTextBoxColumn());
             control.Columns[0].Visible = false;
 
             using DataGridViewTopLeftHeaderCell cell = new();
@@ -216,8 +215,7 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrder()
         {
             using DataGridView control = new();
-            control.Columns.Add("Column 1", "Header text 1");
-            control.Columns.Add("Column 2", "Header text 2");
+            control.Columns.AddRange(new DataGridViewTextBoxColumn(), new DataGridViewTextBoxColumn());
             control.Columns[0].DisplayIndex = 1;
             control.Columns[1].DisplayIndex = 0;
 
@@ -234,8 +232,7 @@ namespace System.Windows.Forms.Tests
         public void DataGridViewTopLeftHeaderCellAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfCustomOrderAndFirstDisplayedColumnHidden()
         {
             using DataGridView control = new();
-            control.Columns.Add("Column 1", "Header text 1");
-            control.Columns.Add("Column 1", "Header text 1");
+            control.Columns.AddRange(new DataGridViewTextBoxColumn(), new DataGridViewTextBoxColumn());
             control.Columns[0].DisplayIndex = 1;
             control.Columns[1].DisplayIndex = 0;
             control.Columns[1].Visible = false;


### PR DESCRIPTION
Part of #6094

## Proposed changes

- Add missing unit tests to check the method behavior in base class and derived classes

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0.0-rc.1.22426.10
- Windows 11



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7930)