### PR TITLE
CA2019 Improper 'ThreadStatic' field initialization

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -436,7 +436,7 @@ dotnet_diagnostic.CA2017.severity = warning
 dotnet_diagnostic.CA2018.severity = warning
 
 # CA2019: Improper 'ThreadStatic' field initialization
-dotnet_diagnostic.CA2019.severity = none # TODO: warning
+dotnet_diagnostic.CA2019.severity = warning
 
 # CA2100: Review SQL queries for security vulnerabilities
 dotnet_diagnostic.CA2100.severity = none

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesignerUtils.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms.Design
         [ThreadStatic]
         private static Dictionary<Type, ToolboxItem> s_cachedToolboxItems;
         [ThreadStatic]
-        private static int s_customToolStripItemCount = 0;
+        private static int s_customToolStripItemCount;
         private const int TOOLSTRIPCHARCOUNT = 9;
         // used to cache in the selection. This is used when the selection is changing and we need to invalidate the original selection Especially, when the selection is changed through NON UI designer action like through propertyGrid or through Doc Outline.
         public static ArrayList originalSelComps;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxBaseAdapter.cs
@@ -12,14 +12,14 @@ namespace System.Windows.Forms.ButtonInternal
         protected const int FlatCheckSize = 11;
 
         [ThreadStatic]
-        private static Bitmap? t_checkImageChecked = null;
+        private static Bitmap? t_checkImageChecked;
         [ThreadStatic]
-        private static Color t_checkImageCheckedBackColor = Color.Empty;
+        private static Color t_checkImageCheckedBackColor;
 
         [ThreadStatic]
-        private static Bitmap? t_checkImageIndeterminate = null;
+        private static Bitmap? t_checkImageIndeterminate;
         [ThreadStatic]
-        private static Color t_checkImageIndeterminateBackColor = Color.Empty;
+        private static Color t_checkImageIndeterminateBackColor;
 
         internal CheckBoxBaseAdapter(ButtonBase control)
             : base(control)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonRenderer.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms
     {
         //Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
         private static readonly VisualStyleElement s_buttonElement = VisualStyleElement.Button.PushButton.Normal;
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckBoxRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckBoxRenderer.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms
     {
         // Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
         private static readonly VisualStyleElement s_checkBoxElement = VisualStyleElement.Button.CheckBox.UncheckedNormal;
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBoxRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBoxRenderer.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms
     {
         //Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
         private static readonly VisualStyleElement ComboBoxElement = VisualStyleElement.ComboBox.DropDownButton.Normal;
         private static readonly VisualStyleElement TextBoxElement = VisualStyleElement.TextBox.TextEdit.Normal;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -216,10 +216,10 @@ namespace System.Windows.Forms
 
 #pragma warning disable IDE1006 // Naming Styles
         [ThreadStatic]
-        private static bool t_inCrossThreadSafeCall = false;
+        private static bool t_inCrossThreadSafeCall;
 
         [ThreadStatic]
-        internal static HelpInfo? t_currentHelpInfo = null;
+        internal static HelpInfo? t_currentHelpInfo;
 
 #pragma warning restore IDE1006
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/GroupBoxRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/GroupBoxRenderer.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms
     {
         // Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
         private static readonly VisualStyleElement s_groupBoxElement = VisualStyleElement.Button.GroupBox.Normal;
         private const int TextOffset = 8;
         private const int BoxHeaderWidth = 7;    // The groupbox frame shows 7 pixels before the caption.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.cs
@@ -33,10 +33,10 @@ namespace System.Windows.Forms
         private static bool s_anyHandleCreatedInApp;
 
         [ThreadStatic]
-        private static byte t_wndProcFlags = 0;
+        private static byte t_wndProcFlags;
 
         [ThreadStatic]
-        private static byte t_userSetProcFlags = 0;
+        private static byte t_userSetProcFlags;
         private static byte s_userSetProcFlagsForApp;
 
         // Need to Store Table of Ids and Handles

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBarRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ProgressBarRenderer.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms
     {
         //Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
 
         /// <summary>
         ///  Returns true if this class is supported for the current OS and user/application settings,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RadioButtonRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RadioButtonRenderer.cs
@@ -16,7 +16,7 @@ namespace System.Windows.Forms
     {
         // Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
 
         private static readonly VisualStyleElement s_radioElement = VisualStyleElement.Button.RadioButton.UncheckedNormal;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBarRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBarRenderer.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms
     {
         //Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
 
         /// <summary>
         ///  Returns true if this class is supported for the current OS and user/application settings,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabRenderer.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms
     {
         //Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
 
         /// <summary>
         ///  Returns true if this class is supported for the current OS and user/application settings,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxRenderer.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms
     {
         //Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
         private static readonly VisualStyleElement s_textBoxElement = VisualStyleElement.TextBox.TextEdit.Normal;
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSystemRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSystemRenderer.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms
     public class ToolStripSystemRenderer : ToolStripRenderer
     {
         [ThreadStatic]
-        private static VisualStyleRenderer? t_renderer = null;
+        private static VisualStyleRenderer? t_renderer;
         private ToolStripRenderer? _toolStripHighContrastRenderer;
 
         public ToolStripSystemRenderer()

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBarRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBarRenderer.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms
     {
         //Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
         const int lineWidth = 2;
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/VisualStyles/VisualStyleInformation.cs
@@ -20,7 +20,7 @@ namespace System.Windows.Forms.VisualStyles
     {
         // Make this per-thread, so that different threads can safely use these methods.
         [ThreadStatic]
-        private static VisualStyleRenderer? t_visualStyleRenderer = null;
+        private static VisualStyleRenderer? t_visualStyleRenderer;
 
         /// <summary>
         ///  Used to find whether visual styles are supported by the current OS. Same as


### PR DESCRIPTION
Enable CA2019 Analyzer.

Manually fixed based on message: `'ThreadStatic' fields should not use inline initialization`. All values were `default`, so the initializations were removed.

Related: #7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7967)