### PR TITLE
SA1212 A get accessor appears after a set accessor within a property …

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1113,7 +1113,7 @@ dotnet_diagnostic.SA1210.severity = none
 dotnet_diagnostic.SA1211.severity = none
 
 # SA1212: A get accessor appears after a set accessor within a property or indexer
-dotnet_diagnostic.SA1212.severity = none # TODO: warning
+dotnet_diagnostic.SA1212.severity = warning
 
 # SA1213: Event accessors should follow order
 dotnet_diagnostic.SA1213.severity = none

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -487,13 +487,13 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
         internal Com2Properties PropertyManager
         {
-            set
-            {
-                com2props = value;
-            }
             get
             {
                 return com2props;
+            }
+            set
+            {
+                com2props = value;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1678,7 +1678,6 @@ namespace System.Windows.Forms
 
         internal bool ValidationCancelled
         {
-            set => SetState(States.ValidationCancelled, value);
             get
             {
                 if (GetState(States.ValidationCancelled))
@@ -1696,6 +1695,7 @@ namespace System.Windows.Forms
                     return false;
                 }
             }
+            set => SetState(States.ValidationCancelled, value);
         }
 
         /// <summary>


### PR DESCRIPTION
Enable SA1212 anaylzer.
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md

Used solution wide code fix.

Related: #7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7964)