### PR TITLE
SA1129 Do not use default value type constructor

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1041,7 +1041,7 @@ dotnet_diagnostic.SA1127.severity = none
 dotnet_diagnostic.SA1128.severity = none
 
 # SA1129: Do not use default value type constructor
-dotnet_diagnostic.SA1129.severity = none # TODO: warning
+dotnet_diagnostic.SA1129.severity = warning
 
 # SA1130: Use lambda syntax
 dotnet_diagnostic.SA1130.severity = none

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/DesignerHost.cs
@@ -63,7 +63,7 @@ namespace System.ComponentModel.Design
         public DesignerHost(DesignSurface surface)
         {
             _surface = surface;
-            _state = new BitVector32();
+            _state = default(BitVector32);
             _designers = new Hashtable();
             _events = new EventHandlerList();
 

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.MultilineStringEditorUI.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/MultilineStringEditor.MultilineStringEditorUI.cs
@@ -183,7 +183,7 @@ namespace System.ComponentModel.Design
                     using PInvoke.ObjectScope font = new(Font.ToHFONT());
                     using PInvoke.SelectObjectScope fontSelection = new(hdc, font);
 
-                    RECT rect = new RECT();
+                    RECT rect = default(RECT);
                     User32.DrawTextW(hdc, Text, Text.Length, ref rect, User32.DT.CALCRECT);
                     return new Size(rect.right - rect.left + CaretPadding, rect.bottom - rect.top);
                 }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/SelectionService.cs
@@ -42,7 +42,7 @@ namespace System.ComponentModel.Design
         internal SelectionService(IServiceProvider provider) : base()
         {
             _provider = provider;
-            _state = new BitVector32();
+            _state = default(BitVector32);
             _events = new EventHandlerList();
             _statusCommandUI = new StatusCommandUI(provider);
         }

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/Serialization/CodeDomSerializerBase.cs
@@ -458,7 +458,7 @@ namespace System.ComponentModel.Design.Serialization
             Trace(name);
             traceScope.Push(name);
 #endif
