### PR TITLE
SA1028 Code should not contain trailing whitespace

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -951,7 +951,7 @@ dotnet_diagnostic.SA1026.severity = warning
 dotnet_diagnostic.SA1027.severity = warning
 
 # SA1028: Code should not contain trailing whitespace
-dotnet_diagnostic.SA1028.severity = none # TODO: warning
+dotnet_diagnostic.SA1028.severity = warning
 
 # SA1100: Do not prefix calls with base unless local implementation exists
 dotnet_diagnostic.SA1100.severity = none

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ContentAlignmentEditor.ContentUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ContentAlignmentEditor.ContentUI.cs
@@ -108,7 +108,7 @@ namespace System.Drawing.Design
             }
 
             protected override ControlCollection SelectionOptions => Controls;
-            
+
             private void InitComponent()
             {
                 BackColor = SystemColors.Control;
@@ -271,7 +271,7 @@ namespace System.Drawing.Design
                     ResumeLayout();
                 }
             }
-            
+
             /// <summary>
             ///  Imagine a grid to choose alignment:
             ///

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/SelectionPanelBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/SelectionPanelBase.cs
@@ -81,7 +81,7 @@ namespace System.Drawing.Design
                     break;
                 case Keys.Return:
                     // Will tear down editor
-                    InvokeOnClick(radioButton, EventArgs.Empty); 
+                    InvokeOnClick(radioButton, EventArgs.Empty);
                     return;
                 default:
                     return;

--- a/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumFORMATETCVtbl.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/WinFormsComWrappers.IEnumFORMATETCVtbl.cs
@@ -37,7 +37,7 @@ internal partial class Interop
                     FORMATETC[] elt = new FORMATETC[celt];
                     int[] celtFetched = new int[1];
 
-                    // Eliminate null bang after https://github.com/dotnet/runtime/pull/68537 lands, or 
+                    // Eliminate null bang after https://github.com/dotnet/runtime/pull/68537 lands, or
                     // IEnumFORMATETC annotations would be corrected.
                     var result = instance.Next((int)celt, elt, pceltFetched is null ? null! : celtFetched);
                     for (var i = 0; i < celt; i++)

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
@@ -440,7 +440,7 @@ namespace System.Windows.Forms
                         // Necessary for RS1, since this SetProcessIntPtr IS available here.
                         PInvoke.IsValidDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
                         ? DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2
-                        : DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE, 
+                        : DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_SYSTEM_AWARE,
                     HighDpiMode.DpiUnawareGdiScaled =>
                         // Let's make sure, we do not try to set a value which has been introduced in later Windows releases.
                         PInvoke.IsValidDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED)

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/FW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/FW.cs
@@ -21,5 +21,5 @@ namespace Windows.Win32.Graphics.Gdi
         ULTRABOLD = 800,
         HEAVY = 900,
         BLACK = 900
-    }  
+    }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindableComponent.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindableComponent.cs
@@ -8,8 +8,8 @@ using System.Runtime.Versioning;
 namespace System.Windows.Forms
 {
     /// <summary>
-    /// Base class for components which provide properties which can be 
-    /// data bound with the WinForms Designer. 
+    /// Base class for components which provide properties which can be
+    /// data bound with the WinForms Designer.
     /// </summary>
     [RequiresPreviewFeatures]
     public abstract class BindableComponent : Component, IBindableComponent

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CommonDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CommonDialog.cs
@@ -236,7 +236,7 @@ namespace System.Windows.Forms
                     ThemingScope.Deactivate(userCookie);
 
                     _priorWindowProcedure = 0;
-                    
+
                     // Ensure that the subclass delegate will not be GC collected until after it has been subclassed.
                     GC.KeepAlive(ownerWindowProcedure);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -886,7 +886,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 {
                     lastValue = pVarResult[0];
                 }
-                
+
                 return lastValue;
             }
             else if (hr == HRESULT.DISP_E_EXCEPTION)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.PageSelector.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.PageSelector.cs
