### PR TITLE
Update Anchor Layout to support high DPI machines.

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -11,12 +11,21 @@ namespace System.Windows.Forms.Primitives
     internal static partial class LocalAppContextSwitches
     {
         private const string ScaleTopLevelFormMinMaxSizeForDpiSwitchName = "System.Windows.Forms.ScaleTopLevelFormMinMaxSizeForDpi";
+        private const string EnableImprovedAnchorLayoutSwitchName = "System.Windows.Forms.EnableImprovedAnchorLayout";
 
         private static int s_scaleTopLevelFormMinMaxSizeForDpi;
+        private static int s_enableImprovedAnchorLayout;
+
         public static bool ScaleTopLevelFormMinMaxSizeForDpi
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => GetCachedSwitchValue(ScaleTopLevelFormMinMaxSizeForDpiSwitchName, ref s_scaleTopLevelFormMinMaxSizeForDpi);
+        }
+
+        public static bool EnableImprovedAnchorLayout
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetCachedSwitchValue(EnableImprovedAnchorLayoutSwitchName, ref s_enableImprovedAnchorLayout);
         }
 
         private static readonly FrameworkName? s_targetFrameworkName = GetTargetFrameworkName();

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms.Primitives
     internal static partial class LocalAppContextSwitches
     {
         private const string ScaleTopLevelFormMinMaxSizeForDpiSwitchName = "System.Windows.Forms.ScaleTopLevelFormMinMaxSizeForDpi";
-        internal const string EnableImprovedAnchorLayoutSwitchName = "System.Windows.Forms.EnableImprovedAnchorLayout";
+        internal const string EnableAnchorLayoutV2SwitchName = "System.Windows.Forms.EnableAnchorLayoutV2";
 
         private static int s_scaleTopLevelFormMinMaxSizeForDpi;
         private static int s_enableImprovedAnchorLayout;
@@ -22,10 +22,10 @@ namespace System.Windows.Forms.Primitives
             get => GetCachedSwitchValue(ScaleTopLevelFormMinMaxSizeForDpiSwitchName, ref s_scaleTopLevelFormMinMaxSizeForDpi);
         }
 
-        public static bool EnableImprovedAnchorLayout
+        public static bool EnableAnchorLayoutV2
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => GetCachedSwitchValue(EnableImprovedAnchorLayoutSwitchName, ref s_enableImprovedAnchorLayout);
+            get => GetCachedSwitchValue(EnableAnchorLayoutV2SwitchName, ref s_enableImprovedAnchorLayout);
         }
 
         private static readonly FrameworkName? s_targetFrameworkName = GetTargetFrameworkName();
@@ -78,6 +78,11 @@ namespace System.Windows.Forms.Primitives
                     if (s_targetFrameworkName!.Version.CompareTo(new Version("8.0")) >= 0)
                     {
                         if (switchName == ScaleTopLevelFormMinMaxSizeForDpiSwitchName)
+                        {
+                            return true;
+                        }
+
+                        if (switchName == EnableAnchorLayoutV2SwitchName)
                         {
                             return true;
                         }

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -10,11 +10,14 @@ namespace System.Windows.Forms.Primitives
     // Borrowed from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/LocalAppContextSwitches.Common.cs
     internal static partial class LocalAppContextSwitches
     {
+        // Switch names declared internal below are used in unit/integration tests. Refer to
+        // https://github.com/microsoft/winforms/blob/main/docs/AnchorLayoutChangesInNet80.md
+        // for more details on how to enable these switches in the application.
         private const string ScaleTopLevelFormMinMaxSizeForDpiSwitchName = "System.Windows.Forms.ScaleTopLevelFormMinMaxSizeForDpi";
-        internal const string EnableAnchorLayoutV2SwitchName = "System.Windows.Forms.EnableAnchorLayoutV2";
+        internal const string AnchorLayoutV2SwitchName = "System.Windows.Forms.AnchorLayoutV2";
 
         private static int s_scaleTopLevelFormMinMaxSizeForDpi;
-        private static int s_enableImprovedAnchorLayout;
+        private static int s_AnchorLayoutV2;
 
         public static bool ScaleTopLevelFormMinMaxSizeForDpi
         {
@@ -22,10 +25,15 @@ namespace System.Windows.Forms.Primitives
             get => GetCachedSwitchValue(ScaleTopLevelFormMinMaxSizeForDpiSwitchName, ref s_scaleTopLevelFormMinMaxSizeForDpi);
         }
 
-        public static bool EnableAnchorLayoutV2
+        /// <summary>
+        ///  Returns AnchorLayoutV2 switch value from runtimeconfig.json. Defaults to true if application is targeting .NET 8.0 and beyond.
+        ///  Refer to
+        ///  https://github.com/microsoft/winforms/blob/main/docs/AnchorLayoutChangesInNet80.md for more details.
+        /// </summary>
+        public static bool AnchorLayoutV2
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => GetCachedSwitchValue(EnableAnchorLayoutV2SwitchName, ref s_enableImprovedAnchorLayout);
+            get => GetCachedSwitchValue(AnchorLayoutV2SwitchName, ref s_AnchorLayoutV2);
         }
 
         private static readonly FrameworkName? s_targetFrameworkName = GetTargetFrameworkName();
@@ -41,12 +49,7 @@ namespace System.Windows.Forms.Primitives
         private static bool GetCachedSwitchValue(string switchName, ref int cachedSwitchValue)
         {
             // The cached switch value has 3 states: 0 - unknown, 1 - true, -1 - false
-            if (cachedSwitchValue < 0)
-                return false;
-            if (cachedSwitchValue > 0)
-                return true;
-
-            return GetSwitchValue(switchName, ref cachedSwitchValue);
+            return cachedSwitchValue >= 0 && (cachedSwitchValue > 0 || GetSwitchValue(switchName, ref cachedSwitchValue));
         }
 
         private static bool GetSwitchValue(string switchName, ref int cachedSwitchValue)
@@ -73,6 +76,8 @@ namespace System.Windows.Forms.Primitives
                     return false;
                 }
 
+                // We are introducing switch defaults in .NET 8.0+ and support matrix for this product is
+                // is limited to Windows 10 and above versions.
                 if (OsVersion.IsWindows10_1703OrGreater())
                 {
                     if (s_targetFrameworkName!.Version.CompareTo(new Version("8.0")) >= 0)
@@ -82,7 +87,7 @@ namespace System.Windows.Forms.Primitives
                             return true;
                         }
 
-                        if (switchName == EnableAnchorLayoutV2SwitchName)
+                        if (switchName == AnchorLayoutV2SwitchName)
                         {
                             return true;
                         }

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -52,7 +52,17 @@ namespace System.Windows.Forms.Primitives
         private static bool GetCachedSwitchValue(string switchName, ref int cachedSwitchValue)
         {
             // The cached switch value has 3 states: 0 - unknown, 1 - true, -1 - false
-            return cachedSwitchValue >= 0 && (cachedSwitchValue > 0 || GetSwitchValue(switchName, ref cachedSwitchValue));
+            if (cachedSwitchValue < 0)
+            {
+                return false;
+            }
+
+            if (cachedSwitchValue > 0)
+            {
+                return true;
+            }
+
+            return GetSwitchValue(switchName, ref cachedSwitchValue);
         }
 
         private static bool GetSwitchValue(string switchName, ref int cachedSwitchValue)
@@ -80,7 +90,7 @@ namespace System.Windows.Forms.Primitives
                 }
 
                 // We are introducing switch defaults in .NET 8.0+ and support matrix for this product is
