### PR TITLE
Added unit tests for "AccessibleObject.FragmentNavigate" method in MonthCalendar-related classes

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarAccessibleObjectTests.cs
@@ -315,5 +315,125 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(AccessibleStates.None, calendar.State);
             Assert.False(control.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void CalendarAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarAccessibleObject calendar = new(controlAccessibleObject, 0, "");
+
+            Assert.Equal(controlAccessibleObject, calendar.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfSingleMonthView()
+        {
+            using MonthCalendar control = new();
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            CalendarAccessibleObject calendar = controlAccessibleObject.CalendarsAccessibleObjects?.First?.Value;
+
+            Assert.NotNull(calendar);
+            Assert.Equal(controlAccessibleObject.TodayLinkAccessibleObject, calendar.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+        }
+
+        [WinFormsFact]
+        public void CalendarAccessibleObject_FragmentNavigate_NextSibling_ReturnsExpected_IfMultiMonthView()
+        {
+            using MonthCalendar control = new()
+            {
+                CalendarDimensions = new Size { Width = 2, Height = 2 }
+            };
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            LinkedList<CalendarAccessibleObject> calendars = controlAccessibleObject.CalendarsAccessibleObjects;
+            CalendarAccessibleObject calendar1 = calendars?.First?.Value;
+            CalendarAccessibleObject calendar2 = calendars?.First?.Next?.Value;
+            CalendarAccessibleObject calendar3 = calendars?.First?.Next?.Next?.Value;
+            CalendarAccessibleObject calendar4 = calendars?.First?.Next?.Next?.Next?.Value;
+
+            Assert.NotNull(calendar1);
+            Assert.NotNull(calendar2);
+            Assert.NotNull(calendar3);
+            Assert.NotNull(calendar4);
+
+            Assert.Equal(calendar2, calendar1.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(calendar3, calendar2.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(calendar4, calendar3.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(controlAccessibleObject.TodayLinkAccessibleObject, calendar4.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+        }
+
+        [WinFormsFact]
+        public void CalendarAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected_IfSingleMonthView()
+        {
+            using MonthCalendar control = new();
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            CalendarAccessibleObject calendar = controlAccessibleObject.CalendarsAccessibleObjects?.First?.Value;
+
+            Assert.NotNull(calendar);
+            Assert.Equal(controlAccessibleObject.NextButtonAccessibleObject, calendar.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+        }
+
+        [WinFormsFact]
+        public void CalendarAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected_IfMultiMonthView()
+        {
+            using MonthCalendar control = new()
+            {
+                CalendarDimensions = new Size { Width = 2, Height = 2 }
+            };
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            LinkedList<CalendarAccessibleObject> calendars = controlAccessibleObject.CalendarsAccessibleObjects;
+            CalendarAccessibleObject calendar1 = calendars?.First?.Value;
+            CalendarAccessibleObject calendar2 = calendars?.First?.Next?.Value;
+            CalendarAccessibleObject calendar3 = calendars?.First?.Next?.Next?.Value;
+            CalendarAccessibleObject calendar4 = calendars?.First?.Next?.Next?.Next?.Value;
+
+            Assert.NotNull(calendar1);
+            Assert.NotNull(calendar2);
+            Assert.NotNull(calendar3);
+            Assert.NotNull(calendar4);
+
+            Assert.Equal(controlAccessibleObject.NextButtonAccessibleObject, calendar1.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(calendar1, calendar2.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(calendar2, calendar3.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(calendar3, calendar4.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+        }
+
+        [WinFormsFact]
+        public void CalendarAccessibleObject_FragmentNavigate_FirstChild_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarAccessibleObject calendar = new(controlAccessibleObject, 0, "");
+
+            Assert.Equal(calendar.CalendarHeaderAccessibleObject, calendar.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarAccessibleObject_FragmentNavigate_LastChild_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarAccessibleObject calendar = new(controlAccessibleObject, 0, "");
+
+            Assert.Equal(calendar.CalendarBodyAccessibleObject, calendar.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarBodyAccessibleObjectTests.cs
@@ -188,6 +188,56 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void CalendarBodyAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarAccessibleObject calendar = new(controlAccessibleObject, 0, "Test name");
+            CalendarBodyAccessibleObject calendarBody = new(calendar, controlAccessibleObject, 0);
+
+            Assert.Equal(calendar, calendarBody.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarBodyAccessibleObject_FragmentNavigate_NextSibling_ReturnsNull()
+        {
+            using MonthCalendar control = new();
+            CalendarBodyAccessibleObject accessibleObject = CreateCalendarBodyAccessibleObject(control, 0);
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarBodyAccessibleObject_FragmentNavigate_PreviousSibling_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarAccessibleObject calendar = new(controlAccessibleObject, 0, "Test name");
+            CalendarBodyAccessibleObject calendarBody = new(calendar, controlAccessibleObject, 0);
+
+            AccessibleObject expected = calendar.CalendarHeaderAccessibleObject;
+
+            Assert.Equal(expected, calendarBody.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarBodyAccessibleObject_FragmentNavigate_Child_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            CalendarBodyAccessibleObject accessibleObject = CreateCalendarBodyAccessibleObject(control, 0);
+
+            AccessibleObject firstRow = accessibleObject.RowsAccessibleObjects?.First();
+            AccessibleObject lastRow = accessibleObject.RowsAccessibleObjects?.Last();
+
+            Assert.Equal(firstRow, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(lastRow, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
         private CalendarBodyAccessibleObject CreateCalendarBodyAccessibleObject(MonthCalendar control, int calendarIndex = 0)
         {
             MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarDayOfWeekCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarDayOfWeekCellAccessibleObjectTests.cs
@@ -101,6 +101,106 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void CalendarDayOfWeekCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarAccessibleObject calendar = new(controlAccessibleObject, 0, "");
+            CalendarBodyAccessibleObject body = new(calendar, controlAccessibleObject, 0);
+            CalendarRowAccessibleObject row = new(body, controlAccessibleObject, 0, 0);
+            CalendarDayOfWeekCellAccessibleObject cell = new(row, body, controlAccessibleObject, 0, 0, 0, "");
+
+            Assert.Equal(row, cell.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarDayOfWeekCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
+        {
+            using MonthCalendar control = new()
+            {
+                SelectionStart = new DateTime(2022, 10, 1) // Set a date to have a stable test case
+            };
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            CalendarAccessibleObject calendar = controlAccessibleObject.CalendarsAccessibleObjects.First?.Value;
+            Assert.NotNull(calendar);
+
+            CalendarBodyAccessibleObject body = calendar.CalendarBodyAccessibleObject;
+            Assert.NotNull(body);
+
+            CalendarRowAccessibleObject daysOfWeekRow = body.RowsAccessibleObjects?.First?.Value;
+            Assert.NotNull(daysOfWeekRow);
+
+            LinkedList<CalendarCellAccessibleObject> days = daysOfWeekRow.CellsAccessibleObjects;
+            CalendarDayOfWeekCellAccessibleObject sunday = days?.First?.Value as CalendarDayOfWeekCellAccessibleObject;
+            CalendarDayOfWeekCellAccessibleObject monday = days?.First?.Next?.Value as CalendarDayOfWeekCellAccessibleObject;
+            CalendarDayOfWeekCellAccessibleObject tuesday = days?.First?.Next?.Next?.Value as CalendarDayOfWeekCellAccessibleObject;
+            CalendarDayOfWeekCellAccessibleObject friday = days?.Last?.Previous?.Value as CalendarDayOfWeekCellAccessibleObject;
+            CalendarDayOfWeekCellAccessibleObject saturday = days?.Last?.Value as CalendarDayOfWeekCellAccessibleObject;
+
+            Assert.NotNull(sunday);
+            Assert.NotNull(monday);
+            Assert.NotNull(tuesday);
+            Assert.NotNull(friday);
+            Assert.NotNull(saturday);
+
+            Assert.Null(sunday.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(monday, sunday.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(sunday, monday.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(tuesday, monday.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+
+            Assert.Equal(friday, saturday.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(saturday.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+        }
+
+        [WinFormsFact]
+        public void CalendarDayOfWeekCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfWeekNumbersVisible()
+        {
+            using MonthCalendar control = new()
+            {
+                ShowWeekNumbers = true,
+                SelectionStart = new DateTime(2022, 10, 1) // Set a date to have a stable test case
+            };
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            CalendarAccessibleObject calendar = controlAccessibleObject.CalendarsAccessibleObjects.First?.Value;
+            Assert.NotNull(calendar);
+
+            CalendarBodyAccessibleObject body = calendar.CalendarBodyAccessibleObject;
+            Assert.NotNull(body);
+
+            CalendarRowAccessibleObject daysOfWeekRow = body.RowsAccessibleObjects?.First?.Value;
+            Assert.NotNull(daysOfWeekRow);
+
+            LinkedList<CalendarCellAccessibleObject> days = daysOfWeekRow.CellsAccessibleObjects;
+            CalendarDayOfWeekCellAccessibleObject sunday = days?.First?.Value as CalendarDayOfWeekCellAccessibleObject;
+            CalendarDayOfWeekCellAccessibleObject monday = days?.First?.Next?.Value as CalendarDayOfWeekCellAccessibleObject;
+
+            Assert.NotNull(sunday);
+            Assert.NotNull(monday);
+
+            Assert.Null(sunday.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(monday, sunday.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+        }
+
+        [WinFormsFact]
+        public void CalendarDayOfWeekCellAccessibleObject_FragmentNavigate_Child_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            CalendarDayOfWeekCellAccessibleObject cell = CreateCalendarDayOfWeekCellCellAccessibleObject(control, 0, 0, 0);
+
+            Assert.Null(cell.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(cell.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
         private CalendarDayOfWeekCellAccessibleObject CreateCalendarDayOfWeekCellCellAccessibleObject(MonthCalendar control, int calendarIndex = 0, int rowIndex = 0, int columnIndex = 0)
         {
             MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarHeaderAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarHeaderAccessibleObjectTests.cs
@@ -72,6 +72,42 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void CalendarHeaderAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarAccessibleObject calendar = new(controlAccessibleObject, 0, "");
+            CalendarHeaderAccessibleObject header = new(calendar, controlAccessibleObject, 0);
+
+            Assert.Equal(calendar, header.FragmentNavigate(Interop.UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarHeaderAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarAccessibleObject calendar = new(controlAccessibleObject, 0, "");
+            CalendarHeaderAccessibleObject header = new(calendar, controlAccessibleObject, 0);
+
+            Assert.Equal(calendar.CalendarBodyAccessibleObject, header.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            Assert.Null(header.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarHeaderAccessibleObject_FragmentNavigate_Child_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            CalendarHeaderAccessibleObject header = CreateCalendarHeaderAccessibleObject(control, 0);
+
+            Assert.Null(header.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(header.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
         private CalendarHeaderAccessibleObject CreateCalendarHeaderAccessibleObject(MonthCalendar control, int calendarIndex = 0)
         {
             MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarNextButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarNextButtonAccessibleObjectTests.cs
@@ -58,5 +58,43 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(SR.MonthCalendarNextButtonAccessibleName, actual);
             Assert.False(control.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void CalendarNextButtonAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = new(control);
+            CalendarNextButtonAccessibleObject nextButton = new(controlAccessibleObject);
+
+            Assert.Equal(controlAccessibleObject, nextButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarNextButtonAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = new(control);
+            CalendarNextButtonAccessibleObject nextButton = new(controlAccessibleObject);
+
+            AccessibleObject previousButton = controlAccessibleObject.PreviousButtonAccessibleObject;
+            AccessibleObject firstCalendar = controlAccessibleObject.CalendarsAccessibleObjects?.First?.Value;
+
+            Assert.Equal(previousButton, nextButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(firstCalendar, nextButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarNextButtonAccessibleObject_FragmentNavigate_Child_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = new(control);
+            CalendarNextButtonAccessibleObject nextButton = new(controlAccessibleObject);
+
+            Assert.Null(nextButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(nextButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarPreviousButtonAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarPreviousButtonAccessibleObjectTests.cs
@@ -58,5 +58,42 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(SR.MonthCalendarPreviousButtonAccessibleName, actual);
             Assert.False(control.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void CalendarPreviousButtonAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = new(control);
+            CalendarPreviousButtonAccessibleObject prevButton = new(controlAccessibleObject);
+
+            Assert.Equal(controlAccessibleObject, prevButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarPreviousButtonAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = new(control);
+            CalendarPreviousButtonAccessibleObject prevButton = new(controlAccessibleObject);
+
+            AccessibleObject nextButton = controlAccessibleObject.NextButtonAccessibleObject;
+
+            Assert.Null(prevButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(nextButton, prevButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarPreviousButtonAccessibleObject_FragmentNavigate_Child_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = new(control);
+            CalendarPreviousButtonAccessibleObject prevButton = new(controlAccessibleObject);
+
+            Assert.Null(prevButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(prevButton.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarRowAccessibleObjectTests.cs
@@ -104,6 +104,102 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void CalendarRowAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarAccessibleObject calendar = new(controlAccessibleObject, 0, "");
+            CalendarBodyAccessibleObject body = new(calendar, controlAccessibleObject, 0);
+            CalendarRowAccessibleObject row = new(body, controlAccessibleObject, 0, 2);
+
+            Assert.Equal(body, row.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarRowAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            CalendarAccessibleObject calendar = controlAccessibleObject.CalendarsAccessibleObjects.First?.Value;
+            Assert.NotNull(calendar);
+
+            CalendarBodyAccessibleObject body = calendar.CalendarBodyAccessibleObject;
+            Assert.NotNull(body);
+
+            CalendarRowAccessibleObject daysOfWeekRow = body.RowsAccessibleObjects?.First?.Value;
+            Assert.NotNull(daysOfWeekRow);
+
+            CalendarRowAccessibleObject firstWeek = body.RowsAccessibleObjects?.First?.Next?.Value;
+            Assert.NotNull(firstWeek);
+
+            CalendarRowAccessibleObject secondWeek = body.RowsAccessibleObjects?.First?.Next?.Next?.Value;
+            Assert.NotNull(secondWeek);
+
+            CalendarRowAccessibleObject thirdWeek = body.RowsAccessibleObjects?.First?.Next?.Next?.Next?.Value;
+            Assert.NotNull(thirdWeek);
+
+            Assert.Null(daysOfWeekRow.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(daysOfWeekRow, firstWeek.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(firstWeek, secondWeek.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+
+            Assert.Equal(firstWeek, daysOfWeekRow.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(secondWeek, firstWeek.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+            Assert.Equal(thirdWeek, secondWeek.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+        }
+
+        [WinFormsFact]
+        public void CalendarRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            CalendarAccessibleObject calendar = controlAccessibleObject.CalendarsAccessibleObjects.First?.Value;
+            Assert.NotNull(calendar);
+
+            CalendarBodyAccessibleObject body = calendar.CalendarBodyAccessibleObject;
+            Assert.NotNull(body);
+
+            CalendarRowAccessibleObject firstWeek = body.RowsAccessibleObjects?.First?.Next?.Value;
+            Assert.NotNull(firstWeek);
+
+            CalendarCellAccessibleObject sunday = firstWeek.CellsAccessibleObjects?.First?.Value;
+            CalendarCellAccessibleObject saturday = firstWeek.CellsAccessibleObjects?.Last?.Value;
+
+            Assert.Equal(sunday, firstWeek.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(saturday, firstWeek.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+        }
+
+        [WinFormsFact]
+        public void CalendarRowAccessibleObject_FragmentNavigate_Child_ReturnsExpected_IfWeekNumbersVisible()
+        {
+            using MonthCalendar control = new() { ShowWeekNumbers = true };
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            CalendarAccessibleObject calendar = controlAccessibleObject.CalendarsAccessibleObjects.First?.Value;
+            Assert.NotNull(calendar);
+
+            CalendarBodyAccessibleObject body = calendar.CalendarBodyAccessibleObject;
+            Assert.NotNull(body);
+
+            CalendarRowAccessibleObject firstWeek = body.RowsAccessibleObjects?.First?.Next?.Value;
+            Assert.NotNull(firstWeek);
+
+            CalendarWeekNumberCellAccessibleObject weekNumber = firstWeek.WeekNumberCellAccessibleObject;
+            CalendarCellAccessibleObject saturday = firstWeek.CellsAccessibleObjects?.Last?.Value;
+
+            Assert.Equal(weekNumber, firstWeek.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Equal(saturday, firstWeek.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+        }
+
         private CalendarRowAccessibleObject CreateCalendarRowAccessibleObject(MonthCalendar control, int calendarIndex = 0, int rowIndex = 0)
         {
             MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarTodayLinkAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarTodayLinkAccessibleObjectTests.cs
@@ -78,5 +78,42 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected, actual);
             Assert.False(control.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void CalendarTodayLinkAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = new(control);
+            CalendarTodayLinkAccessibleObject todayLink = new(controlAccessibleObject);
+
+            Assert.Equal(controlAccessibleObject, todayLink.FragmentNavigate(Interop.UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarTodayLinkAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = new(control);
+            CalendarTodayLinkAccessibleObject todayLink = new(controlAccessibleObject);
+
+            AccessibleObject lastCalendar = controlAccessibleObject.CalendarsAccessibleObjects?.Last?.Value;
+
+            Assert.Equal(lastCalendar, todayLink.FragmentNavigate(Interop.UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(todayLink.FragmentNavigate(Interop.UiaCore.NavigateDirection.NextSibling));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarTodayLinkAccessibleObject_FragmentNavigate_Child_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            MonthCalendarAccessibleObject controlAccessibleObject = new(control);
+            CalendarTodayLinkAccessibleObject todayLink = new(controlAccessibleObject);
+
+            Assert.Null(todayLink.FragmentNavigate(Interop.UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(todayLink.FragmentNavigate(Interop.UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
     }
 }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarWeekNumberCellAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.CalendarWeekNumberCellAccessibleObjectTests.cs
@@ -112,6 +112,92 @@ namespace System.Windows.Forms.Tests
             Assert.False(control.IsHandleCreated);
         }
 
+        [WinFormsFact]
+        public void CalendarWeekNumberCellAccessibleObject_FragmentNavigate_Parent_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+            CalendarAccessibleObject calendar = new(controlAccessibleObject, 0, "");
+            CalendarBodyAccessibleObject body = new(calendar, controlAccessibleObject, 0);
+            CalendarRowAccessibleObject row = new(body, controlAccessibleObject, 0, 0);
+            CalendarWeekNumberCellAccessibleObject cell = new(row, body, controlAccessibleObject, 0, 0, 0, "");
+
+            Assert.Equal(row, cell.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+            Assert.False(control.IsHandleCreated);
+        }
+
+        [WinFormsFact]
+        public void CalendarWeekNumberCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected()
+        {
+            using MonthCalendar control = new()
+            {
+                ShowWeekNumbers = true
+            };
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            CalendarAccessibleObject calendar = controlAccessibleObject.CalendarsAccessibleObjects.First?.Value;
+            Assert.NotNull(calendar);
+
+            CalendarBodyAccessibleObject body = calendar.CalendarBodyAccessibleObject;
+            Assert.NotNull(body);
+
+            CalendarRowAccessibleObject secondRow = body.RowsAccessibleObjects?.First?.Next?.Next.Value;
+            Assert.NotNull(secondRow);
+
+            CalendarWeekNumberCellAccessibleObject weekNumber = secondRow.WeekNumberCellAccessibleObject;
+            CalendarCellAccessibleObject sunday = secondRow.CellsAccessibleObjects?.First?.Value as CalendarCellAccessibleObject;
+
+            Assert.NotNull(weekNumber);
+            Assert.NotNull(sunday);
+
+            Assert.Null(weekNumber.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(sunday, weekNumber.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+        }
+
+        [WinFormsFact]
+        public void CalendarWeekNumberCellAccessibleObject_FragmentNavigate_Sibling_ReturnsExpected_IfWeekNumbersVisible()
+        {
+            using MonthCalendar control = new()
+            {
+                ShowWeekNumbers = true,
+                SelectionStart = new DateTime(2022, 10, 1) // Set a date to have a stable test case
+            };
+            control.CreateControl();
+
+            var controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;
+
+            CalendarAccessibleObject calendar = controlAccessibleObject.CalendarsAccessibleObjects.First?.Value;
+            Assert.NotNull(calendar);
+
+            CalendarBodyAccessibleObject body = calendar.CalendarBodyAccessibleObject;
+            Assert.NotNull(body);
+
+            CalendarRowAccessibleObject daysOfWeekRow = body.RowsAccessibleObjects?.First?.Value;
+            Assert.NotNull(daysOfWeekRow);
+
+            CalendarCellAccessibleObject sunday = daysOfWeekRow.CellsAccessibleObjects?.First?.Value;
+            CalendarCellAccessibleObject monday = daysOfWeekRow.CellsAccessibleObjects?.First?.Next?.Value;
+
+            Assert.NotNull(sunday);
+            Assert.NotNull(monday);
+
+            Assert.Null(sunday.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Equal(monday, sunday.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+        }
+
+        [WinFormsFact]
+        public void CalendarWeekNumberCellAccessibleObject_FragmentNavigate_Child_ReturnsExpected()
+        {
+            using MonthCalendar control = new();
+            CalendarWeekNumberCellAccessibleObject cell = CreateCalendarWeekNumberCellAccessibleObject(control, 0, 0, 0);
+
+            Assert.Null(cell.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+            Assert.Null(cell.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+            Assert.False(control.IsHandleCreated);
+        }
+
         private CalendarWeekNumberCellAccessibleObject CreateCalendarWeekNumberCellAccessibleObject(MonthCalendar control, int calendarIndex = 0, int rowIndex = 0, int columnIndex = 0)
         {
             MonthCalendarAccessibleObject controlAccessibleObject = (MonthCalendarAccessibleObject)control.AccessibilityObject;

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObjectTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/MonthCalendar.MonthCalendarAccessibleObjectTests.cs
@@ -225,5 +225,57 @@ namespace System.Windows.Forms.Tests
             Assert.Equal(expected.End, actual.End);
             Assert.True(monthCalendar.IsHandleCreated);
         }
+
+        [WinFormsFact]
+        public void MonthCalendarAccessibleObject_FragmentNavigate_Parent_Returns_Expected()
+        {
+            using MonthCalendar monthCalendar = new();
+            MonthCalendarAccessibleObject accessibleObject = new(monthCalendar);
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.Parent));
+        }
+
+        [WinFormsFact]
+        public void MonthCalendarAccessibleObject_FragmentNavigate_Sibling_Returns_Expected()
+        {
+            using MonthCalendar monthCalendar = new();
+            MonthCalendarAccessibleObject accessibleObject = new(monthCalendar);
+
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.PreviousSibling));
+            Assert.Null(accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.NextSibling));
+        }
+
+        [WinFormsFact]
+        public void MonthCalendarAccessibleObject_FragmentNavigate_FirstChild_Returns_Expected()
+        {
+            using MonthCalendar monthCalendar = new();
+            var accessibleObject = new MonthCalendarAccessibleObject(monthCalendar);
+
+            AccessibleObject previousButton = accessibleObject.PreviousButtonAccessibleObject;
+
+            Assert.Equal(previousButton, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.FirstChild));
+        }
+
+        [WinFormsFact]
+        public void MonthCalendarAccessibleObject_FragmentNavigate_LastChild_Returns_Expected()
+        {
+            using MonthCalendar monthCalendar = new();
+            var accessibleObject = new MonthCalendarAccessibleObject(monthCalendar);
+
+            AccessibleObject todayLink = accessibleObject.TodayLinkAccessibleObject;
+
+            Assert.Equal(todayLink, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+        }
+
+        [WinFormsFact]
+        public void MonthCalendarAccessibleObject_FragmentNavigate_LastChild_Returns_Expected_IfTodayLinkHidden()
+        {
+            using MonthCalendar monthCalendar = new() { ShowToday = false };
+            var accessibleObject = new MonthCalendarAccessibleObject(monthCalendar);
+
+            AccessibleObject lastCalendar = accessibleObject.CalendarsAccessibleObjects?.Last?.Value;
+
+            Assert.Equal(lastCalendar, accessibleObject.FragmentNavigate(UiaCore.NavigateDirection.LastChild));
+        }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Part of https://github.com/dotnet/winforms/issues/6094


## Proposed changes

Added missing unit tests to check the method behavior in these classes:
- MonthCalendarAccessibleObject
- CalendarAccessibleObject
- CalendarPreviousButtonAccessibleObject
- CalendarNextButtonAccessibleObject
- CalendarTodayLinkAccessibleObject
- CalendarBodyAccessibleObject
- CalendarHeaderAccessibleObject
- CalendarDayOfWeekCellAccessibleObject
- CalendarWeekNumberCellAccessibleObject
- CalendarRowAccessibleObject
- CalendarCellAccessibleObject



## Test environment(s) <!-- Remove any that don't apply -->

- .NET 7.0.0-rc.1.22426.10
- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8039)