### PR TITLE
Fixing incorrect Column value in ListViewSubItemAccessibleObject

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObject.cs
@@ -83,7 +83,7 @@ namespace System.Windows.Forms
 
                 internal override int Column
                     => _owningListView.View == View.Details
-                        ? ParentInternal.GetChildIndex(this)
+                        ? ParentInternal.GetChildIndex(this) - ParentInternal.FirstSubItemIndex
                         : InvalidIndex;
 
                 /// <summary>
@@ -146,7 +146,9 @@ namespace System.Windows.Forms
                 internal override int Row => _owningItem.Index;
 
                 internal override UiaCore.IRawElementProviderSimple[]? GetColumnHeaderItems()
-                    => new UiaCore.IRawElementProviderSimple[] { _owningListView.Columns[Column].AccessibilityObject };
+                    => _owningListView.View == View.Details
+                        ? new UiaCore.IRawElementProviderSimple[] { _owningListView.Columns[Column].AccessibilityObject }
+                        : null;
 
                 internal override bool IsPatternSupported(UiaCore.UIA patternId)
                 {

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewSubItem.ListViewSubItemAccessibleObjectTests.cs
@@ -974,6 +974,72 @@ namespace System.Windows.Forms.Tests
         }
 
         [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_GetColumnHeaderItems_IsExpected()
+        {
+            using ListView control = GetListViewWithSubItemData(
+                View.Details,
+                createControl: false,
+                virtualMode: false,
+                showGroups: false,
+                columnCount: 3,
+                subItemCount: 2);
+
+            ListViewSubItemAccessibleObject_GetColumnHeaderItems_IsExpected_Internal(control);
+        }
+
+        [WinFormsFact]
+        public void ListViewSubItemAccessibleObject_GetColumnHeaderItems_IsExpected_WithImage()
+        {
+            using ImageList imageCollection = new();
+            imageCollection.Images.Add(Form.DefaultIcon);
+            using ListView control = GetListViewWithSubItemData(
+                View.Details,
+                createControl: false,
+                virtualMode: false,
+                showGroups: false,
+                columnCount: 3,
+                subItemCount: 2);
+            control.SmallImageList = imageCollection;
+            control.Items[0].ImageIndex = 0;
+
+            ListViewSubItemAccessibleObject_GetColumnHeaderItems_IsExpected_Internal(control);
+        }
+
+        private void ListViewSubItemAccessibleObject_GetColumnHeaderItems_IsExpected_Internal(ListView control)
+        {
+            ListView.ColumnHeaderCollection columns = control.Columns;
+            for (int i = 0; i < columns.Count; i++)
+            {
+                var subItemAccessibleObject = (ListViewSubItemAccessibleObject)control.Items[0].SubItems[i].AccessibilityObject;
+                AccessibleObject columnHeaderAccessibleObject = columns[i].AccessibilityObject;
+                UiaCore.IRawElementProviderSimple[] columnHeaderItems = subItemAccessibleObject.GetColumnHeaderItems();
+
+                Assert.Equal(1, columnHeaderItems.Length);
+                Assert.Same(columnHeaderAccessibleObject, columnHeaderItems[0]);
+            }
+        }
+
+        [WinFormsTheory]
+        [InlineData(View.LargeIcon)]
+        [InlineData(View.List)]
+        [InlineData(View.SmallIcon)]
+        [InlineData(View.Tile)]
+        public void ListViewSubItemAccessibleObject_GetColumnHeaderItems_ReturnsNull_NoColumsViews(View view)
+        {
+            using ListView control = GetListViewWithSubItemData(
+                view,
+                createControl: false,
+                virtualMode: false,
+                showGroups: false,
+                columnCount: 3,
+                subItemCount: 2);
+
+            var subItemAccessibleObject = (ListViewSubItemAccessibleObject)control.Items[0].SubItems[1].AccessibilityObject;
+
+            Assert.Null(subItemAccessibleObject.GetColumnHeaderItems());
+        }
+
+        [WinFormsFact]
         public void ListViewSubItemAccessibleObject_State_ReturnsFocusable()
         {
             using ListView listview = new();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8025


## Proposed changes

- Fixed value in the `Column` property of `ListViewSubItemAccessibleObject` class.
- Covered `ListViewSubItemAccessibleObject.GetColumnHeaderItems` method with tests.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Customer will see correct header info from a sub-item.

## Regression? 

- Yes

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![Screenshot 2022-10-26 084435](https://user-images.githubusercontent.com/109065597/197952731-1a3a8d94-458a-405e-96ce-36d7f7974eb2.png)
![Screenshot 2022-10-26 084406](https://user-images.githubusercontent.com/109065597/197952756-54799e43-dab1-4642-b639-3d0300f5414b.png)


### After

![Screenshot 2022-10-26 084114](https://user-images.githubusercontent.com/109065597/197952793-ce71f38d-541d-461c-ba7e-08efec77ce27.png)


## Test methodology <!-- How did you ensure quality? -->

- Manually
- Unit tests 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

- Inspect


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK:
 Version:   8.0.100-alpha.1.22512.5
 Commit:    1b80461e45

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8032)