-                // is limited to Windows 10 and above versions.
+                // limited to Windows 10 and above versions.
                 if (OsVersion.IsWindows10_1703OrGreater())
                 {
                     if (s_targetFrameworkName!.Version.CompareTo(new Version("8.0")) >= 0)

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms.Primitives
     internal static partial class LocalAppContextSwitches
     {
         // Switch names declared internal below are used in unit/integration tests. Refer to
-        // https://github.com/microsoft/winforms/blob/main/docs/AnchorLayoutChangesInNet80.md
+        // https://github.com/microsoft/winforms/blob/tree/main/docs/design/anchor_layout_changes_in_net80.md
         // for more details on how to enable these switches in the application.
         private const string ScaleTopLevelFormMinMaxSizeForDpiSwitchName = "System.Windows.Forms.ScaleTopLevelFormMinMaxSizeForDpi";
         internal const string AnchorLayoutV2SwitchName = "System.Windows.Forms.AnchorLayoutV2";
@@ -26,10 +26,13 @@ namespace System.Windows.Forms.Primitives
         }
 
         /// <summary>
+        ///  Indicates whether AnchorLayoutV2 feature is enabled.
+        /// </summary>
+        /// <devdoc>
         ///  Returns AnchorLayoutV2 switch value from runtimeconfig.json. Defaults to true if application is targeting .NET 8.0 and beyond.
         ///  Refer to
-        ///  https://github.com/microsoft/winforms/blob/main/docs/AnchorLayoutChangesInNet80.md for more details.
-        /// </summary>
+        ///  https://github.com/microsoft/winforms/blob/tree/main/docs/design/anchor_layout_changes_in_net80.md for more details.
+        /// </devdoc>
         public static bool AnchorLayoutV2
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms.Primitives
     internal static partial class LocalAppContextSwitches
     {
         private const string ScaleTopLevelFormMinMaxSizeForDpiSwitchName = "System.Windows.Forms.ScaleTopLevelFormMinMaxSizeForDpi";
-        private const string EnableImprovedAnchorLayoutSwitchName = "System.Windows.Forms.EnableImprovedAnchorLayout";
+        internal const string EnableImprovedAnchorLayoutSwitchName = "System.Windows.Forms.EnableImprovedAnchorLayout";
 
         private static int s_scaleTopLevelFormMinMaxSizeForDpi;
         private static int s_enableImprovedAnchorLayout;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -7909,7 +7909,6 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual void OnCreateControl()
         {
-            DefaultLayout.UpdateAnchorInfoV2(this);
         }
 
         /// <summary>
@@ -12205,6 +12204,7 @@ namespace System.Windows.Forms
             _parent?.UpdateChildZOrder(this);
 
             UpdateBounds();
+            DefaultLayout.UpdateAnchorInfoV2(this);
 
             // Let any interested sites know that we've now created a handle
             OnHandleCreated(EventArgs.Empty);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -10589,8 +10589,8 @@ namespace System.Windows.Forms
             if (DpiHelper.IsScalingRequirementMet
                 && ParentInternal is not null
                 && (ParentInternal.LayoutEngine == DefaultLayout.Instance)
-                // In V2(.NET 8.0 and beyond) version, anchors are updated/computed after the controls bounds changed
-                // and doesn't need to be scaled.
+                // In the v2 layout, anchors are updated/computed after the controls bounds changed
+                // and, thus, don't need scaling.
                 && !LocalAppContextSwitches.EnableAnchorLayoutV2)
             {
                 // We need to scale AnchorInfo to update distances to container edges

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -15,6 +15,7 @@ using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Windows.Forms.Automation;
 using System.Windows.Forms.Layout;
+using System.Windows.Forms.Primitives;
 using Microsoft.Win32;
 using static Interop;
 using Encoding = System.Text.Encoding;
@@ -10587,11 +10588,11 @@ namespace System.Windows.Forms
             scaledSize = LayoutUtils.UnionSizes(scaledSize, minSize);
 
             if (DpiHelper.IsScalingRequirementMet
-                && (ParentInternal is not null)
+                && ParentInternal is not null
                 && (ParentInternal.LayoutEngine == DefaultLayout.Instance)
-                // In V2(.NET 8.0 and beyond) version, anchors are updated after the controls bounds changed
+                // In V2(.NET 8.0 and beyond) version, anchors are updated/computed after the controls bounds changed
                 // and doesn't need to be scaled.
-                /*&& !LocalAppContextSwitches.EnableAnchorLayoutV2*/)
+                && !LocalAppContextSwitches.EnableAnchorLayoutV2)
             {
                 // We need to scale AnchorInfo to update distances to container edges
                 DefaultLayout.ScaleAnchorInfo(this, factor);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -10815,7 +10815,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal void UpdateAnchorsIfRequired()
+        private void UpdateAnchorsIfRequired()
         {
             if (!LocalAppContextSwitches.AnchorLayoutV2)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -827,10 +827,10 @@ namespace System.Windows.Forms.Layout
         }
 
         /// <summary>
-        /// Updates anchor calculations if the control is parented and both control's and its parent's handle are created.
-        /// This is the new behavior introduced in .NET 8.0. Refer to
-        /// https://github.com/microsoft/winforms/blob/main/docs/AnchorLayoutChangesInNet80.md for more details.
-        /// Developers may opt-out of this new behavior using switch <see cref="LocalAppContextSwitches.EnableAnchorLayoutV2"/>.
+        ///  Updates anchor calculations if the control is parented and both control's and its parent's handle are created.
+        ///  This is the new behavior introduced in .NET 8.0. Refer to
+        ///  https://github.com/microsoft/winforms/blob/main/docs/AnchorLayoutChangesInNet80.md for more details.
+        ///  Developers may opt-out of this new behavior using switch <see cref="LocalAppContextSwitches.EnableAnchorLayoutV2"/>.
         /// </summary>
         internal static void UpdateAnchorInfoV2(IArrangedElement element)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -373,7 +373,17 @@ namespace System.Windows.Forms.Layout
                     continue;
                 }
 
-                Debug.Assert(GetAnchorInfo(element) is not null, "AnchorInfo should be initialized before LayoutAnchorControls().");
+                if (!LocalAppContextSwitches.EnableAnchorLayoutV2 || element is not Control)
+                {
+                    Debug.Assert(GetAnchorInfo(element) is not null, "AnchorInfo should be initialized before LayoutAnchorControls().");
+                }
+                else
+                {
+                    // It is possible that element's parent handle might not have created when the element's
+                    // handle was created. This case handle those scenarios and compute anchors for the element.
+                    UpdateAnchorInfoV2(element);
+                }
+
                 SetCachedBounds(element, GetAnchorDestination(element, displayRectangle, /*measureOnly=*/false));
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -717,13 +717,6 @@ namespace System.Windows.Forms.Layout
                 return;
             }
 
-            AnchorInfo anchorInfo = GetAnchorInfo(element);
-            if (anchorInfo is null)
-            {
-                anchorInfo = new AnchorInfo();
-                SetAnchorInfo(element, anchorInfo);
-            }
-
             Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, "Update anchor info");
             Debug.Indent();
             Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, element.Container is null ? "No parent" : "Parent");
@@ -735,16 +728,23 @@ namespace System.Windows.Forms.Layout
 
             if (enableImprovedAnchorLayout)
             {
-                ComputeAnchorInfo(element, anchorInfo);
+                ComputeAnchorInfo(element);
             }
             else
             {
-                ComputeLegacyAnchorInfo(element, anchorInfo);
+                ComputeLegacyAnchorInfo(element);
             }
         }
 
-        private static void ComputeLegacyAnchorInfo(IArrangedElement element, AnchorInfo anchorInfo)
+        private static void ComputeLegacyAnchorInfo(IArrangedElement element)
         {
+            AnchorInfo anchorInfo = GetAnchorInfo(element);
+            if (anchorInfo is null)
+            {
+                anchorInfo = new AnchorInfo();
+                SetAnchorInfo(element, anchorInfo);
+            }
+
             Rectangle bounds = GetCachedBounds(element);
             AnchorInfo oldAnchorInfo = new AnchorInfo
             {
@@ -833,8 +833,15 @@ namespace System.Windows.Forms.Layout
             Debug.Unindent();
         }
 
-        private static void ComputeAnchorInfo(IArrangedElement element, AnchorInfo anchorInfo)
+        private static void ComputeAnchorInfo(IArrangedElement element)
         {
+            AnchorInfo anchorInfo = GetAnchorInfo(element);
+            if (anchorInfo is null)
+            {
+                anchorInfo = new AnchorInfo();
+                SetAnchorInfo(element, anchorInfo);
+            }
+
             Rectangle displayRect = element.Container.DisplayRectangle;
             Rectangle elementBounds = element.Bounds;
 
@@ -1042,7 +1049,7 @@ namespace System.Windows.Forms.Layout
             }
         }
 
