### PR TITLE
Enable nullability in ToolStripSplitButton

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -536,13 +536,13 @@ override System.Windows.Forms.ToolStripProgressBar.Text.set -> void
 ~override System.Windows.Forms.ToolStripSeparator.OnPaint(System.Windows.Forms.PaintEventArgs e) -> void
 ~override System.Windows.Forms.ToolStripSeparator.Text.get -> string
 ~override System.Windows.Forms.ToolStripSeparator.Text.set -> void
-~override System.Windows.Forms.ToolStripSplitButton.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject
-~override System.Windows.Forms.ToolStripSplitButton.CreateDefaultDropDown() -> System.Windows.Forms.ToolStripDropDown
-~override System.Windows.Forms.ToolStripSplitButton.OnMouseDown(System.Windows.Forms.MouseEventArgs e) -> void
-~override System.Windows.Forms.ToolStripSplitButton.OnMouseLeave(System.EventArgs e) -> void
-~override System.Windows.Forms.ToolStripSplitButton.OnMouseUp(System.Windows.Forms.MouseEventArgs e) -> void
-~override System.Windows.Forms.ToolStripSplitButton.OnPaint(System.Windows.Forms.PaintEventArgs e) -> void
-~override System.Windows.Forms.ToolStripSplitButton.OnRightToLeftChanged(System.EventArgs e) -> void
+override System.Windows.Forms.ToolStripSplitButton.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
+override System.Windows.Forms.ToolStripSplitButton.CreateDefaultDropDown() -> System.Windows.Forms.ToolStripDropDown!
+override System.Windows.Forms.ToolStripSplitButton.OnMouseDown(System.Windows.Forms.MouseEventArgs! e) -> void
+override System.Windows.Forms.ToolStripSplitButton.OnMouseLeave(System.EventArgs! e) -> void
+override System.Windows.Forms.ToolStripSplitButton.OnMouseUp(System.Windows.Forms.MouseEventArgs! e) -> void
+override System.Windows.Forms.ToolStripSplitButton.OnPaint(System.Windows.Forms.PaintEventArgs! e) -> void
+override System.Windows.Forms.ToolStripSplitButton.OnRightToLeftChanged(System.EventArgs! e) -> void
 override System.Windows.Forms.ToolStripStatusLabel.CreateAccessibilityInstance() -> System.Windows.Forms.AccessibleObject!
 override System.Windows.Forms.ToolStripStatusLabel.OnPaint(System.Windows.Forms.PaintEventArgs! e) -> void
 override System.Windows.Forms.ToolStripStatusLabel.OnTextChanged(System.EventArgs! e) -> void
@@ -1531,14 +1531,14 @@ System.Windows.Forms.ToolStripProgressBar.ToolStripProgressBar(string? name) -> 
 ~System.Windows.Forms.ToolStripSeparator.ImageKey.set -> void
 ~System.Windows.Forms.ToolStripSeparator.ToolTipText.get -> string
 ~System.Windows.Forms.ToolStripSeparator.ToolTipText.set -> void
-~System.Windows.Forms.ToolStripSplitButton.DefaultItem.get -> System.Windows.Forms.ToolStripItem
-~System.Windows.Forms.ToolStripSplitButton.DefaultItem.set -> void
-~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string text) -> void
-~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string text, System.Drawing.Image image) -> void
-~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string text, System.Drawing.Image image, params System.Windows.Forms.ToolStripItem[] dropDownItems) -> void
-~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string text, System.Drawing.Image image, System.EventHandler onClick) -> void
-~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string text, System.Drawing.Image image, System.EventHandler onClick, string name) -> void
-~System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(System.Drawing.Image image) -> void
+System.Windows.Forms.ToolStripSplitButton.DefaultItem.get -> System.Windows.Forms.ToolStripItem?
+System.Windows.Forms.ToolStripSplitButton.DefaultItem.set -> void
+System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string? text) -> void
+System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string? text, System.Drawing.Image? image) -> void
+System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string? text, System.Drawing.Image? image, params System.Windows.Forms.ToolStripItem![]? dropDownItems) -> void
+System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string? text, System.Drawing.Image? image, System.EventHandler? onClick) -> void
+System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(string? text, System.Drawing.Image? image, System.EventHandler? onClick, string? name) -> void
+System.Windows.Forms.ToolStripSplitButton.ToolStripSplitButton(System.Drawing.Image? image) -> void
 System.Windows.Forms.ToolStripStatusLabel.ToolStripStatusLabel(string? text) -> void
 System.Windows.Forms.ToolStripStatusLabel.ToolStripStatusLabel(string? text, System.Drawing.Image? image) -> void
 System.Windows.Forms.ToolStripStatusLabel.ToolStripStatusLabel(string? text, System.Drawing.Image? image, System.EventHandler? onClick) -> void