-            return new TracingScope();
+            return default(TracingScope);
         }
 
         [Conditional("DEBUG")]

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.ColorPaletteAccessibleObject.ColorCellAccessibleObject.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.ColorPaletteAccessibleObject.ColorCellAccessibleObject.cs
@@ -30,7 +30,7 @@ namespace System.Drawing.Design
                         get
                         {
                             Point cellPt = Get2DFrom1D(_cell);
-                            Rectangle rect = new Rectangle();
+                            Rectangle rect = default(Rectangle);
                             FillRectWithCellBounds(cellPt.X, cellPt.Y, ref rect);
 
                             // Translate rect to screen coordinates

--- a/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.cs
+++ b/src/System.Windows.Forms.Design/src/System/Drawing/Design/ColorEditor.ColorPalette.cs
@@ -210,7 +210,7 @@ namespace System.Drawing.Design
                     {
                         if (SelectedColor.Equals(GetColorFromCell(x, y)))
                         {
-                            Rectangle r = new Rectangle();
+                            Rectangle r = default(Rectangle);
                             FillRectWithCellBounds(x, y, ref r);
                             Invalidate(Rectangle.Inflate(r, 5, 5));
                             break;
@@ -221,7 +221,7 @@ namespace System.Drawing.Design
 
             private void InvalidateFocus()
             {
-                Rectangle r = new Rectangle();
+                Rectangle r = default(Rectangle);
                 FillRectWithCellBounds(_focus.X, _focus.Y, ref r);
                 Invalidate(Rectangle.Inflate(r, 5, 5));
                 NotifyWinEvent((uint)AccessibleEvents.Focus, new HandleRef(this, Handle), OBJID.CLIENT, 1 + Get1DFrom2D(_focus.X, _focus.Y));

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/Behavior/BehaviorService.AdornerWindow.cs
@@ -331,7 +331,7 @@ namespace System.Windows.Forms.Design.Behavior
                     case User32.WM.NCHITTEST:
                         Point pt = PARAM.ToPoint(m.LParamInternal);
 
-                        var pt1 = new Point();
+                        var pt1 = default(Point);
                         pt1 = PointToClient(pt1);
                         pt.Offset(pt1.X, pt1.Y);
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ComponentTray.cs
@@ -970,7 +970,7 @@ namespace System.Windows.Forms.Design
             if (c is null)
             {
                 Debug.Fail("Anything we're extending should have a component view.");
-                return new Point();
+                return default(Point);
             }
 
             Point loc = c.Location;
@@ -2536,7 +2536,7 @@ namespace System.Windows.Forms.Design
                         {
                             // Make sure tha we send our glyphs hit test messages over the TrayControls too
                             Point pt = PARAM.ToPoint(m.LParamInternal);
-                            var pt1 = new Point();
+                            var pt1 = default(Point);
                             pt1 = PointToClient(pt1);
                             pt.Offset(pt1.X, pt1.Y);
                             pt.Offset(Location.X, Location.Y); //offset the loc of the traycontrol -so now we're in comptray coords
@@ -2788,7 +2788,7 @@ namespace System.Windows.Forms.Design
             public TraySelectionUIHandler(ComponentTray tray)
             {
                 _tray = tray;
-                _snapSize = new Size();
+                _snapSize = default(Size);
             }
 
             /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ControlDesigner.cs
@@ -316,7 +316,7 @@ namespace System.Windows.Forms.Design
 
         internal Point GetOffsetToClientArea()
         {
-            var nativeOffset = new Point();
+            var nativeOffset = default(Point);
             PInvoke.MapWindowPoints(Control, Control.Parent, ref nativeOffset);
             Point offset = Control.Location;
 
@@ -2100,7 +2100,7 @@ namespace System.Windows.Forms.Design
 
                         // First, save off the update region and call our base class.
 
-                        RECT clip = new();
+                        RECT clip = default(RECT);
                         using var hrgn = new PInvoke.RegionScope(0, 0, 0, 0);
                         PInvoke.GetUpdateRgn(m.HWND, hrgn, false);
                         PInvoke.GetUpdateRect(m.HWND, &clip, false);

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/OleDragDropHandler.cs
@@ -888,7 +888,7 @@ namespace System.Windows.Forms.Design
 
                                     if (loc != null && !loc.IsReadOnly)
                                     {
-                                        Rectangle bounds = new Rectangle();
+                                        Rectangle bounds = default(Rectangle);
                                         Point pt = (Point)loc.GetValue(comp);
                                         bounds.X = dropPt.X + pt.X;
                                         bounds.Y = dropPt.Y + pt.Y;

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ParentControlDesigner.cs
@@ -528,7 +528,7 @@ namespace System.Windows.Forms.Design
                 && (host.GetDesigner(newChild) as ControlDesigner) != null
                 && !(newChild is Form && ((Form)newChild).TopLevel))
             {
-                Rectangle bounds = new Rectangle();
+                Rectangle bounds = default(Rectangle);
 
                 // If we were provided with a location, convert it to parent control coordinates.
                 // Otherwise, get the control's size and put the location in the middle of it

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIHandler.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIHandler.cs
@@ -38,7 +38,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public virtual bool BeginDrag(object[] components, SelectionRules rules, int initialX, int initialY)
         {
-            dragOffset = new Rectangle();
+            dragOffset = default(Rectangle);
             originalCoords = null;
             this.rules = rules;
 
@@ -92,7 +92,7 @@ namespace System.Windows.Forms.Design
         {
             Debug.Assert(bounds != null && controls != null && bounds.Length == controls.Length, "bounds->controls mismatch");
 
-            Rectangle b = new Rectangle();
+            Rectangle b = default(Rectangle);
 
             // Whip through each of the controls.
             //
@@ -208,7 +208,7 @@ namespace System.Windows.Forms.Design
             Control[] controls = dragControls;
             Rectangle offset = dragOffset;
             BoundsInfo[] bounds = originalCoords;
-            Point adjustedLoc = new Point();
+            Point adjustedLoc = default(Point);
 
             // Erase the clipping and other state if this is the final move.
             //

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/SelectionUIService.cs
@@ -106,7 +106,7 @@ namespace System.Windows.Forms.Design
             _mouseDragAnchor = anchor;
             _mouseDragging = true;
             _mouseDragHitTest = hitTest;
-            _mouseDragOffset = new Rectangle();
+            _mouseDragOffset = default(Rectangle);
             _savedVisible = Visible;
         }
 

--- a/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/Windows/Forms/Design/ToolStripDesigner.cs
@@ -92,7 +92,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                Rectangle rect = new Rectangle();
+                Rectangle rect = default(Rectangle);
                 if (_miniToolStrip is null)
                 {
                     return rect;
@@ -371,7 +371,7 @@ namespace System.Windows.Forms.Design
         {
             get
             {
-                Rectangle rect = new Rectangle();
+                Rectangle rect = default(Rectangle);
                 if (ToolStrip.OverflowButton.Visible)
                 {
                     return ToolStrip.OverflowButton.Bounds;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Automation/UiaTextProvider.cs
@@ -110,7 +110,7 @@ namespace System.Windows.Forms.Automation
 
         public unsafe int SendKeyboardInputVK(short vk, bool press)
         {
-            INPUT keyboardInput = new INPUT();
+            INPUT keyboardInput = default(INPUT);
 
             keyboardInput.type = INPUTENUM.KEYBOARD;
             keyboardInput.inputUnion.ki.wVk = (ushort)vk;

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextExtensions.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/DeviceContextExtensions.cs
@@ -91,7 +91,7 @@ namespace System.Windows.Forms
             using PInvoke.SetBkModeScope bkScope = new(hdc, BACKGROUND_MODE.TRANSPARENT);
             using PInvoke.SelectObjectScope selection = new(hdc, (HGDIOBJ)hpen.Value);
 
-            Point oldPoint = new();
+            Point oldPoint = default(Point);
 
             for (int i = 0; i < lines.Length; i += 4)
             {

--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/WeakRefCollection.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/WeakRefCollection.cs
@@ -107,7 +107,7 @@ namespace System.Windows.Forms
 
         public override int GetHashCode()
         {
-            var hash = new HashCode();
+            var hash = default(HashCode);
             foreach (WeakRefObject? o in InnerList)
             {
                 hash.Add(o);

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/LOGFONTW.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/Graphics/Gdi/LOGFONTW.cs
@@ -25,14 +25,14 @@ namespace Windows.Win32.Graphics.Gdi
 
         public static LOGFONTW FromFont(Font font)
         {
-            object logFont = new LOGFONTW();
+            object logFont = default(LOGFONTW);
             font.ToLogFont(logFont);
             return (LOGFONTW)logFont;
         }
 
         public static LOGFONTW FromFont(Font font, global::System.Drawing.Graphics graphics)
         {
-            object logFont = new LOGFONTW();
+            object logFont = default(LOGFONTW);
             font.ToLogFont(logFont, graphics);
             return (LOGFONTW)logFont;
         }

--- a/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SelectPaletteScope.cs
+++ b/src/System.Windows.Forms.Primitives/src/Windows/Win32/PInvoke.SelectPaletteScope.cs
@@ -45,8 +45,11 @@ namespace Windows.Win32
                     //
                     // Doing this is a bit pointless when the color depth is much higher (the normal scenario). As such
                     // we'll skip doing this unless we see 8bpp or less.
-
+#if DEBUG
                     return new SelectPaletteScope();
+#else
+                    return default(SelectPaletteScope);
+#endif
                 }
 
                 return new SelectPaletteScope(

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -515,7 +515,7 @@ namespace System.Resources
         /// </summary>
         public Point GetNodePosition()
         {
-            return _nodeInfo?.ReaderPosition ?? new Point();
+            return _nodeInfo?.ReaderPosition ?? default(Point);
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ComponentManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ComponentManager.cs
@@ -239,7 +239,7 @@ namespace System.Windows.Forms
             BOOL IMsoComponentManager.FContinueIdle()
             {
                 // If we have a message on queue, then don't continue idle processing.
-                var msg = new MSG();
+                var msg = default(MSG);
                 return User32.PeekMessageW(ref msg);
             }
 
@@ -262,7 +262,7 @@ namespace System.Windows.Forms
 
                 try
                 {
-                    MSG msg = new MSG();
+                    MSG msg = default(MSG);
                     IMsoComponent requestingComponent = entry.component;
                     _activeComponent = requestingComponent;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -1177,7 +1177,7 @@ namespace System.Windows.Forms
                 try
                 {
                     // Execute the message loop until the active component tells us to stop.
-                    var msg = new MSG();
+                    var msg = default(MSG);
                     bool unicodeWindow = false;
                     bool continueLoop = true;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPerPropertyBrowsingEnum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPerPropertyBrowsingEnum.cs
@@ -97,7 +97,7 @@ namespace System.Windows.Forms
                                 continue;
                             }
 
-                            using VARIANT var = new();
+                            using VARIANT var = default(VARIANT);
                             HRESULT hr = ppb.GetPredefinedValue(_target.Dispid, cookie, &var);
                             if (hr.Succeeded && var.Type != VARENUM.VT_EMPTY)
                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -1182,7 +1182,7 @@ namespace System.Windows.Forms
         private unsafe void HiMetric2Pixel(ref Size sz)
         {
             var phm = new Point(sz.Width, sz.Height);
-            var pcont = new PointF();
+            var pcont = default(PointF);
             ((Ole32.IOleControlSite)_oleSite).TransformCoords(&phm, &pcont, Ole32.XFORMCOORDS.SIZE | Ole32.XFORMCOORDS.HIMETRICTOCONTAINER);
             sz.Width = (int)pcont.X;
             sz.Height = (int)pcont.Y;
@@ -1190,7 +1190,7 @@ namespace System.Windows.Forms
 
         private unsafe void Pixel2hiMetric(ref Size sz)
         {
-            var phm = new Point();
+            var phm = default(Point);
             var pcont = new PointF(sz.Width, sz.Height);
             ((Ole32.IOleControlSite)_oleSite).TransformCoords(&phm, &pcont, Ole32.XFORMCOORDS.SIZE | Ole32.XFORMCOORDS.CONTAINERTOHIMETRIC);
             sz.Width = phm.X;
@@ -1241,7 +1241,7 @@ namespace System.Windows.Forms
 
         private unsafe Size GetExtent()
         {
-            var sz = new Size();
+            var sz = default(Size);
             GetOleObject().GetExtent(Ole32.DVASPECT.CONTENT, &sz);
             HiMetric2Pixel(ref sz);
             return sz;
@@ -3191,7 +3191,7 @@ namespace System.Windows.Forms
             }
 
             Ole32.ISpecifyPropertyPages ispp = (Ole32.ISpecifyPropertyPages)GetOcx();
-            var uuids = new Ole32.CAUUID();
+            var uuids = default(Ole32.CAUUID);
             try
             {
                 HRESULT hr = ispp.GetPages(&uuids);
@@ -3274,7 +3274,7 @@ namespace System.Windows.Forms
             }
 
             Ole32.ISpecifyPropertyPages ispp = (Ole32.ISpecifyPropertyPages)GetOcx();
-            var uuids = new Ole32.CAUUID();
+            var uuids = default(Ole32.CAUUID);
             HRESULT hr = ispp.GetPages(&uuids);
             if (!hr.Succeeded || uuids.cElems == 0)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.LayoutOptions.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.LayoutOptions.cs
@@ -177,7 +177,7 @@ namespace System.Windows.Forms.ButtonInternal
 
             private Composition GetHorizontalComposition()
             {
-                BitVector32 action = new BitVector32();
+                BitVector32 action = default(BitVector32);
 
                 // Checks reserve space horizontally if possible, so only AnyLeft/AnyRight prevents combination.
                 action[s_combineCheck] =
@@ -240,7 +240,7 @@ namespace System.Windows.Forms.ButtonInternal
 
             private Composition GetVerticalComposition()
             {
-                BitVector32 action = new BitVector32();
+                BitVector32 action = default(BitVector32);
 
                 // Checks reserve space horizontally if possible, so only Top/Bottom prevents combination.
                 action[s_combineCheck] = CheckAlign == ContentAlignment.MiddleCenter || !LayoutUtils.IsVerticalAlignment(CheckAlign);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/ButtonBaseAdapter.cs
@@ -52,7 +52,7 @@ namespace System.Windows.Forms.ButtonInternal
         {
             LayoutOptions? options = default;
             using (var screen = GdiCache.GetScreenHdc())
-            using (PaintEventArgs pe = new PaintEventArgs(screen, new Rectangle()))
+            using (PaintEventArgs pe = new PaintEventArgs(screen, default(Rectangle)))
             {
                 options = Layout(pe);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxStandardAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckBoxStandardAdapter.cs
@@ -96,7 +96,7 @@ namespace System.Windows.Forms.ButtonInternal
             {
                 LayoutOptions? options = default;
                 using (var screen = GdiCache.GetScreenHdc())
-                using (PaintEventArgs pe = new PaintEventArgs(screen, new Rectangle()))
+                using (PaintEventArgs pe = new PaintEventArgs(screen, default(Rectangle)))
                 {
                     options = Layout(pe);
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckableControlBaseAdapter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ButtonInternal/CheckableControlBaseAdapter.cs
@@ -39,7 +39,7 @@ namespace System.Windows.Forms.ButtonInternal
 
             LayoutOptions? options = default;
             using (var screen = GdiCache.GetScreenHdc())
-            using (PaintEventArgs pe = new PaintEventArgs(screen, new Rectangle()))
+            using (PaintEventArgs pe = new PaintEventArgs(screen, default(Rectangle)))
             {
                 options = Layout(pe);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/CheckedListBox.cs
@@ -416,7 +416,7 @@ namespace System.Windows.Forms
         {
             if (IsHandleCreated)
             {
-                var rect = new RECT();
+                var rect = default(RECT);
                 PInvoke.SendMessage(this, (User32.WM)User32.LB.GETITEMRECT, (WPARAM)index, ref rect);
                 PInvoke.InvalidateRect(this, &rect, bErase: false);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxItemAccessibleObject.cs
@@ -42,7 +42,7 @@ namespace System.Windows.Forms
                 {
                     int currentIndex = GetCurrentIndex();
                     var listHandle = _owningComboBox.GetListHandle();
-                    RECT itemRect = new();
+                    RECT itemRect = default(RECT);
 
                     int result = (int)PInvoke.SendMessage(
                         listHandle,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.ComboBoxUiaTextProvider.cs
@@ -384,7 +384,7 @@ namespace System.Windows.Forms
             private RECT GetFormattingRectangle()
             {
                 // Send an EM_GETRECT message to find out the bounding rectangle.
-                RECT rectangle = new RECT();
+                RECT rectangle = default(RECT);
                 PInvoke.SendMessage(_owningChildEdit, (WM)EM.GETRECT, (WPARAM)0, ref rectangle);
 
                 return rectangle;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ComponentEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ComponentEditor.cs
@@ -27,7 +27,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             if (obj is ISpecifyPropertyPages ispp)
             {
-                var uuids = new CAUUID();
+                var uuids = default(CAUUID);
                 try
                 {
                     HRESULT hr = ispp.GetPages(&uuids);
@@ -85,7 +85,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             {
                 try
                 {
-                    var uuids = new CAUUID();
+                    var uuids = default(CAUUID);
                     HRESULT hr = ispp.GetPages(&uuids);
                     if (!hr.Succeeded || uuids.cElems == 0)
                     {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptor.cs
@@ -862,8 +862,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             Oleaut32.IDispatch pDisp = (Oleaut32.IDispatch)component;
             object[] pVarResult = new object[1];
-            EXCEPINFO pExcepInfo = new();
-            DISPPARAMS dispParams = new();
+            EXCEPINFO pExcepInfo = default(EXCEPINFO);
+            DISPPARAMS dispParams = default(DISPPARAMS);
             Guid g = Guid.Empty;
 
             HRESULT hr = pDisp.Invoke(
@@ -1234,7 +1234,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             Oleaut32.IDispatch pDisp = (Oleaut32.IDispatch)owner;
 
-            EXCEPINFO excepInfo = new();
+            EXCEPINFO excepInfo = default(EXCEPINFO);
             Ole32.DispatchID namedArg = Ole32.DispatchID.PROPERTYPUT;
             DISPPARAMS dispParams = new()
             {
@@ -1243,7 +1243,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 rgdispidNamedArgs = (int*)&namedArg
             };
 
-            using VARIANT variant = new();
+            using VARIANT variant = default(VARIANT);
             Marshal.GetNativeVariantForObject(value, (IntPtr)(&variant));
             dispParams.rgvarg = &variant;
             Guid g = Guid.Empty;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -506,8 +506,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             VARFLAGS flags)
         {
             // Get the name and the helpstring.
-            using var nameBstr = new BSTR();
-            using var helpStringBstr = new BSTR();
+            using var nameBstr = default(BSTR);
+            using var helpStringBstr = default(BSTR);
             HRESULT hr = typeInfo.GetDocumentation(dispid, &nameBstr, &helpStringBstr, null, null);
             ComNativeDescriptor cnd = ComNativeDescriptor.Instance;
             if (!hr.Succeeded)
@@ -736,8 +736,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                     object varValue = null;
 
-                    using var enumNameBstr = new BSTR();
-                    using var enumHelpStringBstr = new BSTR();
+                    using var enumNameBstr = default(BSTR);
+                    using var enumHelpStringBstr = default(BSTR);
                     enumTypeInfo.GetDocumentation(Ole32.DispatchID.MEMBERID_NIL, &enumNameBstr, &enumHelpStringBstr, null, null);
 
                     // For each item in the enum type info, we just need it's name and value and
@@ -764,8 +764,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             varValue = null;
 
                             // get the name and the helpstring
-                            using BSTR nameBstr = new();
-                            using BSTR helpBstr = new();
+                            using BSTR nameBstr = default(BSTR);
+                            using BSTR helpBstr = default(BSTR);
                             hr = enumTypeInfo.GetDocumentation((Ole32.DispatchID)pVarDesc->memid, &nameBstr, &helpBstr, null, null);
                             if (!hr.Succeeded)
                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2AboutBoxPropertyDescriptor.AboutBoxUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2AboutBoxPropertyDescriptor.AboutBoxUITypeEditor.cs
@@ -23,8 +23,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                 if (Marshal.IsComObject(component) && component is Oleaut32.IDispatch pDisp)
                 {
-                    EXCEPINFO pExcepInfo = new();
-                    DISPPARAMS dispParams = new();
+                    EXCEPINFO pExcepInfo = default(EXCEPINFO);
+                    DISPPARAMS dispParams = default(DISPPARAMS);
                     Guid g = Guid.Empty;
                     HRESULT hr = pDisp.Invoke(
                         Ole32.DispatchID.ABOUTBOX,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2IPerPropertyBrowsingHandler.Com2IPerPropertyBrowsingEnum.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2IPerPropertyBrowsingHandler.Com2IPerPropertyBrowsingEnum.cs
@@ -89,7 +89,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             continue;
                         }
 
-                        using VARIANT variant = new();
+                        using VARIANT variant = default(VARIANT);
                         HRESULT hr = ppb.GetPredefinedValue(_target.DISPID, cookie, &variant);
                         if (hr.Succeeded && variant.Type != VARENUM.VT_EMPTY)
                         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
@@ -99,7 +99,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 return string.Empty;
             }
 
-            using BSTR nameBstr = new();
+            using BSTR nameBstr = default(BSTR);
             pTypeInfo.GetDocumentation(DispatchID.MEMBERID_NIL, &nameBstr, null, null, null);
             return nameBstr.AsSpan().TrimStart('_').ToString();
         }
@@ -192,8 +192,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             try
             {
                 Guid g = Guid.Empty;
-                EXCEPINFO pExcepInfo = new();
-                DISPPARAMS dispParams = new();
+                EXCEPINFO pExcepInfo = default(EXCEPINFO);
+                DISPPARAMS dispParams = default(DISPPARAMS);
                 try
                 {
                     HRESULT hr = dispatch.Invoke(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -732,7 +732,7 @@ namespace System.Windows.Forms
             {
                 // Get window's client rectangle (i.e. without chrome) expressed in screen coordinates
                 PInvoke.GetClientRect(this, out RECT clientRectangle);
-                var topLeftPoint = new Point();
+                var topLeftPoint = default(Point);
                 PInvoke.ClientToScreen(this, ref topLeftPoint);
                 return new Rectangle(topLeftPoint.X, topLeftPoint.Y, clientRectangle.right, clientRectangle.bottom);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.cs
@@ -67,7 +67,7 @@ namespace System.Windows.Forms
                 control.WindowTarget = this;
 
                 _adviseList = new List<IAdviseSink>();
-                _activeXState = new BitVector32();
+                _activeXState = default(BitVector32);
                 _ambientProperties = new AmbientProperty[]
                 {
                     new AmbientProperty("Font", Ole32.DispatchID.AMBIENT_FONT),
@@ -206,7 +206,7 @@ namespace System.Windows.Forms
                 {
                     if (s_logPixels.IsEmpty)
                     {
-                        s_logPixels = new Point();
+                        s_logPixels = default(Point);
                         using var dc = User32.GetDcScope.ScreenDC;
                         s_logPixels.X = PInvoke.GetDeviceCaps(dc, GET_DEVICE_CAPS_INDEX.LOGPIXELSX);
                         s_logPixels.Y = PInvoke.GetDeviceCaps(dc, GET_DEVICE_CAPS_INDEX.LOGPIXELSY);
@@ -546,7 +546,7 @@ namespace System.Windows.Forms
                 {
                     Debug.WriteLineIf(CompModSwitches.ActiveX.TraceInfo, "clientSite implements IDispatch");
 
-                    DISPPARAMS dispParams = new();
+                    DISPPARAMS dispParams = default(DISPPARAMS);
                     object[] pvt = new object[1];
                     Guid g = Guid.Empty;
                     HRESULT hr = disp.Invoke(
@@ -811,8 +811,8 @@ namespace System.Windows.Forms
                         ThrowHr(hr);
                     }
 
-                    var posRect = new RECT();
-                    var clipRect = new RECT();
+                    var posRect = default(RECT);
+                    var clipRect = default(RECT);
 
                     if (_inPlaceUiWindow is not null && Marshal.IsComObject(_inPlaceUiWindow))
                     {
@@ -1457,7 +1457,7 @@ namespace System.Windows.Forms
 
                     if (converter.CanConvertFrom(typeof(string)))
                     {
-                        VARIANT variant = new();
+                        VARIANT variant = default(VARIANT);
                         value = converter.ConvertToInvariantString(props[i].GetValue(_control));
                         Marshal.GetNativeVariantForObject(value, (nint)(void*)&variant);
                         pPropBag.Write(props[i].Name, ref value!);
@@ -1954,7 +1954,7 @@ namespace System.Windows.Forms
                 {
                     if (_clientSite is Ole32.IOleInPlaceSite ioleClientSite)
                     {
-                        var rc = new RECT();
+                        var rc = default(RECT);
                         if (flags.HasFlag(SET_WINDOW_POS_FLAGS.SWP_NOMOVE))
                         {
                             rc.left = _control.Left;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -5122,7 +5122,7 @@ namespace System.Windows.Forms
                     {
                         if (s_threadCallbackMessage != 0)
                         {
-                            var msg = new MSG();
+                            var msg = default(MSG);
                             BOOL result = User32.PeekMessageW(
                                 ref msg,
                                 this,
@@ -9790,7 +9790,7 @@ namespace System.Windows.Forms
         {
             if (!IsDisposed)
             {
-                var msg = new MSG();
+                var msg = default(MSG);
                 while (User32.PeekMessageW(ref msg, this, msgMin, msgMax, User32.PM.REMOVE))
                 {
                     // No-op.
@@ -11578,7 +11578,7 @@ namespace System.Windows.Forms
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected internal void UpdateBounds()
         {
-            RECT rect = new();
+            RECT rect = default(RECT);
             int clientWidth = 0;
             int clientHeight = 0;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ControlPaint.cs
@@ -2621,7 +2621,7 @@ namespace System.Windows.Forms
 
         internal static TextFormatFlags TextFormatFlagsForAlignmentGDI(ContentAlignment align)
         {
-            TextFormatFlags output = new TextFormatFlags();
+            TextFormatFlags output = default(TextFormatFlags);
             output |= TranslateAlignmentForGDI(align);
             output |= TranslateLineAlignmentForGDI(align);
             return output;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -10575,7 +10575,7 @@ namespace System.Windows.Forms
                     }
                 }
 
-                _layout.ResizeBoxRect = new Rectangle();
+                _layout.ResizeBoxRect = default(Rectangle);
                 if (needVertScrollbar && needHorizScrollbar)
                 {
                     _layout.ResizeBoxRect = new Rectangle(

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewCellStyle.cs
@@ -659,7 +659,7 @@ namespace System.Windows.Forms
 
         public override int GetHashCode()
         {
-            var hash = new HashCode();
+            var hash = default(HashCode);
             hash.Add(Alignment);
             hash.Add(WrapMode);
             hash.Add(Padding);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.OleConverter.cs
@@ -50,8 +50,8 @@ namespace System.Windows.Forms
             /// </summary>
             private unsafe object? GetDataFromOleIStream(string format)
             {
-                FORMATETC formatetc = new FORMATETC();
-                STGMEDIUM medium = new STGMEDIUM();
+                FORMATETC formatetc = default(FORMATETC);
+                STGMEDIUM medium = default(STGMEDIUM);
 
                 formatetc.cfFormat = unchecked((short)(ushort)(DataFormats.GetFormat(format).Id));
                 formatetc.dwAspect = DVASPECT.DVASPECT_CONTENT;
@@ -164,8 +164,8 @@ namespace System.Windows.Forms
                 done = false;
                 Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
 
-                FORMATETC formatetc = new FORMATETC();
-                STGMEDIUM medium = new STGMEDIUM();
+                FORMATETC formatetc = default(FORMATETC);
+                STGMEDIUM medium = default(STGMEDIUM);
 
                 formatetc.cfFormat = unchecked((short)(ushort)(DataFormats.GetFormat(format).Id));
                 formatetc.dwAspect = DVASPECT.DVASPECT_CONTENT;
@@ -210,8 +210,8 @@ namespace System.Windows.Forms
             {
                 Debug.Assert(_innerData is not null, "You must have an innerData on all DataObjects");
 
-                FORMATETC formatetc = new FORMATETC();
-                STGMEDIUM medium = new STGMEDIUM();
+                FORMATETC formatetc = default(FORMATETC);
+                STGMEDIUM medium = default(STGMEDIUM);
 
                 TYMED tymed = (TYMED)0;
 
@@ -614,7 +614,7 @@ namespace System.Windows.Forms
                 {
                     enumFORMATETC.Reset();
 
-                    FORMATETC[] formatetc = new FORMATETC[] { new FORMATETC() };
+                    FORMATETC[] formatetc = new FORMATETC[] { default(FORMATETC) };
                     int[] retrieved = new int[] { 1 };
 
                     while (retrieved[0] > 0)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataObject.cs
@@ -544,7 +544,7 @@ namespace System.Windows.Forms
                 return converter.OleDataObject.GetCanonicalFormatEtc(ref pformatetcIn, out pformatetcOut);
             }
 
-            pformatetcOut = new FORMATETC();
+            pformatetcOut = default(FORMATETC);
             return DATA_S_SAMEFORMATETC;
         }
 
@@ -564,7 +564,7 @@ namespace System.Windows.Forms
                 string formatName = DataFormats.GetFormat(formatetc.cfFormat).Name;
                 if (!_innerData.GetDataPresent(formatName))
                 {
-                    medium = new STGMEDIUM();
+                    medium = default(STGMEDIUM);
                     Debug.WriteLineIf(CompModSwitches.DataObject.TraceVerbose, $" drag-and-drop private format requested '{formatName}' not present");
                     return;
                 }
@@ -577,7 +577,7 @@ namespace System.Windows.Forms
                 }
             }
 
-            medium = new STGMEDIUM();
+            medium = default(STGMEDIUM);
 
             if (!GetTymedUseable(formatetc.tymed))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DateTimePicker.cs
@@ -340,7 +340,7 @@ namespace System.Windows.Forms
                 // The information from win32 DateTimePicker is reliable only when ShowCheckBoxes is True
                 if (ShowCheckBox && IsHandleCreated)
                 {
-                    var sys = new SYSTEMTIME();
+                    var sys = default(SYSTEMTIME);
                     NMDATETIMECHANGE_FLAGS gdt = (NMDATETIMECHANGE_FLAGS)PInvoke.SendMessage(this, (User32.WM)PInvoke.DTM_GETSYSTEMTIME, 0, ref sys);
                     return gdt == NMDATETIMECHANGE_FLAGS.GDT_VALID;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.PageSelector.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.PageSelector.cs
@@ -95,8 +95,8 @@ namespace System.Windows.Forms.Design
                 COLORREF backColor,
                 COLORREF textColor)
             {
-                Size size = new();
-                RECT rc2 = new();
+                Size size = default(Size);
+                RECT rc2 = default(RECT);
                 RECT rc = rcIn;
                 ImageList imagelist = ImageList;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DragDropFormat.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DragDropFormat.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms
         /// </returns>
         private static STGMEDIUM CopyData(short format, STGMEDIUM mediumSource)
         {
-            STGMEDIUM mediumDestination = new();
+            STGMEDIUM mediumDestination = default(STGMEDIUM);
 
             try
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DragDropHelper.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DragDropHelper.cs
@@ -169,7 +169,7 @@ namespace System.Windows.Forms
                     return false;
                 }
 
-                medium = new();
+                medium = default(STGMEDIUM);
                 dataObject.GetData(ref formatEtc, out medium);
                 void* basePtr = PInvoke.GlobalLock(medium.unionmember);
                 return (basePtr is not null) && (*(BOOL*)basePtr == true);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Form.cs
@@ -3732,7 +3732,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            Point p = new Point();
+            Point p = default(Point);
             Size s = Size;
             HWND ownerHandle = (HWND)PInvoke.GetWindowLong(this, WINDOW_LONG_PTR_INDEX.GWL_HWNDPARENT);
 
@@ -3778,7 +3778,7 @@ namespace System.Windows.Forms
         /// </summary>
         protected void CenterToScreen()
         {
-            Point p = new Point();
+            Point p = default(Point);
             Screen desktop;
             if (OwnerInternal is not null)
             {
@@ -4358,7 +4358,7 @@ namespace System.Windows.Forms
         {
             DefWndProc(ref m);
 
-            Size desiredSize = new Size();
+            Size desiredSize = default(Size);
             if (OnGetDpiScaledSize(_deviceDpi, m.WParamInternal.LOWORD, ref desiredSize))
             {
                 SIZE* size = (SIZE*)m.LParamInternal;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlDocument.cs
@@ -457,7 +457,7 @@ namespace System.Windows.Forms
                         };
 
                         var retVals = new object[1];
-                        EXCEPINFO excepInfo = new();
+                        EXCEPINFO excepInfo = default(EXCEPINFO);
                         hr = scriptObject.Invoke(
                             dispid,
                             &g,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/HtmlElement.cs
@@ -476,7 +476,7 @@ namespace System.Windows.Forms
                         };
 
                         var retVals = new object[1];
-                        EXCEPINFO excepInfo = new();
+                        EXCEPINFO excepInfo = default(EXCEPINFO);
                         hr = scriptObject.Invoke(
                             dispid,
                             &g,

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Internal/Gdi/GdiCache.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Internal/Gdi/GdiCache.cs
@@ -83,7 +83,11 @@ namespace System.Windows.Forms
         public static FontCache.Scope GetHFONT(Font? font, FONT_QUALITY quality = FONT_QUALITY.DEFAULT_QUALITY)
         {
             Debug.Assert(font is not null);
+#if DEBUG
             return font is null ? new FontCache.Scope() : s_fontCache.GetEntry(font, quality);
+#else
+            return font is null ? default : s_fontCache.GetEntry(font, quality);
+#endif
         }
 
         public static FontCache.Scope GetHFONT(Font? font, FONT_QUALITY quality, HDC hdc)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ArrangedElementCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/ArrangedElementCollection.cs
@@ -49,7 +49,7 @@ namespace System.Windows.Forms.Layout
 
         public override int GetHashCode()
         {
-            var hash = new HashCode();
+            var hash = default(HashCode);
             foreach (object o in InnerList)
             {
                 hash.Add(o);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/LayoutTransaction.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/LayoutTransaction.cs
@@ -86,7 +86,7 @@ namespace System.Windows.Forms.Layout
             else
             {
                 CommonProperties.xClearPreferredSizeCache(elementCausingLayout);
-                return new NullLayoutTransaction();
+                return default(NullLayoutTransaction);
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.LayoutInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.LayoutInfo.cs
@@ -74,7 +74,7 @@ namespace System.Windows.Forms.Layout
 
             public override int GetHashCode()
             {
-                var hash = new HashCode();
+                var hash = default(HashCode);
                 hash.Add(RowStart);
                 hash.Add(ColumnStart);
                 hash.Add(RowSpan);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListBox.cs
@@ -1470,7 +1470,7 @@ namespace System.Windows.Forms
         public Rectangle GetItemRectangle(int index)
         {
             CheckIndex(index);
-            var rect = new RECT();
+            var rect = default(RECT);
             if (PInvoke.SendMessage(this, (WM)LB.GETITEMRECT, (uint)index, ref rect) == 0)
             {
                 return Rectangle.Empty;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -401,7 +401,7 @@ namespace System.Windows.Forms
                         // We don't need to delete it and this causes BAD problems w/ the Win32 list view control.
                         fixed (char* pBackgroundImageFileName = _backgroundImageFileName)
                         {
-                            var lvbkImage = new LVBKIMAGEW();
+                            var lvbkImage = default(LVBKIMAGEW);
                             if (BackgroundImageTiled)
                             {
                                 lvbkImage.ulFlags = LIST_VIEW_BACKGROUND_IMAGE_FLAGS.LVBKIF_STYLE_TILE;
@@ -3372,7 +3372,7 @@ namespace System.Windows.Forms
             {
                 fixed (char* pText = text)
                 {
-                    var lvFindInfo = new LVFINDINFOW();
+                    var lvFindInfo = default(LVFINDINFOW);
                     if (isTextSearch)
                     {
                         lvFindInfo.flags = LVFINDINFOW_FLAGS.LVFI_STRING;
@@ -3624,7 +3624,7 @@ namespace System.Windows.Forms
 
         internal Point GetItemPosition(int index)
         {
-            var pt = new Point();
+            var pt = default(Point);
             PInvoke.SendMessage(this, (User32.WM)PInvoke.LVM_GETITEMPOSITION, (WPARAM)index, ref pt);
             return pt;
         }
@@ -5002,7 +5002,7 @@ namespace System.Windows.Forms
 
         private void RealizeAllSubItems()
         {
-            var lvItem = new LVITEMW();
+            var lvItem = default(LVITEMW);
             for (int i = 0; i < _itemCount; i++)
             {
                 int subItemCount = Items[i].SubItems.Count;
@@ -5210,7 +5210,7 @@ namespace System.Windows.Forms
             // needed for OleInitialize
             Application.OleRequired();
 
-            var lvbkImage = new LVBKIMAGEW();
+            var lvbkImage = default(LVBKIMAGEW);
 
             // first, is there an existing temporary file to delete, remember its name
             // so that we can delete it if the list control doesn't...
@@ -5557,7 +5557,7 @@ namespace System.Windows.Forms
 
         internal void SetItemText(int itemIndex, int subItemIndex, string text)
         {
-            var lvItem = new LVITEMW();
+            var lvItem = default(LVITEMW);
             SetItemText(itemIndex, subItemIndex, text, ref lvItem);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewGroup.ListViewGroupAccessibleObject.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms
                         : PInvoke.LVGGR_GROUP;
 
                     // Get the native rectangle
-                    RECT groupRect = new();
+                    RECT groupRect = default(RECT);
 
                     // Using the "top" property, we set which rectangle type of the group we want to get
                     // This is described in more detail in https://docs.microsoft.com/windows/win32/controls/lvm-getgrouprect

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewInsertionMark.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                var rect = new RECT();
+                var rect = default(RECT);
                 PInvoke.SendMessage(_listView, (User32.WM)PInvoke.LVM_GETINSERTMARKRECT, (WPARAM)0, ref rect);
                 return Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.cs
@@ -294,7 +294,7 @@ namespace System.Windows.Forms
                 }
                 else
                 {
-                    return new Rectangle();
+                    return default(Rectangle);
                 }
             }
         }
@@ -950,7 +950,7 @@ namespace System.Windows.Forms
                 return listView.GetItemRect(Index, portion);
             }
 
-            return new Rectangle();
+            return default(Rectangle);
         }
 
         public ListViewSubItem GetSubItemAt(int x, int y)
@@ -1030,7 +1030,7 @@ namespace System.Windows.Forms
 
         internal void UpdateStateToListView(int index)
         {
-            var lvItem = new LVITEMW();
+            var lvItem = default(LVITEMW);
             UpdateStateToListView(index, ref lvItem, true);
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewLabelEditUiaTextProvider.cs
@@ -309,7 +309,7 @@ namespace System.Windows.Forms
         private RECT GetFormattingRectangle()
         {
             // Send an EM_GETRECT message to find out the bounding rectangle.
-            RECT rectangle = new RECT();
+            RECT rectangle = default(RECT);
             PInvoke.SendMessage(_owningChildEdit, (User32.WM)User32.EM.GETRECT, 0, ref rectangle);
 
             return rectangle;
@@ -329,7 +329,7 @@ namespace System.Windows.Forms
 
         private unsafe bool GetTextExtentPoint32(char item, out Size size)
         {
-            size = new Size();
+            size = default(Size);
 
             using var hdc = new User32.GetDcScope(_owningChildEdit.Handle);
             if (hdc.IsNull)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MDIClient.cs
@@ -285,7 +285,7 @@ namespace System.Windows.Forms
         /// </summary>
         private void SetWindowRgn()
         {
-            RECT rect = new();
+            RECT rect = default(RECT);
             CreateParams cp = CreateParams;
 
             AdjustWindowRectExForControlDpi(ref rect, (WINDOW_STYLE)cp.Style, false, (WINDOW_EX_STYLE)cp.ExStyle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarButtonAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.CalendarButtonAccessibleObject.cs
@@ -119,7 +119,7 @@ namespace System.Windows.Forms
                     flags |= User32.MOUSEEVENTF.VIRTUALDESK;
                 }
 
-                User32.INPUT mouseInput = new();
+                User32.INPUT mouseInput = default(User32.INPUT);
                 mouseInput.type = User32.INPUTENUM.MOUSE;
                 mouseInput.inputUnion.mi.dx = x;
                 mouseInput.inputUnion.mi.dy = y;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -860,7 +860,7 @@ namespace System.Windows.Forms
             {
                 if (IsHandleCreated)
                 {
-                    RECT rect = new RECT();
+                    RECT rect = default(RECT);
                     if (PInvoke.SendMessage(this, (User32.WM)PInvoke.MCM_GETMINREQRECT, 0, ref rect) == 0)
                     {
                         throw new InvalidOperationException(SR.InvalidSingleMonthSize);
@@ -923,7 +923,7 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    SYSTEMTIME systemTime = new();
+                    SYSTEMTIME systemTime = default(SYSTEMTIME);
                     int result = (int)PInvoke.SendMessage(this, (User32.WM)PInvoke.MCM_GETTODAY, 0, ref systemTime);
                     Debug.Assert(result != 0, "MCM_GETTODAY failed");
                     return ((DateTime)systemTime).Date;
@@ -1394,7 +1394,7 @@ namespace System.Windows.Forms
             {
                 cbSize = (uint)sizeof(MCHITTESTINFO),
                 pt = new Point(x, y),
-                st = new SYSTEMTIME()
+                st = default(SYSTEMTIME)
             };
 
             PInvoke.SendMessage(this, (User32.WM)PInvoke.MCM_HITTEST, 0, ref mchi);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/NativeWindow.WindowClass.cs
@@ -130,7 +130,7 @@ namespace System.Windows.Forms
             /// </summary>
             private unsafe void RegisterClass()
             {
-                WNDCLASSW windowClass = new();
+                WNDCLASSW windowClass = default(WNDCLASSW);
 
                 string? localClassName = _className;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -5065,7 +5065,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // potentially causing an accidental button click. Problem occurs because we trap clicks using a system hook,
             // which usually discards the message by returning 1 to GetMessage(). But this won't occur until after the
             // error dialog gets closed, which is much too late.
-            var mouseMessage = new MSG();
+            var mouseMessage = default(MSG);
             while (User32.PeekMessageW(ref mouseMessage,
                 IntPtr.Zero,
                 User32.WM.MOUSEFIRST,
@@ -5141,7 +5141,7 @@ namespace System.Windows.Forms.PropertyGridInternal
             // potentially causing an accidental button click. Problem occurs because we trap clicks using a system hook,
             // which usually discards the message by returning 1 to GetMessage(). But this won't occur until after the
             // error dialog gets closed, which is much too late.
-            var mouseMsg = new MSG();
+            var mouseMsg = default(MSG);
             while (User32.PeekMessageW(ref mouseMsg, IntPtr.Zero, User32.WM.MOUSEFIRST, User32.WM.MOUSELAST, User32.PM.REMOVE))
             {
                 // No-op.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/RichTextBox.cs
@@ -1888,7 +1888,7 @@ namespace System.Windows.Forms
                 throw new ArgumentException(string.Format(SR.RichTextFindEndInvalid, end));
             }
 
-            var ft = new FINDTEXTW();
+            var ft = default(FINDTEXTW);
             if ((options & RichTextBoxFinds.Reverse) != RichTextBoxFinds.Reverse)
             {
                 // normal
@@ -2049,7 +2049,7 @@ namespace System.Windows.Forms
                 end = textLen;
             }
 
-            var chrg = new Richedit.CHARRANGE(); // The range of characters we have searched
+            var chrg = default(Richedit.CHARRANGE); // The range of characters we have searched
             chrg.cpMax = chrg.cpMin = start;
 
             // Use the TEXTRANGE to move our text buffer forward
@@ -2342,7 +2342,7 @@ namespace System.Windows.Forms
                 return Point.Empty;
             }
 
-            var pt = new Point();
+            var pt = default(Point);
             PInvoke.SendMessage(this, (User32.WM)User32.EM.POSFROMCHAR, (WPARAM)(&pt), index);
             return pt;
         }
@@ -2932,7 +2932,7 @@ namespace System.Windows.Forms
             // clear out the selection only if we are replacing all the text
             if ((flags & SF.F_SELECTION) == 0)
             {
-                var cr = new CHARRANGE();
+                var cr = default(CHARRANGE);
                 PInvoke.SendMessage(this, (User32.WM)EM.EXSETSEL, 0, ref cr);
             }
 
@@ -2964,7 +2964,7 @@ namespace System.Windows.Forms
                 int cookieVal = 0;
 
                 // set up structure to do stream operation
-                var es = new EDITSTREAM();
+                var es = default(EDITSTREAM);
 
                 if ((flags & SF.UNICODE) != 0)
                 {
@@ -3068,7 +3068,7 @@ namespace System.Windows.Forms
             try
             {
                 int cookieVal = 0;
-                var es = new EDITSTREAM();
+                var es = default(EDITSTREAM);
                 if ((flags & SF.UNICODE) != 0)
                 {
                     cookieVal = OUTPUT | UNICODE;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SplitContainer.cs
@@ -102,7 +102,7 @@ namespace System.Windows.Forms
             // either the right or bottom panel - LTR
             // either the left or bottom panel - RTL
             Panel2 = new SplitterPanel(this);
-            _splitterRect = new Rectangle();
+            _splitterRect = default(Rectangle);
 
             SetStyle(ControlStyles.SupportsTransparentBackColor, true);
             SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
@@ -1391,7 +1391,7 @@ namespace System.Windows.Forms
         /// </summary>
         private Rectangle CalcSplitLine(int splitSize, int minWeight)
         {
-            Rectangle r = new Rectangle();
+            Rectangle r = default(Rectangle);
             switch (Orientation)
             {
                 case Orientation.Vertical:

--- a/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/SystemInformation.cs
@@ -195,7 +195,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                var rect = new RECT();
+                var rect = default(RECT);
                 PInvoke.SystemParametersInfo(SPI_GETWORKAREA, ref rect);
                 return rect;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TabControl.cs
@@ -1129,7 +1129,7 @@ namespace System.Windows.Forms
             }
 
             SetState(State.GetTabRectfromItemSize, false);
-            RECT rect = new RECT();
+            RECT rect = default(RECT);
 
             // normally, we would not want to create the handle for this, but since
             // it is dependent on the actual physical display, we simply must.
@@ -2062,7 +2062,7 @@ namespace System.Windows.Forms
             Invalidate(true);
 
             // Remove other TabBaseReLayout messages from the message queue
-            var msg = new MSG();
+            var msg = default(MSG);
             while (User32.PeekMessageW(ref msg, this, _tabBaseReLayoutMessage, _tabBaseReLayoutMessage, User32.PM.REMOVE))
             {
                 // No-op.
@@ -2156,7 +2156,7 @@ namespace System.Windows.Forms
 
         private unsafe int SendMessage(uint msg, int wParam, TabPage tabPage)
         {
-            var tcitem = new ComCtl32.TCITEMW();
+            var tcitem = default(ComCtl32.TCITEMW);
             string text = tabPage.Text;
             PrefixAmpersands(ref text);
             if (text is not null)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TableLayoutSettings.cs
@@ -520,7 +520,7 @@ namespace System.Windows.Forms
                 {
                     if (element is Control c)
                     {
-                        ControlInformation controlInfo = new ControlInformation();
+                        ControlInformation controlInfo = default(ControlInformation);
 
                         // We need to go through the PropertyDescriptor for the Name property
                         // since it is shadowed.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseUiaTextProvider.cs
@@ -366,7 +366,7 @@ namespace System.Windows.Forms
                 Debug.Assert(_owningTextBoxBase.IsHandleCreated);
 
                 // Send an EM_GETRECT message to find out the bounding rectangle.
-                RECT rectangle = new RECT();
+                RECT rectangle = default(RECT);
                 PInvoke.SendMessage(_owningTextBoxBase, (WM)EM.GETRECT, (WPARAM)0, ref rectangle);
                 return rectangle;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.FeedbackRectangle.FeedbackDropDown.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanel.FeedbackRectangle.FeedbackDropDown.cs
@@ -59,7 +59,7 @@ namespace System.Windows.Forms
                     // Protect against re-entrancy.
                     try
                     {
-                        MSG msg = new();
+                        MSG msg = default(MSG);
                         while (User32.PeekMessageW(ref msg, IntPtr.Zero, User32.WM.PAINT, User32.WM.PAINT, User32.PM.REMOVE))
                         {
                             PInvoke.UpdateWindow(msg.hwnd);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripTextBox.ToolStripTextBoxControl.cs
@@ -30,7 +30,7 @@ namespace System.Windows.Forms
             {
                 get
                 {
-                    RECT rect = new();
+                    RECT rect = default(RECT);
                     CreateParams cp = CreateParams;
 
                     AdjustWindowRectExForControlDpi(ref rect, (WINDOW_STYLE)cp.Style, false, (WINDOW_EX_STYLE)cp.ExStyle);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolTip.cs
@@ -1987,7 +1987,7 @@ namespace System.Windows.Forms
 
         private HWND GetCurrentToolHwnd()
         {
-            var toolInfo = new ToolInfoWrapper<Control>();
+            var toolInfo = default(ToolInfoWrapper<Control>);
             if (toolInfo.SendMessage(this, (User32.WM)PInvoke.TTM_GETCURRENTTOOLW) != 0)
             {
                 return (HWND)toolInfo.Info.hwnd;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeNode.cs
@@ -115,7 +115,7 @@ namespace System.Windows.Forms
         /// </summary>
         public TreeNode()
         {
-            treeNodeState = new Collections.Specialized.BitVector32();
+            treeNodeState = default(Collections.Specialized.BitVector32);
         }
 
         internal TreeNode(TreeView treeView) : this()
@@ -231,7 +231,7 @@ namespace System.Windows.Forms
                     return Rectangle.Empty;
                 }
 
-                RECT rc = new RECT();
+                RECT rc = default(RECT);
                 unsafe
                 { *((IntPtr*)&rc.left) = Handle; }
                 // wparam: 1=include only text, 0=include entire line
@@ -254,7 +254,7 @@ namespace System.Windows.Forms
             get
             {
                 TreeView tv = TreeView;
-                RECT rc = new RECT();
+                RECT rc = default(RECT);
                 unsafe
                 { *((IntPtr*)&rc.left) = Handle; }
 
@@ -646,7 +646,7 @@ namespace System.Windows.Forms
                     return false;
                 }
 
-                RECT rc = new RECT();
+                RECT rc = default(RECT);
                 unsafe
                 { *((IntPtr*)&rc.left) = Handle; }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -2670,7 +2670,7 @@ namespace System.Windows.Forms
             }
 
             // TreeView doesn't properly revert back to the unselected image if the unselected image is blank.
-            var rc = new RECT();
+            var rc = default(RECT);
             *((IntPtr*)&rc.left) = nmtv->itemOld.hItem;
             if (nmtv->itemOld.hItem != IntPtr.Zero)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserBase.cs
@@ -1181,7 +1181,7 @@ namespace System.Windows.Forms
 
         private unsafe Size GetExtent()
         {
-            var sz = new Size();
+            var sz = default(Size);
             axOleObject.GetExtent(Ole32.DVASPECT.CONTENT, &sz);
             HiMetric2Pixel(ref sz);
             return sz;
@@ -1190,7 +1190,7 @@ namespace System.Windows.Forms
         private unsafe void HiMetric2Pixel(ref Size sz)
         {
             var phm = new Point(sz.Width, sz.Height);
-            var pcont = new PointF();
+            var pcont = default(PointF);
             ((Ole32.IOleControlSite)ActiveXSite).TransformCoords(&phm, &pcont, Ole32.XFORMCOORDS.SIZE | Ole32.XFORMCOORDS.HIMETRICTOCONTAINER);
             sz.Width = (int)pcont.X;
             sz.Height = (int)pcont.Y;
@@ -1198,7 +1198,7 @@ namespace System.Windows.Forms
 
         private unsafe void Pixel2hiMetric(ref Size sz)
         {
-            var phm = new Point();
+            var phm = default(Point);
             var pcont = new PointF(sz.Width, sz.Height);
             ((Ole32.IOleControlSite)ActiveXSite).TransformCoords(&phm, &pcont, Ole32.XFORMCOORDS.SIZE | Ole32.XFORMCOORDS.CONTAINERTOHIMETRIC);
             sz.Width = phm.X;


### PR DESCRIPTION
Enabled SA1129 analyzer.
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1129.md

Applied solution wide code fix.
Related: #7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8029)