### PR TITLE
Fix `FolderBrowserDialog.ShowDialog`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -494,7 +494,7 @@ namespace System.Windows.Forms
                     {
                         // Try to retrieve the path from the IDList
                         char* buffer = stackalloc char[PInvoke.MAX_PATH + 1];
-                        bool isFileSystemFolder = PInvoke.SHGetPathFromIDList(selectedPidl, (PWSTR)b);
+                        bool isFileSystemFolder = PInvoke.SHGetPathFromIDList(selectedPidl, (PWSTR)buffer);
                         PInvoke.SendMessage(hwnd, (User32.WM)PInvoke.BFFM_ENABLEOK, 0, (nint)(BOOL)isFileSystemFolder);
                     }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FolderBrowserDialog.cs
@@ -490,15 +490,12 @@ namespace System.Windows.Forms
                 case PInvoke.BFFM_SELCHANGED:
                     // Indicates the selection has changed. The lpData parameter points to the item identifier list for the newly selected item.
                     ITEMIDLIST* selectedPidl = (ITEMIDLIST*)lParam;
-                    Span<char> buffer = stackalloc char[PInvoke.MAX_PATH + 1];
-                    fixed (char* b = buffer)
+                    if (selectedPidl is not null)
                     {
-                        if (selectedPidl is not null)
-                        {
-                            // Try to retrieve the path from the IDList
-                            bool isFileSystemFolder = PInvoke.SHGetPathFromIDList(selectedPidl, (PWSTR)b);
-                            PInvoke.SendMessage(hwnd, (User32.WM)PInvoke.BFFM_ENABLEOK, 0, (nint)(BOOL)isFileSystemFolder);
-                        }
+                        // Try to retrieve the path from the IDList
+                        char* buffer = stackalloc char[PInvoke.MAX_PATH + 1];
+                        bool isFileSystemFolder = PInvoke.SHGetPathFromIDList(selectedPidl, (PWSTR)b);
+                        PInvoke.SendMessage(hwnd, (User32.WM)PInvoke.BFFM_ENABLEOK, 0, (nint)(BOOL)isFileSystemFolder);
                     }
 
                     break;


### PR DESCRIPTION
Fixes #7981

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7982)