@@ -195,7 +195,7 @@ namespace System.Windows.Forms.Design
             private unsafe void OnCustomDraw(ref Message m)
             {
                 NMTVCUSTOMDRAW* nmtvcd = (NMTVCUSTOMDRAW*)(nint)m.LParamInternal;
-                
+
                 switch (nmtvcd->nmcd.dwDrawStage)
                 {
                     case NMCUSTOMDRAW_DRAW_STAGE.CDDS_PREPAINT:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DragDropHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DragDropHelper.cs
@@ -23,7 +23,7 @@ namespace System.Windows.Forms
     /// </summary>
     internal static class DragDropHelper
     {
-        private const int DSH_ALLOWDROPDESCRIPTIONTEXT = 0x0001; 
+        private const int DSH_ALLOWDROPDESCRIPTIONTEXT = 0x0001;
         internal const string CF_DRAGIMAGEBITS = "DragImageBits";
         internal const string CF_DROPDESCRIPTION = "DropDescription";
         internal const string CF_INSHELLDRAGLOOP = "InShellDragLoop";

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.cs
@@ -633,7 +633,7 @@ namespace System.Windows.Forms
                 if (AddExtension && !Path.HasExtension(fileName))
                 {
                     bool fileMustExist = CheckFileExists;
-                    
+
                     for (int j = 0; j < extensions.Length; j++)
                     {
                         var currentExtension = Path.GetExtension(fileName.AsSpan());

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.AccessibleObject.cs
@@ -36,7 +36,7 @@ namespace System.Windows.Forms
 
                     if (_owner.Parent is null)
                     {
-                        // If the Forms is a main window and a root object. 
+                        // If the Forms is a main window and a root object.
                         return _owner.Bounds;
                     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ICommandBindingTargetProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ICommandBindingTargetProvider.cs
@@ -48,7 +48,7 @@ namespace System.Windows.Forms
         protected void RaiseCommandChanged(EventArgs e);
 
         /// <summary>
-        /// An implementation should raise the <see cref="CommandCanExecuteChanged"/> event 
+        /// An implementation should raise the <see cref="CommandCanExecuteChanged"/> event
         /// by calling component's or control's OnCommandCanExecuteChanged method.
         /// </summary>
         /// <param name="e">An empty <see cref="EventArgs"/> instance.</param>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.AccessibleObject.cs
@@ -178,7 +178,7 @@ namespace System.Windows.Forms
             internal void ResetListItemAccessibleObjects()
             {
                 if (OsVersion.IsWindows8OrGreater())
-                { 
+                {
                     foreach (ListBoxItemAccessibleObject itemAccessibleObject in _itemAccessibleObjects.Values)
                     {
                         UiaCore.UiaDisconnectProvider(itemAccessibleObject);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.cs
@@ -1137,7 +1137,7 @@ namespace System.Windows.Forms
         }
 
         internal override bool SupportsUiaProviders => true;
-        
+
         /// <summary>
         ///  The Text setter validates the input char by char, raising the MaskInputRejected event for invalid chars.
         ///  The Text getter returns the formatted text according to the IncludeLiterals and IncludePrompt properties.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -383,7 +383,7 @@ namespace System.Windows.Forms
         ///  caption and sizing borders.
         /// </summary>
         public static Size MaxWindowTrackSize => GetSize(SM_CXMAXTRACK, SM_CYMAXTRACK);
-        
+
         /// <summary>
         ///  Gets the default dimensions, in pixels, of a maximized top-left window on the
         ///  primary monitor.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripComboBox.cs
@@ -443,7 +443,7 @@ namespace System.Windows.Forms
         {
             RaiseEvent(s_eventTextUpdate, e);
         }
-#pragma warning restore CA2252 
+#pragma warning restore CA2252
 
         protected override void OnSubscribeControlEvents(Control control)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripControlHost.cs
@@ -546,7 +546,7 @@ namespace System.Windows.Forms
             OnMouseHover(e);
             RaiseEvent(ToolStripItem.s_mouseHoverEvent, e);
         }
-#pragma warning restore CA2252 
+#pragma warning restore CA2252
 
         private void HandleMouseMove(object sender, MouseEventArgs e)
         {
@@ -638,7 +638,7 @@ namespace System.Windows.Forms
         ///  called when the control has lost focus
         /// </summary>
         protected virtual void OnLostFocus(EventArgs e) => RaiseEvent(s_lostFocusEvent, e);
-#pragma warning restore CA2252 
+#pragma warning restore CA2252
 
         protected virtual void OnKeyDown(KeyEventArgs e) => RaiseKeyEvent(s_keyDownEvent, e);
 
@@ -804,7 +804,7 @@ namespace System.Windows.Forms
 
 #pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
         protected virtual void OnValidated(EventArgs e) => RaiseEvent(s_validatedEvent, e);
-#pragma warning restore CA2252 
+#pragma warning restore CA2252
 
         private static ReadOnlyControlCollection GetControlCollection(ToolStrip toolStrip)
             => (ReadOnlyControlCollection)toolStrip?.Controls;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -3742,5 +3742,5 @@ namespace System.Windows.Forms
             return local is not null;
         }
     }
-#pragma warning restore CA2252 
+#pragma warning restore CA2252
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripProgressBar.cs
@@ -259,7 +259,7 @@ namespace System.Windows.Forms
         {
 #pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
             RaiseEvent(EventRightToLeftLayoutChanged, e);
-#pragma warning restore CA2252 
+#pragma warning restore CA2252
         }
 
         protected override void OnSubscribeControlEvents(Control control)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSeparator.cs
@@ -300,7 +300,7 @@ namespace System.Windows.Forms
             // Perf: don't call base, we don't care if the font changes
 #pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
             RaiseEvent(s_fontChangedEvent, e);
-#pragma warning restore CA2252 
+#pragma warning restore CA2252
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
@@ -126,7 +126,7 @@ namespace System.Windows.Forms
                 using PInvoke.RegionScope hNonClientRegion = new(0, 0, 0, 0);
 
                 PInvoke.CombineRgn(hNonClientRegion, hTotalRegion, hClientRegion, RGN_COMBINE_MODE.RGN_XOR);
-                
+
                 // Call RedrawWindow with the region.
                 PInvoke.RedrawWindow(
                     this,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
@@ -190,7 +190,7 @@ namespace System.Windows.Forms
         {
             RaiseEvent(s_eventReadOnlyChanged, e);
         }
-#pragma warning restore CA2252 
+#pragma warning restore CA2252
 
         protected override void OnSubscribeControlEvents(Control control)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2755,7 +2755,7 @@ namespace System.Windows.Forms
             // This stops the style from being removed for any derived classes that set it using P/Invoke.
             if (treeViewState[TREEVIEWSTATE_doubleBufferedPropertySet])
             {
-                PInvoke.SendMessage(this, (User32.WM)PInvoke.TVM_SETEXTENDEDSTYLE, (WPARAM)(nint)PInvoke.TVS_EX_DOUBLEBUFFER, (LPARAM)(nint)(DoubleBuffered ? PInvoke.TVS_EX_DOUBLEBUFFER : 0)); 
+                PInvoke.SendMessage(this, (User32.WM)PInvoke.TVM_SETEXTENDEDSTYLE, (WPARAM)(nint)PInvoke.TVS_EX_DOUBLEBUFFER, (LPARAM)(nint)(DoubleBuffered ? PInvoke.TVS_EX_DOUBLEBUFFER : 0));
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleRenderer.cs
@@ -452,7 +452,7 @@ namespace System.Windows.Forms.VisualStyles
             {
                 return null;
             }
-            
+
             using DeviceContextHdcScope hdc = new(dc);
             HRGN hrgn;
             _lastHResult = PInvoke.GetThemeBackgroundRegion(Handle, hdc, Part, State, bounds, &hrgn);


### PR DESCRIPTION
Enable SA1028 analyzer
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1028.md

Used solution wide code fix.

Related: #7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7965)