### PR TITLE
Fix the original save dialog

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetOpenFileName.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.GetOpenFileName.cs
@@ -10,10 +10,10 @@ namespace Windows.Win32
     // https://github.com/microsoft/win32metadata/issues/1300
     internal static partial class PInvoke
     {
-        [DllImport("COMDLG32.dll", EntryPoint = "GetOpenFileNameW", ExactSpelling = true, PreserveSig = false)]
-        public static extern unsafe BOOL GetOpenFileName([In][Out] OPENFILENAME* param0);
+        [DllImport("COMDLG32.dll", EntryPoint = "GetOpenFileNameW", ExactSpelling = true)]
+        public static extern unsafe BOOL GetOpenFileName(OPENFILENAME* param0);
 
-        [DllImport("COMDLG32.dll", EntryPoint = "GetSaveFileNameW", ExactSpelling = true, PreserveSig = false)]
-        public static extern unsafe BOOL GetSaveFileName([In][Out] OPENFILENAME* param0);
+        [DllImport("COMDLG32.dll", EntryPoint = "GetSaveFileNameW", ExactSpelling = true)]
+        public static extern unsafe BOOL GetSaveFileName(OPENFILENAME* param0);
     }
 }


### PR DESCRIPTION
I copied from the Win32 metadata directly and it had `PreserveSig = false`, which is only valid with HRESULT returns.

Fixes #7975


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7978)