### PR TITLE
CA2007 Consider calling ConfigureAwait on the awaited task

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -403,7 +403,7 @@ dotnet_diagnostic.CA2000.severity = none
 dotnet_diagnostic.CA2002.severity = none
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = none # TODO: warning
+dotnet_diagnostic.CA2007.severity = warning
 
 # CA2008: Do not create tasks without passing a TaskScheduler
 dotnet_diagnostic.CA2008.severity = warning

--- a/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
+++ b/src/Microsoft.VisualBasic.Forms/src/Microsoft/VisualBasic/ApplicationServices/WindowsFormsApplicationBase.vb
@@ -881,7 +881,7 @@ Namespace Microsoft.VisualBasic.ApplicationServices
                 _formLoadWaiter = New AutoResetEvent(False)
 
                 Task.Run(Async Function() As Task
-                             Await _splashScreenCompletionSource.Task
+                             Await _splashScreenCompletionSource.Task.ConfigureAwait(False)
                              _formLoadWaiter.Set()
                          End Function)
 


### PR DESCRIPTION
Enabled CA2007 analyzer.
https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007

Manually fixed. 
**Team needs to verify whether `ConfigureAwait(False)` or `ConfigureAwait(True)` is appropriate.**
Related: https://github.com/dotnet/winforms/issues/7887

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8031)