### PR TITLE
SA1205 Partial elements should declare an access modifier

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1092,7 +1092,7 @@ dotnet_diagnostic.SA1203.severity = none
 dotnet_diagnostic.SA1204.severity = none
 
 # SA1205: Partial elements should declare an access modifier
-dotnet_diagnostic.SA1205.severity = none # TODO: warning
+dotnet_diagnostic.SA1205.severity = warning
 
 # SA1206: Keyword ordering - TODO Re-enable as warning after https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3527
 dotnet_diagnostic.SA1206.severity = suggestion

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewTextBoxEditingControl.DataGridViewTextBoxEditingControlAccessibleObject.cs
@@ -6,7 +6,7 @@ using static Interop;
 
 namespace System.Windows.Forms
 {
-    partial class DataGridViewTextBoxEditingControl
+    public partial class DataGridViewTextBoxEditingControl
     {
         /// <summary>
         ///  Defines the DataGridView TextBox EditingControl accessible object.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItem.ControlItemAccessibleObject.cs
@@ -9,7 +9,7 @@ using static Interop;
 
 namespace System.Windows.Forms
 {
-    partial class ErrorProvider
+    public partial class ErrorProvider
     {
         internal partial class ControlItem
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ControlItem.cs
@@ -9,7 +9,7 @@ using System.Drawing;
 
 namespace System.Windows.Forms
 {
-    partial class ErrorProvider
+    public partial class ErrorProvider
     {
         /// <summary>
         ///  There is one ControlItem for each control that the ErrorProvider is tracking state for.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.ErrorWindowAccessibleObject.cs
@@ -8,7 +8,7 @@ using static Interop;
 
 namespace System.Windows.Forms
 {
-    partial class ErrorProvider
+    public partial class ErrorProvider
     {
         internal partial class ErrorWindow
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.ErrorWindow.cs
@@ -9,7 +9,7 @@ using static Interop;
 
 namespace System.Windows.Forms
 {
-    partial class ErrorProvider
+    public partial class ErrorProvider
     {
         /// <summary>
         ///  There is one ErrorWindow for each control parent. It is parented to the

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ErrorProvider.IconRegion.cs
@@ -7,7 +7,7 @@ using System.Drawing;
 
 namespace System.Windows.Forms
 {
-    partial class ErrorProvider
+    public partial class ErrorProvider
     {
         /// <summary>
         ///  This represents the HRGN of icon. The region is calculate from the icon's mask.


### PR DESCRIPTION
Enabled SA1205 analyzer.
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1205.md

Applied solution wide code fix.
Related: #7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8030)