@@ -2185,9 +2185,9 @@ virtual System.Windows.Forms.ToolStripComboBox.OnTextUpdate(System.EventArgs! e)
 ~virtual System.Windows.Forms.ToolStripPanelRow.OnControlRemoved(System.Windows.Forms.Control control, int index) -> void
 ~virtual System.Windows.Forms.ToolStripPanelRow.OnLayout(System.Windows.Forms.LayoutEventArgs e) -> void
 virtual System.Windows.Forms.ToolStripProgressBar.OnRightToLeftLayoutChanged(System.EventArgs! e) -> void
-~virtual System.Windows.Forms.ToolStripSplitButton.OnButtonClick(System.EventArgs e) -> void
-~virtual System.Windows.Forms.ToolStripSplitButton.OnButtonDoubleClick(System.EventArgs e) -> void
-~virtual System.Windows.Forms.ToolStripSplitButton.OnDefaultItemChanged(System.EventArgs e) -> void
+virtual System.Windows.Forms.ToolStripSplitButton.OnButtonClick(System.EventArgs! e) -> void
+virtual System.Windows.Forms.ToolStripSplitButton.OnButtonDoubleClick(System.EventArgs! e) -> void
+virtual System.Windows.Forms.ToolStripSplitButton.OnDefaultItemChanged(System.EventArgs! e) -> void
 virtual System.Windows.Forms.ToolStripTextBox.OnAcceptsTabChanged(System.EventArgs! e) -> void
 virtual System.Windows.Forms.ToolStripTextBox.OnBorderStyleChanged(System.EventArgs! e) -> void
 virtual System.Windows.Forms.ToolStripTextBox.OnHideSelectionChanged(System.EventArgs! e) -> void
@@ -11609,11 +11609,11 @@ System.Windows.Forms.ToolStripSplitButton
 System.Windows.Forms.ToolStripSplitButton.AutoToolTip.get -> bool
 System.Windows.Forms.ToolStripSplitButton.AutoToolTip.set -> void
 System.Windows.Forms.ToolStripSplitButton.ButtonBounds.get -> System.Drawing.Rectangle
-System.Windows.Forms.ToolStripSplitButton.ButtonClick -> System.EventHandler
-System.Windows.Forms.ToolStripSplitButton.ButtonDoubleClick -> System.EventHandler
+System.Windows.Forms.ToolStripSplitButton.ButtonClick -> System.EventHandler?
+System.Windows.Forms.ToolStripSplitButton.ButtonDoubleClick -> System.EventHandler?
 System.Windows.Forms.ToolStripSplitButton.ButtonPressed.get -> bool
 System.Windows.Forms.ToolStripSplitButton.ButtonSelected.get -> bool
-System.Windows.Forms.ToolStripSplitButton.DefaultItemChanged -> System.EventHandler
+System.Windows.Forms.ToolStripSplitButton.DefaultItemChanged -> System.EventHandler?
 System.Windows.Forms.ToolStripSplitButton.DropDownButtonBounds.get -> System.Drawing.Rectangle
 System.Windows.Forms.ToolStripSplitButton.DropDownButtonPressed.get -> bool
 System.Windows.Forms.ToolStripSplitButton.DropDownButtonSelected.get -> bool

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripSplitButton.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
@@ -16,10 +14,10 @@ namespace System.Windows.Forms
     [DefaultEvent(nameof(ButtonClick))]
     public partial class ToolStripSplitButton : ToolStripDropDownItem
     {
-        private ToolStripItem _defaultItem;
-        private ToolStripSplitButtonButton _splitButtonButton;
+        private ToolStripItem? _defaultItem;
+        private ToolStripSplitButtonButton? _splitButtonButton;
         private Rectangle _dropDownButtonBounds = Rectangle.Empty;
-        private ToolStripSplitButtonButtonLayout _splitButtonButtonLayout;
+        private ToolStripSplitButtonButtonLayout? _splitButtonButtonLayout;
         private int _dropDownButtonWidth;
         private int _splitterWidth = 1;
         private Rectangle _splitterBounds = Rectangle.Empty;
@@ -40,32 +38,38 @@ namespace System.Windows.Forms
             Initialize(); // all additional work should be done in Initialize
         }
 
-        public ToolStripSplitButton(string text) : base(text, null, (EventHandler)null)
+        public ToolStripSplitButton(string? text)
+            : base(text, image: null, onClick: null)
         {
             Initialize();
         }
 
-        public ToolStripSplitButton(Image image) : base(null, image, (EventHandler)null)
+        public ToolStripSplitButton(Image? image)
+            : base(text: null, image, onClick: null)
         {
             Initialize();
         }
 
-        public ToolStripSplitButton(string text, Image image) : base(text, image, (EventHandler)null)
+        public ToolStripSplitButton(string? text, Image? image)
+            : base(text, image, onClick: null)
         {
             Initialize();
         }
 
