### PR TITLE
Enable nullability in ToolStripDropTargetManager

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -7203,7 +7203,7 @@ System.Windows.Forms.DragEventArgs
 System.Windows.Forms.DragEventArgs.AllowedEffect.get -> System.Windows.Forms.DragDropEffects
 System.Windows.Forms.DragEventArgs.Data.get -> System.Windows.Forms.IDataObject?
 System.Windows.Forms.DragEventArgs.DragEventArgs(System.Windows.Forms.IDataObject? data, int keyState, int x, int y, System.Windows.Forms.DragDropEffects allowedEffect, System.Windows.Forms.DragDropEffects effect) -> void
-System.Windows.Forms.DragEventArgs.DragEventArgs(System.Windows.Forms.IDataObject? data, int keyState, int x, int y, System.Windows.Forms.DragDropEffects allowedEffect, System.Windows.Forms.DragDropEffects effect, System.Windows.Forms.DropImageType dropImageType, string! message, string! messageReplacementToken) -> void
+System.Windows.Forms.DragEventArgs.DragEventArgs(System.Windows.Forms.IDataObject? data, int keyState, int x, int y, System.Windows.Forms.DragDropEffects allowedEffect, System.Windows.Forms.DragDropEffects effect, System.Windows.Forms.DropImageType dropImageType, string? message, string? messageReplacementToken) -> void
 System.Windows.Forms.DragEventArgs.DropImageType.get -> System.Windows.Forms.DropImageType
 System.Windows.Forms.DragEventArgs.DropImageType.set -> void
 System.Windows.Forms.DragEventArgs.Effect.get -> System.Windows.Forms.DragDropEffects

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DragEventArgs.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DragEventArgs.cs
@@ -35,8 +35,8 @@ namespace System.Windows.Forms
             DragDropEffects allowedEffect,
             DragDropEffects effect,
             DropImageType dropImageType,
