### PR TITLE
Remove BinaryFormatter support from Control's ActiveX projection.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -655,9 +655,8 @@ namespace System.Windows.Forms
         private IntPtr ActiveXHWNDParent => ActiveXInstance.HWNDParent;
 
         /// <summary>
-        ///  Retrieves the ActiveX control implementation for
-        ///  this control.  This will demand create the implementation
-        ///  if it does not already exist.
+        ///  Retrieves the ActiveX control implementation for this control.
+        ///  This will demand create the implementation if it does not already exist.
         /// </summary>
         private ActiveXImpl ActiveXInstance
         {


### PR DESCRIPTION
In order for properties to be exposed to `IPropertyBag` they must have a TypeConverter to and from either string (preferred) or `byte[]`.

These were always the first choice, `ISerializable` was the final fallback. This matches what we've done elsewhere when we've removed `BinaryFormatter`.

cc: @GrabYourPitchforks, @merriemcgaw 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7986)