### PR TITLE
SA1001 Commas should not be preceded by whitespace

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -870,7 +870,7 @@ dotnet_diagnostic.SA0002.severity = none
 dotnet_diagnostic.SA1000.severity = suggestion
 
 # SA1001: Commas should not be preceded by whitespace
-dotnet_diagnostic.SA1001.severity = none # TODO: warning
+dotnet_diagnostic.SA1001.severity = warning
 
 # SA1002: Semicolons should not be preceded by a space
 dotnet_diagnostic.SA1002.severity = none

--- a/src/System.Windows.Forms.Design/src/System/Resources/Tools/StronglyTypedResourceBuilder.cs
+++ b/src/System.Windows.Forms.Design/src/System/Resources/Tools/StronglyTypedResourceBuilder.cs
@@ -52,7 +52,7 @@ namespace System.Resources.Tools
         // When fixing up identifiers, we will replace all these chars with ReplacementChar ('_').
         private static ReadOnlySpan<char> CharsToReplace => new char[]
         {
-            ' ', '\u00A0' /* non-breaking space */, '.', ',', ';', '|', '~','@', '#', '%', '^', '&', '*', '+', '-',
+            ' ', '\u00A0' /* non-breaking space */, '.', ',', ';', '|', '~', '@', '#', '%', '^', '&', '*', '+', '-',
             '/', '\\', '<', '>', '?', '[', ']', '(', ')', '{', '}', '\"', '\'', ':', '!'
         };
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridEntry.cs
@@ -1644,7 +1644,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                     using var compatibleDC = new PInvoke.CreateDcScope(default);
 
                     int planes = PInvoke.GetDeviceCaps(compatibleDC, GET_DEVICE_CAPS_INDEX.PLANES);
-                    int bitsPixel = PInvoke.GetDeviceCaps(compatibleDC,GET_DEVICE_CAPS_INDEX.BITSPIXEL);
+                    int bitsPixel = PInvoke.GetDeviceCaps(compatibleDC, GET_DEVICE_CAPS_INDEX.BITSPIXEL);
                     HBITMAP compatibleBitmap = PInvoke.CreateBitmap(rectangle.Width, rectangle.Height, (uint)planes, (uint)bitsPixel, lpBits: null);
                     using PInvoke.SelectObjectScope targetBitmapSelection = new(compatibleDC, compatibleBitmap);
 


### PR DESCRIPTION
Enable SA1001 analyzer.
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1001.md

Used solution wide code fix.

Related: #7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7966)