### PR TITLE
SA1411 Attribute constructor shouldn't use unnecessary parenthesis

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1209,7 +1209,7 @@ dotnet_diagnostic.SA1409.severity = none
 dotnet_diagnostic.SA1410.severity = warning
 
 # SA1411: Attribute constructor shouldn't use unnecessary parenthesis
-dotnet_diagnostic.SA1411.severity = none # TODO: warning
+dotnet_diagnostic.SA1411.severity = warning
 
 # SA1412: Store files as UTF-8 with byte order mark
 dotnet_diagnostic.SA1412.severity = none

--- a/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.IMsoComponent.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.IMsoComponent.cs
@@ -24,7 +24,7 @@ internal static partial class Interop
         ///  can query the reg info  of the active (or tracking) component at any time via
         ///  <see cref="IMsoComponentManager.FGetActiveComponent"/>.
         /// </remarks>
-        [ComImport()]
+        [ComImport]
         [Guid(ComponentIds.IID_IMsoComponent)]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         public unsafe interface IMsoComponent

--- a/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.IMsoComponentManager.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/Mso/Interop.IMsoComponentManager.cs
@@ -28,7 +28,7 @@ internal static partial class Interop
         ///  that are outside of the component manager's state context. <see cref="FInState"/> is used to query the
         ///  state of the component manager's state context at its root.
         /// </remarks>
-        [ComImport()]
+        [ComImport]
         [Guid(ComponentIds.IID_IMsoComponentManager)]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
         public unsafe interface IMsoComponentManager

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AssemblyAttributes.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AssemblyAttributes.cs
@@ -11,8 +11,8 @@ using System.Runtime.CompilerServices;
 [assembly: Dependency("System.Core", LoadHint.Sometimes)]
 // This is now trun on by default, use source file NO_RUNTIMECOMPATIBILITY_ATTRIBUTE flag to control this
 // [assembly:RuntimeCompatibility(WrapNonExceptionThrows = true)]
-[assembly: StringFreezing()]
+[assembly: StringFreezing]
 [assembly: System.Runtime.InteropServices.TypeLibVersion(2, 4)]
 
 // Opts into the VS loading icons from the Icon Satellite assembly: System.Windows.Forms.VisualStudio.<version>.0.dll
-[assembly: System.Drawing.BitmapSuffixInSatelliteAssembly()]
+[assembly: System.Drawing.BitmapSuffixInSatelliteAssembly]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSystemRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSystemRenderer.cs
@@ -9,7 +9,7 @@ namespace System.Windows.Forms
 {
     public class ToolStripSystemRenderer : ToolStripRenderer
     {
-        [ThreadStatic()]
+        [ThreadStatic]
         private static VisualStyleRenderer? t_renderer = null;
         private ToolStripRenderer? _toolStripHighContrastRenderer;
 


### PR DESCRIPTION
Enable SA1411 analyzer.
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1411.md

Used solution wide code fix in visual studio.

Related: #7887