### PR TITLE
Fixed MaskedTextBoxAccessibleObject.Name if Owner.Mask is filled

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.MaskedTextBoxAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MaskedTextBox.MaskedTextBoxAccessibleObject.cs
@@ -12,6 +12,16 @@ namespace System.Windows.Forms
             {
             }
 
+            public override string? Name
+            {
+                get => string.IsNullOrEmpty((Owner as MaskedTextBox)?.Mask)
+                    ? base.Name
+                    // If base.Name is null mask template will be used as a name, which is not descriptive for users.
+                    // Instead, we want to show an empty string to signal developers to set an appropriate name.
+                    : base.Name ?? string.Empty;
+                set => base.Name = value;
+            }
+
             protected override string ValueInternal => Owner.WindowText;
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MaskedTextBox.MaskedTextBoxAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MaskedTextBox.MaskedTextBoxAccessibleObjectTests.cs
@@ -75,6 +75,37 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
+        [InlineData(null, null)]
+        [InlineData("Test", "Test")]
+        public void MaskedTextBoxAccessibleObject_Name_IsExpected_WithoutMask(string accessibleName, string expectedAccessibleName)
+        {
+            using MaskedTextBox maskedTextBox = new MaskedTextBox();
+            maskedTextBox.Text = "000000";
+            maskedTextBox.AccessibleName = accessibleName;
+
+            var actual = (string)maskedTextBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+
+            Assert.Equal(expectedAccessibleName, actual);
+            Assert.False(maskedTextBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(null, "")]
+        [InlineData("Test", "Test")]
+        public void MaskedTextBoxAccessibleObject_Name_IsExpected_WithMask(string accessibleName, string expectedAccessibleName)
+        {
+            using MaskedTextBox maskedTextBox = new MaskedTextBox();
+            maskedTextBox.Text = "000000";
+            maskedTextBox.Mask = "00/00/0000";
+            maskedTextBox.AccessibleName = accessibleName;
+
+            var actual = (string)maskedTextBox.AccessibilityObject.GetPropertyValue(UiaCore.UIA.NamePropertyId);
+
+            Assert.Equal(expectedAccessibleName, actual);
+            Assert.False(maskedTextBox.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
         [InlineData(true)]
         [InlineData(false)]
         public void MaskedTextBoxAccessibleObject_GetPropertyValue_Value_IsExpected_WithMask(bool useMask)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7938


## Proposed changes

- Overriden `Name` property in `MaskedTextBoxAccessibleObject`.
- Added new unit tests. 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- The `Name` of `MaskedTextBoxAccessibleObject` is more clarify.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Screenshot 2022-10-21 121439](https://user-images.githubusercontent.com/109065597/197153169-8f374228-f98d-4d75-b17f-0c260f8c3305.png)

### After

![Screenshot 2022-10-21 120955](https://user-images.githubusercontent.com/109065597/197153188-7b791d7d-4e62-4a59-9a5c-3deb5603a3e6.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit testing 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK:
 Version:   8.0.100-alpha.1.22512.5
 Commit:    1b80461e45

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621
 OS Platform: Windows


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7983)