-        private static AnchorInfo GetAnchorInfo(IArrangedElement element)
+        internal static AnchorInfo GetAnchorInfo(IArrangedElement element)
         {
             return (AnchorInfo)element.Properties.GetObject(s_layoutInfoProperty);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -183,17 +183,14 @@ namespace System.Windows.Forms.Layout
             int y = anchorInfo.Top;
             int height = elementBounds.Height;
 
-            if (x < 0 || width < 0 || y < 0 || height < 0)
-            {
-                Debug.WriteLine($"\t\t'{element}' destination bounds resulted in negative");
-            }
+            Debug.WriteLineIf(x < 0 || width < 0 || y < 0 || height < 0, $"\t\t'{element}' destination bounds resulted in negative");
 
             // Compute element bounds according to AnchorStyles set on it.
             AnchorStyles anchor = GetAnchor(element);
             if (IsAnchored(anchor, AnchorStyles.Left))
             {
-                // If Anchored both left anf right, element's width will be forced to update according to
-                // parents DisplayRect.
+                // If anchored both left and right, element's width will be forced to update according to
+                // parent's DisplayRect.
                 if (IsAnchored(anchor, AnchorStyles.Right))
                 {
                     width = displayRect.Width - (anchorInfo.Right + x);
@@ -201,10 +198,10 @@ namespace System.Windows.Forms.Layout
             }
             else
             {
-                // If anchored Right but not Left, element's X- co-ordinate should be updated according to parents DisplayRect.
+                // If anchored Right but not Left, element's X- co-ordinate should be updated according to parent's DisplayRect.
                 x = IsAnchored(anchor, AnchorStyles.Right)
                     ? displayRect.Width - elementBounds.Width - anchorInfo.Right
-                    // Element neither anchored Right or Left but anchored Top or Bottom,  elements X-coordinate is adjusted relative to  DisplayRect chnage.
+                    // Element neither anchored Right or Left but anchored Top or Bottom,  elements X-coordinate is adjusted relative to parent's DisplayRect change.
                     : (int)(anchorInfo.Left * (((float)displayRect.Width - elementBounds.Width) / (anchorInfo.Left + anchorInfo.Right)));
             }
 
@@ -212,21 +209,20 @@ namespace System.Windows.Forms.Layout
             {
                 if (IsAnchored(anchor, AnchorStyles.Bottom))
                 {
-                    // If Anchored both Top anf Bottom, element's height will be forced to update according to
-                    // parents DisplayRect.
+                    // If anchored both Top and Bottom, element's height will be forced to update according to parent's DisplayRect.
                     height = displayRect.Height - (anchorInfo.Bottom + y);
                 }
             }
             else
             {
-                // If anchored Bottom but not Top, element's Y- co-ordinate should be updated according to parents DisplayRect.
+                // If anchored Bottom but not Top, element's Y- co-ordinate should be updated according to parent's DisplayRect.
                 y = IsAnchored(anchor, AnchorStyles.Bottom)
                     ? displayRect.Height - elementBounds.Height - anchorInfo.Bottom
-                    // Element neither anchored Top or Bottom but anchored Right or left,  elements X-coordinate is adjusted relative to  DisplayRect chnage.
+                    // Element neither anchored Top or Bottom but anchored Right or left,  elements X-coordinate is adjusted relative to parent's DisplayRect change.
                     : (int)(anchorInfo.Top * (((float)displayRect.Height - elementBounds.Height) / (anchorInfo.Top + anchorInfo.Bottom)));
             }
 
-            // We clip element but not position at negative location with respect parents DisplayRect.
+            // We clip the element but does not position element at negative location with respect to parents DisplayRect.
             if (x < 0)
             {
                 x = 0;
@@ -249,12 +245,7 @@ namespace System.Windows.Forms.Layout
             int right = layout.Right + displayRect.X;
             int bottom = layout.Bottom + displayRect.Y;
 
-            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, "\t\t...anchor dim (l,t,r,b) {"
-                              + left
-                              + ", " + top
-                              + ", " + right
-                              + ", " + bottom
-                              + "}");
+            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, $"\t\t...anchor dim (l,t,r,b) {{{left}, {top}, {right}, {bottom}}}");
 
             AnchorStyles anchor = GetAnchor(element);
 
@@ -350,12 +341,7 @@ namespace System.Windows.Forms.Layout
                 }
             }
 
-            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, "\t\t...new anchor dim (l,t,r,b) {"
-                                                                      + left
-                                                                      + ", " + top
-                                                                      + ", " + right
-                                                                      + ", " + bottom
-                                                                      + "}");
+            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, $"\t\t...new anchor dim (l,t,r,b) {{{left}, {top}, {right}, {bottom}}}");
 
             return new Rectangle(left, top, right - left, bottom - top);
         }
@@ -363,7 +349,7 @@ namespace System.Windows.Forms.Layout
         private static void LayoutAnchoredControls(IArrangedElement container)
         {
             Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, "\tAnchor Processing");
-            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, "\t\tdisplayRect: " + container.DisplayRectangle.ToString());
+            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, $"\t\tdisplayRect: {container.DisplayRectangle.ToString()}");
 
             if (!IsElementReadyForComputingAnchors(container))
             {
@@ -392,10 +378,12 @@ namespace System.Windows.Forms.Layout
             }
         }
 
-        // Checks if element is ready to compute anchors by checking if this element
-        // and its parents handle are created to make sure bounds are applied with current DPI.
-        private static bool IsElementReadyForComputingAnchors(IArrangedElement element
-            ) => LocalAppContextSwitches.EnableAnchorLayoutV2 ? element is not Control control || control.IsHandleCreated : true;
+        /// <summary>
+        /// Checks if element is ready to compute anchors by checking if this element and its parents
+        /// handle are created to make sure bounds are applied with current DPI.
+        /// </summary>
+        private static bool IsElementReadyForComputingAnchors(IArrangedElement element)
+            => !LocalAppContextSwitches.EnableAnchorLayoutV2 || element is not Control control || control.IsHandleCreated;
 
         private static Size LayoutDockedControls(IArrangedElement container, bool measureOnly)
         {
@@ -659,8 +647,8 @@ namespace System.Windows.Forms.Layout
                 }
             }
 
-            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, "\tanchor : " + anchor.ToString());
-            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, "\tdock :   " + dock.ToString());
+            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, $"\tanchor : {anchor.ToString()}");
+            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, $"\tdock :   {dock.ToString()}");
 
             Size preferredSizeForDocking = Size.Empty;
             Size preferredSizeForAnchoring = Size.Empty;
@@ -765,7 +753,7 @@ namespace System.Windows.Forms.Layout
             anchorInfo.Bottom = element.Bounds.Bottom;
 
             Rectangle parentDisplayRect = element.Container.DisplayRectangle;
-            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, "Parent displayRectangle" + parentDisplayRect);
+            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, $"Parent displayRectangle{parentDisplayRect}");
             int parentWidth = parentDisplayRect.Width;
             int parentHeight = parentDisplayRect.Height;
 
@@ -834,14 +822,14 @@ namespace System.Windows.Forms.Layout
                 anchorInfo.Top -= parentHeight / 2;
             }
 
-            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, "anchor info (l,t,r,b): (" + anchorInfo.Left + ", " + anchorInfo.Top + ", " + anchorInfo.Right + ", " + anchorInfo.Bottom + ")");
+            Debug.WriteLineIf(CompModSwitches.RichLayout.TraceInfo, $"anchor info (l,t,r,b): ({anchorInfo.Left}, {anchorInfo.Top}, {anchorInfo.Right}, {anchorInfo.Bottom})");
             Debug.Unindent();
         }
 
         /// <summary>
         /// Updates anchor calculations if the control is parented and both control's and its parent's handle are created.
         /// This is the new behavior introduced in .NET 8.0. Refer to
-        /// (ToDo)https://github.com/microsoft/winforms/blob/main/docs/AnchorLayoutChangesInNet80.md for more details.
+        /// https://github.com/microsoft/winforms/blob/main/docs/AnchorLayoutChangesInNet80.md for more details.
         /// Developers may opt-out of this new behavior using switch <see cref="LocalAppContextSwitches.EnableAnchorLayoutV2"/>.
         /// </summary>
         internal static void UpdateAnchorInfoV2(IArrangedElement element)
