### PR TITLE
Enable nullability in ToolStripTextBox

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -546,10 +546,10 @@ override System.Windows.Forms.LinkLabel.Text.set -> void
 ~override System.Windows.Forms.ToolStripStatusLabel.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
 ~override System.Windows.Forms.ToolStripStatusLabel.OnPaint(System.Windows.Forms.PaintEventArgs e) -> void
 ~override System.Windows.Forms.ToolStripStatusLabel.OnTextChanged(System.EventArgs e) -> void
-~override System.Windows.Forms.ToolStripTextBox.BackgroundImage.get -> System.Drawing.Image
-~override System.Windows.Forms.ToolStripTextBox.BackgroundImage.set -> void
-~override System.Windows.Forms.ToolStripTextBox.OnSubscribeControlEvents(System.Windows.Forms.Control control) -> void
-~override System.Windows.Forms.ToolStripTextBox.OnUnsubscribeControlEvents(System.Windows.Forms.Control control) -> void
+override System.Windows.Forms.ToolStripTextBox.BackgroundImage.get -> System.Drawing.Image?
+override System.Windows.Forms.ToolStripTextBox.BackgroundImage.set -> void
+override System.Windows.Forms.ToolStripTextBox.OnSubscribeControlEvents(System.Windows.Forms.Control? control) -> void
+override System.Windows.Forms.ToolStripTextBox.OnUnsubscribeControlEvents(System.Windows.Forms.Control? control) -> void
 ~override System.Windows.Forms.ToolTip.ToString() -> string
 ~override System.Windows.Forms.TreeNode.ToString() -> string
 ~override System.Windows.Forms.TreeView.BackgroundImage.get -> System.Drawing.Image
@@ -1544,16 +1544,16 @@ System.Windows.Forms.LinkLabel.PointInLink(int x, int y) -> System.Windows.Forms
 ~System.Windows.Forms.ToolStripStatusLabel.ToolStripStatusLabel(string text, System.Drawing.Image image, System.EventHandler onClick) -> void
 ~System.Windows.Forms.ToolStripStatusLabel.ToolStripStatusLabel(string text, System.Drawing.Image image, System.EventHandler onClick, string name) -> void
 ~System.Windows.Forms.ToolStripStatusLabel.ToolStripStatusLabel(System.Drawing.Image image) -> void
-~System.Windows.Forms.ToolStripTextBox.AppendText(string text) -> void
-~System.Windows.Forms.ToolStripTextBox.AutoCompleteCustomSource.get -> System.Windows.Forms.AutoCompleteStringCollection
-~System.Windows.Forms.ToolStripTextBox.AutoCompleteCustomSource.set -> void
-~System.Windows.Forms.ToolStripTextBox.Lines.get -> string[]
-~System.Windows.Forms.ToolStripTextBox.Lines.set -> void
-~System.Windows.Forms.ToolStripTextBox.SelectedText.get -> string
-~System.Windows.Forms.ToolStripTextBox.SelectedText.set -> void
-~System.Windows.Forms.ToolStripTextBox.TextBox.get -> System.Windows.Forms.TextBox
-~System.Windows.Forms.ToolStripTextBox.ToolStripTextBox(string name) -> void
-~System.Windows.Forms.ToolStripTextBox.ToolStripTextBox(System.Windows.Forms.Control c) -> void
+System.Windows.Forms.ToolStripTextBox.AppendText(string? text) -> void
+System.Windows.Forms.ToolStripTextBox.AutoCompleteCustomSource.get -> System.Windows.Forms.AutoCompleteStringCollection!
+System.Windows.Forms.ToolStripTextBox.AutoCompleteCustomSource.set -> void
+System.Windows.Forms.ToolStripTextBox.Lines.get -> string![]!
+System.Windows.Forms.ToolStripTextBox.Lines.set -> void
+System.Windows.Forms.ToolStripTextBox.SelectedText.get -> string!
+System.Windows.Forms.ToolStripTextBox.SelectedText.set -> void
+System.Windows.Forms.ToolStripTextBox.TextBox.get -> System.Windows.Forms.TextBox!
+System.Windows.Forms.ToolStripTextBox.ToolStripTextBox(string? name) -> void
+System.Windows.Forms.ToolStripTextBox.ToolStripTextBox(System.Windows.Forms.Control! c) -> void
 ~System.Windows.Forms.ToolTip.CanExtend(object target) -> bool
 ~System.Windows.Forms.ToolTip.GetToolTip(System.Windows.Forms.Control control) -> string
 ~System.Windows.Forms.ToolTip.Hide(System.Windows.Forms.IWin32Window win) -> void
