### PR TITLE
Fix top-level window size for non-linear dimensions based on AutoScaleMode

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -150,7 +150,9 @@ namespace System.Windows.Forms
         }
 
         internal static SizeF GetCurrentAutoScaleFactor(SizeF currentAutoScaleDimensions, SizeF savedAutoScaleDimensions)
-            => savedAutoScaleDimensions.IsEmpty ? new SizeF(1.0F, 1.0F) : new SizeF(currentAutoScaleDimensions.Width / savedAutoScaleDimensions.Width, currentAutoScaleDimensions.Height / savedAutoScaleDimensions.Height);
+            => savedAutoScaleDimensions.IsEmpty ?
+            new SizeF(1.0F, 1.0F)
+            : new SizeF(currentAutoScaleDimensions.Width / savedAutoScaleDimensions.Width, currentAutoScaleDimensions.Height / savedAutoScaleDimensions.Height);
 
         /// <summary>
         ///  Determines the scaling mode of this control. The default is no scaling.
@@ -1471,6 +1473,8 @@ namespace System.Windows.Forms
                 _isScaledByDpiChangedEvent = true;
 
                 TryGetDpiFont(deviceDpiNew, out Font? fontForDpi);
+
+                // For test scenarios, if we send WM_DPICHNAGED message but not WM_GETDPISCALEDSIZE message, fontForDpi may be null.
                 Debug.Assert(fontForDpi != null, "We should have Font updated for Dpi from WM_GETDPISCALEDSIZE message");
 
                 ScaledControlFont = fontForDpi;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -1475,7 +1475,7 @@ namespace System.Windows.Forms
                 TryGetDpiFont(deviceDpiNew, out Font? fontForDpi);
 
                 // For test scenarios, if we send WM_DPICHANGED message but not WM_GETDPISCALEDSIZE message, fontForDpi may be null.
