### PR TITLE
SA1121 Use built-in type alias

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1017,7 +1017,7 @@ dotnet_diagnostic.SA1119.severity = none
 dotnet_diagnostic.SA1120.severity = none
 
 # SA1121: Use built-in type alias
-dotnet_diagnostic.SA1121.severity = none # TODO: warning
+dotnet_diagnostic.SA1121.severity = warning
 
 # SA1122: Use string.Empty for empty strings
 dotnet_diagnostic.SA1122.severity = none

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -15115,7 +15115,7 @@ namespace System.Windows.Forms
 
             if (CurrentCell is not null && (ShowCellToolTips || (ShowCellErrors && !string.IsNullOrEmpty(CurrentCell?.ErrorText))))
             {
-                ActivateToolTip(false /*activate*/, String.Empty, CurrentCell.ColumnIndex, CurrentCell.RowIndex);
+                ActivateToolTip(false /*activate*/, string.Empty, CurrentCell.ColumnIndex, CurrentCell.RowIndex);
                 KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(CurrentCell);
             }
         }
@@ -15778,7 +15778,7 @@ namespace System.Windows.Forms
                 AccessibilityNotifyCurrentCellChanged(_ptCurrentCell);
                 if (CurrentCell is not null && (ShowCellToolTips || (ShowCellErrors && !string.IsNullOrEmpty(CurrentCell.ErrorText))))
                 {
-                    ActivateToolTip(false /*activate*/, String.Empty, CurrentCell.ColumnIndex, CurrentCell.RowIndex);
+                    ActivateToolTip(false /*activate*/, string.Empty, CurrentCell.ColumnIndex, CurrentCell.RowIndex);
                     KeyboardToolTipStateMachine.Instance.NotifyAboutGotFocus(CurrentCell);
                 }
             }
@@ -22650,7 +22650,7 @@ namespace System.Windows.Forms
 
             DataGridViewCell dataGridViewCell = CurrentCell;
 
-            ActivateToolTip(false /*activate*/, String.Empty, dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex);
+            ActivateToolTip(false /*activate*/, string.Empty, dataGridViewCell.ColumnIndex, dataGridViewCell.RowIndex);
             if (KeyboardToolTip.IsActivatedByKeyboard)
             {
                 KeyboardToolTipStateMachine.Instance.NotifyAboutLostFocus(dataGridViewCell);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Formatter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Formatter.cs
@@ -398,7 +398,7 @@ namespace System.Windows.Forms
             else
             {
                 // Otherwise perform default comparison based on object types
-                return Object.Equals(value, formattedNullValue);
+                return object.Equals(value, formattedNullValue);
             }
         }
 
@@ -480,7 +480,7 @@ namespace System.Windows.Forms
         {
             return value is null ||
                    value == System.DBNull.Value ||
-                   Object.Equals(value, NullData(value.GetType(), dataSourceNullValue));
+                   object.Equals(value, NullData(value.GetType(), dataSourceNullValue));
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.cs
@@ -71,7 +71,7 @@ namespace System.Windows.Forms.Layout
 
             foreach (string propertyName in _propertiesWhichInvalidateCache)
             {
-                if (Object.ReferenceEquals(args.AffectedProperty, propertyName))
+                if (object.ReferenceEquals(args.AffectedProperty, propertyName))
                 {
                     ClearCachedAssignments(containerInfo);
                     break;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripItem.cs
@@ -3659,7 +3659,7 @@ namespace System.Windows.Forms
                 bool found = false;
                 while (!found && i < count)
                 {
-                    found = Object.ReferenceEquals(items[i], this);
+                    found = object.ReferenceEquals(items[i], this);
                     if (found)
                     {
                         int previousIndex = i - 1;


### PR DESCRIPTION
Enable SA1121 analyzer.
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1121.md

Used solution wide code fix.

Related: #7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8028)