@@ -2188,12 +2188,12 @@ virtual System.Windows.Forms.LinkLabel.OnLinkClicked(System.Windows.Forms.LinkLa
 ~virtual System.Windows.Forms.ToolStripSplitButton.OnButtonClick(System.EventArgs e) -> void
 ~virtual System.Windows.Forms.ToolStripSplitButton.OnButtonDoubleClick(System.EventArgs e) -> void
 ~virtual System.Windows.Forms.ToolStripSplitButton.OnDefaultItemChanged(System.EventArgs e) -> void
-~virtual System.Windows.Forms.ToolStripTextBox.OnAcceptsTabChanged(System.EventArgs e) -> void
-~virtual System.Windows.Forms.ToolStripTextBox.OnBorderStyleChanged(System.EventArgs e) -> void
-~virtual System.Windows.Forms.ToolStripTextBox.OnHideSelectionChanged(System.EventArgs e) -> void
-~virtual System.Windows.Forms.ToolStripTextBox.OnModifiedChanged(System.EventArgs e) -> void
-~virtual System.Windows.Forms.ToolStripTextBox.OnMultilineChanged(System.EventArgs e) -> void
-~virtual System.Windows.Forms.ToolStripTextBox.OnReadOnlyChanged(System.EventArgs e) -> void
+virtual System.Windows.Forms.ToolStripTextBox.OnAcceptsTabChanged(System.EventArgs! e) -> void
+virtual System.Windows.Forms.ToolStripTextBox.OnBorderStyleChanged(System.EventArgs! e) -> void
+virtual System.Windows.Forms.ToolStripTextBox.OnHideSelectionChanged(System.EventArgs! e) -> void
+virtual System.Windows.Forms.ToolStripTextBox.OnModifiedChanged(System.EventArgs! e) -> void
+virtual System.Windows.Forms.ToolStripTextBox.OnMultilineChanged(System.EventArgs! e) -> void
+virtual System.Windows.Forms.ToolStripTextBox.OnReadOnlyChanged(System.EventArgs! e) -> void
 ~virtual System.Windows.Forms.ToolTip.CreateParams.get -> System.Windows.Forms.CreateParams
 ~virtual System.Windows.Forms.TreeNode.Clone() -> object
 ~virtual System.Windows.Forms.TreeNode.ContextMenuStrip.get -> System.Windows.Forms.ContextMenuStrip
@@ -11650,14 +11650,14 @@ System.Windows.Forms.ToolStripTextBox.AcceptsReturn.get -> bool
 System.Windows.Forms.ToolStripTextBox.AcceptsReturn.set -> void
 System.Windows.Forms.ToolStripTextBox.AcceptsTab.get -> bool
 System.Windows.Forms.ToolStripTextBox.AcceptsTab.set -> void
-System.Windows.Forms.ToolStripTextBox.AcceptsTabChanged -> System.EventHandler
+System.Windows.Forms.ToolStripTextBox.AcceptsTabChanged -> System.EventHandler?
 System.Windows.Forms.ToolStripTextBox.AutoCompleteMode.get -> System.Windows.Forms.AutoCompleteMode
 System.Windows.Forms.ToolStripTextBox.AutoCompleteMode.set -> void
 System.Windows.Forms.ToolStripTextBox.AutoCompleteSource.get -> System.Windows.Forms.AutoCompleteSource
 System.Windows.Forms.ToolStripTextBox.AutoCompleteSource.set -> void
 System.Windows.Forms.ToolStripTextBox.BorderStyle.get -> System.Windows.Forms.BorderStyle
 System.Windows.Forms.ToolStripTextBox.BorderStyle.set -> void
-System.Windows.Forms.ToolStripTextBox.BorderStyleChanged -> System.EventHandler
+System.Windows.Forms.ToolStripTextBox.BorderStyleChanged -> System.EventHandler?
 System.Windows.Forms.ToolStripTextBox.CanUndo.get -> bool
 System.Windows.Forms.ToolStripTextBox.CharacterCasing.get -> System.Windows.Forms.CharacterCasing
 System.Windows.Forms.ToolStripTextBox.CharacterCasing.set -> void
@@ -11674,19 +11674,19 @@ System.Windows.Forms.ToolStripTextBox.GetLineFromCharIndex(int index) -> int
 System.Windows.Forms.ToolStripTextBox.GetPositionFromCharIndex(int index) -> System.Drawing.Point
 System.Windows.Forms.ToolStripTextBox.HideSelection.get -> bool
 System.Windows.Forms.ToolStripTextBox.HideSelection.set -> void
-System.Windows.Forms.ToolStripTextBox.HideSelectionChanged -> System.EventHandler
+System.Windows.Forms.ToolStripTextBox.HideSelectionChanged -> System.EventHandler?
 System.Windows.Forms.ToolStripTextBox.MaxLength.get -> int
 System.Windows.Forms.ToolStripTextBox.MaxLength.set -> void
 System.Windows.Forms.ToolStripTextBox.Modified.get -> bool
 System.Windows.Forms.ToolStripTextBox.Modified.set -> void
-System.Windows.Forms.ToolStripTextBox.ModifiedChanged -> System.EventHandler
+System.Windows.Forms.ToolStripTextBox.ModifiedChanged -> System.EventHandler?
 System.Windows.Forms.ToolStripTextBox.Multiline.get -> bool
 System.Windows.Forms.ToolStripTextBox.Multiline.set -> void
-System.Windows.Forms.ToolStripTextBox.MultilineChanged -> System.EventHandler
+System.Windows.Forms.ToolStripTextBox.MultilineChanged -> System.EventHandler?
 System.Windows.Forms.ToolStripTextBox.Paste() -> void
 System.Windows.Forms.ToolStripTextBox.ReadOnly.get -> bool
 System.Windows.Forms.ToolStripTextBox.ReadOnly.set -> void
-System.Windows.Forms.ToolStripTextBox.ReadOnlyChanged -> System.EventHandler
+System.Windows.Forms.ToolStripTextBox.ReadOnlyChanged -> System.EventHandler?
 System.Windows.Forms.ToolStripTextBox.ScrollToCaret() -> void
 System.Windows.Forms.ToolStripTextBox.Select(int start, int length) -> void
 System.Windows.Forms.ToolStripTextBox.SelectAll() -> void
@@ -11698,7 +11698,7 @@ System.Windows.Forms.ToolStripTextBox.ShortcutsEnabled.get -> bool
 System.Windows.Forms.ToolStripTextBox.ShortcutsEnabled.set -> void
 System.Windows.Forms.ToolStripTextBox.TextBoxTextAlign.get -> System.Windows.Forms.HorizontalAlignment
 System.Windows.Forms.ToolStripTextBox.TextBoxTextAlign.set -> void
-System.Windows.Forms.ToolStripTextBox.TextBoxTextAlignChanged -> System.EventHandler
+System.Windows.Forms.ToolStripTextBox.TextBoxTextAlignChanged -> System.EventHandler?
 System.Windows.Forms.ToolStripTextBox.TextLength.get -> int
 System.Windows.Forms.ToolStripTextBox.ToolStripTextBox() -> void
 System.Windows.Forms.ToolStripTextBox.Undo() -> void

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms
         public ToolStripTextBox()
             : base(CreateControlInstance())
         {
-            ToolStripTextBoxControl textBox = (Control as ToolStripTextBoxControl)!;
+            ToolStripTextBoxControl textBox = (ToolStripTextBoxControl)Control;
             textBox.Owner = this;
 
             if (DpiHelper.IsScalingRequirementMet)
@@ -106,7 +106,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return (Control as TextBox)!;
+                return (TextBox)Control;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.cs
@@ -2,9 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Drawing.Design;
 using System.Runtime.InteropServices;
@@ -30,9 +29,10 @@ namespace System.Windows.Forms
         private Padding _scaledDefaultMargin = s_defaultMargin;
         private Padding _scaledDefaultDropDownMargin = s_defaultDropDownMargin;
 
-        public ToolStripTextBox() : base(CreateControlInstance())
+        public ToolStripTextBox()
+            : base(CreateControlInstance())
         {
-            ToolStripTextBoxControl textBox = Control as ToolStripTextBoxControl;
+            ToolStripTextBoxControl textBox = (Control as ToolStripTextBoxControl)!;
             textBox.Owner = this;
 
             if (DpiHelper.IsScalingRequirementMet)
@@ -42,13 +42,15 @@ namespace System.Windows.Forms
             }
         }
 
-        public ToolStripTextBox(string name) : this()
+        public ToolStripTextBox(string? name)
+            : this()
         {
             Name = name;
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public ToolStripTextBox(Control c) : base(c)
+        public ToolStripTextBox(Control c)
+            : base(c)
         {
             throw new NotSupportedException(SR.ToolStripMustSupplyItsOwnTextBox);
         }
@@ -56,7 +58,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public override Image BackgroundImage
+        public override Image? BackgroundImage
         {
             get => base.BackgroundImage;
             set => base.BackgroundImage = value;
@@ -104,7 +106,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                return Control as TextBox;
+                return (Control as TextBox)!;
             }
         }
 
@@ -125,38 +127,38 @@ namespace System.Windows.Forms
             return new Size(bounds.Width, TextBox.PreferredHeight);
         }
 
