### PR TITLE
Fix scaling in SplitContainer controls for high DPI machines

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -1785,6 +1785,14 @@ namespace System.Windows.Forms
                 }
 
                 SplitterWidth = (int)Math.Round((float)SplitterWidth * scale);
+                _splitterDistance = (int)Math.Round((float)_splitterDistance * scale);
+                _splitDistance = _splitterDistance;
+
+                // If FixedPanel property is set.
+                if (_panelSize != 0)
+                {
+                    _panelSize = (int)Math.Round((float)_panelSize * scale);
+                }
             }
             finally
             {

--- a/src/System.Windows.Forms/tests/UnitTests/SplitContainerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/SplitContainerTests.cs
@@ -35,7 +35,7 @@ namespace System.Windows.Forms.Tests
             }
 
             using var form = new Form();
-            using var splitContainer = new()
+            using SplitContainer splitContainer = new()
             {
                 FixedPanel = FixedPanel.Panel1,
                 Location = new Drawing.Point(0, 0),

--- a/src/System.Windows.Forms/tests/UnitTests/SplitContainerTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/SplitContainerTests.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms.Tests
         [ActiveIssue("https://github.com/dotnet/winforms/issues/7579")]
         [WinFormsTheory(Skip = "Lab machines seems not setting thread's Dpi context. See https://github.com/dotnet/winforms/issues/7579")]
         [InlineData(3.5 * DpiHelper.LogicalDpi)]
-        public void SplitContainer_Properties_Scaling(int newDpi)
+        public void SplitContainer_Properties_HorizontalSplitter_Scaling(int newDpi)
         {
             // Run tests only on Windows 10 versions that support thread dpi awareness.
             if (!PlatformDetection.IsWindows10Version1803OrGreater)
@@ -35,17 +35,20 @@ namespace System.Windows.Forms.Tests
             }
 
             using var form = new Form();
-            using var splitContainer = new SplitContainer();
+            using var splitContainer = new()
+            {
+                FixedPanel = FixedPanel.Panel1,
+                Location = new Drawing.Point(0, 0),
+                Margin = new Padding(0),
+                Name = "splitContainer2",
+                Orientation = Orientation.Horizontal,
+                Size = new Drawing.Size(812, 619),
+                SplitterDistance = 90,
+                SplitterWidth = 2
+            };
 
-            splitContainer.FixedPanel = FixedPanel.Panel1;
-            splitContainer.Location = new Drawing.Point(0, 0);
-            splitContainer.Margin = new Padding(0);
-            splitContainer.Name = "splitContainer2";
-            splitContainer.Orientation = Orientation.Horizontal;
-            splitContainer.Size = new Drawing.Size(812, 619);
-            splitContainer.SplitterDistance = 90;
-            splitContainer.SplitterWidth = 2;
             form.AutoScaleMode = AutoScaleMode.Dpi;
+            form.Controls.Add(splitContainer);
             form.Show();
 
             DpiMessageHelper.TriggerDpiMessage(User32.WM.DPICHANGED, form, newDpi);


### PR DESCRIPTION


Fixes #3168 in combination with https://github.com/dotnet/winforms/pull/7956


## Proposed changes

- Scaling SplitterDistance property when DPI changed event occurs.
- Updating Panel sizes when FixedPanel property is set and DPI changed event occurs.
- Add unit test for future reference.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7990)