### PR TITLE
Fix WM_GETDPISCALEDSIZE message handling.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -1435,7 +1435,7 @@ namespace System.Windows.Forms
             }
         }
 
-        internal void ScaleContainerForDpi(int deviceDpiNew, Rectangle suggestedRectangle)
+        internal void ScaleContainerForDpi(int deviceDpiNew, int deviceDpiOld, Rectangle suggestedRectangle)
         {
             CommonProperties.xClearAllPreferredSizeCaches(this);
             SuspendAllLayout(this);
@@ -1472,11 +1472,7 @@ namespace System.Windows.Forms
                 // this control further by the 'OnFontChanged' event.
                 _isScaledByDpiChangedEvent = true;
 
-                TryGetDpiFont(deviceDpiNew, out Font? fontForDpi);
-
-                // For test scenarios, if we send WM_DPICHANGED message but not WM_GETDPISCALEDSIZE message, fontForDpi may be null.
-                Debug.Assert(fontForDpi is not null, "Font should have been updated for DPI from WM_GETDPISCALEDSIZE message");
-
+                Font fontForDpi = GetScaledFont(Font, deviceDpiNew, deviceDpiOld);
                 ScaledControlFont = fontForDpi;
                 if (IsFontSet())
                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2196,7 +2196,8 @@ namespace System.Windows.Forms
             Debug.Assert(PInvoke.AreDpiAwarenessContextsEqualInternal(DpiAwarenessContext, DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2),
                 $"Fonts need to be cached only for PermonitorV2 mode applications : {DpiHelper.IsPerMonitorV2Awareness} : {DpiAwarenessContext}");
 
-            if(_dpiFonts is not null && _dpiFonts.TryGetValue(dpiNew, out Font? scaledFont))
+            _dpiFonts ??= new Dictionary<int, Font>();
+            if (_dpiFonts.TryGetValue(dpiNew, out Font? scaledFont))
             {
                 return scaledFont!;
             }
@@ -2204,7 +2205,6 @@ namespace System.Windows.Forms
             float factor = ((float)newDpi / oldDpi);
             scaledFont = font.WithSize(font.Size * factor);
 
-            _dpiFonts ??= new Dictionary<int, Font>();
             _dpiFonts.Add(dpiNew, scaledFont);
 
             return scaledFont;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2197,7 +2197,7 @@ namespace System.Windows.Forms
                 $"Fonts need to be cached only for PermonitorV2 mode applications : {DpiHelper.IsPerMonitorV2Awareness} : {DpiAwarenessContext}");
 
             _dpiFonts ??= new Dictionary<int, Font>();
-            if (_dpiFonts.TryGetValue(dpiNew, out Font? scaledFont))
+            if (_dpiFonts.TryGetValue(newDpi, out Font? scaledFont))
             {
                 return scaledFont!;
             }
@@ -2205,7 +2205,7 @@ namespace System.Windows.Forms
             float factor = ((float)newDpi / oldDpi);
             scaledFont = font.WithSize(font.Size * factor);
 
-            _dpiFonts.Add(dpiNew, scaledFont);
+            _dpiFonts.Add(newDpi, scaledFont);
 
             return scaledFont;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -2191,28 +2191,23 @@ namespace System.Windows.Forms
             }
         }
 
-        private protected void AddToDpiFonts(int dpi, Font font)
+        internal Font GetScaledFont(Font font, int newDpi, int oldDpi)
         {
-            if (!PInvoke.AreDpiAwarenessContextsEqualInternal(DpiAwarenessContext, DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2))
+            Debug.Assert(PInvoke.AreDpiAwarenessContextsEqualInternal(DpiAwarenessContext, DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2),
+                $"Fonts need to be cached only for PermonitorV2 mode applications : {DpiHelper.IsPerMonitorV2Awareness} : {DpiAwarenessContext}");
+
+            if(_dpiFonts is not null && _dpiFonts.TryGetValue(dpiNew, out Font? scaledFont))
             {
-                Debug.Assert(false, "Fonts need to be cached only for PerMonitorV2 mode applications");
-                return;
+                return scaledFont!;
             }
+
+            float factor = ((float)newDpi / oldDpi);
+            scaledFont = font.WithSize(font.Size * factor);
 
             _dpiFonts ??= new Dictionary<int, Font>();
-            _dpiFonts.Add(dpi, font);
-        }
+            _dpiFonts.Add(dpiNew, scaledFont);
 