-        private void HandleAcceptsTabChanged(object sender, EventArgs e)
+        private void HandleAcceptsTabChanged(object? sender, EventArgs e)
         {
             OnAcceptsTabChanged(e);
         }
 
-        private void HandleBorderStyleChanged(object sender, EventArgs e)
+        private void HandleBorderStyleChanged(object? sender, EventArgs e)
         {
             OnBorderStyleChanged(e);
         }
 
-        private void HandleHideSelectionChanged(object sender, EventArgs e)
+        private void HandleHideSelectionChanged(object? sender, EventArgs e)
         {
             OnHideSelectionChanged(e);
         }
 
-        private void HandleModifiedChanged(object sender, EventArgs e)
+        private void HandleModifiedChanged(object? sender, EventArgs e)
         {
             OnModifiedChanged(e);
         }
 
-        private void HandleMultilineChanged(object sender, EventArgs e)
+        private void HandleMultilineChanged(object? sender, EventArgs e)
         {
             OnMultilineChanged(e);
         }
 
-        private void HandleReadOnlyChanged(object sender, EventArgs e)
+        private void HandleReadOnlyChanged(object? sender, EventArgs e)
         {
             OnReadOnlyChanged(e);
         }
 
 #pragma warning disable CA2252 // Suppress 'Opt in to preview features' (https://aka.ms/dotnet-warnings/preview-features)
