### PR TITLE
Fixed unit tests for "AccessibleObject.FragmentNavigate" method in ListViewItem-related classes

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemAccessibleObjectTests.cs
@@ -125,7 +125,7 @@ namespace System.Windows.Forms.Tests
                     foreach (bool virtualMode in new[] { true, false })
                     {
                         // View.Tile is not supported by ListView in virtual mode
-                        if (view == View.Tile)
+                        if (view == View.Tile && virtualMode)
                         {
                             continue;
                         }
@@ -177,7 +177,7 @@ namespace System.Windows.Forms.Tests
                 foreach (bool virtualMode in new[] { true, false })
                 {
                     // View.Tile is not supported by ListView in virtual mode
-                    if (view == View.Tile)
+                    if (view == View.Tile && virtualMode)
                     {
                         continue;
                     }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemBaseAccessibleObjectTests.cs
@@ -398,5 +398,7 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, accessibleObject.GetPropertyValue(UiaCore.UIA.AutomationIdPropertyId));
             Assert.False(listView.IsHandleCreated);
         }
+
+        // More tests for this class has been created already in ListViewItem_ListViewItemAccessibleObjectTests
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemListAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListViewItem.ListViewItemListAccessibleObjectTests.cs
@@ -83,5 +83,7 @@ namespace System.Windows.Forms.Tests
 
             Assert.True(control.IsHandleCreated);
         }
+
+        // More tests for this class has been created already in ListViewItem_ListViewItemAccessibleObjectTests
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Part of https://github.com/dotnet/winforms/issues/6094


## Proposed changes

- Fixed tests for ListView in virtual mode
- Added comments on related test cases code location


## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0.0-rc.2.22472.3
- Windows 11


<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8037)