### PR TITLE
Enable nullability in ToolStripButton

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -448,9 +448,9 @@ override System.Windows.Forms.LinkLabel.Text.set -> void
 ~override System.Windows.Forms.ToolStrip.OnTabStopChanged(System.EventArgs e) -> void
 ~override System.Windows.Forms.ToolStrip.OnVisibleChanged(System.EventArgs e) -> void
 ~override System.Windows.Forms.ToolStrip.ToString() -> string
-~override System.Windows.Forms.ToolStripButton.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.ToolStripButton.OnClick(System.EventArgs e) -> void
-~override System.Windows.Forms.ToolStripButton.OnPaint(System.Windows.Forms.PaintEventArgs e) -> void
+override System.Windows.Forms.ToolStripButton.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
+override System.Windows.Forms.ToolStripButton.OnClick(System.EventArgs! e) -> void
+override System.Windows.Forms.ToolStripButton.OnPaint(System.Windows.Forms.PaintEventArgs! e) -> void
 ~override System.Windows.Forms.ToolStripComboBox.BackgroundImage.get -> System.Drawing.Image
 ~override System.Windows.Forms.ToolStripComboBox.BackgroundImage.set -> void
 ~override System.Windows.Forms.ToolStripComboBox.OnSubscribeControlEvents(System.Windows.Forms.Control control) -> void
@@ -1407,11 +1407,11 @@ System.Windows.Forms.LinkLabel.PointInLink(int x, int y) -> System.Windows.Forms
 ~System.Windows.Forms.ToolStrip.SetItemLocation(System.Windows.Forms.ToolStripItem item, System.Drawing.Point location) -> void
 ~System.Windows.Forms.ToolStrip.ToolStrip(params System.Windows.Forms.ToolStripItem[] items) -> void
 ~System.Windows.Forms.ToolStrip.VerticalScroll.get -> System.Windows.Forms.VScrollProperties
-~System.Windows.Forms.ToolStripButton.ToolStripButton(string text) -> void
-~System.Windows.Forms.ToolStripButton.ToolStripButton(string text, System.Drawing.Image image) -> void
-~System.Windows.Forms.ToolStripButton.ToolStripButton(string text, System.Drawing.Image image, System.EventHandler onClick) -> void
-~System.Windows.Forms.ToolStripButton.ToolStripButton(string text, System.Drawing.Image image, System.EventHandler onClick, string name) -> void
-~System.Windows.Forms.ToolStripButton.ToolStripButton(System.Drawing.Image image) -> void
+System.Windows.Forms.ToolStripButton.ToolStripButton(string? text) -> void
+System.Windows.Forms.ToolStripButton.ToolStripButton(string? text, System.Drawing.Image? image) -> void
+System.Windows.Forms.ToolStripButton.ToolStripButton(string? text, System.Drawing.Image? image, System.EventHandler? onClick) -> void
+System.Windows.Forms.ToolStripButton.ToolStripButton(string? text, System.Drawing.Image? image, System.EventHandler? onClick, string? name) -> void
+System.Windows.Forms.ToolStripButton.ToolStripButton(System.Drawing.Image? image) -> void
 ~System.Windows.Forms.ToolStripComboBox.AutoCompleteCustomSource.get -> System.Windows.Forms.AutoCompleteStringCollection
 ~System.Windows.Forms.ToolStripComboBox.AutoCompleteCustomSource.set -> void
 ~System.Windows.Forms.ToolStripComboBox.ComboBox.get -> System.Windows.Forms.ComboBox
