### PR TITLE
Enable nullability in ToolStripNumericUpDown

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripNumericUpDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripNumericUpDown.cs
@@ -2,17 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     internal partial class ToolStripNumericUpDown : ToolStripControlHost
     {
         private ToolStripNumericUpDownControl _numericUpDownControl;
 
-        public ToolStripNumericUpDown() : base(CreateControlInstance())
+        public ToolStripNumericUpDown()
+            : base(CreateControlInstance())
         {
-            _numericUpDownControl = Control as ToolStripNumericUpDownControl;
+            _numericUpDownControl = (ToolStripNumericUpDownControl)Control;
             _numericUpDownControl.Owner = this;
         }
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripNumericUpDown.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8003)