-        private void HandleTextBoxTextAlignChanged(object sender, EventArgs e)
+        private void HandleTextBoxTextAlignChanged(object? sender, EventArgs e)
         {
             RaiseEvent(s_eventTextBoxTextAlignChanged, e);
         }
@@ -192,12 +194,11 @@ namespace System.Windows.Forms
         }
 #pragma warning restore CA2252
 
-        protected override void OnSubscribeControlEvents(Control control)
+        protected override void OnSubscribeControlEvents(Control? control)
         {
             if (control is TextBox textBox)
             {
-                // Please keep this alphabetized and in sync with Unsubscribe
-                //
+                // Please keep this alphabetized and in sync with Unsubscribe.
                 textBox.AcceptsTabChanged += new EventHandler(HandleAcceptsTabChanged);
                 textBox.BorderStyleChanged += new EventHandler(HandleBorderStyleChanged);
                 textBox.HideSelectionChanged += new EventHandler(HandleHideSelectionChanged);
@@ -210,12 +211,11 @@ namespace System.Windows.Forms
             base.OnSubscribeControlEvents(control);
         }
 
-        protected override void OnUnsubscribeControlEvents(Control control)
+        protected override void OnUnsubscribeControlEvents(Control? control)
         {
             if (control is TextBox textBox)
             {
-                // Please keep this alphabetized and in sync with Subscribe
-                //
+                // Please keep this alphabetized and in sync with Subscribe.
                 textBox.AcceptsTabChanged -= new EventHandler(HandleAcceptsTabChanged);
                 textBox.BorderStyleChanged -= new EventHandler(HandleBorderStyleChanged);
                 textBox.HideSelectionChanged -= new EventHandler(HandleHideSelectionChanged);
@@ -258,6 +258,7 @@ namespace System.Windows.Forms
         [Editor("System.Windows.Forms.Design.ListControlStringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [Browsable(true)]
         [EditorBrowsable(EditorBrowsableState.Always)]
+        [AllowNull]
         public AutoCompleteStringCollection AutoCompleteCustomSource
         {
             get { return TextBox.AutoCompleteCustomSource; }
@@ -326,6 +327,7 @@ namespace System.Windows.Forms
         [Localizable(true)]
         [SRDescription(nameof(SR.TextBoxLinesDescr))]
         [Editor("System.Windows.Forms.Design.StringArrayEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [AllowNull]
         public string[] Lines
         {
             get { return TextBox.Lines; }
@@ -378,6 +380,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [SRDescription(nameof(SR.TextBoxSelectedTextDescr))]
+        [AllowNull]
         public string SelectedText
         {
             get { return TextBox.SelectedText; }
@@ -446,7 +449,7 @@ namespace System.Windows.Forms
         #region WrappedEvents
         [SRCategory(nameof(SR.CatPropertyChanged))]
         [SRDescription(nameof(SR.TextBoxBaseOnAcceptsTabChangedDescr))]
-        public event EventHandler AcceptsTabChanged
+        public event EventHandler? AcceptsTabChanged
         {
             add => Events.AddHandler(s_eventAcceptsTabChanged, value);
             remove => Events.RemoveHandler(s_eventAcceptsTabChanged, value);
@@ -454,7 +457,7 @@ namespace System.Windows.Forms
 
         [SRCategory(nameof(SR.CatPropertyChanged))]
         [SRDescription(nameof(SR.TextBoxBaseOnBorderStyleChangedDescr))]
-        public event EventHandler BorderStyleChanged
+        public event EventHandler? BorderStyleChanged
         {
             add => Events.AddHandler(s_eventBorderStyleChanged, value);
             remove => Events.RemoveHandler(s_eventBorderStyleChanged, value);
@@ -462,7 +465,7 @@ namespace System.Windows.Forms
 
         [SRCategory(nameof(SR.CatPropertyChanged))]
         [SRDescription(nameof(SR.TextBoxBaseOnHideSelectionChangedDescr))]
-        public event EventHandler HideSelectionChanged
+        public event EventHandler? HideSelectionChanged
         {
             add => Events.AddHandler(s_eventHideSelectionChanged, value);
             remove => Events.RemoveHandler(s_eventHideSelectionChanged, value);
@@ -470,7 +473,7 @@ namespace System.Windows.Forms
 
         [SRCategory(nameof(SR.CatPropertyChanged))]
         [SRDescription(nameof(SR.TextBoxBaseOnModifiedChangedDescr))]
-        public event EventHandler ModifiedChanged
+        public event EventHandler? ModifiedChanged
         {
             add => Events.AddHandler(s_eventModifiedChanged, value);
             remove => Events.RemoveHandler(s_eventModifiedChanged, value);
@@ -480,7 +483,7 @@ namespace System.Windows.Forms
         [SRDescription(nameof(SR.TextBoxBaseOnMultilineChangedDescr))]
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public event EventHandler MultilineChanged
+        public event EventHandler? MultilineChanged
         {
             add => Events.AddHandler(s_eventMultilineChanged, value);
             remove => Events.RemoveHandler(s_eventMultilineChanged, value);
@@ -488,7 +491,7 @@ namespace System.Windows.Forms
 
         [SRCategory(nameof(SR.CatPropertyChanged))]
         [SRDescription(nameof(SR.TextBoxBaseOnReadOnlyChangedDescr))]
-        public event EventHandler ReadOnlyChanged
+        public event EventHandler? ReadOnlyChanged
         {
             add => Events.AddHandler(s_eventReadOnlyChanged, value);
             remove => Events.RemoveHandler(s_eventReadOnlyChanged, value);
@@ -496,7 +499,7 @@ namespace System.Windows.Forms
 
         [SRCategory(nameof(SR.CatPropertyChanged))]
         [SRDescription(nameof(SR.ToolStripTextBoxTextBoxTextAlignChangedDescr))]
-        public event EventHandler TextBoxTextAlignChanged
+        public event EventHandler? TextBoxTextAlignChanged
         {
             add => Events.AddHandler(s_eventTextBoxTextAlignChanged, value);
             remove => Events.RemoveHandler(s_eventTextBoxTextAlignChanged, value);
@@ -504,7 +507,7 @@ namespace System.Windows.Forms
         #endregion WrappedEvents
 
         #region WrappedMethods
-        public void AppendText(string text) { TextBox.AppendText(text); }
+        public void AppendText(string? text) { TextBox.AppendText(text); }
         public void Clear() { TextBox.Clear(); }
         public void ClearUndo() { TextBox.ClearUndo(); }
         public void Copy() { TextBox.Copy(); }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripTextBox.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/7999)