-        public ToolStripSplitButton(string text, Image image, EventHandler onClick) : base(text, image, onClick)
+        public ToolStripSplitButton(string? text, Image? image, EventHandler? onClick)
+            : base(text, image, onClick)
         {
             Initialize();
         }
 
-        public ToolStripSplitButton(string text, Image image, EventHandler onClick, string name) : base(text, image, onClick, name)
+        public ToolStripSplitButton(string? text, Image? image, EventHandler? onClick, string? name)
+            : base(text, image, onClick, name)
         {
             Initialize();
         }
 
-        public ToolStripSplitButton(string text, Image image, params ToolStripItem[] dropDownItems) : base(text, image, dropDownItems)
+        public ToolStripSplitButton(string? text, Image? image, params ToolStripItem[]? dropDownItems)
+            : base(text, image, dropDownItems)
         {
             Initialize();
         }
@@ -111,7 +115,7 @@ namespace System.Windows.Forms
         /// </summary>
         [SRCategory(nameof(SR.CatAction))]
         [SRDescription(nameof(SR.ToolStripSplitButtonOnButtonClickDescr))]
-        public event EventHandler ButtonClick
+        public event EventHandler? ButtonClick
         {
             add => Events.AddHandler(s_eventButtonClick, value);
             remove => Events.RemoveHandler(s_eventButtonClick, value);
@@ -122,7 +126,7 @@ namespace System.Windows.Forms
         /// </summary>
         [SRCategory(nameof(SR.CatAction))]
         [SRDescription(nameof(SR.ToolStripSplitButtonOnButtonDoubleClickDescr))]
-        public event EventHandler ButtonDoubleClick
+        public event EventHandler? ButtonDoubleClick
         {
             add => Events.AddHandler(s_eventButtonDoubleClick, value);
             remove => Events.RemoveHandler(s_eventButtonDoubleClick, value);
@@ -138,7 +142,7 @@ namespace System.Windows.Forms
 
         [DefaultValue(null)]
         [Browsable(false)]
-        public ToolStripItem DefaultItem
+        public ToolStripItem? DefaultItem
         {
             get
             {
@@ -159,7 +163,7 @@ namespace System.Windows.Forms
         /// </summary>
         [SRCategory(nameof(SR.CatAction))]
         [SRDescription(nameof(SR.ToolStripSplitButtonOnDefaultItemChangedDescr))]
-        public event EventHandler DefaultItemChanged
+        public event EventHandler? DefaultItemChanged
         {
             add => Events.AddHandler(s_eventDefaultItemChanged, value);
             remove => Events.RemoveHandler(s_eventDefaultItemChanged, value);
@@ -293,7 +297,7 @@ namespace System.Windows.Forms
                     _splitButtonButtonLayout = new ToolStripSplitButtonButtonLayout(this);
                 }
 
-                return _splitButtonButtonLayout;
+                return _splitButtonButtonLayout!;
             }
         }
 
@@ -380,7 +384,7 @@ namespace System.Windows.Forms
         protected override ToolStripDropDown CreateDefaultDropDown()
         {
             // AutoGenerate a ToolStrip DropDown - set the property so we hook events
-            return new ToolStripDropDownMenu(this, /*isAutoGenerated=*/true);
+            return new ToolStripDropDownMenu(this, isAutoGenerated: true);
         }
 
         private protected override ToolStripItemInternalLayout CreateInternalLayout()
@@ -434,7 +438,7 @@ namespace System.Windows.Forms
         protected virtual void OnButtonClick(EventArgs e)
         {
             DefaultItem?.FireEvent(ToolStripItemEventType.Click);
-            ((EventHandler)Events[s_eventButtonClick])?.Invoke(this, e);
+            ((EventHandler?)Events[s_eventButtonClick])?.Invoke(this, e);
         }
 
         /// <summary>
@@ -444,7 +448,7 @@ namespace System.Windows.Forms
         public virtual void OnButtonDoubleClick(EventArgs e)
         {
             DefaultItem?.FireEvent(ToolStripItemEventType.DoubleClick);
-            ((EventHandler)Events[s_eventButtonDoubleClick])?.Invoke(this, e);
+            ((EventHandler?)Events[s_eventButtonDoubleClick])?.Invoke(this, e);
         }
 
         /// <summary>
@@ -472,7 +476,7 @@ namespace System.Windows.Forms
                     {
                         Debug.Assert(ParentInternal is not null, "Parent is null here, not going to get accurate ID");
                         _openMouseId = (ParentInternal is null) ? (byte)0 : ParentInternal.GetMouseId();
-                        ShowDropDown(/*mousePress = */true);
+                        ShowDropDown(mousePush: true);
                     }
                 }
             }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripSplitButton.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8040)