-                Debug.Assert(fontForDpi is not null, "Font should have been updated for DPI from WM_GETDPISCALEDSIZE message");```
+                Debug.Assert(fontForDpi is not null, "Font should have been updated for DPI from WM_GETDPISCALEDSIZE message");
 
                 ScaledControlFont = fontForDpi;
                 if (IsFontSet())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -150,9 +150,9 @@ namespace System.Windows.Forms
         }
 
         internal static SizeF GetCurrentAutoScaleFactor(SizeF currentAutoScaleDimensions, SizeF savedAutoScaleDimensions)
-            => savedAutoScaleDimensions.IsEmpty ?
-            new SizeF(1.0F, 1.0F)
-            : new SizeF(currentAutoScaleDimensions.Width / savedAutoScaleDimensions.Width, currentAutoScaleDimensions.Height / savedAutoScaleDimensions.Height);
+            => savedAutoScaleDimensions.IsEmpty
+                ? new(1.0F, 1.0F)
+                : new(currentAutoScaleDimensions.Width / savedAutoScaleDimensions.Width, currentAutoScaleDimensions.Height / savedAutoScaleDimensions.Height);
 
         /// <summary>
         ///  Determines the scaling mode of this control. The default is no scaling.
@@ -1474,8 +1474,8 @@ namespace System.Windows.Forms
 
                 TryGetDpiFont(deviceDpiNew, out Font? fontForDpi);
 
-                // For test scenarios, if we send WM_DPICHNAGED message but not WM_GETDPISCALEDSIZE message, fontForDpi may be null.
-                Debug.Assert(fontForDpi != null, "We should have Font updated for Dpi from WM_GETDPISCALEDSIZE message");
+                // For test scenarios, if we send WM_DPICHANGED message but not WM_GETDPISCALEDSIZE message, fontForDpi may be null.
+                Debug.Assert(fontForDpi is not null, "Font should have been updated for DPI from WM_GETDPISCALEDSIZE message");```
 
                 ScaledControlFont = fontForDpi;
                 if (IsFontSet())

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4321,10 +4321,9 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual bool OnGetDpiScaledSize(int deviceDpiOld, int deviceDpiNew, ref Size desiredSize)
         {
-            // Compute and update Font for the current Dpi.
-            var factor = ((float)deviceDpiNew) / deviceDpiOld;
+            float factor = ((float)deviceDpiNew) / deviceDpiOld;
 
-            // Dpi specific fonts cache is available only in PermonitorV2 mode applications.
+            // Compute font for the current DPI and cache it. DPI specific fonts cache is available only in PermonitorV2 mode applications.
             if (!TryGetDpiFont(deviceDpiNew, out Font? fontForDpi))
             {
                 Font currentFont = Font;
@@ -4332,15 +4331,15 @@ namespace System.Windows.Forms
                 AddToDpiFonts(deviceDpiNew, fontForDpi);
             }
 
-            // If AutoScaleMode is Dpi, We continue with the linear size we get from Windows for the top-level window.
+            // If AutoScaleMode=AutoScaleMode.Dpi, We continue with the linear size we get from Windows for the top-level window.
             if (AutoScaleMode == AutoScaleMode.Dpi)
             {
                 return false;
             }
 
-            // Calculate AutoscaleFactor for AutoScaleMode.Font that we will be using to scale child controls and use same factor to
-            // compute desired size for top-level windows for the current Dpi. This way, we notify Windows that we
-            // need non-linear size for top-level window based on AutoScaleMode property.
+            // Calculate AutoscaleFactor for AutoScaleMode.Font. We will be using this factor to scale child controls
+            // and use same factor to compute desired size for top-level windows for the current DPI.
+            // This desired size is then used to notify Windows that we need non-linear size for top-level window.
             FontHandleWrapper fontwrapper = new FontHandleWrapper(fontForDpi);
             SizeF currentAutoScaleDimensions = GetCurrentAutoScaleDimensions(fontwrapper.Handle);
             SizeF autoScaleFactor = GetCurrentAutoScaleFactor(currentAutoScaleDimensions, AutoScaleDimensions);
@@ -4349,7 +4348,8 @@ namespace System.Windows.Forms
             desiredSize.Height = (int)(Size.Height * autoScaleFactor.Height);
             Debug.WriteLine($"AutoScaleFactor computed for new Dpi = {autoScaleFactor.Width} - {autoScaleFactor.Height}");
 
-            return true; // Notifying Windows that the top-level window size should be based on AutoScale mode.
+            // Notify Windows that the top-level window size should be based on AutoScaleMode value.
+            return true; 
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -524,7 +524,7 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.ControlOnAutoSizeChangedDescr))]
         [Browsable(true)]
         [EditorBrowsable(EditorBrowsableState.Always)]