-            string message,
-            string messageReplacementToken)
+            string? message,
+            string? messageReplacementToken)
         {
             Data = data;
             KeyState = keyState;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropTargetManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropTargetManager.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms
 #if DEBUG
         internal static readonly TraceSwitch DragDropDebug = new TraceSwitch("DragDropDebug", "Debug ToolStrip DragDrop code");
 #else
-        internal static readonly TraceSwitch DragDropDebug;
+        internal static readonly TraceSwitch? DragDropDebug;
 #endif
 
         public ToolStrip Owner
@@ -37,19 +37,18 @@ namespace System.Windows.Forms
 
         public ToolStripDropTargetManager(ToolStrip owner)
         {
-            this._owner = owner;
-            ArgumentNullException.ThrowIfNull(owner);
+            _owner = owner.OrThrowIfNull();
         }
 
         public void EnsureRegistered()
         {
-            Debug.WriteLineIf(DragDropDebug.TraceVerbose, "Ensuring drop target registered");
+            Debug.WriteLineIf(DragDropDebug!.TraceVerbose, "Ensuring drop target registered");
             SetAcceptDrops(true);
         }
 
         public void EnsureUnRegistered()
         {
-            Debug.WriteLineIf(DragDropDebug.TraceVerbose, "Attempting to unregister droptarget");
+            Debug.WriteLineIf(DragDropDebug!.TraceVerbose, "Attempting to unregister droptarget");
             for (int i = 0; i < _owner.Items.Count; i++)
             {
                 if (_owner.Items[i].AllowDrop)
@@ -79,7 +78,7 @@ namespace System.Windows.Forms
 
         public void OnDragEnter(DragEventArgs e)
         {
-            Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG ENTER] ==============");
+            Debug.WriteLineIf(DragDropDebug!.TraceVerbose, "[DRAG ENTER] ==============");
 
             // If we are supporting Item Reordering
             // and this is a ToolStripItem - snitch it.
@@ -133,7 +132,7 @@ namespace System.Windows.Forms
 
         public void OnDragOver(DragEventArgs e)
         {
-            Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG OVER] ==============");
+            Debug.WriteLineIf(DragDropDebug!.TraceVerbose, "[DRAG OVER] ==============");
 
             IDropTarget? newDropTarget = null;
 
@@ -141,7 +140,7 @@ namespace System.Windows.Forms
             // and this is a ToolStripItem - snitch it.
             if (_owner.AllowItemReorder && e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
             {
-                Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ItemReorderTarget taking this...");
+                Debug.WriteLineIf(DragDropDebug!.TraceVerbose, "ItemReorderTarget taking this...");
                 newDropTarget = _owner.ItemReorderDropTarget;
             }
             else
@@ -185,7 +184,7 @@ namespace System.Windows.Forms
 
         public void OnDragLeave(EventArgs e)
         {
-            Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG LEAVE] ==============");
+            Debug.WriteLineIf(DragDropDebug!.TraceVerbose, "[DRAG LEAVE] ==============");
 
             if (_lastDropTarget is not null)
             {
@@ -206,7 +205,7 @@ namespace System.Windows.Forms
 
         public void OnDragDrop(DragEventArgs e)
         {
-            Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG DROP] ==============");
+            Debug.WriteLineIf(DragDropDebug!.TraceVerbose, "[DRAG DROP] ==============");
 
             if (_lastDropTarget is not null)
             {
@@ -236,7 +235,7 @@ namespace System.Windows.Forms
                         throw new ThreadStateException(SR.ThreadMustBeSTA);
                     }
 
-                    Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "Registering as drop target: " + _owner.Handle.ToString());
+                    Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"Registering as drop target: {_owner.Handle}");
 
                     // Register
                     HRESULT n = Ole32.RegisterDragDrop(_owner, new DropTarget(this));

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropTargetManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropTargetManager.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -19,7 +17,7 @@ namespace System.Windows.Forms
     /// </summary>
     internal class ToolStripDropTargetManager : IDropTarget
     {
-        private IDropTarget lastDropTarget;
+        private IDropTarget? lastDropTarget;
         private readonly ToolStrip owner;
 
 #if DEBUG
@@ -85,7 +83,7 @@ namespace System.Windows.Forms
 
             // If we are supporting Item Reordering
             // and this is a ToolStripItem - snitch it.
-            if (owner.AllowItemReorder && e.Data.GetDataPresent(typeof(ToolStripItem)))
+            if (owner.AllowItemReorder && e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ItemReorderTarget taking this...");
                 lastDropTarget = owner.ItemReorderDropTarget;
@@ -137,11 +135,11 @@ namespace System.Windows.Forms
         {
             Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG OVER] ==============");
 
-            IDropTarget newDropTarget = null;
+            IDropTarget? newDropTarget = null;
 
             // If we are supporting Item Reordering
             // and this is a ToolStripItem - snitch it.
-            if (owner.AllowItemReorder && e.Data.GetDataPresent(typeof(ToolStripItem)))
+            if (owner.AllowItemReorder && e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ItemReorderTarget taking this...");
                 newDropTarget = owner.ItemReorderDropTarget;
@@ -245,7 +243,7 @@ namespace System.Windows.Forms
                     Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"   ret:{n}");
                     if (n != HRESULT.S_OK && n != HRESULT.DRAGDROP_E_ALREADYREGISTERED)
                     {
-                        throw Marshal.GetExceptionForHR((int)n);
+                        throw Marshal.GetExceptionForHR((int)n)!;
                     }
                 }
                 catch (Exception e)
@@ -259,7 +257,7 @@ namespace System.Windows.Forms
         ///  If we have a new active item, fire drag leave and enter. This corresponds to the case
         ///  where you are dragging between items and haven't actually left the ToolStrip's client area.
         /// </summary>
-        private void UpdateDropTarget(IDropTarget newTarget, DragEventArgs e)
+        private void UpdateDropTarget(IDropTarget? newTarget, DragEventArgs e)
         {
             if (newTarget != lastDropTarget)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropTargetManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripDropTargetManager.cs
@@ -17,11 +17,11 @@ namespace System.Windows.Forms
     /// </summary>
     internal class ToolStripDropTargetManager : IDropTarget
     {
-        private IDropTarget? lastDropTarget;
-        private readonly ToolStrip owner;
+        private IDropTarget? _lastDropTarget;
+        private readonly ToolStrip _owner;
 
 #if DEBUG
-        private bool dropTargetIsEntered;
+        private bool _dropTargetIsEntered;
 #endif
 
 #if DEBUG
@@ -32,12 +32,12 @@ namespace System.Windows.Forms
 
         public ToolStrip Owner
         {
-            get => owner;
+            get => _owner;
         }
 
         public ToolStripDropTargetManager(ToolStrip owner)
         {
-            this.owner = owner;
+            this._owner = owner;
             ArgumentNullException.ThrowIfNull(owner);
         }
 
@@ -50,23 +50,23 @@ namespace System.Windows.Forms
         public void EnsureUnRegistered()
         {
             Debug.WriteLineIf(DragDropDebug.TraceVerbose, "Attempting to unregister droptarget");
-            for (int i = 0; i < owner.Items.Count; i++)
+            for (int i = 0; i < _owner.Items.Count; i++)
             {
-                if (owner.Items[i].AllowDrop)
+                if (_owner.Items[i].AllowDrop)
                 {
                     Debug.WriteLineIf(DragDropDebug.TraceVerbose, "An item still has allowdrop set to true - can't unregister");
                     return; // can't unregister this as a drop target unless everyone is done.
                 }
             }
 
-            if (owner.AllowDrop || owner.AllowItemReorder)
+            if (_owner.AllowDrop || _owner.AllowItemReorder)
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "The ToolStrip has AllowDrop or AllowItemReorder set to true - can't unregister");
                 return;  // can't unregister this as a drop target if ToolStrip is still accepting drops
             }
 
             SetAcceptDrops(false);
-            owner.DropTargetManager = null;
+            _owner.DropTargetManager = null;
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace System.Windows.Forms
         /// </summary>
         private ToolStripItem FindItemAtPoint(int x, int y)
         {
-            return owner.GetItemAt(owner.PointToClient(new Point(x, y)));
+            return _owner.GetItemAt(_owner.PointToClient(new Point(x, y)));
         }
 
         public void OnDragEnter(DragEventArgs e)
@@ -83,10 +83,10 @@ namespace System.Windows.Forms
 
             // If we are supporting Item Reordering
             // and this is a ToolStripItem - snitch it.
-            if (owner.AllowItemReorder && e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
+            if (_owner.AllowItemReorder && e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ItemReorderTarget taking this...");
-                lastDropTarget = owner.ItemReorderDropTarget;
+                _lastDropTarget = _owner.ItemReorderDropTarget;
             }
             else
             {
@@ -97,13 +97,13 @@ namespace System.Windows.Forms
                     // the item wants this event
                     Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ToolStripItem taking this: " + item.ToString());
 
-                    lastDropTarget = ((IDropTarget)item);
+                    _lastDropTarget = ((IDropTarget)item);
                 }
-                else if (owner.AllowDrop)
+                else if (_owner.AllowDrop)
                 {
                     // the ToolStrip wants this event
                     Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ToolStrip taking this because AllowDrop set to true.");
-                    lastDropTarget = ((IDropTarget)owner);
+                    _lastDropTarget = ((IDropTarget)_owner);
                 }
                 else
                 {
@@ -117,17 +117,17 @@ namespace System.Windows.Forms
 
                     Debug.WriteLineIf(DragDropDebug.TraceVerbose, "No one wanted it.");
 
-                    lastDropTarget = null;
+                    _lastDropTarget = null;
                 }
             }
 
-            if (lastDropTarget is not null)
+            if (_lastDropTarget is not null)
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "Calling OnDragEnter on target...");
 #if DEBUG
-                dropTargetIsEntered = true;
+                _dropTargetIsEntered = true;
 #endif
-                lastDropTarget.OnDragEnter(e);
+                _lastDropTarget.OnDragEnter(e);
             }
         }
 
@@ -139,10 +139,10 @@ namespace System.Windows.Forms
 
             // If we are supporting Item Reordering
             // and this is a ToolStripItem - snitch it.
-            if (owner.AllowItemReorder && e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
+            if (_owner.AllowItemReorder && e.Data is not null && e.Data.GetDataPresent(typeof(ToolStripItem)))
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ItemReorderTarget taking this...");
-                newDropTarget = owner.ItemReorderDropTarget;
+                newDropTarget = _owner.ItemReorderDropTarget;
             }
             else
             {
@@ -154,11 +154,11 @@ namespace System.Windows.Forms
                     Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ToolStripItem taking this: " + item.ToString());
                     newDropTarget = ((IDropTarget)item);
                 }
-                else if (owner.AllowDrop)
+                else if (_owner.AllowDrop)
                 {
                     // the ToolStrip wants this event
                     Debug.WriteLineIf(DragDropDebug.TraceVerbose, "ToolStrip taking this because AllowDrop set to true.");
-                    newDropTarget = ((IDropTarget)owner);
+                    newDropTarget = ((IDropTarget)_owner);
                 }
                 else
                 {
@@ -169,17 +169,17 @@ namespace System.Windows.Forms
 
             // if we've switched drop targets - then
             // we need to create drag enter and leave events
-            if (newDropTarget != lastDropTarget)
+            if (newDropTarget != _lastDropTarget)
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "NEW DROP TARGET!");
                 UpdateDropTarget(newDropTarget, e);
             }
 
             // now call drag over
-            if (lastDropTarget is not null)
+            if (_lastDropTarget is not null)
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "Calling OnDragOver on target...");
-                lastDropTarget.OnDragOver(e);
+                _lastDropTarget.OnDragOver(e);
             }
         }
 
