### PR TITLE
Enable nullability in ToolStripOverflowButton

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms
     public partial class ToolStripOverflowButton : ToolStripDropDownButton
     {
         // we need to cache this away as the Parent property gets reset a lot.
-        private readonly ToolStrip parentToolStrip;
+        private readonly ToolStrip _parentToolStrip;
 
         private static bool isScalingInitialized;
         private const int MAX_WIDTH = 16;
@@ -37,7 +37,7 @@ namespace System.Windows.Forms
             }
 
             SupportsItemClick = false;
-            this.parentToolStrip = parentToolStrip;
+            _parentToolStrip = parentToolStrip;
         }
 
         protected override void Dispose(bool disposing)
@@ -73,7 +73,7 @@ namespace System.Windows.Forms
 
         internal ToolStrip ParentToolStrip
         {
-            get { return parentToolStrip; }
+            get { return _parentToolStrip; }
         }
 
         [Browsable(false)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripOverflowButton.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms.Design;


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripOverflowButton.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8009)