### PR TITLE
Fixed ToolStrip overflow button arrow color in HC themes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -199,7 +199,9 @@ namespace System.Windows.Forms
                 RenderItemInternalFilled(e, /*pressFill = */false);
                 ToolStripItem item = e.Item;
                 Graphics g = e.Graphics;
-                Color arrowColor = item.Enabled ? SystemColors.ControlText : SystemColors.ControlDark;
+                Color arrowColor = !item.Enabled ? SystemColors.ControlDark
+                    : item.Selected && !item.Pressed ? SystemColors.HighlightText
+                    : SystemColors.ControlText;
                 DrawArrow(new ToolStripArrowRenderEventArgs(g, item, new Rectangle(Point.Empty, item.Size), arrowColor, ArrowDirection.Down));
             }
             else


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7724


## Proposed changes

- Changed ToolStrip overflow button arrow color when the button is in selected state. Affects HC themes only.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Better button arrow visibility on HC themes

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Windows 11:
![win11_before](https://user-images.githubusercontent.com/113603457/198006539-66ac2850-fd86-4d5c-bc83-39639e21f5d1.png)

Windows 10:
![win10_before](https://user-images.githubusercontent.com/113603457/198006551-afb2949b-05e3-4a4c-96fa-fa05644e482e.png)

### After

Windows 11:
![win11_after](https://user-images.githubusercontent.com/113603457/198006643-d874d034-747c-4869-a431-7e27dc7591e1.png)

Windows10:
![win10_after](https://user-images.githubusercontent.com/113603457/198006667-cef8dccf-17bc-45f4-9f3e-d1e9b98757ab.png)

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

- Accessibility Insights for Windows - Color contrast analyzer
 

## Test environment(s) <!-- Remove any that don't apply -->

- Windows 10: .NET SDK 7.0.100-rc.2.22477.23
- Windows 11: .NET SDK 7.0.100-rc.2.22477.23


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8034)