@@ -187,39 +187,39 @@ namespace System.Windows.Forms
         {
             Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG LEAVE] ==============");
 
-            if (lastDropTarget is not null)
+            if (_lastDropTarget is not null)
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "Calling OnDragLeave on current target...");
 #if DEBUG
-                dropTargetIsEntered = false;
+                _dropTargetIsEntered = false;
 #endif
-                lastDropTarget.OnDragLeave(e);
+                _lastDropTarget.OnDragLeave(e);
             }
 #if DEBUG
             else
             {
-                Debug.Assert(!dropTargetIsEntered, "Why do we have an entered droptarget and NO lastDropTarget?");
+                Debug.Assert(!_dropTargetIsEntered, "Why do we have an entered droptarget and NO lastDropTarget?");
             }
 #endif
-            lastDropTarget = null;
+            _lastDropTarget = null;
         }
 
         public void OnDragDrop(DragEventArgs e)
         {
             Debug.WriteLineIf(DragDropDebug.TraceVerbose, "[DRAG DROP] ==============");
 
-            if (lastDropTarget is not null)
+            if (_lastDropTarget is not null)
             {
                 Debug.WriteLineIf(DragDropDebug.TraceVerbose, "Calling OnDragDrop on current target...");
 
-                lastDropTarget.OnDragDrop(e);
+                _lastDropTarget.OnDragDrop(e);
             }
             else
             {
                 Debug.Assert(false, "Why is lastDropTarget null?");
             }
 
-            lastDropTarget = null;
+            _lastDropTarget = null;
         }
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void SetAcceptDrops(bool accept)
         {
-            if (accept && owner.IsHandleCreated)
+            if (accept && _owner.IsHandleCreated)
             {
                 try
                 {
@@ -236,10 +236,10 @@ namespace System.Windows.Forms
                         throw new ThreadStateException(SR.ThreadMustBeSTA);
                     }
 
-                    Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "Registering as drop target: " + owner.Handle.ToString());
+                    Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, "Registering as drop target: " + _owner.Handle.ToString());
 
                     // Register