-        private protected bool TryGetDpiFont(int dpi, [NotNullWhen(true)] out Font? font)
-        {
-            font = null;
-            if (!PInvoke.AreDpiAwarenessContextsEqualInternal(DpiAwarenessContext, DPI_AWARENESS_CONTEXT.DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2))
-            {
-                Debug.Assert(false, $"Fonts need to be cached only for PermonitorV2 mode applications : {DpiHelper.IsPerMonitorV2Awareness} : {DpiAwarenessContext}");
-                return false;
-            }
-
-            return _dpiFonts?.TryGetValue(dpi, out font) ?? false;
+            return scaledFont;
         }
 
         private void ClearDpiFonts()
@@ -7941,14 +7936,7 @@ namespace System.Windows.Forms
                         {
                             // Controls are by default font scaled.
                             // Dpi change requires font to be recalculated in order to get controls scaled with right dpi.
-                            var factor = (float)_deviceDpi / fontDpi;
-
-                            if (!TryGetDpiFont(_deviceDpi, out Font fontForDpi))
-                            {
-                                fontForDpi = localFont.WithSize(localFont.Size * factor);
-                                AddToDpiFonts(_deviceDpi, fontForDpi);
-                            }
-
+                            Font fontForDpi = GetScaledFont(localFont, _deviceDpi, fontDpi);
                             ScaledControlFont = fontForDpi;
 
                             // If it is a container control that inherit Font and is scaled by parent, we simply scale Font
@@ -7956,7 +7944,7 @@ namespace System.Windows.Forms
                             // 'OnFontChanged' event explicitly. ex: winforms designer natively hosted in VS.
                             if (IsFontSet())
                             {
-                                SetScaledFont(ScaledControlFont);
+                                SetScaledFont(fontForDpi);
                             }
                         }
 
@@ -12395,23 +12383,13 @@ namespace System.Windows.Forms
                 return;
             }
 
-            // Controls are by default font scaled.
-            // Dpi change requires font to be recalculated in order to get controls scaled with right dpi.
-
-            var factor = (float)_deviceDpi / fontDpi;
-
-            if (!TryGetDpiFont(_deviceDpi, out Font? fontForDpi))
-            {
-                fontForDpi = localFont.WithSize(localFont.Size * factor);
-                AddToDpiFonts(_deviceDpi, fontForDpi);
-            }
-
             // If it is a container control that inherit Font and is scaled by parent, we simply scale Font
             // and wait for OnFontChangedEvent caused by its parent. Otherwise, we scale Font and trigger
             // 'OnFontChanged' event explicitly. ex: winforms designer in VS.
             var container = this as ContainerControl;
             var isLocalFontSet = IsFontSet();
-            ScaledControlFont = fontForDpi;
+
+            ScaledControlFont = GetScaledFont(localFont, _deviceDpi, fontDpi);
 
             if (isLocalFontSet || container is null || !IsScaledByParent(this))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -4284,7 +4284,7 @@ namespace System.Windows.Forms
 
                 if (!e.Cancel)
                 {
-                    ScaleContainerForDpi(e.DeviceDpiNew, e.SuggestedRectangle);
+                    ScaleContainerForDpi(e.DeviceDpiNew, e.DeviceDpiOld, e.SuggestedRectangle);
                 }
             }
         }
@@ -4321,15 +4321,8 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual bool OnGetDpiScaledSize(int deviceDpiOld, int deviceDpiNew, ref Size desiredSize)
         {
-            float factor = ((float)deviceDpiNew) / deviceDpiOld;
-
             // Compute font for the current DPI and cache it. DPI specific fonts cache is available only in PermonitorV2 mode applications.
-            if (!TryGetDpiFont(deviceDpiNew, out Font? fontForDpi))
-            {
-                Font currentFont = Font;
-                fontForDpi = currentFont.WithSize(currentFont.Size * factor);
-                AddToDpiFonts(deviceDpiNew, fontForDpi);
-            }
+            Font fontForDpi = GetScaledFont(Font, deviceDpiNew, deviceDpiOld);
 
             // If AutoScaleMode=AutoScaleMode.Dpi then we continue with the linear size we get from Windows for the top-level window.
             if (AutoScaleMode == AutoScaleMode.Dpi)


### PR DESCRIPTION
WM_GETDPISCALEDSIZE is sent once per device and when moved back to same device, we only get DPI_CHANGED message but not WM_GETDPISCALEDSIZE. Windows cache the result from the first time and reuse it. This isn't very clear from the [documentation](https://learn.microsoft.com/en-us/windows/win32/hidpi/wm-getdpiscaledsize) and is found while experimenting and validating the scenarios.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8018)