@@ -854,12 +842,11 @@ namespace System.Windows.Forms.Layout
             Control control = element as Control;
             Debug.Assert(control != null, "AnchorLayoutV2 and beyond are expected to be used only on Control type");
 
-            if (control is null || control.Parent is null)
-            {
-                return;
-            }
-
-            if (!control.IsHandleCreated || !control.Parent.IsHandleCreated)
+            // Check if control is ready for anchor calculation.
+            if (control is null
+                || !control.IsHandleCreated
+                || control.Parent is null
+                || !control.Parent.IsHandleCreated)
             {
                 return;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -164,8 +164,8 @@ namespace System.Windows.Forms.Layout
             }
 
             return LocalAppContextSwitches.EnableAnchorLayoutV2
-                ? ComputeAnchorDestination(element, displayRect)
-                : ComputeLegacyAnchorDestination(element, displayRect, measureOnly);
+                ? ComputeAnchoredBoundsV2(element, displayRect)
+                : ComputeAnchoredBounds(element, displayRect, measureOnly);
         }
 
         private static Rectangle ComputeAnchoredBoundsV2(IArrangedElement element, Rectangle displayRect)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -1155,8 +1155,8 @@ namespace System.Windows.Forms.Layout
                         else
                         {
                             prefSize.Height = anchorDest.Height < 0
-                            ? Math.Max(prefSize.Height, elementSpace.Bottom + anchorDest.Height)
-                            : Math.Max(prefSize.Height, anchorDest.Bottom);
+                                ? Math.Max(prefSize.Height, elementSpace.Bottom + anchorDest.Height)
+                                : Math.Max(prefSize.Height, anchorDest.Bottom);
                         }
                     }
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -377,7 +377,7 @@ namespace System.Windows.Forms.Layout
                 {
                     Debug.Assert(GetAnchorInfo(element) is not null, "AnchorInfo should be initialized before LayoutAnchorControls().");
                 }
-                else
+                else if (GetAnchorInfo(element) is null)
                 {
                     // It is possible that element's parent handle might not have created when the element's
                     // handle was created. This case handle those scenarios and compute anchors for the element.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -437,8 +437,7 @@ namespace System.Windows.Forms.Layout
             for (int i = children.Count - 1; i >= 0; i--)
             {
                 IArrangedElement element = children[i];
-                Rectangle bounds = element.Bounds;
-                Debug.Assert(bounds == GetCachedBounds(element), "Why do we have cachedBounds for a docked element?");
+                Debug.Assert(element.Bounds == GetCachedBounds(element), "Why do we have cachedBounds for a docked element?");
                 if (CommonProperties.GetNeedsDockLayout(element))
                 {
                     // Some controls modify their bounds when you call SetBoundsCore. We
@@ -453,8 +452,8 @@ namespace System.Windows.Forms.Layout
                                 TryCalculatePreferredSizeDockedControl(element, newElementBounds, measureOnly, ref preferredSize, ref remainingBounds);
 
                                 // What we are really doing here: top += control.Bounds.Height;
-                                remainingBounds.Y += bounds.Height;
-                                remainingBounds.Height -= bounds.Height;
+                                remainingBounds.Y += element.Bounds.Height;
+                                remainingBounds.Height -= element.Bounds.Height;
                                 break;
                             }
 
@@ -466,7 +465,7 @@ namespace System.Windows.Forms.Layout
                                 TryCalculatePreferredSizeDockedControl(element, newElementBounds, measureOnly, ref preferredSize, ref remainingBounds);
 
                                 // What we are really doing here: bottom -= control.Bounds.Height;
-                                remainingBounds.Height -= bounds.Height;
+                                remainingBounds.Height -= element.Bounds.Height;
 
                                 break;
                             }
@@ -479,8 +478,8 @@ namespace System.Windows.Forms.Layout
                                 TryCalculatePreferredSizeDockedControl(element, newElementBounds, measureOnly, ref preferredSize, ref remainingBounds);
 
                                 // What we are really doing here: left += control.Bounds.Width;
-                                remainingBounds.X += bounds.Width;
-                                remainingBounds.Width -= bounds.Width;
+                                remainingBounds.X += element.Bounds.Width;
+                                remainingBounds.Width -= element.Bounds.Width;
                                 break;
                             }
 
@@ -492,7 +491,7 @@ namespace System.Windows.Forms.Layout
                                 TryCalculatePreferredSizeDockedControl(element, newElementBounds, measureOnly, ref preferredSize, ref remainingBounds);
 
                                 // What we are really doing here: right -= control.Bounds.Width;
-                                remainingBounds.Width -= bounds.Width;
+                                remainingBounds.Width -= element.Bounds.Width;
                                 break;
                             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -168,7 +168,7 @@ namespace System.Windows.Forms.Layout
                 : ComputeLegacyAnchorDestination(element, displayRect, measureOnly);
         }
 
-        private static Rectangle ComputeAnchorDestination(IArrangedElement element, Rectangle displayRect)
+        private static Rectangle ComputeAnchoredBoundsV2(IArrangedElement element, Rectangle displayRect)
         {
             var anchorInfo = GetAnchorInfo(element);
 
@@ -189,8 +189,8 @@ namespace System.Windows.Forms.Layout
             AnchorStyles anchor = GetAnchor(element);
             if (IsAnchored(anchor, AnchorStyles.Left))
             {
-                // If anchored both left and right, element's width will be forced to update according to
-                // parent's DisplayRect.
+                // If anchored both Left and Right, the element's width will be forced to update according to
+                // the parent's DisplayRect.
                 if (IsAnchored(anchor, AnchorStyles.Right))
                 {
                     width = displayRect.Width - (anchorInfo.Right + x);
@@ -198,10 +198,11 @@ namespace System.Windows.Forms.Layout
             }
             else
             {
-                // If anchored Right but not Left, element's X- co-ordinate should be updated according to parent's DisplayRect.
+                // If anchored Right but not Left, the element's X-coordinate should be updated according to the parent's DisplayRect.
                 x = IsAnchored(anchor, AnchorStyles.Right)
                     ? displayRect.Width - elementBounds.Width - anchorInfo.Right
-                    // Element neither anchored Right or Left but anchored Top or Bottom,  elements X-coordinate is adjusted relative to parent's DisplayRect change.
+                    // The element neither anchored Right or Left but anchored Top or Bottom, the element's X-coordinate
+                    // is adjusted relative to the parent's DisplayRect.
                     : (int)(anchorInfo.Left * (((float)displayRect.Width - elementBounds.Width) / (anchorInfo.Left + anchorInfo.Right)));
             }
 
@@ -209,20 +210,21 @@ namespace System.Windows.Forms.Layout
             {
                 if (IsAnchored(anchor, AnchorStyles.Bottom))
                 {
-                    // If anchored both Top and Bottom, element's height will be forced to update according to parent's DisplayRect.
+                    // If anchored both Top and Bottom, the element's height will be forced to update according to the parent's DisplayRect.
                     height = displayRect.Height - (anchorInfo.Bottom + y);
                 }
             }
             else
             {
-                // If anchored Bottom but not Top, element's Y- co-ordinate should be updated according to parent's DisplayRect.
+                // If anchored Bottom but not Top, the element's Y-coordinate will be updated according to the parent's DisplayRect.
                 y = IsAnchored(anchor, AnchorStyles.Bottom)
                     ? displayRect.Height - elementBounds.Height - anchorInfo.Bottom
-                    // Element neither anchored Top or Bottom but anchored Right or left,  elements X-coordinate is adjusted relative to parent's DisplayRect change.
+                    // The element neither anchored Top or Bottom but anchored Right or Left, the element's X-coordinate
+                    // is adjusted relative to the parent's DisplayRect.
                     : (int)(anchorInfo.Top * (((float)displayRect.Height - elementBounds.Height) / (anchorInfo.Top + anchorInfo.Bottom)));
             }
 
-            // We clip the element but does not position element at negative location with respect to parents DisplayRect.
+            // Clip the element but don't position it at a negative location with respect to the parent's DisplayRect.
             if (x < 0)
             {
                 x = 0;
@@ -236,7 +238,7 @@ namespace System.Windows.Forms.Layout
             return new Rectangle(x, y, width, height);
         }
 
-        private static Rectangle ComputeLegacyAnchorDestination(IArrangedElement element, Rectangle displayRect, bool measureOnly)
+        private static Rectangle ComputeAnchoredBounds(IArrangedElement element, Rectangle displayRect, bool measureOnly)
         {
             AnchorInfo layout = GetAnchorInfo(element);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -381,8 +381,8 @@ namespace System.Windows.Forms.Layout
                 }
                 else if (GetAnchorInfo(element) is null)
                 {
-                    // It is possible that element's parent handle might not have created when the element's
-                    // handle was created. This case handle those scenarios and compute anchors for the element.
+                    // It is possible that the parent's handle might not have been created when the element's
+                    // handle was created. If that's the case, compute the element's anchors.
                     UpdateAnchorInfoV2(element);
                 }
 
@@ -391,8 +391,7 @@ namespace System.Windows.Forms.Layout
         }
 
         /// <summary>
-        /// Checks if element is ready to compute anchors by checking if this element and its parents
-        /// handle are created to make sure bounds are applied with current DPI.
+        ///  Inidcates that the element is ready to compute its anchors.
         /// </summary>
         private static bool IsElementReadyForComputingAnchors(IArrangedElement element)
             => !LocalAppContextSwitches.EnableAnchorLayoutV2 || element is not Control control || control.IsHandleCreated;
@@ -715,13 +714,12 @@ namespace System.Windows.Forms.Layout
         }
 
         /// <summary>
