### PR TITLE
Adding the ListViewItemImageAccessibleObject as a child in a ListViewItem in LargeIcon, SmallIcon and List views.

### DIFF
--- a/src/System.Windows.Forms/src/Resources/SR.resx
+++ b/src/System.Windows.Forms/src/Resources/SR.resx
@@ -6832,9 +6832,6 @@ Stack trace where the illegal operation occurred was:
   <data name="ListViewItemAccessibilityObjectInvalidViewException" xml:space="preserve">
     <value>The current accessibility object is only for the ListView in {0} view</value>
   </data>
-  <data name="ListViewItemAccessibilityObjectInvalidViewsException" xml:space="preserve">
-    <value>The current accessibility object is only for the ListView in {0}, {1} or {2} view</value>
-  </data>
   <data name="TrackBarLargeDecreaseButtonName" xml:space="preserve">
     <value>Large decrease</value>
   </data>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.cs.xlf
@@ -6616,11 +6616,6 @@ Trasování zásobníku, kde došlo k neplatné operaci:
         <target state="translated">Aktuální objekt přístupnosti je určený jenom pro ovládací prvek ListView v zobrazení {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">Aktuální objekt přístupnosti je určený jenom pro ovládací prvek ListView v zobrazení {0}, {1} nebo {2}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">Nelze načíst objekt přístupnosti, pokud položka ListViewItem není připojena k ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.de.xlf
@@ -6616,11 +6616,6 @@ Stapelüberwachung, in der der unzulässige Vorgang auftrat:
         <target state="translated">Das aktuelle Objekt für Barrierefreiheit gilt nur für ListView in der Ansicht "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">Das aktuelle Objekt für Barrierefreiheit gilt nur für ListView in der Ansicht "{0}", "{1}" oder "{2}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">Das Accessiblity-Objekt kann nicht abgerufen werden, wenn ListViewItem nicht an eine ListView angefügt ist.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.es.xlf
@@ -6616,11 +6616,6 @@ El seguimiento de la pila donde tuvo lugar la operación no válida fue:
         <target state="translated">El objeto de accesibilidad actual solo es para la vista ListView {0} vista</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">El objeto de accesibilidad actual solo es para la vista ListView en {0}, {1} o {2} Vista</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">No se puede obtener el objeto accessiblity cuando ListViewItem no está asociado a listView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.fr.xlf
@@ -6616,11 +6616,6 @@ Cette opération non conforme s'est produite sur la trace de la pile :
         <target state="translated">L’objet d’accessibilité actuel est uniquement destiné à ListView dans l’affichage {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">L’objet d’accessibilité actuel est uniquement destiné à ListView dans l’affichage {0}, {1} ou {2}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">Impossible d'obtenir un objet d'accessibilité lorsque ListViewItem n'est pas attaché à une ListView</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.it.xlf
@@ -6616,11 +6616,6 @@ Traccia dello stack da cui si è verificata l'operazione non valida:
         <target state="translated">L'oggetto accessibilità corrente viene usato solo per il controllo ListView nella visualizzazione {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">L'oggetto accessibilità corrente viene usato solo per il controllo ListView nella visualizzazione {0}, {1} o {2}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">Impossibile ottenere l'oggetto di accessibilità quando ListViewItem non è collegato a un controllo ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ja.xlf
@@ -6616,11 +6616,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">現在のアクセシビリティ オブジェクトは {0} ビューの ListView にのみ使用できます</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">現在のアクセシビリティ オブジェクトは {0}、{1} または {2} ビューの ListView にのみ使用できます</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">ListViewItem が ListView にアタッチされていない場合、アクセシビリティ オブジェクトは取得できません。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ko.xlf
@@ -6616,11 +6616,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">현재 접근성 개체는 {0} 보기의 ListView에만 해당됩니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">현재 접근성 개체는 {0}, {1} 또는 {2} 보기의 ListView에만 해당됩니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">ListView 항목이 ListView에 연결되어 있지 않으면 접근성 개체를 가져올 수 없습니다.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pl.xlf
@@ -6616,11 +6616,6 @@ Stos śledzenia, w którym wystąpiła zabroniona operacja:
         <target state="translated">Bieżący obiekt ułatwień dostępu jest przeznaczony tylko dla elementu ListView w widoku {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">Bieżący obiekt ułatwień dostępu jest przeznaczony tylko dla elementu ListView w widoku {0}, {1} lub {2}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">Nie można uzyskać obiektu dostępności, gdy element ListViewItem nie jest dołączony do elementu ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.pt-BR.xlf
@@ -6616,11 +6616,6 @@ Rastreamento de pilha em que a operação ilegal ocorreu:
         <target state="translated">O objeto de acessibilidade atual é somente para a ListView no modo de exibição {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">O objeto de acessibilidade atual é apenas para ListView no modo de exibição {0}, {1} ou {2}</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">Não é possível obter o objeto de acessibilidade quando o Item ListView não está anexado a um ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.ru.xlf
@@ -6617,11 +6617,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">Текущий объект специальных возможностей предназначен только для ListView в представлении {0}</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">Текущий объект специальных возможностей предназначен только для ListView в представлениях {0}, {1} или {2}.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">Невозможно получить объект доступа, если ListViewItem не присоединен к ListView.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.tr.xlf
@@ -6616,11 +6616,6 @@ Geçersiz işlemin gerçekleştiği yığın izi:
         <target state="translated">Geçerli erişilebilirlik nesnesi yalnızca {0} görünümündeki ListView içindir</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">Geçerli erişilebilirlik nesnesi yalnızca {0}, {1} veya {2} görünümündeki ListView içindir</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">ListViewItem bir ListView'a ekli olmadığında erişilebilirlik nesnesi alınamaz.</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hans.xlf
@@ -6616,11 +6616,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">当前的可访问性对象仅适用于 {0} 视图中的 ListView</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">当前的可访问性对象仅适用于 {0}、{1} 或 {2} 视图中的 ListView</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">ListViewItem 未附加到 ListView 时，无法获取 accessiblity 对象。</target>

--- a/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/System.Windows.Forms/src/Resources/xlf/SR.zh-Hant.xlf
@@ -6616,11 +6616,6 @@ Stack trace where the illegal operation occurred was:
         <target state="translated">目前的協助工具物件僅適用於 {0} 檢視中的 ListView</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListViewItemAccessibilityObjectInvalidViewsException">
-        <source>The current accessibility object is only for the ListView in {0}, {1} or {2} view</source>
-        <target state="translated">目前的協助工具物件僅適用於 {0}、 {1} 或 {2} 檢視中的 ListView</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListViewItemAccessibilityObjectRequiresListView">
         <source>Cannot get accessiblity object when ListViewItem is not attached to a ListView.</source>
         <target state="translated">當 ListViewItem 未附加到 ListView 時，無法取得 accessiblity 物件。</target>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.ListViewAccessibleObject.cs
@@ -313,32 +313,38 @@ namespace System.Windows.Forms
 
                 if (hitTestInfo.Item is not null)
                 {
+                    AccessibleObject itemAccessibleObject = hitTestInfo.Item.AccessibilityObject;
+
                     if (hitTestInfo.SubItem is not null)
                     {
                         return _owningListView.View switch
                         {
-                            View.Details => ((ListViewItem.ListViewItemDetailsAccessibleObject)hitTestInfo.Item.AccessibilityObject)
+                            View.Details => ((ListViewItem.ListViewItemDetailsAccessibleObject)itemAccessibleObject)
                                 .GetChild(hitTestInfo.SubItem.Index, point),
 
                             // Only additional ListViewSubItem are displayed in the accessibility tree if the ListView
                             // in the "Tile" view (the first ListViewSubItem is responsible for the ListViewItem)
-                            View.Tile => hitTestInfo.SubItem.Index > 0 ? hitTestInfo.SubItem.AccessibilityObject : hitTestInfo.Item.AccessibilityObject,
-                            _ => hitTestInfo.Item.AccessibilityObject
+                            View.Tile => hitTestInfo.SubItem.Index > 0 ? hitTestInfo.SubItem.AccessibilityObject : itemAccessibleObject,
+                            _ => itemAccessibleObject
                         };
                     }
 
-                    if (hitTestInfo.Item.AccessibilityObject is ListViewItem.ListViewItemDetailsAccessibleObject itemAccessibleObject)
+                    if (itemAccessibleObject is ListViewItem.ListViewItemDetailsAccessibleObject itemDetailsAccessibleObject)
                     {
                         for (int i = 1; i < _owningListView.Columns.Count; i++)
                         {
-                            if (itemAccessibleObject.GetSubItemBounds(i).Contains(point))
+                            if (itemDetailsAccessibleObject.GetSubItemBounds(i).Contains(point))
                             {
-                                return itemAccessibleObject.GetDetailsSubItemOrFake(i);
+                                return itemDetailsAccessibleObject.GetDetailsSubItemOrFake(i);
                             }
                         }
                     }
+                    else if (itemAccessibleObject is ListViewItem.ListViewItemWithImageAccessibleObject itemIconAccessibleObject)
+                    {
+                        return itemIconAccessibleObject.GetAccessibleObject(point);
+                    }
 
-                    return hitTestInfo.Item.AccessibilityObject;
+                    return itemAccessibleObject;
                 }
 
                 return null;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObject.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms
         ///  The implementation of this class fully corresponds to the behavior of the ListViewItem accessibility object
         ///  when the ListView is in "LargeIcon" or "SmallIcon" view.
         /// </remarks>
-        internal class ListViewItemBaseAccessibleObject : AccessibleObject
+        internal abstract class ListViewItemBaseAccessibleObject : AccessibleObject
         {
             private protected readonly ListView _owningListView;
             private protected readonly ListViewItem _owningItem;
@@ -54,6 +54,8 @@ namespace System.Windows.Forms
 
             internal override UiaCore.IRawElementProviderFragmentRoot FragmentRoot
                 => _owningListView.AccessibilityObject;
+
+            protected bool HasImage => _owningItem.ImageIndex != ImageList.Indexer.DefaultIndex;
 
             internal override bool IsItemSelected
                 => (State & AccessibleStates.Selected) != 0;
@@ -106,6 +108,8 @@ namespace System.Windows.Forms
                 }
             }
 
+            protected abstract View View { get; }
+
             internal override void AddToSelection()
                 => SelectItem();
 
@@ -157,12 +161,9 @@ namespace System.Windows.Forms
 
             public override AccessibleObject? GetChild(int index)
             {
-                if (_owningListView.View == View.Details || _owningListView.View == View.Tile)
+                if (_owningListView.View != View)
                 {
-                    throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewsException,
-                        nameof(View.LargeIcon),
-                        nameof(View.List),
-                        nameof(View.SmallIcon)));
+                    throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewException, View.ToString()));
                 }
 
                 return null;