-                    HRESULT n = Ole32.RegisterDragDrop(owner, new DropTarget(this));
+                    HRESULT n = Ole32.RegisterDragDrop(_owner, new DropTarget(this));
                     Debug.WriteLineIf(CompModSwitches.DragDrop.TraceInfo, $"   ret:{n}");
                     if (n != HRESULT.S_OK && n != HRESULT.DRAGDROP_E_ALREADYREGISTERED)
                     {
@@ -259,10 +259,10 @@ namespace System.Windows.Forms
         /// </summary>
         private void UpdateDropTarget(IDropTarget? newTarget, DragEventArgs e)
         {
-            if (newTarget != lastDropTarget)
+            if (newTarget != _lastDropTarget)
             {
                 // tell the last drag target you've left
-                if (lastDropTarget is not null)
+                if (_lastDropTarget is not null)
                 {
                     OnDragLeave(EventArgs.Empty);
 
@@ -274,7 +274,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                lastDropTarget = newTarget;
+                _lastDropTarget = newTarget;
                 if (newTarget is not null)
                 {
                     DragEventArgs dragEnterArgs = new DragEventArgs(e.Data, e.KeyState, e.X, e.Y, e.AllowedEffect, e.Effect, e.DropImageType, e.Message, e.MessageReplacementToken)
@@ -289,7 +289,7 @@ namespace System.Windows.Forms
                     OnDragEnter(dragEnterArgs);
 
                     // tell the drag image manager you've entered
-                    if (dragEnterArgs.DropImageType > DropImageType.Invalid && owner is ToolStrip toolStrip && toolStrip.IsHandleCreated)
+                    if (dragEnterArgs.DropImageType > DropImageType.Invalid && _owner is ToolStrip toolStrip && toolStrip.IsHandleCreated)
                     {
                         DragDropHelper.SetDropDescription(dragEnterArgs);
                         DragDropHelper.DragEnter(toolStrip.Handle, dragEnterArgs);


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripDropTargetManager.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8004)