-        new public event EventHandler? AutoSizeChanged
+        public new event EventHandler? AutoSizeChanged
         {
             add => base.AutoSizeChanged += value;
             remove => base.AutoSizeChanged -= value;
@@ -741,7 +741,7 @@ namespace System.Windows.Forms
         /// </summary>
         [Localizable(true)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        new public Size ClientSize
+        public new Size ClientSize
         {
             get => base.ClientSize;
             set => base.ClientSize = value;
@@ -2002,7 +2002,7 @@ namespace System.Windows.Forms
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Localizable(false)]
-        new public Size Size
+        public new Size Size
         {
             get => base.Size;
             set => base.Size = value;
@@ -2060,7 +2060,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        new public int TabIndex
+        public new int TabIndex
         {
             get => base.TabIndex;
             set => base.TabIndex = value;
@@ -2068,7 +2068,7 @@ namespace System.Windows.Forms
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        new public event EventHandler? TabIndexChanged
+        public new event EventHandler? TabIndexChanged
         {
             add => base.TabIndexChanged += value;
             remove => base.TabIndexChanged -= value;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4341,7 +4341,7 @@ namespace System.Windows.Forms
             // Calculate AutoscaleFactor for AutoScaleMode.Font that we will be using to scale child controls and use same factor to
             // compute desired size for top-level windows for the current Dpi. This way, we notify Windows that we
             // need non-linear size for top-level window based on AutoScaleMode property.
-            using FontHandleWrapper fontwrapper = new FontHandleWrapper(fontForDpi);
+            FontHandleWrapper fontwrapper = new FontHandleWrapper(fontForDpi);
             SizeF currentAutoScaleDimensions = GetCurrentAutoScaleDimensions(fontwrapper.Handle);
             SizeF autoScaleFactor = GetCurrentAutoScaleFactor(currentAutoScaleDimensions, AutoScaleDimensions);
 
@@ -4366,12 +4366,16 @@ namespace System.Windows.Forms
             DefWndProc(ref m);
 
             Size desiredSize = new Size();
-            m.ResultInternal = OnGetDpiScaledSize(_deviceDpi, m.WParamInternal.LOWORD, ref desiredSize)
-                ? (LRESULT)1
-                : (LRESULT)0;
-            SIZE* size = (SIZE*)m.LParamInternal;
-            size->cx = desiredSize.Width;
-            size->cy = desiredSize.Height;
+            if (OnGetDpiScaledSize(_deviceDpi, m.WParamInternal.LOWORD, ref desiredSize))
+            {
+                SIZE* size = (SIZE*)m.LParamInternal;
+                size->cx = desiredSize.Width;
+                size->cy = desiredSize.Height;
+                m.ResultInternal = (LRESULT)1;
+                return;
+            }
+
+            m.ResultInternal = (LRESULT)0;
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4349,7 +4349,7 @@ namespace System.Windows.Forms
             Debug.WriteLine($"AutoScaleFactor computed for new Dpi = {autoScaleFactor.Width} - {autoScaleFactor.Height}");
 
             // Notify Windows that the top-level window size should be based on AutoScaleMode value.
-            return true; 
+            return true;
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4331,7 +4331,7 @@ namespace System.Windows.Forms
                 AddToDpiFonts(deviceDpiNew, fontForDpi);
             }
 
-            // If AutoScaleMode=AutoScaleMode.Dpi, We continue with the linear size we get from Windows for the top-level window.
+            // If AutoScaleMode=AutoScaleMode.Dpi then we continue with the linear size we get from Windows for the top-level window.
             if (AutoScaleMode == AutoScaleMode.Dpi)
             {
                 return false;
@@ -4346,7 +4346,7 @@ namespace System.Windows.Forms
 
             desiredSize.Width = (int)(Size.Width * autoScaleFactor.Width);
             desiredSize.Height = (int)(Size.Height * autoScaleFactor.Height);
-            Debug.WriteLine($"AutoScaleFactor computed for new Dpi = {autoScaleFactor.Width} - {autoScaleFactor.Height}");
+            Debug.WriteLine($"AutoScaleFactor computed for new DPI = {autoScaleFactor.Width} - {autoScaleFactor.Height}");
 
             // Notify Windows that the top-level window size should be based on AutoScaleMode value.
             return true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4321,7 +4321,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual bool OnGetDpiScaledSize(int deviceDpiOld, int deviceDpiNew, ref Size desiredSize)
         {
-            // Compute and update Font for the current Dpi. 
+            // Compute and update Font for the current Dpi.
             var factor = ((float)deviceDpiNew) / deviceDpiOld;
 
             // Dpi specific fonts cache is available only in PermonitorV2 mode applications.
@@ -4654,7 +4654,7 @@ namespace System.Windows.Forms
             return e.Cancel;
         }
 
-        internal unsafe override void RecreateHandleCore()
+        internal override unsafe void RecreateHandleCore()
         {
             WINDOWPLACEMENT wp = default;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4332,7 +4332,7 @@ namespace System.Windows.Forms
                 AddToDpiFonts(deviceDpiNew, fontForDpi);
             }
 
-            // If AutoScaleMode is Dpi, We continue with the linear size we get from windows for top-level window.
+            // If AutoScaleMode is Dpi, We continue with the linear size we get from Windows for the top-level window.
             if (AutoScaleMode == AutoScaleMode.Dpi)
             {
                 return false;
@@ -4349,7 +4349,7 @@ namespace System.Windows.Forms
             desiredSize.Height = (int)(Size.Height * autoScaleFactor.Height);
             Debug.WriteLine($"AutoScaleFactor computed for new Dpi = {autoScaleFactor.Width} - {autoScaleFactor.Height}");
 
-            return true; // Notifying window on what the top-level window size should be based on AutoScale mode.
+            return true; // Notifying Windows that the top-level window size should be based on AutoScale mode.
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/DpiMessageHelper.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/DpiMessageHelper.cs
@@ -15,18 +15,20 @@ namespace System.Windows.Forms.Tests.Dpi
 
             _ = message switch
             {
-                User32.WM.DPICHANGED => SendWmDpiChangedMessage(),
+                User32.WM.DPICHANGED => SendWmDpiChangedMessage(message),
                 User32.WM.DPICHANGED_BEFOREPARENT => PInvoke.SendMessage(control, message, wParam),
                 User32.WM.DPICHANGED_AFTERPARENT => PInvoke.SendMessage(control, message),
                 _ => throw new NotImplementedException()
             };
 
-            nint SendWmDpiChangedMessage()
+            nint SendWmDpiChangedMessage(User32.WM message)
             {
                 RECT suggestedRect = new(0,
                     0,
                     (int)Math.Round(control.Width * factor),
                     (int)Math.Round(control.Height * factor));
+
+                PInvoke.SendMessage(control, User32.WM.GETDPISCALEDSIZE, wParam, ref suggestedRect);
                 return PInvoke.SendMessage(control, message, wParam, ref suggestedRect);
             }
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/FormTests.Dpi.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/FormTests.Dpi.cs
@@ -123,5 +123,41 @@ namespace System.Windows.Forms.Tests.Dpi
                 PInvoke.SetThreadDpiAwarenessContext(originalAwarenessContext);
             }
         }
+
+        [ActiveIssue("https://github.com/dotnet/winforms/issues/7579")]
+        [WinFormsTheory(Skip = "Lab machines seems not setting thread's Dpi context. See https://github.com/dotnet/winforms/issues/7579")]
+        [InlineData(3.5 * DpiHelper.LogicalDpi)]
+        public void Form_DpiChanged_NonLinear_DesiredSize(int newDpi)
+        {
+            // Run tests only on Windows 10 versions that support thread dpi awareness.
+            if (!PlatformDetection.IsWindows10Version1803OrGreater)
+            {
+                return;
+            }
+
+            DPI_AWARENESS_CONTEXT originalAwarenessContext = PInvoke.SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+            try
+            {
+                using var form = new Form();
+                form.AutoScaleMode = AutoScaleMode.Font;
+                form.Show();
+
+                DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED, form, newDpi);
+                Drawing.Size nonLInearSize = form.Size;
+
+                // Rollback to 96 Dpi, and chnage AutoScaleMode to check with linear size
+                DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED, form, (int)DpiHelper.LogicalDpi);
+                form.AutoScaleMode = AutoScaleMode.Dpi;
+
+                DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED, form, newDpi);
+                Assert.NotEqual(form.Size, nonLInearSize);
+                form.Close();
+            }
+            finally
+            {
+                // Reset back to original awareness context.
+                PInvoke.SetThreadDpiAwarenessContext(originalAwarenessContext);
+            }
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/FormTests.Dpi.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/Dpi/FormTests.Dpi.cs
@@ -145,7 +145,7 @@ namespace System.Windows.Forms.Tests.Dpi
                 DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED, form, newDpi);
                 Drawing.Size nonLInearSize = form.Size;
 
-                // Rollback to 96 Dpi, and chnage AutoScaleMode to check with linear size
+                // Rollback to 96 Dpi, and change AutoScaleMode to check with linear size
                 DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED, form, (int)DpiHelper.LogicalDpi);
                 form.AutoScaleMode = AutoScaleMode.Dpi;
 


### PR DESCRIPTION
In PermonV2 mode applications, We have been using linear sizes for top-level windows that are provided by the Windows irrespective of the AutoScaleMode.  This has been problematic for AutoScaleMode.Font, where Form scaling should be non-linear given its child controls are scaled non-linearly and depend on the Font that was assigned to Form/child controls.

We are making changes to utilize [GetDpiScaledSize](https://learn.microsoft.com/en-us/windows/win32/hidpi/wm-getdpiscaledsize) message and let Windows know that Form may need non-linear sizes depending on AutoScaleMode.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7973)