@@ -2097,8 +2097,8 @@ virtual System.Windows.Forms.LinkLabel.OnLinkClicked(System.Windows.Forms.LinkLa
 ~virtual System.Windows.Forms.ToolStrip.OnLayoutStyleChanged(System.EventArgs e) -> void
 ~virtual System.Windows.Forms.ToolStrip.OnPaintGrip(System.Windows.Forms.PaintEventArgs e) -> void
 ~virtual System.Windows.Forms.ToolStrip.OnRendererChanged(System.EventArgs e) -> void
-~virtual System.Windows.Forms.ToolStripButton.OnCheckedChanged(System.EventArgs e) -> void
-~virtual System.Windows.Forms.ToolStripButton.OnCheckStateChanged(System.EventArgs e) -> void
+virtual System.Windows.Forms.ToolStripButton.OnCheckedChanged(System.EventArgs! e) -> void
+virtual System.Windows.Forms.ToolStripButton.OnCheckStateChanged(System.EventArgs! e) -> void
 ~virtual System.Windows.Forms.ToolStripComboBox.OnDropDown(System.EventArgs e) -> void
 ~virtual System.Windows.Forms.ToolStripComboBox.OnDropDownClosed(System.EventArgs e) -> void
 ~virtual System.Windows.Forms.ToolStripComboBox.OnDropDownStyleChanged(System.EventArgs e) -> void
@@ -10968,12 +10968,12 @@ System.Windows.Forms.ToolStripButton.AutoToolTip.get -> bool
 System.Windows.Forms.ToolStripButton.AutoToolTip.set -> void
 System.Windows.Forms.ToolStripButton.Checked.get -> bool
 System.Windows.Forms.ToolStripButton.Checked.set -> void
-System.Windows.Forms.ToolStripButton.CheckedChanged -> System.EventHandler
+System.Windows.Forms.ToolStripButton.CheckedChanged -> System.EventHandler?
 System.Windows.Forms.ToolStripButton.CheckOnClick.get -> bool
 System.Windows.Forms.ToolStripButton.CheckOnClick.set -> void
 System.Windows.Forms.ToolStripButton.CheckState.get -> System.Windows.Forms.CheckState
 System.Windows.Forms.ToolStripButton.CheckState.set -> void
-System.Windows.Forms.ToolStripButton.CheckStateChanged -> System.EventHandler
+System.Windows.Forms.ToolStripButton.CheckStateChanged -> System.EventHandler?
 System.Windows.Forms.ToolStripButton.ToolStripButton() -> void
 System.Windows.Forms.ToolStripComboBox
 System.Windows.Forms.ToolStripComboBox.AutoCompleteMode.get -> System.Windows.Forms.AutoCompleteMode

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripButton.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.Design;
@@ -25,27 +23,32 @@ namespace System.Windows.Forms
             Initialize();
         }
 
-        public ToolStripButton(string text) : base(text, null, null)
+        public ToolStripButton(string? text)
+            : base(text, image: null, onClick: null)
         {
             Initialize();
         }
 
-        public ToolStripButton(Image image) : base(null, image, null)
+        public ToolStripButton(Image? image)
+            : base(text: null, image, onClick: null)
         {
             Initialize();
         }
 
-        public ToolStripButton(string text, Image image) : base(text, image, null)
+        public ToolStripButton(string? text, Image? image)
+            : base(text, image, onClick: null)
         {
             Initialize();
         }
 
-        public ToolStripButton(string text, Image image, EventHandler onClick) : base(text, image, onClick)
+        public ToolStripButton(string? text, Image? image, EventHandler? onClick)
+            : base(text, image, onClick)
         {
             Initialize();
         }
 
-        public ToolStripButton(string text, Image image, EventHandler onClick, string name) : base(text, image, onClick, name)
+        public ToolStripButton(string? text, Image? image, EventHandler? onClick, string? name)
+            : base(text, image, onClick, name)
         {
             Initialize();
         }
@@ -111,7 +114,7 @@ namespace System.Windows.Forms
         ///  Occurs when the value of the <see cref="CheckBox.Checked"/> property changes.
         /// </summary>
         [SRDescription(nameof(SR.CheckBoxOnCheckedChangedDescr))]
-        public event EventHandler CheckedChanged
+        public event EventHandler? CheckedChanged
         {
             add => Events.AddHandler(s_checkedChangedEvent, value);
             remove => Events.RemoveHandler(s_checkedChangedEvent, value);
@@ -121,7 +124,7 @@ namespace System.Windows.Forms
         ///  Occurs when the value of the <see cref="CheckBox.CheckState"/> property changes.
         /// </summary>
         [SRDescription(nameof(SR.CheckBoxOnCheckStateChangedDescr))]
-        public event EventHandler CheckStateChanged
+        public event EventHandler? CheckStateChanged
         {
             add => Events.AddHandler(s_checkStateChangedEvent, value);
             remove => Events.RemoveHandler(s_checkStateChangedEvent, value);
@@ -173,7 +176,7 @@ namespace System.Windows.Forms
         ///  Raises the <see cref="ToolStripMenuItem.CheckedChanged"/> event.
         /// </summary>
         protected virtual void OnCheckedChanged(EventArgs e)
-            => ((EventHandler)Events[s_checkedChangedEvent])?.Invoke(this, e);
+            => ((EventHandler?)Events[s_checkedChangedEvent])?.Invoke(this, e);
 
         /// <summary>
         ///  Raises the <see cref="ToolStripMenuItem.CheckStateChanged"/> event.
@@ -181,7 +184,7 @@ namespace System.Windows.Forms
         protected virtual void OnCheckStateChanged(EventArgs e)
         {
             AccessibilityNotifyClients(AccessibleEvents.StateChange);
-            ((EventHandler)Events[s_checkStateChangedEvent])?.Invoke(this, e);
+            ((EventHandler?)Events[s_checkStateChangedEvent])?.Invoke(this, e);
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripButton.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8001)