@@ -172,12 +173,9 @@ namespace System.Windows.Forms
 
             public override int GetChildCount()
             {
-                if (_owningListView.View == View.Details || _owningListView.View == View.Tile)
+                if (_owningListView.View != View)
                 {
-                    throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewsException,
-                        nameof(View.LargeIcon),
-                        nameof(View.List),
-                        nameof(View.SmallIcon)));
+                    throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewException, View.ToString()));
                 }
 
                 return InvalidIndex;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemDetailsAccessibleObject.cs
@@ -21,9 +21,9 @@ namespace System.Windows.Forms
 
             internal override int FirstSubItemIndex => HasImage ? 1 : 0;
 
-            private bool HasImage => _owningItem.ImageIndex != ImageList.Indexer.DefaultIndex;
-
             private int LastChildIndex => HasImage ? _owningListView.Columns.Count : _owningListView.Columns.Count - 1;
+
+            protected override View View => View.Details;
 
             /// <summary>
             ///  Converts the provided index of the <see cref="AccessibleObject"/>'s child to an index of a <see cref="ListViewSubItem"/>.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemLargeIconAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemLargeIconAccessibleObject.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    public partial class ListViewItem
+    {
+        internal class ListViewItemLargeIconAccessibleObject : ListViewItemWithImageAccessibleObject
+        {
+            public ListViewItemLargeIconAccessibleObject(ListViewItem owningItem) : base(owningItem)
+            {
+            }
+
+            protected override View View => View.LargeIcon;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemListAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemListAccessibleObject.cs
@@ -9,7 +9,7 @@ namespace System.Windows.Forms
 {
     public partial class ListViewItem
     {
-        internal class ListViewItemListAccessibleObject : ListViewItemBaseAccessibleObject
+        internal class ListViewItemListAccessibleObject : ListViewItemWithImageAccessibleObject
         {
             public ListViewItemListAccessibleObject(ListViewItem owningItem) : base(owningItem)
             {
@@ -23,6 +23,8 @@ namespace System.Windows.Forms
                         _owningListView.AccessibilityObject.Bounds.Y + _owningItem.Bounds.Y,
                         _owningItem.Bounds.Width,
                         _owningItem.Bounds.Height);
+
+            protected override View View => View.List;
 
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemSmallIconAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemSmallIconAccessibleObject.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms
+{
+    public partial class ListViewItem
+    {
+        internal class ListViewItemSmallIconAccessibleObject : ListViewItemWithImageAccessibleObject
+        {
+            public ListViewItemSmallIconAccessibleObject(ListViewItem owningItem) : base(owningItem)
+            {
+            }
+
+            protected override View View => View.SmallIcon;
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemTileAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemTileAccessibleObject.cs
@@ -15,6 +15,8 @@ namespace System.Windows.Forms
             {
             }
 
+            protected override View View => View.Tile;
+
             internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
             {
                 switch (direction)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObject.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using static Interop;
+
+namespace System.Windows.Forms
+{
+    public partial class ListViewItem
+    {
+        internal abstract class ListViewItemWithImageAccessibleObject : ListViewItemBaseAccessibleObject
+        {
+            private const int ImageAccessibleObjectIndex = 0;
+
+            private ListViewItemImageAccessibleObject? _imageAccessibleObject;
+
+            public ListViewItemWithImageAccessibleObject(ListViewItem owningItem) : base(owningItem)
+            {
+            }
+
+            internal override int FirstSubItemIndex => HasImage ? 1 : 0;
+
+            private ListViewItemImageAccessibleObject ImageAccessibleObject => _imageAccessibleObject ??= new(_owningItem);
+
+            internal override UiaCore.IRawElementProviderFragment? FragmentNavigate(UiaCore.NavigateDirection direction)
+            {
+                switch (direction)
+                {
+                    case UiaCore.NavigateDirection.FirstChild:
+                    case UiaCore.NavigateDirection.LastChild:
+                        return GetChild(ImageAccessibleObjectIndex);
+                }
+
+                return base.FragmentNavigate(direction);
+            }
+
+            internal AccessibleObject GetAccessibleObject(Point point)
+            {
+                return HasImage && ImageAccessibleObject.GetImageRectangle().Contains(point)
+                    ? ImageAccessibleObject
+                    : this;
+            }
+
+            public override AccessibleObject? GetChild(int index)
+            {
+                if (_owningListView.View != View)
+                {
+                    throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewException, View.ToString()));
+                }
+
+                return index == ImageAccessibleObjectIndex && HasImage
+                    ? ImageAccessibleObject
+                    : (AccessibleObject?)null;
+            }
+
+            public override int GetChildCount()
+            {
+                if (_owningListView.View != View)
+                {
+                    throw new InvalidOperationException(string.Format(SR.ListViewItemAccessibilityObjectInvalidViewException, View.ToString()));
+                }
+
+                return !_owningListView.IsHandleCreated || !HasImage
+                    ? InvalidIndex
+                    : 1;
+            }
+
+            internal override int GetChildIndex(AccessibleObject? child)
+                => child is ListViewItemImageAccessibleObject
+                    ? ImageAccessibleObjectIndex
+                    : InvalidIndex;
+
+            internal override Rectangle GetSubItemBounds(int accessibleChildIndex)
+                => _owningListView.IsHandleCreated && accessibleChildIndex == ImageAccessibleObjectIndex && HasImage
+                    ? ImageAccessibleObject.Bounds
+                    : Rectangle.Empty;
+
+            /// <devdoc>
+            ///  Caller should ensure that the current OS is Windows 8 or greater.
+            /// </devdoc>
+            internal override void ReleaseChildUiaProviders()
+            {
+                base.ReleaseChildUiaProviders();
+
+                UiaCore.UiaDisconnectProvider(_imageAccessibleObject);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -237,10 +237,10 @@ namespace System.Windows.Forms
                     _accessibilityObjectView = owningListView.View;
                     _accessibilityObject = _accessibilityObjectView switch
                     {
-                        View.Details => new ListViewItem.ListViewItemDetailsAccessibleObject(this),
-                        View.LargeIcon => new ListViewItem.ListViewItemBaseAccessibleObject(this),
+                        View.Details => new ListViewItemDetailsAccessibleObject(this),
+                        View.LargeIcon => new ListViewItemLargeIconAccessibleObject(this),
                         View.List => new ListViewItemListAccessibleObject(this),
-                        View.SmallIcon => new ListViewItem.ListViewItemBaseAccessibleObject(this),
+                        View.SmallIcon => new ListViewItemSmallIconAccessibleObject(this),
                         View.Tile => new ListViewItemTileAccessibleObject(this),
                         _ => throw new Exception()
                     };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListVIew.ListViewAccessibleObjectTests.cs
@@ -129,8 +129,8 @@ namespace System.Windows.Forms.Tests
 
             AccessibleObject firstChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
             AccessibleObject lastChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
-            Assert.IsType<ListViewItemBaseAccessibleObject>(firstChild);
-            Assert.IsType<ListViewItemBaseAccessibleObject>(lastChild);
+            Assert.IsAssignableFrom<ListViewItemBaseAccessibleObject>(firstChild);
+            Assert.IsAssignableFrom<ListViewItemBaseAccessibleObject>(lastChild);
             Assert.NotEqual(firstChild, lastChild);
             Assert.True(listView.IsHandleCreated);
         }
@@ -170,8 +170,8 @@ namespace System.Windows.Forms.Tests
 
             AccessibleObject firstChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild) as AccessibleObject;
             AccessibleObject lastChild = accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild) as AccessibleObject;
-            Assert.IsType<ListViewItemBaseAccessibleObject>(firstChild);
-            Assert.IsType<ListViewItemBaseAccessibleObject>(lastChild);
+            Assert.IsAssignableFrom<ListViewItemBaseAccessibleObject>(firstChild);
+            Assert.IsAssignableFrom<ListViewItemBaseAccessibleObject>(lastChild);
             Assert.NotEqual(firstChild, lastChild);
             Assert.True(listView.IsHandleCreated);
         }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -1663,11 +1663,13 @@ namespace System.Windows.Forms.Tests
                     Assert.IsType<ListViewItemDetailsAccessibleObject>(listView.Items[0].AccessibilityObject);
                     break;
                 case View.LargeIcon:
-                case View.SmallIcon:
-                    Assert.IsType<ListViewItemBaseAccessibleObject>(listView.Items[0].AccessibilityObject);
+                    Assert.IsType<ListViewItemLargeIconAccessibleObject>(listView.Items[0].AccessibilityObject);
                     break;
                 case View.List:
                     Assert.IsType<ListViewItemListAccessibleObject>(listView.Items[0].AccessibilityObject);
+                    break;
+                case View.SmallIcon:
+                    Assert.IsType<ListViewItemSmallIconAccessibleObject>(listView.Items[0].AccessibilityObject);
                     break;
                 case View.Tile:
                     Assert.IsType<ListViewItemTileAccessibleObject>(listView.Items[0].AccessibilityObject);
@@ -1709,11 +1711,13 @@ namespace System.Windows.Forms.Tests
                         Assert.IsType<ListViewItemDetailsAccessibleObject>(listView.Items[0].AccessibilityObject);
                         break;
                     case View.LargeIcon:
-                    case View.SmallIcon:
-                        Assert.IsType<ListViewItemBaseAccessibleObject>(listView.Items[0].AccessibilityObject);
+                        Assert.IsType<ListViewItemLargeIconAccessibleObject>(listView.Items[0].AccessibilityObject);
                         break;
                     case View.List:
                         Assert.IsType<ListViewItemListAccessibleObject>(listView.Items[0].AccessibilityObject);
+                        break;
+                    case View.SmallIcon:
+                        Assert.IsType<ListViewItemSmallIconAccessibleObject>(listView.Items[0].AccessibilityObject);
                         break;
                     case View.Tile:
                         Assert.IsType<ListViewItemTileAccessibleObject>(listView.Items[0].AccessibilityObject);
@@ -1728,10 +1732,16 @@ namespace System.Windows.Forms.Tests
         [InlineData(View.Details, View.SmallIcon)]
         [InlineData(View.Details, View.Tile)]
         [InlineData(View.LargeIcon, View.Details)]
+        [InlineData(View.LargeIcon, View.List)]
+        [InlineData(View.LargeIcon, View.SmallIcon)]
         [InlineData(View.LargeIcon, View.Tile)]
         [InlineData(View.List, View.Details)]
+        [InlineData(View.List, View.LargeIcon)]
+        [InlineData(View.List, View.SmallIcon)]
         [InlineData(View.List, View.Tile)]
         [InlineData(View.SmallIcon, View.Details)]
+        [InlineData(View.SmallIcon, View.LargeIcon)]
+        [InlineData(View.SmallIcon, View.List)]
         [InlineData(View.SmallIcon, View.Tile)]
         [InlineData(View.Tile, View.Details)]
         [InlineData(View.Tile, View.LargeIcon)]
@@ -1750,34 +1760,21 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsTheory]
-        [InlineData(View.LargeIcon, View.List)]
-        [InlineData(View.LargeIcon, View.SmallIcon)]
-        [InlineData(View.List, View.LargeIcon)]
-        [InlineData(View.List, View.SmallIcon)]
-        [InlineData(View.SmallIcon, View.LargeIcon)]
-        [InlineData(View.SmallIcon, View.List)]
-        public void ListViewItemAccessibleObject_GetChild_DoesNotReturnException_AfterChangingView(View oldView, View newView)
-        {
-            using ListView listView = new() { View = oldView };
-            listView.Items.Add(new ListViewItem(new string[] { "1", "2" }));
-            AccessibleObject accessibleObject = listView.Items[0].AccessibilityObject;
-            Assert.Null(accessibleObject.GetChild(0));
-
-            listView.View = newView;
-
-            Assert.Null(accessibleObject.GetChild(0));
-        }
-
-        [WinFormsTheory]
         [InlineData(View.Details, View.LargeIcon)]
         [InlineData(View.Details, View.List)]
         [InlineData(View.Details, View.SmallIcon)]
         [InlineData(View.Details, View.Tile)]
         [InlineData(View.LargeIcon, View.Details)]
+        [InlineData(View.LargeIcon, View.List)]
+        [InlineData(View.LargeIcon, View.SmallIcon)]
         [InlineData(View.LargeIcon, View.Tile)]
         [InlineData(View.List, View.Details)]
+        [InlineData(View.List, View.LargeIcon)]
+        [InlineData(View.List, View.SmallIcon)]
         [InlineData(View.List, View.Tile)]
         [InlineData(View.SmallIcon, View.Details)]
+        [InlineData(View.SmallIcon, View.LargeIcon)]
+        [InlineData(View.SmallIcon, View.List)]
         [InlineData(View.SmallIcon, View.Tile)]
         [InlineData(View.Tile, View.Details)]
         [InlineData(View.Tile, View.LargeIcon)]
@@ -1793,25 +1790,6 @@ namespace System.Windows.Forms.Tests
             listView.View = newView;
 
             Assert.Throws<InvalidOperationException>(() => accessibleObject.GetChildCount());
-        }
-
-        [WinFormsTheory]
-        [InlineData(View.LargeIcon, View.List)]
-        [InlineData(View.LargeIcon, View.SmallIcon)]
-        [InlineData(View.List, View.LargeIcon)]
-        [InlineData(View.List, View.SmallIcon)]
-        [InlineData(View.SmallIcon, View.LargeIcon)]
-        [InlineData(View.SmallIcon, View.List)]
-        public void ListViewItemAccessibleObject_GetChildCount_DoesNotReturnException_AfterChangingView(View oldView, View newView)
-        {
-            using ListView listView = new() { View = oldView };
-            listView.Items.Add(new ListViewItem(new string[] { "1", "2" }));
-            AccessibleObject accessibleObject = listView.Items[0].AccessibilityObject;
-            Assert.NotEqual(2, accessibleObject.GetChildCount());
-
-            listView.View = newView;
-
-            Assert.NotEqual(2, accessibleObject.GetChildCount());
         }
 
         public static IEnumerable<object[]> ListViewItemAccessibleObject_GetPropertyValue_TestData()

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
@@ -15,7 +15,7 @@ namespace System.Windows.Forms.Tests
         [WinFormsFact]
         public void ListViewItemBaseAccessibleObject_Ctor_OwnerListViewItemCannotBeNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new ListViewItemBaseAccessibleObject(null));
+            Assert.Throws<ArgumentNullException>(() => new SubListViewItemBaseAccessibleObject(null));
         }
 
         [WinFormsFact]
@@ -397,6 +397,15 @@ namespace System.Windows.Forms.Tests
             var expected = string.Format("{0}-{1}", nameof(ListViewItem), accessibleObject.CurrentIndex);
             Assert.Equal(expected, accessibleObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
             Assert.False(listView.IsHandleCreated);
+        }
+
+        private class SubListViewItemBaseAccessibleObject : ListViewItemBaseAccessibleObject
+        {
+            protected override View View => View.List;
+
+            public SubListViewItemBaseAccessibleObject(ListViewItem owningItem) : base(owningItem)
+            {
+            }
         }
 
         // More tests for this class has been created already in ListViewItem_ListViewItemAccessibleObjectTests

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemWithImageAccessibleObjectTests.cs
@@ -1,0 +1,134 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using static System.Windows.Forms.ListViewItem;
+using static Interop;
+
+namespace System.Windows.Forms.Tests
+{
+    public class ListViewItem_ListViewItemWithImageAccessibleObjectTests
+    {
+        [WinFormsTheory]
+        [MemberData(nameof(GetViewTheoryData))]
+        public void ListViewItemListAccessibleObject_FragmentNavigate_Children_ReturnsNull_WithoutImage(View view)
+        {
+            using ListView control = new();
+            control.View = view;
+            control.Items.AddRange(new ListViewItem[] { new() });
+
+            AccessibleObject listViewItemAccessibleObject = control.Items[0].AccessibilityObject;
+
+            Assert.Null(listViewItemAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(listViewItemAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GetViewTheoryData))]
+        public void ListViewItemListAccessibleObject_FragmentNavigate_Children_IsExpected_WithImage(View view)
+        {
+            using ImageList imageCollection = new();
+            imageCollection.Images.Add(Form.DefaultIcon);
+
+            ListViewItem listViewItem = new("Test", 0);
+            using ListView control = new()
+            {
+                View = view,
+                SmallImageList = imageCollection
+            };
+            control.Items.Add(listViewItem);
+
+            AccessibleObject listViewItemAccessibleObject = control.Items[0].AccessibilityObject;
+            var firstChild = listViewItemAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild);
+            var lastChild = listViewItemAccessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild);
+
+            Assert.IsType<ListViewItemImageAccessibleObject>(firstChild);
+            Assert.IsType<ListViewItemImageAccessibleObject>(lastChild);
+            Assert.Same(firstChild, lastChild);
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GetViewTheoryData))]
+        public void ListViewItemListAccessibleObject_GetChild_ReturnsNull_WithoutImage(View view)
+        {
+            using ListView control = new();
+            control.View = view;
+            control.Items.AddRange(new ListViewItem[] { new() });
+
+            AccessibleObject listViewItemAccessibleObject = control.Items[0].AccessibilityObject;
+
+            Assert.Null(listViewItemAccessibleObject.GetChild(0));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GetViewTheoryData))]
+        public void ListViewItemListAccessibleObject_GetChild_IsExpected_WithImage(View view)
+        {
+            using ImageList imageCollection = new();
+            imageCollection.Images.Add(Form.DefaultIcon);
+
+            ListViewItem listViewItem = new("Test", 0);
+            using ListView control = new()
+            {
+                View = view,
+                SmallImageList = imageCollection
+            };
+            control.Items.Add(listViewItem);
+
+            AccessibleObject listViewItemAccessibleObject = control.Items[0].AccessibilityObject;
+
+            Assert.IsType<ListViewItemImageAccessibleObject>(listViewItemAccessibleObject.GetChild(0));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GetViewTheoryData))]
+        public void ListViewItemListAccessibleObject_GetChildCount_WithoutImage(View view)
+        {
+            using ListView control = new();
+            control.View = view;
+            control.Items.AddRange(new ListViewItem[] { new() });
+            control.CreateControl();
+
+            AccessibleObject listViewItemAccessibleObject = control.Items[0].AccessibilityObject;
+
+            Assert.Equal(AccessibleObject.InvalidIndex, listViewItemAccessibleObject.GetChildCount());
+            Assert.True(control.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [MemberData(nameof(GetViewTheoryData))]
+        public void ListViewItemListAccessibleObject_GetChildCount_WithImage(View view)
+        {
+            using ImageList imageCollection = new();
+            imageCollection.Images.Add(Form.DefaultIcon);
+
+            ListViewItem listViewItem = new("Test", 0);
+            using ListView control = new()
+            {
+                View = view,
+                SmallImageList = imageCollection
+            };
+            control.Items.Add(listViewItem);
+            control.CreateControl();
+
+            AccessibleObject listViewItemAccessibleObject = control.Items[0].AccessibilityObject;
+
+            Assert.Equal(1, listViewItemAccessibleObject.GetChildCount());
+            Assert.True(control.IsHandleCreated);
+        }
+
+        public static TheoryData<View> GetViewTheoryData()
+        {
+            return new TheoryData<View>
+            {
+                View.LargeIcon,
+                View.SmallIcon
+            };
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewTests.cs
@@ -5764,6 +5764,8 @@ namespace System.Windows.Forms.Tests
 
         private class SubListViewItemAccessibleObject : ListViewItemBaseAccessibleObject
         {
+            protected override View View => View.List;
+
             public int RaiseAutomationEventCalls;
 
             public SubListViewItemAccessibleObject(ListViewItem owningItem) : base(owningItem)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Part of #4690 


## Proposed changes

- Added base class `ListViewItemIconAccessibleObject` and its implementations `ListViewItemLargeIconAccessibleObject` and `ListViewItemSmallIconAccessibleObject`.
- Used `ListViewItemIconAccessibleObject` as base class of `ListViewItemListAccessibleObject`.
- Refactored `ListViewItemBaseAccessibleObject` and implementations. Moved common logic to the base class.
- Removed unused resource string `ListViewItemAccessibilityObjectInvalidViewsException`.
- Configured `ListViewItem` to support new item AO.
- Modified ListViewAccessibleObject to support image's AO in `LargeIcon`, `SmallIcon` and `List`  views.
- Fixed old unit tests.
- Added new unit tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- User can see information about ListViewItem's image via accessibility tools in `LargeIcon`, `SmallIcon` and `List` views.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Screenshot 2022-10-25 095038](https://user-images.githubusercontent.com/109065597/197694538-55f8e977-87b8-4d78-97ca-8d0507996fc8.png)
_LargeIcon view_

![Screenshot 2022-10-25 094947](https://user-images.githubusercontent.com/109065597/197694563-457ef6c9-2cc4-4148-97b1-4316e07ad798.png)
_SmallIcon view_

![Screenshot 2022-10-25 152011](https://user-images.githubusercontent.com/109065597/197759844-c579608d-6d7d-4125-9ccb-350e1d3768f4.png)
_List view_

### After

![Screenshot 2022-10-25 094535](https://user-images.githubusercontent.com/109065597/197694626-f98db8bc-132e-45ab-b896-cf2022991a6b.png)
_LargeIcon view_

![Screenshot 2022-10-25 094647](https://user-images.githubusercontent.com/109065597/197694644-ae185029-5c1a-4e3b-9191-08a49f96ec79.png)
_SmallIcon view_

![Screenshot 2022-10-25 151244](https://user-images.githubusercontent.com/109065597/197759873-b66fbc6b-9b8f-4282-a78a-3b01d5d7c04f.png)
_List view_

## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit testing 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect
- AI


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK:
 Version:   8.0.100-alpha.1.22512.5
 Commit:    1b80461e45

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8022)