-        ///  Updates the element's anchors information based on element's current bounds.
+        ///  Updates the element's anchors information based on the element's current bounds.
         /// </summary>
         private static void UpdateAnchorInfo(IArrangedElement element)
         {
             Debug.Assert(!HasCachedBounds(element.Container), "Do not call this method with an active cached bounds list.");
 
-            // Skip when element is not anchored or EnableAnchorLayoutV2 switch is enabled.
             if (!CommonProperties.GetNeedsAnchorLayout(element))
             {
                 return;
@@ -751,7 +749,7 @@ namespace System.Windows.Forms.Layout
             }
 
             Rectangle bounds = GetCachedBounds(element);
-            AnchorInfo oldAnchorInfo = new AnchorInfo
+            AnchorInfo oldAnchorInfo = new()
             {
                 Left = anchorInfo.Left,
                 Top = anchorInfo.Top,

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
@@ -26,9 +26,9 @@ namespace System.Windows.Forms.UITests
         [InlineData(AnchorStyles.Top | AnchorStyles.Bottom, 120, 30, 20, 330)]
         [InlineData(AnchorStyles.Left | AnchorStyles.Right, 20, 180, 220, 30)]
         [InlineData(AnchorStyles.Bottom | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Left, 20, 30, 220, 330)]
-        public void ResizeAnchoredControlsParent_HanldeCreated_NewAnchorsApplied(AnchorStyles anchor, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
+        public void Control_ResizeAnchoredControls_ParentHanldeCreated_NewAnchorsApplied(AnchorStyles anchors, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
         {
-            var (form, button) = GetFormWithAnchoredButton(anchor);
+            (Form form, Button button) = GetFormWithAnchoredButton(anchors);
             form.Shown += OnFormShown;
 
             // Showing the dialog will execute the assertions
@@ -40,24 +40,25 @@ namespace System.Windows.Forms.UITests
 
             void OnFormShown(object? sender, EventArgs e)
             {
-                Form formLocal = (Form)sender!;
-                Control button1 = formLocal.Controls[0];
+                // Resize the form to compute button anchors.
+                form.Size = new Size(400, 600);
+                Rectangle buttonBounds = button.Bounds;
 
-                //Resize the form to compute button anchors.
-                formLocal.Size = new Size(400, 600);
+                Assert.Equal(expectedX, buttonBounds.X);
+                Assert.Equal(expectedY, buttonBounds.Y);
+                Assert.Equal(expectedWidth, buttonBounds.Width);
+                Assert.Equal(expectedHeight, buttonBounds.Height);
 
-                Assert.Equal(expectedX, button1.Bounds.X);
-                Assert.Equal(expectedY, button1.Bounds.Y);
-                Assert.Equal(expectedWidth, button1.Bounds.Width);
-                Assert.Equal(expectedHeight, button1.Bounds.Height);
                 form.Close();
             }
         }
 
         private static (Form, Button) GetFormWithAnchoredButton(AnchorStyles buttonAnchors)
         {
-            Form form = new();
-            form.Size = new Size(200, 300);
+            Form form = new()
+            {
+                Size = new Size(200, 300)
+            };
 
             Button button = new()
             {

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
@@ -16,18 +16,6 @@ namespace System.Windows.Forms.UITests
         {
         }
 
-        private static (Form, Button) GetFormWithAnchoredButton()
-        {
-            Form form = new();
-            form.Size = new Size(200, 300);
-            Button button = new();
-            button.Location = new Point(20, 30);
-            button.Size = new Size(20, 30);
-            button.Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Right | AnchorStyles.Bottom;
-
-            return (form, button);
-        }
-
         [WinFormsTheory]
         [InlineData(AnchorStyles.Top, 120, 30, 20, 30)]
         [InlineData(AnchorStyles.Left, 20, 180, 20, 30)]
@@ -38,32 +26,52 @@ namespace System.Windows.Forms.UITests
         [InlineData(AnchorStyles.Top | AnchorStyles.Bottom, 120, 30, 20, 330)]
         [InlineData(AnchorStyles.Left | AnchorStyles.Right, 20, 180, 220, 30)]
         [InlineData(AnchorStyles.Bottom | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Left, 20, 30, 220, 330)]
-        public void ResizeAnchoredControlsParent_HanldeCreated_AnchorsApplied(AnchorStyles anchor, int x, int y, int width, int height)
+        public void ResizeAnchoredControlsParent_HanldeCreated_NewAnchorsApplied(AnchorStyles anchor, int expectedX, int expectedY, int expectedWidth, int expectedHeight)
         {
-            var (form, button) = GetFormWithAnchoredButton();
-            button.Anchor = anchor;
-            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
-            Assert.Null(anchorInfo);
-            form.Controls.Add(button);
+            var (form, button) = GetFormWithAnchoredButton(anchor);
             form.Shown += OnFormShown;
+
+            // Showing the dialog will execute the assertions
             form.ShowDialog();
+
             button?.Dispose();
             form?.Dispose();
+            return;
 
             void OnFormShown(object? sender, EventArgs e)
             {
                 Form formLocal = (Form)sender!;
                 Control button1 = formLocal.Controls[0];
 
-                //Resize Form to compute button anchors.
+                //Resize the form to compute button anchors.
                 formLocal.Size = new Size(400, 600);
 
-                Assert.Equal(x, button1.Bounds.X);
-                Assert.Equal(y, button1.Bounds.Y);
-                Assert.Equal(width, button1.Bounds.Width);
-                Assert.Equal(height, button1.Bounds.Height);                
+                Assert.Equal(expectedX, button1.Bounds.X);
+                Assert.Equal(expectedY, button1.Bounds.Y);
+                Assert.Equal(expectedWidth, button1.Bounds.Width);
+                Assert.Equal(expectedHeight, button1.Bounds.Height);
                 form.Close();
             }
+        }
+
+        private static (Form, Button) GetFormWithAnchoredButton(AnchorStyles buttonAnchors)
+        {
+            Form form = new();
+            form.Size = new Size(200, 300);
+
+            Button button = new()
+            {
+                Location = new Point(20, 30),
+                Size = new Size(20, 30),
+                Anchor = buttonAnchors
+            };
+
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
+
+            form.Controls.Add(button);
+
+            return (form, button);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/AnchorLayoutTests.cs
@@ -1,0 +1,69 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Windows.Forms.Layout;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Windows.Forms.UITests
+{
+    public class AnchorLayoutTests : ControlTestBase
+    {
+        public AnchorLayoutTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+        }
+
+        private static (Form, Button) GetFormWithAnchoredButton()
+        {
+            Form form = new();
+            form.Size = new Size(200, 300);
+            Button button = new();
+            button.Location = new Point(20, 30);
+            button.Size = new Size(20, 30);
+            button.Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Right | AnchorStyles.Bottom;
+
+            return (form, button);
+        }
+
+        [WinFormsTheory]
+        [InlineData(AnchorStyles.Top, 120, 30, 20, 30)]
+        [InlineData(AnchorStyles.Left, 20, 180, 20, 30)]
+        [InlineData(AnchorStyles.Right, 220, 180, 20, 30)]
+        [InlineData(AnchorStyles.Bottom, 120, 330, 20, 30)]
+        [InlineData(AnchorStyles.Top | AnchorStyles.Left, 20, 30, 20, 30)]
+        [InlineData(AnchorStyles.Top | AnchorStyles.Right, 220, 30, 20, 30)]
+        [InlineData(AnchorStyles.Top | AnchorStyles.Bottom, 120, 30, 20, 330)]
+        [InlineData(AnchorStyles.Left | AnchorStyles.Right, 20, 180, 220, 30)]
+        [InlineData(AnchorStyles.Bottom | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Left, 20, 30, 220, 330)]
+        public void ResizeAnchoredControlsParent_HanldeCreated_AnchorsApplied(AnchorStyles anchor, int x, int y, int width, int height)
+        {
+            var (form, button) = GetFormWithAnchoredButton();
+            button.Anchor = anchor;
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
+            form.Controls.Add(button);
+            form.Shown += OnFormShown;
+            form.ShowDialog();
+            button?.Dispose();
+            form?.Dispose();
+
+            void OnFormShown(object? sender, EventArgs e)
+            {
+                Form formLocal = (Form)sender!;
+                Control button1 = formLocal.Controls[0];
+
+                //Resize Form to compute button anchors.
+                formLocal.Size = new Size(400, 600);
+
+                Assert.Equal(x, button1.Bounds.X);
+                Assert.Equal(y, button1.Bounds.Y);
+                Assert.Equal(width, button1.Bounds.Width);
+                Assert.Equal(height, button1.Bounds.Height);                
+                form.Close();
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
@@ -65,7 +65,7 @@ namespace System.Windows.Forms.Layout.Tests
         [WinFormsFact]
         public void ConfigSwitchDisabled_NoHanldeCreated_AnchorsComputed()
         {
-            AppContext.SetSwitch(LocalAppContextSwitches.EnableImprovedAnchorLayoutSwitchName, false);
+            AppContext.SetSwitch(LocalAppContextSwitches.EnableAnchorLayoutV2SwitchName, false);
             var (form, button) = GetFormWithAnchoredButton();
             form.Controls.Add(button);
             DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
@@ -85,7 +85,6 @@ namespace System.Windows.Forms.Layout.Tests
         [InlineData(AnchorStyles.Bottom | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Left, 20, 30, 220, 330)]
         public void ResizeAnchoredControlsParent_HanldeCreated_AnchorsApplied(AnchorStyles anchor, int x, int y, int width, int height)
         {
-            AppContext.SetSwitch(LocalAppContextSwitches.EnableImprovedAnchorLayoutSwitchName, true);
             var (form, button) = GetFormWithAnchoredButton();
             button.Anchor = anchor;
             DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
@@ -72,43 +72,5 @@ namespace System.Windows.Forms.Layout.Tests
             Assert.NotNull(anchorInfo);
             Dispose(form, button);
         }
-
-        [WinFormsTheory]
-        [InlineData(AnchorStyles.Top, 120, 30, 20, 30)]
-        [InlineData(AnchorStyles.Left, 20, 180, 20, 30)]
-        [InlineData(AnchorStyles.Right, 220, 68, 20, 30)]
-        [InlineData(AnchorStyles.Bottom, 120, 330, 20, 30)]
-        [InlineData(AnchorStyles.Top | AnchorStyles.Left, 20, 30, 20, 30)]
-        [InlineData(AnchorStyles.Top | AnchorStyles.Right, 220, 30, 20, 30)]
-        [InlineData(AnchorStyles.Top | AnchorStyles.Bottom, 120, 30, 20, 330)]
-        [InlineData(AnchorStyles.Left | AnchorStyles.Right, 20, 180, 220, 30)]
-        [InlineData(AnchorStyles.Bottom | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Left, 20, 30, 220, 330)]
-        public void ResizeAnchoredControlsParent_HanldeCreated_AnchorsApplied(AnchorStyles anchor, int x, int y, int width, int height)
-        {
-            var (form, button) = GetFormWithAnchoredButton();
-            button.Anchor = anchor;
-            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
-            Assert.Null(anchorInfo);
-            form.Controls.Add(button);
-            form.Shown += OnFormShown;
-            form.ShowDialog();
-            Dispose(form, button);
-
-            void OnFormShown(object sender, EventArgs e)
-            {
-                Form formLocal = (Form)sender;
-                Control button1 = formLocal.Controls[0];
-
-                //Resize Form to compute button anchors.
-                formLocal.Size = new Size(400, 600);
-
-                Assert.Equal(x, button1.Bounds.X);
-                Assert.Equal(y, button1.Bounds.Y);
-                Assert.Equal(width, button1.Bounds.Width);
-                Assert.Equal(height, button1.Bounds.Height);
-
-                form.Close();
-            }
-        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms.Primitives;
 
@@ -74,14 +75,14 @@ namespace System.Windows.Forms.Layout.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(AnchorStyles.Top, 44, 30, 20, 30)]
-        [InlineData(AnchorStyles.Left, 20, 68, 20, 30)]
+        [InlineData(AnchorStyles.Top, 120, 30, 20, 30)]
+        [InlineData(AnchorStyles.Left, 20, 180, 20, 30)]
         [InlineData(AnchorStyles.Right, 220, 68, 20, 30)]
-        [InlineData(AnchorStyles.Bottom, 44, 330, 20, 30)]
+        [InlineData(AnchorStyles.Bottom, 120, 330, 20, 30)]
         [InlineData(AnchorStyles.Top | AnchorStyles.Left, 20, 30, 20, 30)]
         [InlineData(AnchorStyles.Top | AnchorStyles.Right, 220, 30, 20, 30)]
-        [InlineData(AnchorStyles.Top | AnchorStyles.Bottom, 44, 30, 20, 330)]
-        [InlineData(AnchorStyles.Left | AnchorStyles.Right, 20, 68, 220, 30)]
+        [InlineData(AnchorStyles.Top | AnchorStyles.Bottom, 120, 30, 20, 330)]
+        [InlineData(AnchorStyles.Left | AnchorStyles.Right, 20, 180, 220, 30)]
         [InlineData(AnchorStyles.Bottom | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Left, 20, 30, 220, 330)]
         public void ResizeAnchoredControlsParent_HanldeCreated_AnchorsApplied(AnchorStyles anchor, int x, int y, int width, int height)
         {
@@ -106,6 +107,7 @@ namespace System.Windows.Forms.Layout.Tests
                 Assert.Equal(y, button1.Bounds.Y);
                 Assert.Equal(width, button1.Bounds.Width);
                 Assert.Equal(height, button1.Bounds.Height);
+
                 form.Close();
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
@@ -11,23 +11,23 @@ namespace System.Windows.Forms.Layout.Tests
     public class AnchorLayoutTests : IClassFixture<ThreadExceptionFixture>
     {
         [WinFormsFact]
-        public void Control_NotParented_NoAnchorsComputed()
+        public void Control_NotParented_AnchorsNotComputed()
         {
-            var (form, button) = GetFormWithAnchoredButton();
+            (Form form, Button button) = GetFormWithAnchoredButton();
 
             DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
             Assert.Null(anchorInfo);
 
-            _ = button.Handle; // Force handle creation;
+            Assert.NotEqual(IntPtr.Zero, button.Handle);
             Assert.Null(anchorInfo);
 
             Dispose(form, button);
         }
 
         [WinFormsFact]
-        public void Control_HandleNotCreated_NoAnchorsComputed()
+        public void Control_HandleNotCreated_AnchorsNotComputed()
         {
-            var (form, button) = GetFormWithAnchoredButton();
+            (Form form, Button button) = GetFormWithAnchoredButton();
 
             DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
             Assert.Null(anchorInfo);
@@ -39,14 +39,15 @@ namespace System.Windows.Forms.Layout.Tests
         }
 
         [WinFormsFact]
-        public void Control_ParentHandleNotCreated_NoAnchorsComputed()
+        public void Control_ParentHandleNotCreated_AnchorsNotComputed()
         {
-            var (form, button) = GetFormWithAnchoredButton();
+            (Form form, Button button) = GetFormWithAnchoredButton();
 
             DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
             Assert.Null(anchorInfo);
 
-            _ = button.Handle; // Force handle creation;
+            Assert.NotEqual(IntPtr.Zero, button.Handle);
+
             form.Controls.Add(button);
             Assert.Null(anchorInfo);
 
@@ -54,10 +55,11 @@ namespace System.Windows.Forms.Layout.Tests
         }
 
         [WinFormsFact]
-        public void ConfigSwitch_Disabled_NoHanldeCreated_AnchorsComputed()
+        public void ConfigSwitch_Disabled_HanldeNotCreated_AnchorsComputed()
         {
-            AppContext.SetSwitch(LocalAppContextSwitches.EnableAnchorLayoutV2SwitchName, false);
-            var (form, button) = GetFormWithAnchoredButton();
+            AppContext.SetSwitch(LocalAppContextSwitches.AnchorLayoutV2SwitchName, false);
+
+            (Form form, Button button) = GetFormWithAnchoredButton();
             form.Controls.Add(button);
 
             DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
@@ -68,8 +70,11 @@ namespace System.Windows.Forms.Layout.Tests
 
         private static (Form, Button) GetFormWithAnchoredButton()
         {
-            Form form = new ();
-            form.Size = new Size(200, 300);
+            Form form = new()
+            {
+                Size = new Size(200, 300)
+            };
+
             Button button = new()
             {
                 Location = new Point(20, 30),

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
@@ -1,0 +1,114 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Drawing;
+using System.Windows.Forms.Primitives;
+
+namespace System.Windows.Forms.Layout.Tests
+{
+    public class AnchorLayoutTests : IClassFixture<ThreadExceptionFixture>
+    {
+        private static (Form, Button) GetFormWithAnchoredButton()
+        {
+            Form form = new ();
+            form.Size = new Size(200, 300);
+            Button button = new ();
+            button.Location = new Point(20, 30);
+            button.Size = new Size(20, 30);
+            button.Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Right | AnchorStyles.Bottom;
+
+            return (form, button);
+        }
+
+        private static void Dispose(Form form, Button button)
+        {
+            button?.Dispose();
+            form?.Dispose();
+        }
+
+        [WinFormsFact]
+        public void ControlNotParented_NoAnchorsComputed()
+        {
+            var (form, button) = GetFormWithAnchoredButton();
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
+            _ = button.Handle; // Force handle creation;
+            Assert.Null(anchorInfo);
+            Dispose(form, button);
+        }
+
+        [WinFormsFact]
+        public void ControlHandleNotCreated_NoAnchorsComputed()
+        {
+            var (form, button) = GetFormWithAnchoredButton();
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
+            form.Controls.Add(button);
+            Assert.Null(anchorInfo);
+            Dispose(form, button);
+        }
+
+        [WinFormsFact]
+        public void ControlParentHandleNotCreated_NoAnchorsComputed()
+        {
+            var (form, button) = GetFormWithAnchoredButton();
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
+            _ = button.Handle; // Force handle creation;
+            form.Controls.Add(button);
+            Assert.Null(anchorInfo);
+            Dispose(form, button);
+        }
+
+        [WinFormsFact]
+        public void ConfigSwitchDisabled_NoHanldeCreated_AnchorsComputed()
+        {
+            AppContext.SetSwitch(LocalAppContextSwitches.EnableImprovedAnchorLayoutSwitchName, false);
+            var (form, button) = GetFormWithAnchoredButton();
+            form.Controls.Add(button);
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.NotNull(anchorInfo);
+            Dispose(form, button);
+        }
+
+        [WinFormsTheory]
+        [InlineData(AnchorStyles.Top, 44, 30, 20, 30)]
+        [InlineData(AnchorStyles.Left, 20, 68, 20, 30)]
+        [InlineData(AnchorStyles.Right, 220, 68, 20, 30)]
+        [InlineData(AnchorStyles.Bottom, 44, 330, 20, 30)]
+        [InlineData(AnchorStyles.Top | AnchorStyles.Left, 20, 30, 20, 30)]
+        [InlineData(AnchorStyles.Top | AnchorStyles.Right, 220, 30, 20, 30)]
+        [InlineData(AnchorStyles.Top | AnchorStyles.Bottom, 44, 30, 20, 330)]
+        [InlineData(AnchorStyles.Left | AnchorStyles.Right, 20, 68, 220, 30)]
+        [InlineData(AnchorStyles.Bottom | AnchorStyles.Right | AnchorStyles.Top | AnchorStyles.Left, 20, 30, 220, 330)]
+        public void ResizeAnchoredControlsParent_HanldeCreated_AnchorsApplied(AnchorStyles anchor, int x, int y, int width, int height)
+        {
+            AppContext.SetSwitch(LocalAppContextSwitches.EnableImprovedAnchorLayoutSwitchName, true);
+            var (form, button) = GetFormWithAnchoredButton();
+            button.Anchor = anchor;
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
+            form.Controls.Add(button);
+            form.Shown += OnFormShown;
+            form.ShowDialog();
+            Dispose(form, button);
+
+            void OnFormShown(object sender, EventArgs e)
+            {
+                Form formLocal = (Form)sender;
+                Control button1 = formLocal.Controls[0];
+
+                //Resize Form to compute button anchors.
+                formLocal.Size = new Size(400, 600);
+
+                Assert.Equal(x, button1.Bounds.X);
+                Assert.Equal(y, button1.Bounds.Y);
+                Assert.Equal(width, button1.Bounds.Width);
+                Assert.Equal(height, button1.Bounds.Height);
+                form.Close();
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
@@ -10,14 +10,72 @@ namespace System.Windows.Forms.Layout.Tests
 {
     public class AnchorLayoutTests : IClassFixture<ThreadExceptionFixture>
     {
+        [WinFormsFact]
+        public void Control_NotParented_NoAnchorsComputed()
+        {
+            var (form, button) = GetFormWithAnchoredButton();
+
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
+
+            _ = button.Handle; // Force handle creation;
+            Assert.Null(anchorInfo);
+
+            Dispose(form, button);
+        }
+
+        [WinFormsFact]
+        public void Control_HandleNotCreated_NoAnchorsComputed()
+        {
+            var (form, button) = GetFormWithAnchoredButton();
+
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
+
+            form.Controls.Add(button);
+            Assert.Null(anchorInfo);
+
+            Dispose(form, button);
+        }
+
+        [WinFormsFact]
+        public void Control_ParentHandleNotCreated_NoAnchorsComputed()
+        {
+            var (form, button) = GetFormWithAnchoredButton();
+
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.Null(anchorInfo);
+
+            _ = button.Handle; // Force handle creation;
+            form.Controls.Add(button);
+            Assert.Null(anchorInfo);
+
+            Dispose(form, button);
+        }
+
+        [WinFormsFact]
+        public void ConfigSwitch_Disabled_NoHanldeCreated_AnchorsComputed()
+        {
+            AppContext.SetSwitch(LocalAppContextSwitches.EnableAnchorLayoutV2SwitchName, false);
+            var (form, button) = GetFormWithAnchoredButton();
+            form.Controls.Add(button);
+
+            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
+            Assert.NotNull(anchorInfo);
+
+            Dispose(form, button);
+        }
+
         private static (Form, Button) GetFormWithAnchoredButton()
         {
             Form form = new ();
             form.Size = new Size(200, 300);
-            Button button = new ();
-            button.Location = new Point(20, 30);
-            button.Size = new Size(20, 30);
-            button.Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Right | AnchorStyles.Bottom;
+            Button button = new()
+            {
+                Location = new Point(20, 30),
+                Size = new Size(20, 30),
+                Anchor = AnchorStyles.Left | AnchorStyles.Top | AnchorStyles.Right | AnchorStyles.Bottom
+            };
 
             return (form, button);
         }
@@ -26,51 +84,6 @@ namespace System.Windows.Forms.Layout.Tests
         {
             button?.Dispose();
             form?.Dispose();
-        }
-
-        [WinFormsFact]
-        public void ControlNotParented_NoAnchorsComputed()
-        {
-            var (form, button) = GetFormWithAnchoredButton();
-            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
-            Assert.Null(anchorInfo);
-            _ = button.Handle; // Force handle creation;
-            Assert.Null(anchorInfo);
-            Dispose(form, button);
-        }
-
-        [WinFormsFact]
-        public void ControlHandleNotCreated_NoAnchorsComputed()
-        {
-            var (form, button) = GetFormWithAnchoredButton();
-            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
-            Assert.Null(anchorInfo);
-            form.Controls.Add(button);
-            Assert.Null(anchorInfo);
-            Dispose(form, button);
-        }
-
-        [WinFormsFact]
-        public void ControlParentHandleNotCreated_NoAnchorsComputed()
-        {
-            var (form, button) = GetFormWithAnchoredButton();
-            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
-            Assert.Null(anchorInfo);
-            _ = button.Handle; // Force handle creation;
-            form.Controls.Add(button);
-            Assert.Null(anchorInfo);
-            Dispose(form, button);
-        }
-
-        [WinFormsFact]
-        public void ConfigSwitchDisabled_NoHanldeCreated_AnchorsComputed()
-        {
-            AppContext.SetSwitch(LocalAppContextSwitches.EnableAnchorLayoutV2SwitchName, false);
-            var (form, button) = GetFormWithAnchoredButton();
-            form.Controls.Add(button);
-            DefaultLayout.AnchorInfo anchorInfo = DefaultLayout.GetAnchorInfo(button);
-            Assert.NotNull(anchorInfo);
-            Dispose(form, button);
         }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Layout/AnchorLayoutTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using System.Diagnostics;
 using System.Drawing;
 using System.Windows.Forms.Primitives;
 


### PR DESCRIPTION
We have multiple [issues](https://github.com/dotnet/winforms/issues?q=is%3Aissue+is%3Aopen+anchor+-label%3Atest-bug+-label%3A%22%3Aconstruction%3A+work+in+progress%22+-label%3Aapi-suggestion+-label%3Aapi-approved+-label%3Atenet-localization) reported in WinForms around the anchor layout being problematic on higher DPI scale monitors, irrespective of application DPI mode. This document outlines the changes being made in .NET 8.0 to address these issues along with setting the goal to support all supported application DPI modes in WinForms.

**Problem in Scope:**
	Anchored control’s position with respect to its parent should be able to determine at the design time and would only need to be changed if there were explicit changes in the control’s Bounds or when the control is scaled in response to a DPI changed event. Bounds changes as result of Parent’s bounds change shouldn’t alter control’s relative position in the parent’s rectangle. However, layout in WinForms computes the anchored control’s position every time there are changes to control’s bounds or control’s property change that may impact its position. This is leading to the [issues](https://github.com/dotnet/winforms/issues?q=is%3Aissue+is%3Aopen+anchor+-label%3Atest-bug+-label%3A%22%3Aconstruction%3A+work+in+progress%22+-label%3Aapi-suggestion+-label%3Aapi-approved+-label%3Atenet-localization) we have been seeing. The following is a source snippet that is being serialized in WinForms designer and added comments show the various events that trigger anchor computations and why they could be wrong or unnecessary.

```CS
this.button14.Anchor = (System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) // Layout tries to compute anchors with default button14 size and without parent. 
this.button14.Location = new System.Drawing.Point(431, 110); // Layout updates computed anchors for this new bounds, still with default size and no parent.
this.button14.Name = "button14";
this.button14.Size = new System.Drawing.Size(111, 23); // Layout updates computed anchors for this new bounds, still with no parent.
this.Controls.Add(this.button14); // Layout updates computed anchors with parents default size. Which may still be wrong.
this.Size = new System.Drawing.Size(828, 146); // Layout updates computed anchors with parents new size but this size could change based on the Dpi when parent Handle is created.
this.ResumeLayout(false) // Layout updates computed anchors with parents size. Dpi of the screen is still not considered (Handle creations or delayed until control is visible)

```

The above snippet does not represent the complete set of instances where anchor computations are unnecessary and may hold invalid anchor values. It gets even more complicated when nested UserControls are involved.

**Known issues:**
We have multiple issues reported [here](https://github.com/dotnet/winforms/issues?q=is%3Aissue+is%3Aopen+anchor+-label%3Atest-bug+-label%3A%22%3Aconstruction%3A+work+in+progress%22+-label%3Aapi-suggestion+-label%3Aapi-approved+-label%3Atenet-localization) from customers and some of them are direct result of anchor miscalculations. The following are snippets of the category of issues we currently see.

**Expected:** 
![image](https://user-images.githubusercontent.com/36968667/196277747-0cbf1820-f42d-4279-9e61-ba67a2a43a6a.png)

![image](https://user-images.githubusercontent.com/36968667/196277893-6325ff9e-0c37-4c89-862d-69b7d00e3473.png)

**Current Behavior:** 
![image](https://user-images.githubusercontent.com/36968667/196277793-26f67908-0f63-4104-8edf-1c3abacad129.png)

![image](https://user-images.githubusercontent.com/36968667/196277917-8784b2e1-514e-460d-9b5c-904ac9d9eee5.png)

**Proposed solution:** 

Unnecessary control’s anchors computation is the root cause for many [issues](https://github.com/dotnet/winforms/issues?q=is%3Aissue+is%3Aopen+anchor+-label%3Atest-bug+-label%3A%22%3Aconstruction%3A+work+in+progress%22+-label%3Aapi-suggestion+-label%3Aapi-approved+-label%3Atenet-localization) reported so far. In this proposal, we are delaying the anchors computation to the specific time in the layout flow - which is when the control’s and its parent’s handles are created. By that time, in the majority of scenarios, the control’s and its parent’s bounds are finalized and the display monitor’s DPI has been applied to them.  We also have issues with how we are calculating anchors but, in this proposal, we are simplifying anchor calculations as mentioned in the above pic to help diagnose any future issues.
We may still have cases where developers are forced to create handle explicitly, out of order, but those cases can be handled separately by the application developer for any anchor miscalculations. The following are the events we would be using to compute anchors and replacing the current set of events mentioned in Figure 1 above.

- WmCreate (Create Control)
- OnParentChanged
- SetBounds

**Source snippet:**

```CS
private void WmCreate()
{
   .....
   DefaultLayout.UpdateAnchorInfoV2(this);
}

internal static void UpdateAnchorInfoV2(IArrangedElement element)
 {
     if (!LocalAppContextSwitches.EnableAnchorLayoutV2 || !CommonProperties.GetNeedsAnchorLayout(element))
      {
          return;
      }

      Control control = element as Control;
      Debug.Assert(control != null, "AnchorLayoutV2 and beyond are expected to be used only on Control type");

      if (control is null || control.Parent is null)
       {
          return;
       }

      if (!control.IsHandleCreated || !control.Parent.IsHandleCreated)
       {
          return;
       }

      ComputeAnchorInfo(IArrangedElement element)
  }

```
**Simplifying Anchor calculations:**
The current anchor calculation implementation is complicated and appears to have been a result of unnecessary attempts to calculate anchors with invalid bounds. Replacing the current implementation with the one described in Figure 1 above. Following is the source snippet that computes the anchors.
```CS
private static void ComputeAnchorInfo(IArrangedElement element)
 {
   AnchorInfo? anchorInfo = GetAnchorInfo(element);
   if (anchorInfo is null)
    {
       anchorInfo = new();
       SetAnchorInfo(element, anchorInfo);
    }

    Rectangle displayRect = element.Container.DisplayRectangle;
    Rectangle elementBounds = element.Bounds;

    int x = elementBounds.X;
    int y = elementBounds.Y;

    anchorInfo.Left = x;
    anchorInfo.Top = y;

    anchorInfo.Right = displayRect.Width - (x + elementBounds.Width);
    anchorInfo.Bottom = displayRect.Height - (y + elementBounds.Height);
 }

```
**Risk mitigation:**
Layout in general is complex and could impact every component in the WinForms. In order to reduce the potential risk and provide backward compatibility, This changes are `quirked` under switch `System.Windows.Forms.EnableAnchorLayoutV2`. These changes are by default on for new/migrating applications targeting .NET 8.0 but the developers can control this by setting the above mentioned flag to `false` in the runtimeconfig.template.json for the application.
Snippet for runtimeconfig.template.json:
```XML
{
  "configProperties": {
    "System.Windows.Forms.EnableAnchorLayoutV2": true
  }
}
```



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7956)