### PR TITLE
Added unit tests for "AccessibleObject.FragmentNavigate" method in UpDown-related classes

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DirectionButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/DirectionButtonAccessibleObjectTests.cs
@@ -79,5 +79,97 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, numericUpDown.Value);
             Assert.True(numericUpDown.IsHandleCreated);
         }
+
+        [WinFormsTheory]
+        [InlineData(0, 1)]
+        [InlineData(1, null)]
+        public void DirectionButtonAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_InDomainUpDown(int childId, int? expectedChildId)
+        {
+            using DomainUpDown domainUpDown = new();
+
+            // UpButton has 0 childId, DownButton has 1 childId
+            AccessibleObject directionButton = domainUpDown.UpDownButtonsInternal.AccessibilityObject.GetChild(childId);
+
+            if (expectedChildId is null)
+            {
+                Assert.Null(directionButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            }
+            else
+            {
+                AccessibleObject expected = domainUpDown.UpDownButtonsInternal.AccessibilityObject.GetChild(expectedChildId.Value);
+                Assert.Equal(expected, directionButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            }
+
+            Assert.False(domainUpDown.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0, 1)]
+        [InlineData(1, null)]
+        public void DirectionButtonAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_InNumericUpDown(int childId, int? expectedChildId)
+        {
+            using NumericUpDown numericUpDown = new();
+
+            // UpButton has 0 childId, DownButton has 1 childId
+            AccessibleObject directionButton = numericUpDown.UpDownButtonsInternal.AccessibilityObject.GetChild(childId);
+
+            if (expectedChildId is null)
+            {
+                Assert.Null(directionButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            }
+            else
+            {
+                AccessibleObject expected = numericUpDown.UpDownButtonsInternal.AccessibilityObject.GetChild(expectedChildId.Value);
+                Assert.Equal(expected, directionButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            }
+
+            Assert.False(numericUpDown.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0, null)]
+        [InlineData(1, 0)]
+        public void DirectionButtonAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected_InDomainUpDown(int childId, int? expectedChildId)
+        {
+            using DomainUpDown domainUpDown = new();
+
+            // UpButton has 0 childId, DownButton has 1 childId
+            AccessibleObject directionButton = domainUpDown.UpDownButtonsInternal.AccessibilityObject.GetChild(childId);
+
+            if (expectedChildId is null)
+            {
+                Assert.Null(directionButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            }
+            else
+            {
+                AccessibleObject expected = domainUpDown.UpDownButtonsInternal.AccessibilityObject.GetChild(expectedChildId.Value);
+                Assert.Equal(expected, directionButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            }
+
+            Assert.False(domainUpDown.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0, null)]
+        [InlineData(1, 0)]
+        public void DirectionButtonAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected_InNumericUpDown(int childId, int? expectedChildId)
+        {
+            using NumericUpDown numericUpDown = new();
+
+            // UpButton has 0 childId, DownButton has 1 childId
+            AccessibleObject directionButton = numericUpDown.UpDownButtonsInternal.AccessibilityObject.GetChild(childId);
+
+            if (expectedChildId is null)
+            {
+                Assert.Null(directionButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            }
+            else
+            {
+                AccessibleObject expected = numericUpDown.UpDownButtonsInternal.AccessibilityObject.GetChild(expectedChildId.Value);
+                Assert.Equal(expected, directionButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            }
+
+            Assert.False(numericUpDown.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObject.DirectionButtonAccessibleObjectTests.cs
@@ -45,6 +45,42 @@ namespace System.Windows.Forms.Tests
             Assert.False(upDownBase.IsHandleCreated);
         }
 
+        [WinFormsTheory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void UpDownButtonsAccessibleObject_DirectionButtonAccessibleObject_FragmentNavigate_Parent_ReturnsExpected(int childIndex)
+        {
+            using SubUpDownBase upDownBase = new();
+            using UpDownButtons upDownButtons = upDownBase.UpDownButtonsInternal;
+            UpDownButtonsAccessibleObject accessibleObject = new(upDownButtons);
+
+            // UpButton has 0 index, DownButton has 1 index
+            AccessibleObject directionButton = accessibleObject.GetChild(childIndex);
+
+            Assert.Equal(accessibleObject, directionButton.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(upDownButtons.IsHandleCreated);
+            Assert.False(upDownBase.IsHandleCreated);
+        }
+
+        [WinFormsTheory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public void UpDownButtonsAccessibleObject_DirectionButtonAccessibleObject_FragmentNavigate_Child_ReturnsNull(int childIndex)
+        {
+            using SubUpDownBase upDownBase = new();
+            using UpDownButtons upDownButtons = upDownBase.UpDownButtonsInternal;
+            UpDownButtonsAccessibleObject accessibleObject = new(upDownButtons);
+
+            // UpButton has 0 index, DownButton has 1 index
+            AccessibleObject directionButton = accessibleObject.GetChild(childIndex);
+
+            Assert.Null(directionButton.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(directionButton.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+
+            Assert.False(upDownButtons.IsHandleCreated);
+            Assert.False(upDownBase.IsHandleCreated);
+        }
+
         private class SubUpDownBase : UpDownBase
         {
             protected override void UpdateEditText() => throw new NotImplementedException();

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/UpDownBase.UpDownButtons.UpDownButtonsAccessibleObjectTests.cs
@@ -159,6 +159,61 @@ namespace System.Windows.Forms.Tests
             Assert.False(upDownBase.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void UpDownButtonsAccessibleObject_FragmentNavigate_Parent_ReturnsNull()
+        {
+            using UpDownBase upDownBase = new SubUpDownBase();
+            using UpDownButtons upDownButtons = new UpDownButtons(upDownBase);
+            UpDownButtonsAccessibleObject accessibleObject = new UpDownButtonsAccessibleObject(upDownButtons);
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(upDownBase.IsHandleCreated);
+            Assert.False(upDownButtons.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void UpDownButtonsAccessibleObject_FragmentNavigate_Sibling_ReturnsNull()
+        {
+            using UpDownBase upDownBase = new SubUpDownBase();
+            using UpDownButtons upDownButtons = new UpDownButtons(upDownBase);
+            UpDownButtonsAccessibleObject accessibleObject = new UpDownButtonsAccessibleObject(upDownButtons);
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(upDownBase.IsHandleCreated);
+            Assert.False(upDownButtons.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void UpDownButtonsAccessibleObject_FragmentNavigate_Child_ReturnsExpected_InNumericUpDown()
+        {
+            using NumericUpDown numericUpDown = new();
+            UpDownButtonsAccessibleObject accessibleObject = (UpDownButtonsAccessibleObject)numericUpDown.UpDownButtonsInternal.AccessibilityObject;
+
+            // UpButton has 0 childId, DownButton has 1 childId
+            AccessibleObject upButton = accessibleObject.GetChild(0);
+            AccessibleObject downButton = accessibleObject.GetChild(1);
+
+            Assert.Equal(upButton, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(downButton, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(numericUpDown.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void UpDownButtonsAccessibleObject_FragmentNavigate_Child_ReturnsExpected_InDomainUpDown()
+        {
+            using DomainUpDown domainUpDown = new();
+            UpDownButtonsAccessibleObject accessibleObject = (UpDownButtonsAccessibleObject)domainUpDown.UpDownButtonsInternal.AccessibilityObject;
+
+            // UpButton has 0 childId, DownButton has 1 childId
+            AccessibleObject upButton = accessibleObject.GetChild(0);
+            AccessibleObject downButton = accessibleObject.GetChild(1);
+
+            Assert.Equal(upButton, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(downButton, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(domainUpDown.IsHandleCreated);
+        }
+
         private class SubUpDownBase : UpDownBase
         {
             protected override void UpdateEditText() => throw new NotImplementedException();


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Part of #6094

## Proposed changes

- Add missing unit tests to check the method behavior in these classes: UpDownButtonsAccessibleObject, DirectionButtonAccessibleObject, DomainUpDownAccessibleObject

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0.0-rc.2.22472.3
- Windows 11


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8036)