### PR TITLE
Null annotate Com2Interop

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.IDispatch.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/OleAut32/Interop.IDispatch.cs
@@ -39,7 +39,7 @@ internal partial class Interop
                 PInvoke.LCID lcid,
                 DISPATCH_FLAGS dwFlags,
                 DISPPARAMS* pDispParams,
-                [Out, MarshalAs(UnmanagedType.LPArray)] object[] pVarResult,
+                [Out, MarshalAs(UnmanagedType.LPArray)] object[]? pVarResult,
                 EXCEPINFO* pExcepInfo,
                 uint* pArgErr);
         }

--- a/src/System.Windows.Forms.Primitives/src/Interop/VSSDK/Interop.IVsPerPropertyBrowsing.cs
+++ b/src/System.Windows.Forms.Primitives/src/Interop/VSSDK/Interop.IVsPerPropertyBrowsing.cs
@@ -68,7 +68,7 @@ internal partial class Interop
             /// </summary>
             [PreserveSig]
             HRESULT GetClassName(
-                ref string pbstrClassName);
+                ref string? pbstrClassName);
 
             /// <summary>
             ///  Checks whether the given property can be reset to some default value.

--- a/src/System.Windows.Forms.Primitives/src/System/CharacterConstants.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/CharacterConstants.cs
@@ -1,0 +1,11 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    internal static class CharacterConstants
+    {
+        public static ReadOnlySpan<char> NewLine => new char[] { '\n', '\r' };
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2AboutBoxPropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2AboutBoxPropertyDescriptor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Design;
@@ -14,11 +12,12 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     internal partial class Com2AboutBoxPropertyDescriptor : Com2PropertyDescriptor
     {
-        private TypeConverter _converter;
-        private UITypeEditor _editor;
+        private TypeConverter? _converter;
+        private UITypeEditor? _editor;
 
         public Com2AboutBoxPropertyDescriptor()
-            : base(Ole32.DispatchID.ABOUTBOX, "About",
+            : base(
+                  Ole32.DispatchID.ABOUTBOX, "About",
                   new Attribute[]
                   {
                       new DispIdAttribute((int)Ole32.DispatchID.ABOUTBOX),
@@ -26,7 +25,10 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                       new DescriptionAttribute(SR.AboutBoxDesc),
                       new ParenthesizePropertyNameAttribute(true)
                   },
-                  true, typeof(string), null, false)
+                  readOnly: true,
+                  typeof(string),
+                  typeData: null,
+                  hrHidden: false)
         {
         }
 
@@ -45,7 +47,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         public override bool CanResetValue(object component) => false;
 
         [RequiresUnreferencedCode($"{TrimmingConstants.EditorRequiresUnreferencedCode} {TrimmingConstants.PropertyDescriptorPropertyTypeMessage}")]
-        public override object GetEditor(Type editorBaseType)
+        public override object? GetEditor(Type editorBaseType)
         {
             if (editorBaseType == typeof(UITypeEditor))
             {
@@ -55,13 +57,13 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             return _editor;
         }
 
-        public override object GetValue(object component) => string.Empty;
+        public override object? GetValue(object? component) => string.Empty;
 
-        public override void ResetValue(object component)
+        public override void ResetValue(object? component)
         {
         }
 
-        public override void SetValue(object component, object value) => throw new ArgumentException();
+        public override void SetValue(object? component, object? value) => throw new ArgumentException();
 
         public override bool ShouldSerializeValue(object component) => false;
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ComponentEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ComponentEditor.cs
@@ -13,11 +13,11 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     internal class Com2ComponentEditor : WindowsFormsComponentEditor
     {
-        public static unsafe bool NeedsComponentEditor(object obj)
+        public static unsafe bool NeedsComponentEditor(object comObject)
         {
-            if (obj is IPerPropertyBrowsing.Interface perPropertyBrowsing)
+            if (comObject is IPerPropertyBrowsing.Interface perPropertyBrowsing)
             {
-                // Check for a property page
+                // Check for a property page.
                 Guid guid = Guid.Empty;
                 HRESULT hr = perPropertyBrowsing.MapPropertyToPage((int)DispatchID.MEMBERID_NIL, &guid);
                 if (hr.Succeeded && !guid.Equals(Guid.Empty))
@@ -26,9 +26,9 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 }
             }
 
-            if (obj is ISpecifyPropertyPages ispp)
+            if (comObject is ISpecifyPropertyPages ispp)
             {
-                var uuids = default(CAUUID);
+                CAUUID uuids = default;
                 try
                 {
                     HRESULT hr = ispp.GetPages(&uuids);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedBrowsingHandler.cs
@@ -40,6 +40,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  Called to setup the property handlers on a given property. In this method, the handler will add listeners
         ///  to the events that the <see cref="Com2PropertyDescriptor"/> surfaces that it cares about.
         /// </summary>
-        public abstract void SetupPropertyHandlers(Com2PropertyDescriptor[]? propDesc);
+        public abstract void SetupPropertyHandlers(Com2PropertyDescriptor[]? properties);
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedTypeConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedTypeConverter.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             _innerConverter = innerConverter;
         }
 
-        public Com2ExtendedTypeConverter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]Type baseType)
+        public Com2ExtendedTypeConverter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type baseType)
         {
             _innerConverter = TypeDescriptor.GetConverter(baseType);
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ExtendedUITypeEditor.cs
@@ -14,12 +14,12 @@ namespace System.Drawing.Design
     {
         private readonly UITypeEditor? _innerEditor;
 
-        public Com2ExtendedUITypeEditor(UITypeEditor baseTypeEditor)
+        public Com2ExtendedUITypeEditor(UITypeEditor? baseTypeEditor)
         {
             _innerEditor = baseTypeEditor;
         }
 
-        public Com2ExtendedUITypeEditor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]Type baseType)
+        public Com2ExtendedUITypeEditor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type baseType)
         {
             _innerEditor = (UITypeEditor?)TypeDescriptor.GetEditor(baseType, typeof(UITypeEditor));
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2FontConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2FontConverter.cs
@@ -67,9 +67,8 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
 
             _lastFont = (Font)managedValue;
-            IFont nativeFont = (IFont)pd.GetNativeValue(pd.TargetObject);
 
-            if (nativeFont is not null)
+            if (pd.GetNativeValue(pd.TargetObject) is IFont nativeFont)
             {
                 bool changed = ControlPaint.FontToIFont(_lastFont, nativeFont);
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ICategorizePropertiesHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2ICategorizePropertiesHandler.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
     {
         public override Type Interface => typeof(VSSDK.ICategorizeProperties);
 
-        private static unsafe string? GetCategoryFromObject(object obj, Ole32.DispatchID dispid)
+        private static unsafe string? GetCategoryFromObject(object? obj, Ole32.DispatchID dispid)
         {
             if (obj is not VSSDK.ICategorizeProperties catObj)
             {
@@ -50,12 +50,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     return SR.PropertyCategoryDDE;
             }
 
-            if (catObj.GetCategoryName(categoryID, PInvoke.GetThreadLocale(), out string categoryName) == HRESULT.S_OK)
-            {
-                return categoryName;
-            }
-
-            return null;
+            return catObj.GetCategoryName(categoryID, PInvoke.GetThreadLocale(), out string categoryName).Succeeded ? categoryName : null;
         }
 
         public override void SetupPropertyHandlers(Com2PropertyDescriptor[]? propDesc)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IDispatchConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IDispatchConverter.cs
@@ -17,14 +17,15 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
         private readonly bool _allowExpand;
 
-        public Com2IDispatchConverter(bool allowExpand, TypeConverter baseConverter)
+        public Com2IDispatchConverter(bool allowExpand, TypeConverter? baseConverter)
             : base(baseConverter)
         {
             _allowExpand = allowExpand;
         }
 
-        public Com2IDispatchConverter(Com2PropertyDescriptor propDesc, bool allowExpand)
-            : base(propDesc.PropertyType)
+        public Com2IDispatchConverter(Com2PropertyDescriptor propertyDescriptor, bool allowExpand)
+            // This will throw in the base.
+            : base(propertyDescriptor.PropertyType!)
         {
             _allowExpand = allowExpand;
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IManagedPerPropertyBrowsingHandler.cs
@@ -34,7 +34,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// </summary>
         private void OnGetAttributes(Com2PropertyDescriptor sender, GetAttributesEvent attrEvent)
         {
-            object target = sender.TargetObject;
+            object? target = sender.TargetObject;
 
             if (target is VSSDK.IVSMDPerPropertyBrowsing browsing)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IProvidePropertyBuilderHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IProvidePropertyBuilderHandler.cs
@@ -63,31 +63,26 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 return;
             }
 
-            string? s = null;
+            string? guidString = null;
             VSSDK.CTLBLDTYPE bldrType = 0;
-            bool builderValid = GetBuilderGuidString(target, sender.DISPID, ref s, &bldrType);
+            bool builderValid = GetBuilderGuidString(target, sender.DISPID, ref guidString, &bldrType);
 
             // We hide IDispatch props by default, we we need to force showing them here
-            if (sender.CanShow && builderValid)
+            if (sender.CanShow && builderValid && typeof(Oleaut32.IDispatch).IsAssignableFrom(sender.PropertyType))
             {
-                if (typeof(Oleaut32.IDispatch).IsAssignableFrom(sender.PropertyType))
-                {
-                    attrEvent.Add(BrowsableAttribute.Yes);
-                }
+                attrEvent.Add(BrowsableAttribute.Yes);
             }
         }
 
         private unsafe void OnGetTypeConverterAndTypeEditor(Com2PropertyDescriptor sender, GetTypeConverterAndTypeEditorEvent gveevent)
         {
-            object target = sender.TargetObject;
-
-            if (target is VSSDK.IProvidePropertyBuilder propBuilder)
+            if (sender.TargetObject is VSSDK.IProvidePropertyBuilder propertyBuilder)
             {
                 string? guidString = null;
                 VSSDK.CTLBLDTYPE pctlBldType = 0;
-                if (GetBuilderGuidString(propBuilder, sender.DISPID, ref guidString, &pctlBldType))
+                if (GetBuilderGuidString(propertyBuilder, sender.DISPID, ref guidString, &pctlBldType))
                 {
-                    gveevent.TypeEditor = new Com2PropertyBuilderUITypeEditor(sender, guidString, pctlBldType, (UITypeEditor)gveevent.TypeEditor);
+                    gveevent.TypeEditor = new Com2PropertyBuilderUITypeEditor(sender, guidString, pctlBldType, (UITypeEditor?)gveevent.TypeEditor);
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IVsPerPropertyBrowsingHandler.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2IVsPerPropertyBrowsingHandler.cs
@@ -162,22 +162,15 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         {
             if (sender.TargetObject is VSSDK.IVsPerPropertyBrowsing browsing)
             {
-                // we only do this for IDispatch types
+                // We only do this for IDispatch types.
                 if (sender.CanShow && typeof(Oleaut32.IDispatch).IsAssignableFrom(sender.PropertyType))
                 {
-                    VSSDK.IVsPerPropertyBrowsing vsObj = browsing;
-
                     // Should we make this read only?
-                    BOOL pfResult = false;
-                    HRESULT hr = vsObj.DisplayChildProperties(sender.DISPID, &pfResult);
-                    if (gveevent.TypeConverter is Com2IDispatchConverter)
-                    {
-                        gveevent.TypeConverter = new Com2IDispatchConverter(sender, hr == HRESULT.S_OK && pfResult);
-                    }
-                    else
-                    {
-                        gveevent.TypeConverter = new Com2IDispatchConverter(hr == HRESULT.S_OK && pfResult, gveevent.TypeConverter);
-                    }
+                    BOOL result;
+                    HRESULT hr = browsing.DisplayChildProperties(sender.DISPID, &result);
+                    gveevent.TypeConverter = gveevent.TypeConverter is Com2IDispatchConverter
+                        ? new Com2IDispatchConverter(sender, hr == HRESULT.S_OK && result)
+                        : new Com2IDispatchConverter(hr == HRESULT.S_OK && result, gveevent.TypeConverter);
                 }
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyBuilderUITypeEditor.cs
@@ -21,7 +21,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             Com2PropertyDescriptor pd,
             string guidString,
             VSSDK.CTLBLDTYPE type,
-            UITypeEditor baseEditor) : base(baseEditor)
+            UITypeEditor? baseEditor) : base(baseEditor)
         {
             _propDesc = pd;
             _guidString = guidString;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptorRefresh.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2PropertyDescriptorRefresh.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     internal static class Com2PropertyDescriptorRefresh

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/COM2TypeInfoProcessor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -20,12 +18,15 @@ using static Interop;
 namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     /// <summary>
-    ///  This is the main worker class of Com2 property interop. It takes an IDispatch Object
-    ///  and translates it's Oleaut32.ITypeInfo into Com2PropertyDescriptor objects that are understandable
-    ///  by managed code.
-    ///
-    ///  This class only knows how to process things that are natively in the typeinfo.  Other property
-    ///  information such as IPerPropertyBrowsing is handled elsewhere.
+    ///  <para>
+    ///   This is the main worker class of Com2 property interop. It takes an IDispatch Object
+    ///   and translates it's ITypeInfo into Com2PropertyDescriptor objects that are understandable
+    ///   by managed code.
+    ///  </para>
+    ///  <para>
+    ///   This class only knows how to process things that are natively in the typeinfo. Other property
+    ///   information such as IPerPropertyBrowsing is handled elsewhere.
+    ///  </para>
     /// </summary>
     internal static partial class Com2TypeInfoProcessor
     {
@@ -33,109 +34,116 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             "DbgTypeInfoProcessor",
              "Com2TypeInfoProcessor: debug Com2 type info processing");
 
-        private static ModuleBuilder moduleBuilder;
+        private static ModuleBuilder? s_moduleBuilder;
 
         private static ModuleBuilder ModuleBuilder
         {
             get
             {
-                if (moduleBuilder is null)
+                if (s_moduleBuilder is null)
                 {
-                    AssemblyName assemblyName = new AssemblyName
+                    AssemblyName assemblyName = new()
                     {
                         Name = "COM2InteropEmit"
                     };
 
                     AssemblyBuilder aBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
-                    moduleBuilder = aBuilder.DefineDynamicModule("COM2Interop.Emit");
+                    s_moduleBuilder = aBuilder.DefineDynamicModule("COM2Interop.Emit");
                 }
 
-                return moduleBuilder;
+                return s_moduleBuilder;
             }
         }
 
-        private static Hashtable builtEnums;
-        private static Hashtable processedLibraries;
+        private static Hashtable? s_builtEnums;
+        private static Dictionary<Guid, CachedProperties>? s_processedLibraries;
 
         /// <summary>
-        ///  Given an Object, this attempts to locate its type info.
+        ///  Given a COM object attempt to locate its type info.
         /// </summary>
-        public static Oleaut32.ITypeInfo FindTypeInfo(object obj, bool wantCoClass)
+        public static Oleaut32.ITypeInfo? FindTypeInfo(object comObject, bool preferIProvideClassInfo)
         {
-            Oleaut32.ITypeInfo pTypeInfo = null;
+            Oleaut32.ITypeInfo? typeInfo = null;
 
             // This is kind of odd.  What's going on here is that if we want the CoClass (e.g. for
             // the interface name), we need to look for IProvideClassInfo first, then look for the
             // typeinfo from the IDispatch. In the case of many Oleaut32 operations, the CoClass
             // doesn't have the interface members on it, although in the shell it usually does, so
             // we need to re-order the lookup if we *actually* want the CoClass if it's available.
-            for (int i = 0; pTypeInfo is null && i < 2; i++)
+            for (int i = 0; typeInfo is null && i < 2; i++)
             {
-                if (wantCoClass == (i == 0))
+                if (preferIProvideClassInfo == (i == 0))
                 {
-                    if (obj is Oleaut32.IProvideClassInfo pProvideClassInfo)
+                    if (comObject is Oleaut32.IProvideClassInfo pProvideClassInfo)
                     {
-                        pProvideClassInfo.GetClassInfo(out pTypeInfo);
+                        pProvideClassInfo.GetClassInfo(out typeInfo);
                     }
                 }
                 else
                 {
-                    if (obj is Oleaut32.IDispatch iDispatch)
+                    if (comObject is Oleaut32.IDispatch iDispatch)
                     {
-                        iDispatch.GetTypeInfo(0, PInvoke.GetThreadLocale(), out pTypeInfo);
+                        iDispatch.GetTypeInfo(0, PInvoke.GetThreadLocale(), out typeInfo);
                     }
                 }
             }
 
-            return pTypeInfo;
+            return typeInfo;
         }
 
         /// <summary>
         ///  Given an Object, this attempts to locate its type info. If it implements IProvideMultipleClassInfo
         ///  all available type infos will be returned, otherwise the primary one will be called.
         /// </summary>
-        public static unsafe Oleaut32.ITypeInfo[] FindTypeInfos(object obj, bool wantCoClass)
+        public static unsafe Oleaut32.ITypeInfo[] FindTypeInfos(object comObject, bool preferIProvideClassInfo)
         {
-            if (obj is Oleaut32.IProvideMultipleClassInfo pCI)
+            if (comObject is Oleaut32.IProvideMultipleClassInfo classInfo)
             {
-                uint n = 0;
-                if (pCI.GetMultiTypeInfoCount(&n).Succeeded && n > 0)
+                uint count = 0;
+                if (classInfo.GetMultiTypeInfoCount(&count).Succeeded && count > 0)
                 {
-                    var typeInfos = new Oleaut32.ITypeInfo[n];
-                    for (uint i = 0; i < n; i++)
+                    var typeInfos = new Oleaut32.ITypeInfo[count];
+                    for (uint i = 0; i < count; i++)
                     {
-                        if (pCI.GetInfoOfIndex(i, Oleaut32.MULTICLASSINFO.GETTYPEINFO, out Oleaut32.ITypeInfo result, null, null, null, null).Failed)
+                        if (classInfo.GetInfoOfIndex(
+                            i,
+                            Oleaut32.MULTICLASSINFO.GETTYPEINFO,
+                            out Oleaut32.ITypeInfo typeInfo,
+                            pdwTIFlags: null,
+                            pcdispidReserved: null,
+                            piidPrimary: null,
+                            piidSource: null).Failed)
                         {
                             continue;
                         }
 
-                        Debug.Assert(
-                            result is not null,
-                            $"IProvideMultipleClassInfo::GetInfoOfIndex returned S_OK for Oleaut32.ITypeInfo index {i}, this is a issue in the object that's being browsed, NOT the property browser.");
-                        typeInfos[i] = result;
+                        Debug.Assert(typeInfo is not null);
+                        if (typeInfo is not null)
+                        {
+                            typeInfos[i] = typeInfo;
+                        }
                     }
 
                     return typeInfos;
                 }
             }
 
-            Oleaut32.ITypeInfo temp = FindTypeInfo(obj, wantCoClass);
-            return temp is not null ? (new Oleaut32.ITypeInfo[] { temp }) : null;
+            Oleaut32.ITypeInfo? temp = FindTypeInfo(comObject, preferIProvideClassInfo);
+            return temp is not null ? (new Oleaut32.ITypeInfo[] { temp }) : Array.Empty<Oleaut32.ITypeInfo>();
         }
 
         /// <summary>
         ///  Retrieve the dispid of the property that we are to use as the name
-        ///  member.  In this case, the grid will put parens around the name.
+        ///  member. In this case, the grid will put parens around the name.
         /// </summary>
         public static unsafe Ole32.DispatchID GetNameDispId(Oleaut32.IDispatch obj)
         {
             Ole32.DispatchID dispid = Ole32.DispatchID.UNKNOWN;
-            string[] names = null;
+            string[]? names = null;
 
-            ComNativeDescriptor cnd = ComNativeDescriptor.Instance;
             bool succeeded = false;
 
-            // first try to find one with a valid value
+            // First try to find one with a valid value.
             ComNativeDescriptor.GetPropertyValue(obj, "__id", ref succeeded);
 
             if (succeeded)
@@ -159,12 +167,12 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 }
             }
 
-            // now get the dispid of the one that worked...
+            // Now get the dispid of the one that worked.
             if (names is not null)
             {
                 Ole32.DispatchID pDispid = Ole32.DispatchID.UNKNOWN;
-                Guid g = Guid.Empty;
-                HRESULT hr = obj.GetIDsOfNames(&g, names, 1, PInvoke.GetThreadLocale(), &pDispid);
+                Guid guid = Guid.Empty;
+                HRESULT hr = obj.GetIDsOfNames(&guid, names, 1, PInvoke.GetThreadLocale(), &pDispid);
                 if (hr.Succeeded)
                 {
                     dispid = pDispid;
@@ -178,84 +186,81 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  Gets the properties for a given Com2 Object.  The returned Com2Properties
         ///  Object contains the properties and relevant data about them.
         /// </summary>
-        public static Com2Properties GetProperties(object obj)
+        public static Com2Properties? GetProperties(object comObject)
         {
             Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, "Com2TypeInfoProcessor.GetProperties");
 
-            if (obj is null || !Marshal.IsComObject(obj))
+            if (comObject is null || !Marshal.IsComObject(comObject))
             {
-                Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, "Com2TypeInfoProcessor.GetProperties returning null: Object is not a com Object");
+                Debug.WriteLineIf(
+                    DbgTypeInfoProcessorSwitch.TraceVerbose,
+                    "Com2TypeInfoProcessor.GetProperties returning null: Object is not a COM object");
+
                 return null;
             }
 
-            Oleaut32.ITypeInfo[] typeInfos = FindTypeInfos(obj, false);
+            Oleaut32.ITypeInfo[] typeInfos = FindTypeInfos(comObject, preferIProvideClassInfo: false);
 
-            // oops, looks like this guy doesn't surface any type info
-            // this is okay, so we just say it has no props
-            if (typeInfos is null || typeInfos.Length == 0)
+            if (typeInfos.Length == 0)
             {
                 Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, "Com2TypeInfoProcessor.GetProperties :: Didn't get typeinfo");
                 return null;
             }
 
-            int defaultProp = -1;
-            int temp = -1;
-            ArrayList propList = new ArrayList();
+            int defaultProperty = -1;
+            List<Com2PropertyDescriptor> propList = new();
             Guid[] typeGuids = new Guid[typeInfos.Length];
 
             for (int i = 0; i < typeInfos.Length; i++)
             {
-                Oleaut32.ITypeInfo ti = typeInfos[i];
-
-                if (ti is null)
-                {
-                    continue;
-                }
+                Oleaut32.ITypeInfo typeInfo = typeInfos[i];
 
                 uint[] versions = new uint[2];
-                Guid typeGuid = GetGuidForTypeInfo(ti, versions);
-                PropertyDescriptor[] props = null;
-                bool dontProcess = typeGuid != Guid.Empty && processedLibraries is not null && processedLibraries.Contains(typeGuid);
+                Guid typeGuid = GetGuidForTypeInfo(typeInfo, versions);
+                Com2PropertyDescriptor[]? properties = null;
 
-                if (dontProcess)
+                s_processedLibraries ??= new();
+
+                bool wasProcessed = typeGuid != Guid.Empty && s_processedLibraries.ContainsKey(typeGuid);
+
+                if (wasProcessed)
                 {
-                    CachedProperties cp = (CachedProperties)processedLibraries[typeGuid];
+                    CachedProperties cachedProperties = s_processedLibraries[typeGuid];
 
-                    if (versions[0] == cp.MajorVersion && versions[1] == cp.MinorVersion)
+                    if (versions[0] == cachedProperties.MajorVersion && versions[1] == cachedProperties.MinorVersion)
                     {
-                        props = cp.Properties;
-                        if (i == 0 && cp.DefaultIndex != -1)
+                        properties = cachedProperties.Properties;
+                        if (i == 0 && cachedProperties.DefaultIndex != -1)
                         {
-                            defaultProp = cp.DefaultIndex;
+                            defaultProperty = cachedProperties.DefaultIndex;
                         }
                     }
                     else
                     {
-                        dontProcess = false;
+                        // Updated version, mark for reprocessing.
+                        wasProcessed = false;
                     }
                 }
 
-                if (!dontProcess)
+                if (!wasProcessed)
                 {
-                    props = InternalGetProperties(obj, ti, Ole32.DispatchID.MEMBERID_NIL, ref temp);
+                    properties = InternalGetProperties(comObject, typeInfo, Ole32.DispatchID.MEMBERID_NIL);
 
-                    // only save the default property from the first type Info
-                    if (i == 0 && temp != -1)
+                    // Only save the default property from the first type Info.
+                    if (i == 0)
                     {
-                        defaultProp = temp;
+                        defaultProperty = -1;
                     }
-
-                    processedLibraries ??= new Hashtable();
 
                     if (typeGuid != Guid.Empty)
                     {
-                        processedLibraries[typeGuid] = new CachedProperties(props, i == 0 ? defaultProp : -1, versions[0], versions[1]);
+                        s_processedLibraries[typeGuid] = new CachedProperties(properties, i == 0 ? defaultProperty : -1, versions[0], versions[1]);
                     }
                 }
 
-                if (props is not null)
+                if (properties is not null)
                 {
-                    propList.AddRange(props);
+                    propList.AddRange(properties);
                 }
             }
 
@@ -265,10 +270,10 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             Com2PropertyDescriptor[] temp2 = new Com2PropertyDescriptor[propList.Count];
             propList.CopyTo(temp2, 0);
 
-            return new Com2Properties(obj, temp2, defaultProp);
+            return new Com2Properties(comObject, propList.ToArray(), defaultProperty);
         }
 
-        private static unsafe Guid GetGuidForTypeInfo(Oleaut32.ITypeInfo typeInfo, uint[] versions)
+        private static unsafe Guid GetGuidForTypeInfo(Oleaut32.ITypeInfo typeInfo, uint[]? versions)
         {
             TYPEATTR* pTypeAttr = null;
             HRESULT hr = typeInfo.GetTypeAttr(&pTypeAttr);
@@ -294,11 +299,11 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         }
 
         /// <summary>
-        ///  Resolves a value type for a property from a TYPEDESC.  Value types can be
-        ///  user defined, which and may be aliased into other type infos.  This function
-        ///  will recursively walk the ITypeInfos to resolve the type to a clr Type.
+        ///  Resolves a value type for a property from a TYPEDESC. Value types can be user defined, which and may be
+        ///  aliased into other type infos. This function will recursively walk the ITypeInfos to resolve the type to
+        ///  a CLR Type.
         /// </summary>
-        private static unsafe Type GetValueTypeFromTypeDesc(in TYPEDESC typeDesc, Oleaut32.ITypeInfo typeInfo, object[] typeData)
+        private static unsafe Type? GetValueTypeFromTypeDesc(in TYPEDESC typeDesc, Oleaut32.ITypeInfo typeInfo, object[] typeData)
         {
             uint hreftype;
             HRESULT hr = HRESULT.S_OK;
@@ -341,80 +346,61 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 throw new ExternalException(string.Format(SR.TYPEINFOPROCESSORGetRefTypeInfoFailed, hr), (int)hr);
             }
 
-            try
-            {
-                // Here is where we look at the next level type info. If we get an enum, process it, otherwise we will
-                // recurse or get a dispatch.
-                if (refTypeInfo is null)
-                {
-                    return null;
-                }
-
-                TYPEATTR* pTypeAttr = null;
-                hr = refTypeInfo.GetTypeAttr(&pTypeAttr);
-                if (!hr.Succeeded)
-                {
-                    throw new ExternalException(string.Format(SR.TYPEINFOPROCESSORGetTypeAttrFailed, hr), (int)hr);
-                }
-
-                try
-                {
-                    Guid g = pTypeAttr->guid;
-
-                    // Save the guid if we've got one here.
-                    if (!Guid.Empty.Equals(g))
-                    {
-                        typeData[0] = g;
-                    }
-
-                    switch (pTypeAttr->typekind)
-                    {
-                        case TKIND_ENUM:
-                            return ProcessTypeInfoEnum(refTypeInfo);
-                        case TKIND_ALIAS:
-                            // Recurse here.
-                            return GetValueTypeFromTypeDesc(pTypeAttr->tdescAlias, refTypeInfo, typeData);
-                        case TKIND_DISPATCH:
-                            return VTToType(VT_DISPATCH);
-                        case TKIND_INTERFACE:
-                        case TKIND_COCLASS:
-                            return VTToType(VT_UNKNOWN);
-                        default:
-                            return null;
-                    }
-                }
-                finally
-                {
-                    refTypeInfo.ReleaseTypeAttr(pTypeAttr);
-                }
-            }
-            finally
-            {
-                refTypeInfo = null;
-            }
-        }
-
-        private static PropertyDescriptor[] InternalGetProperties(
-            object obj,
-            Oleaut32.ITypeInfo typeInfo,
-            Ole32.DispatchID dispidToGet,
-            ref int defaultIndex)
-        {
-            if (typeInfo is null)
+            // Here is where we look at the next level type info. If we get an enum, process it, otherwise we will
+            // recurse or get a dispatch.
+            if (refTypeInfo is null)
             {
                 return null;
             }
 
-            Hashtable propInfos = new Hashtable();
+            TYPEATTR* pTypeAttr = null;
+            hr = refTypeInfo.GetTypeAttr(&pTypeAttr);
+            if (!hr.Succeeded)
+            {
+                throw new ExternalException(string.Format(SR.TYPEINFOPROCESSORGetTypeAttrFailed, hr), (int)hr);
+            }
 
-            Ole32.DispatchID nameDispID = GetNameDispId((Oleaut32.IDispatch)obj);
+            try
+            {
+                Guid guid = pTypeAttr->guid;
+
+                // Save the guid if we've got one here.
+                if (!Guid.Empty.Equals(guid))
+                {
+                    typeData[0] = guid;
+                }
+
+                return pTypeAttr->typekind switch
+                {
+                    TKIND_ENUM => ProcessTypeInfoEnum(refTypeInfo),
+                    // Recurse here.
+                    TKIND_ALIAS => GetValueTypeFromTypeDesc(pTypeAttr->tdescAlias, refTypeInfo, typeData),
+                    TKIND_DISPATCH => VTToType(VT_DISPATCH),
+                    TKIND_INTERFACE or TKIND_COCLASS => VTToType(VT_UNKNOWN),
+                    _ => null,
+                };
+            }
+            finally
+            {
+                refTypeInfo.ReleaseTypeAttr(pTypeAttr);
+            }
+        }
+
+        private static Com2PropertyDescriptor[] InternalGetProperties(
+            object comObject,
+            Oleaut32.ITypeInfo typeInfo,
+            Ole32.DispatchID dispidToGet)
+        {
+            Dictionary<string, PropertyInfo> propertyInfo = new();
+
+            Ole32.DispatchID nameDispID = GetNameDispId((Oleaut32.IDispatch)comObject);
             bool addAboutBox = false;
 
             // Properties can live as functions with get_ and put_ or as variables, so we do two steps here.
             try
             {
                 // Do FUNCDESC things.
-                ProcessFunctions(typeInfo, propInfos, dispidToGet, nameDispID, ref addAboutBox);
+                ProcessFunctions(typeInfo, propertyInfo, dispidToGet, nameDispID, ref addAboutBox);
             }
             catch (ExternalException ex)
             {
@@ -424,55 +410,52 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             try
             {
                 // Do VARDESC things.
-                ProcessVariables(typeInfo, propInfos, dispidToGet, nameDispID);
+                ProcessVariables(typeInfo, propertyInfo, dispidToGet, nameDispID);
             }
             catch (ExternalException ex)
             {
                 Debug.Fail($"ProcessVariables failed with hr={ex.ErrorCode}, message={ex}");
             }
 
-            typeInfo = null;
-
             // Now we take the propertyInfo structures we built up and use them to create the actual descriptors.
-            int cProps = propInfos.Count;
+            int propertyCount = propertyInfo.Count;
 
             if (addAboutBox)
             {
-                cProps++;
+                propertyCount++;
             }
 
-            PropertyDescriptor[] props = new PropertyDescriptor[cProps];
-            int defaultProp = -1;
+            Com2PropertyDescriptor[] properties = new Com2PropertyDescriptor[propertyCount];
+            int defaultProperty = -1;
 
             HRESULT hr = HRESULT.S_OK;
             object[] pvar = new object[1];
-            ComNativeDescriptor cnd = ComNativeDescriptor.Instance;
 
             // For each item in our list, create the descriptor an check if it's the default one.
-            foreach (PropInfo pi in propInfos.Values)
+            foreach (PropertyInfo info in propertyInfo.Values)
             {
-                if (!pi.NonBrowsable)
+                if (!info.NonBrowsable)
                 {
                     // Finally, for each property, make sure we can get the value
                     // if we can't then we should mark it non-browsable.
 
                     try
                     {
-                        hr = ComNativeDescriptor.GetPropertyValue(obj, pi.DispId, pvar);
+                        hr = ComNativeDescriptor.GetPropertyValue(comObject, info.DispId, pvar);
                     }
                     catch (ExternalException ex)
                     {
                         hr = (HRESULT)ex.ErrorCode;
-                        Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, $"IDispatch::Invoke(PROPGET, {pi.Name}) threw an exception :{ex}");
+                        Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, $"IDispatch::Invoke(PROPGET, {info.Name}) threw an exception :{ex}");
                     }
 
                     if (!hr.Succeeded)
                     {
                         Debug.WriteLineIf(
                             DbgTypeInfoProcessorSwitch.TraceVerbose,
-                            $"Adding Browsable(false) to property '{pi.Name}' because Invoke(dispid=0x{pi.DispId:X} ,DISPATCH_PROPERTYGET) returned hr=0x{hr:X}. Properties that do not return S_OK are hidden by default.");
-                        pi.Attributes.Add(new BrowsableAttribute(false));
-                        pi.NonBrowsable = true;
+                            $"Adding Browsable(false) to property '{info.Name}' because Invoke(dispid=0x{info.DispId:X}, DISPATCH_PROPERTYGET) returned hr=0x{hr:X}. Properties that do not return S_OK are hidden by default.");
+                        info.Attributes.Add(new BrowsableAttribute(false));
+                        info.NonBrowsable = true;
                     }
                 }
                 else
@@ -480,26 +463,32 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                     hr = HRESULT.S_OK;
                 }
 
-                Attribute[] temp = new Attribute[pi.Attributes.Count];
-                pi.Attributes.CopyTo(temp, 0);
-                props[pi.Index] = new Com2PropertyDescriptor(pi.DispId, pi.Name, temp, pi.ReadOnly != PropInfo.ReadOnlyFalse, pi.ValueType, pi.TypeData, !hr.Succeeded);
-                if (pi.IsDefault)
+                properties[info.Index] = new Com2PropertyDescriptor(
+                    info.DispId,
+                    info.Name,
+                    info.Attributes.ToArray(),
+                    info.ReadOnly != PropertyInfo.ReadOnlyFalse,
+                    info.ValueType,
+                    info.TypeData,
+                    !hr.Succeeded);
+
+                if (info.IsDefault)
                 {
-                    defaultProp = pi.Index;
+                    defaultProperty = info.Index;
                 }
             }
 
             if (addAboutBox)
             {
-                props[^1] = new Com2AboutBoxPropertyDescriptor();
+                properties[^1] = new Com2AboutBoxPropertyDescriptor();
             }
 
-            return props;
+            return properties;
         }
 
-        private static unsafe PropInfo ProcessDataCore(
+        private static unsafe PropertyInfo ProcessDataCore(
             Oleaut32.ITypeInfo typeInfo,
-            IDictionary propInfoList,
+            IDictionary<string, PropertyInfo> propertyInfo,
             Ole32.DispatchID dispid,
             Ole32.DispatchID nameDispID,
             in TYPEDESC typeDesc,
@@ -509,7 +498,6 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             using var nameBstr = default(BSTR);
             using var helpStringBstr = default(BSTR);
             HRESULT hr = typeInfo.GetDocumentation(dispid, &nameBstr, &helpStringBstr, null, null);
-            ComNativeDescriptor cnd = ComNativeDescriptor.Instance;
             if (!hr.Succeeded)
             {
                 throw new COMException(string.Format(SR.TYPEINFOPROCESSORGetDocumentationFailed, dispid, hr, ComNativeDescriptor.GetClassName(typeInfo)), (int)hr);
@@ -523,97 +511,101 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
 
             // Now we can create our struct. Make sure we don't already have one.
-            PropInfo pi = (PropInfo)propInfoList[name];
-
-            if (pi is null)
+            if (!propertyInfo.TryGetValue(name, out PropertyInfo? info))
             {
-                pi = new PropInfo
+                info = new()
                 {
-                    Index = propInfoList.Count
+                    Index = propertyInfo.Count,
+                    Name = name,
+                    DispId = dispid
                 };
-                propInfoList[name] = pi;
-                pi.Name = name;
-                pi.DispId = dispid;
-                pi.Attributes.Add(new DispIdAttribute((int)pi.DispId));
+
+                propertyInfo.Add(name, info);
+                info.Attributes.Add(new DispIdAttribute((int)info.DispId));
             }
 
             var helpString = helpStringBstr.AsSpan();
             if (!helpString.IsEmpty)
             {
-                pi.Attributes.Add(new DescriptionAttribute(helpString.ToString()));
+                info.Attributes.Add(new DescriptionAttribute(helpString.ToString()));
             }
 
             // Figure out the value type.
-            if (pi.ValueType is null)
+            if (info.ValueType is null)
             {
                 object[] pTypeData = new object[1];
                 try
                 {
-                    pi.ValueType = GetValueTypeFromTypeDesc(in typeDesc, typeInfo, pTypeData);
+                    info.ValueType = GetValueTypeFromTypeDesc(in typeDesc, typeInfo, pTypeData);
                 }
                 catch (Exception ex)
                 {
                     Debug.WriteLineIf(
                         DbgTypeInfoProcessorSwitch.TraceVerbose,
-                         $"Hiding property {pi.Name} because value Type could not be resolved: {ex}");
+                         $"Hiding property {info.Name} because value Type could not be resolved: {ex}");
                 }
 
-                // If we can't resolve the type, mark the property as nonbrowsable from the browser.
-                if (pi.ValueType is null)
+                // If we can't resolve the type, mark the property as nonbrowsable.
+                if (info.ValueType is null)
                 {
-                    pi.NonBrowsable = true;
+                    info.NonBrowsable = true;
                 }
 
-                if (pi.NonBrowsable)
+                if (info.NonBrowsable)
                 {
                     flags |= VARFLAG_FNONBROWSABLE;
                 }
 
                 if (pTypeData[0] is not null)
                 {
-                    pi.TypeData = pTypeData[0];
+                    info.TypeData = pTypeData[0];
                 }
             }
 
             // Check the flags.
             if ((flags & VARFLAG_FREADONLY) != 0)
             {
-                pi.ReadOnly = PropInfo.ReadOnlyTrue;
+                info.ReadOnly = PropertyInfo.ReadOnlyTrue;
             }
 
             if ((flags & VARFLAG_FHIDDEN) != 0 ||
                 (flags & VARFLAG_FNONBROWSABLE) != 0 ||
-                pi.Name[0] == '_' ||
+                info.Name[0] == '_' ||
                 dispid == Ole32.DispatchID.HWND)
             {
-                pi.Attributes.Add(new BrowsableAttribute(false));
-                pi.NonBrowsable = true;
+                info.Attributes.Add(new BrowsableAttribute(false));
+                info.NonBrowsable = true;
             }
 
             if ((flags & VARFLAG_FUIDEFAULT) != 0)
             {
-                pi.IsDefault = true;
+                info.IsDefault = true;
             }
 
             if ((flags & VARFLAG_FBINDABLE) != 0 &&
                 (flags & VARFLAG_FDISPLAYBIND) != 0)
             {
-                pi.Attributes.Add(new BindableAttribute(true));
+                info.Attributes.Add(new BindableAttribute(true));
             }
 
             // Lastly, if it's DISPID_Name, add the ParenthesizeNameAttribute.
             if (dispid == nameDispID)
             {
-                pi.Attributes.Add(new ParenthesizePropertyNameAttribute(true));
+                info.Attributes.Add(new ParenthesizePropertyNameAttribute(true));
 
                 // Don't allow merges on the name.
-                pi.Attributes.Add(new MergablePropertyAttribute(false));
+                info.Attributes.Add(new MergablePropertyAttribute(false));
             }
 
-            return pi;
+            return info;
         }
 
-        private static unsafe void ProcessFunctions(Oleaut32.ITypeInfo typeInfo, IDictionary propInfoList, Ole32.DispatchID dispidToGet, Ole32.DispatchID nameDispID, ref bool addAboutBox)
+        private static unsafe void ProcessFunctions(
+            Oleaut32.ITypeInfo typeInfo,
+            IDictionary<string, PropertyInfo> propertyInfo,
+            Ole32.DispatchID dispidToGet,
+            Ole32.DispatchID nameDispID,
+            ref bool addAboutBox)
         {
             TYPEATTR* pTypeAttr = null;
             HRESULT hr = typeInfo.GetTypeAttr(&pTypeAttr);
@@ -625,7 +617,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             try
             {
                 bool isPropGet;
-                PropInfo pi;
+                PropertyInfo? info;
 
                 for (uint i = 0; i < pTypeAttr->cFuncs; i++)
                 {
@@ -654,7 +646,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                         TYPEDESC typeDesc;
 
-                        // is this a get or a put?
+                        // Is this a get or a put?
                         isPropGet = (pFuncDesc->invkind == INVOKEKIND.INVOKE_PROPERTYGET);
 
                         if (isPropGet)
@@ -664,10 +656,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                                 continue;
                             }
 
-                            unsafe
-                            {
-                                typeDesc = pFuncDesc->elemdescFunc.tdesc;
-                            }
+                            typeDesc = pFuncDesc->elemdescFunc.tdesc;
                         }
                         else
                         {
@@ -677,18 +666,15 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                                 continue;
                             }
 
-                            unsafe
-                            {
-                                typeDesc = pFuncDesc->lprgelemdescParam->tdesc;
-                            }
+                            typeDesc = pFuncDesc->lprgelemdescParam->tdesc;
                         }
 
-                        pi = ProcessDataCore(typeInfo, propInfoList, (Ole32.DispatchID)pFuncDesc->memid, nameDispID, in typeDesc, (VARFLAGS)pFuncDesc->wFuncFlags);
+                        info = ProcessDataCore(typeInfo, propertyInfo, (Ole32.DispatchID)pFuncDesc->memid, nameDispID, in typeDesc, (VARFLAGS)pFuncDesc->wFuncFlags);
 
-                        // if we got a setmethod, it's not readonly
-                        if (pi is not null && !isPropGet)
+                        // Ff we got a set method, it's not readonly.
+                        if (info is not null && !isPropGet)
                         {
-                            pi.ReadOnly = PropInfo.ReadOnlyFalse;
+                            info.ReadOnly = PropertyInfo.ReadOnlyFalse;
                         }
                     }
                     finally
@@ -706,7 +692,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  This converts a type info that describes a IDL defined enum into one we can use
         /// </summary>
-        private static unsafe Type ProcessTypeInfoEnum(Oleaut32.ITypeInfo enumTypeInfo)
+        private static unsafe Type? ProcessTypeInfoEnum(Oleaut32.ITypeInfo enumTypeInfo)
         {
             Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, "ProcessTypeInfoEnum entered");
 
@@ -731,10 +717,10 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                     Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, $"ProcessTypeInfoEnum: processing {nItems} variables");
 
-                    ArrayList strs = new ArrayList();
-                    ArrayList vars = new ArrayList();
+                    List<string> strings = new();
+                    List<object?> vars = new();
 
-                    object varValue = null;
+                    object? varValue = null;
 
                     using var enumNameBstr = default(BSTR);
                     using var enumHelpStringBstr = default(BSTR);
@@ -763,9 +749,9 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
                             varValue = null;
 
-                            // get the name and the helpstring
-                            using BSTR nameBstr = default(BSTR);
-                            using BSTR helpBstr = default(BSTR);
+                            // Get the name and the helpstring
+                            using BSTR nameBstr = default;
+                            using BSTR helpBstr = default;
                             hr = enumTypeInfo.GetDocumentation((Ole32.DispatchID)pVarDesc->memid, &nameBstr, &helpBstr, null, null);
                             if (!hr.Succeeded)
                             {
@@ -811,7 +797,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             }
 
                             Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, $"ProcessTypeInfoEnum: adding name value={nameString}");
-                            strs.Add(nameString);
+                            strings.Add(nameString);
                         }
                         finally
                         {
@@ -819,10 +805,10 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                         }
                     }
 
-                    Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, $"ProcessTypeInfoEnum: returning enum with {strs.Count} items");
+                    Debug.WriteLineIf(DbgTypeInfoProcessorSwitch.TraceVerbose, $"ProcessTypeInfoEnum: returning enum with {strings.Count} items");
 
                     // Just build our enumerator.
-                    if (strs.Count > 0)
+                    if (strings.Count > 0)
                     {
                         // Get the IUnknown value of the Oleaut32.ITypeInfo.
                         IntPtr pTypeInfoUnk = Marshal.GetIUnknownForObject(enumTypeInfo);
@@ -831,30 +817,30 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                         {
                             string enumName = $"{pTypeInfoUnk}_{enumNameBstr.AsSpan()}";
 
-                            if (builtEnums is null)
+                            if (s_builtEnums is null)
                             {
-                                builtEnums = new Hashtable();
+                                s_builtEnums = new Hashtable();
                             }
-                            else if (builtEnums.ContainsKey(enumName))
+                            else if (s_builtEnums.ContainsKey(enumName))
                             {
-                                return (Type)builtEnums[enumName];
+                                return (Type?)s_builtEnums[enumName];
                             }
 
                             Type enumType = typeof(int);
 
-                            if (vars.Count > 0 && vars[0] is not null)
+                            if (vars.Count > 0 && vars[0] is { } var)
                             {
-                                enumType = vars[0].GetType();
+                                enumType = var.GetType();
                             }
 
                             EnumBuilder enumBuilder = ModuleBuilder.DefineEnum(enumName, TypeAttributes.Public, enumType);
-                            for (int i = 0; i < strs.Count; i++)
+                            for (int i = 0; i < strings.Count; i++)
                             {
-                                enumBuilder.DefineLiteral((string)strs[i], vars[i]);
+                                enumBuilder.DefineLiteral(strings[i], vars[i]);
                             }
 
                             Type t = enumBuilder.CreateTypeInfo().AsType();
-                            builtEnums[enumName] = t;
+                            s_builtEnums[enumName] = t;
                             return t;
                         }
                         finally
@@ -878,7 +864,11 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             return null;
         }
 
-        private static unsafe void ProcessVariables(Oleaut32.ITypeInfo typeInfo, IDictionary propInfoList, Ole32.DispatchID dispidToGet, Ole32.DispatchID nameDispID)
+        private static unsafe void ProcessVariables(
+            Oleaut32.ITypeInfo typeInfo,
+            IDictionary<string, PropertyInfo> propertyInfo,
+            Ole32.DispatchID dispidToGet,
+            Ole32.DispatchID nameDispID)
         {
             TYPEATTR* pTypeAttr = null;
             HRESULT hr = typeInfo.GetTypeAttr(&pTypeAttr);
@@ -909,13 +899,17 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                             continue;
                         }
 
-                        unsafe
+                        PropertyInfo pi = ProcessDataCore(
+                            typeInfo,
+                            propertyInfo,
+                            (Ole32.DispatchID)pVarDesc->memid,
+                            nameDispID,
+                            in pVarDesc->elemdescVar.tdesc,
+                            pVarDesc->wVarFlags);
+
+                        if (pi.ReadOnly != PropertyInfo.ReadOnlyTrue)
                         {
-                            PropInfo pi = ProcessDataCore(typeInfo, propInfoList, (Ole32.DispatchID)pVarDesc->memid, nameDispID, in pVarDesc->elemdescVar.tdesc, pVarDesc->wVarFlags);
-                            if (pi.ReadOnly != PropInfo.ReadOnlyTrue)
-                            {
-                                pi.ReadOnly = PropInfo.ReadOnlyFalse;
-                            }
+                            pi.ReadOnly = PropertyInfo.ReadOnlyFalse;
                         }
                     }
                     finally
@@ -930,80 +924,31 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
         }
 
-        private static Type VTToType(VARENUM vt)
+        private static Type? VTToType(VARENUM vt) => vt switch
         {
-            switch (vt)
-            {
-                case VT_EMPTY:
-                case VT_NULL:
-                    return null;
-                case VT_I1:
-                    return typeof(sbyte);
-                case VT_UI1:
-                    return typeof(byte);
-                case VT_I2:
-                    return typeof(short);
-                case VT_UI2:
-                    return typeof(ushort);
-                case VT_I4:
-                case VT_INT:
-                    return typeof(int);
-                case VT_UI4:
-                case VT_UINT:
-                    return typeof(uint);
-                case VT_I8:
-                    return typeof(long);
-                case VT_UI8:
-                    return typeof(ulong);
-                case VT_R4:
-                    return typeof(float);
-                case VT_R8:
-                    return typeof(double);
-                case VT_CY:
-                    return typeof(decimal);
-                case VT_DATE:
-                    return typeof(DateTime);
-                case VT_BSTR:
-                case VT_LPSTR:
-                case VT_LPWSTR:
-                    return typeof(string);
-                case VT_DISPATCH:
-                    return typeof(IDispatch);
-                case VT_UNKNOWN:
-                    return typeof(object);
-                case VT_ERROR:
-                case VT_HRESULT:
-                    return typeof(int);
-                case VT_BOOL:
-                    return typeof(bool);
-                case VT_VARIANT:
-                    return typeof(Com2Variant);
-                case VT_CLSID:
-                    return typeof(Guid);
-                case VT_FILETIME:
-                    return typeof(Runtime.InteropServices.ComTypes.FILETIME);
-                case VT_USERDEFINED:
-                    throw new ArgumentException(string.Format(SR.COM2UnhandledVT, "VT_USERDEFINED"));
-                case VT_VOID:
-                case VT_PTR:
-                case VT_SAFEARRAY:
-                case VT_CARRAY:
-                case VT_RECORD:
-                case VT_BLOB:
-                case VT_STREAM:
-                case VT_STORAGE:
-                case VT_STREAMED_OBJECT:
-                case VT_STORED_OBJECT:
-                case VT_BLOB_OBJECT:
-                case VT_CF:
-                case VT_BSTR_BLOB:
-                case VT_VECTOR:
-                case VT_ARRAY:
-                case VT_BYREF:
-                case VT_RESERVED:
-                default:
-                    throw new ArgumentException(string.Format(SR.COM2UnhandledVT, ((int)vt).ToString(CultureInfo.InvariantCulture)));
-            }
-        }
+            VT_EMPTY or VT_NULL => null,
+            VT_I1 => typeof(sbyte),
+            VT_UI1 => typeof(byte),
+            VT_I2 => typeof(short),
+            VT_UI2 => typeof(ushort),
+            VT_I4 or VT_INT => typeof(int),
+            VT_UI4 or VT_UINT => typeof(uint),
+            VT_I8 => typeof(long),
+            VT_UI8 => typeof(ulong),
+            VT_R4 => typeof(float),
+            VT_R8 => typeof(double),
+            VT_CY => typeof(decimal),
+            VT_DATE => typeof(DateTime),
+            VT_BSTR or VT_LPSTR or VT_LPWSTR => typeof(string),
+            VT_DISPATCH => typeof(IDispatch),
+            VT_UNKNOWN => typeof(object),
+            VT_ERROR or VT_HRESULT => typeof(int),
+            VT_BOOL => typeof(bool),
+            VT_VARIANT => typeof(Com2Variant),
+            VT_CLSID => typeof(Guid),
+            VT_FILETIME => typeof(Runtime.InteropServices.ComTypes.FILETIME),
+            VT_USERDEFINED => throw new ArgumentException(string.Format(SR.COM2UnhandledVT, "VT_USERDEFINED")),
+            _ => throw new ArgumentException(string.Format(SR.COM2UnhandledVT, ((int)vt).ToString(CultureInfo.InvariantCulture))),
+        };
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2AboutBoxPropertyDescriptor.AboutBoxUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2AboutBoxPropertyDescriptor.AboutBoxUITypeEditor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing.Design;
@@ -17,8 +15,9 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
     {
         public class AboutBoxUITypeEditor : UITypeEditor
         {
-            public override unsafe object EditValue(ITypeDescriptorContext context, IServiceProvider provider, object value)
+            public override unsafe object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
             {
+                ArgumentNullException.ThrowIfNull(context);
                 object component = context.Instance;
 
                 if (Marshal.IsComObject(component) && component is Oleaut32.IDispatch pDisp)
@@ -41,10 +40,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                 return value;
             }
 
-            public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext context)
-            {
-                return UITypeEditorEditStyle.Modal;
-            }
+            public override UITypeEditorEditStyle GetEditStyle(ITypeDescriptorContext? context) => UITypeEditorEditStyle.Modal;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2IPerPropertyBrowsingHandler.Com2IPerPropertyEnumConverter.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2IPerPropertyBrowsingHandler.Com2IPerPropertyEnumConverter.cs
@@ -24,21 +24,14 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             public override object? ConvertTo(ITypeDescriptorContext? context, CultureInfo? culture, object? value, Type destType)
             {
-                if (destType == typeof(string) && !_itemsEnum._arraysFetched)
+                if (destType == typeof(string) && !_itemsEnum.ArraysFetched)
                 {
-                    object? curValue = _itemsEnum._target.GetValue(_itemsEnum._target.TargetObject);
-                    if (curValue == value || (curValue is not null && curValue.Equals(value)))
+                    object? currentValue = _itemsEnum.Target.GetValue(_itemsEnum.Target.TargetObject);
+                    if ((currentValue == value || (currentValue is not null && currentValue.Equals(value)))
+                        && _itemsEnum.Target.TargetObject is IPerPropertyBrowsing.Interface propertyBrowsing
+                        && TryGetDisplayString(propertyBrowsing, _itemsEnum.Target.DISPID, out string? displayString))
                     {
-                        bool success = false;
-                        string? result = GetDisplayString(
-                            (IPerPropertyBrowsing.Interface)_itemsEnum._target.TargetObject,
-                            _itemsEnum._target.DISPID,
-                            ref success);
-
-                        if (success)
-                        {
-                            return result;
-                        }
+                        return displayString;
                     }
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2PropertyDescriptor.ValidityScope.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2PropertyDescriptor.ValidityScope.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Windows.Forms.ComponentModel.Com2Interop
+{
+    internal partial class Com2PropertyDescriptor
+    {
+        private readonly ref struct ValidityScope
+        {
+#pragma warning disable IDE0036 // Order modifiers (currently broken, required must come first)
+            required public Com2Properties? Properties { get; init; }
+#pragma warning restore IDE0036
+
+            [SetsRequiredMembers]
+            public ValidityScope(Com2Properties? properties)
+            {
+                Properties = properties;
+
+                // Should never be null- but we can't easily express this with null annotation as it is a post
+                // initialization association.
+                Debug.Assert(properties is not null);
+                if (Properties is not null)
+                {
+                    Properties.AlwaysValid = Properties.CheckValidity();
+                }
+            }
+
+            public void Dispose()
+            {
+                if (Properties is not null)
+                {
+                    Properties.AlwaysValid = false;
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2TypeInfoProcessor.CachedProperties.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2TypeInfoProcessor.CachedProperties.cs
@@ -2,42 +2,40 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.ComponentModel;
-
 namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     internal static partial class Com2TypeInfoProcessor
     {
         internal class CachedProperties
         {
-            private readonly PropertyDescriptor[] _properties;
+            private readonly Com2PropertyDescriptor[] _properties;
 
             public readonly uint MajorVersion;
             public readonly uint MinorVersion;
 
-            internal CachedProperties(PropertyDescriptor[] props, int defIndex, uint majVersion, uint minVersion)
+            internal CachedProperties(Com2PropertyDescriptor[] properties, int defaultIndex, uint majorVersion, uint minorVersion)
             {
-                _properties = ClonePropertyDescriptors(props);
-                MajorVersion = majVersion;
-                MinorVersion = minVersion;
-                DefaultIndex = defIndex;
+                _properties = ClonePropertyDescriptors(properties);
+                MajorVersion = majorVersion;
+                MinorVersion = minorVersion;
+                DefaultIndex = defaultIndex;
             }
 
-            public PropertyDescriptor[] Properties => ClonePropertyDescriptors(_properties);
+            public Com2PropertyDescriptor[] Properties => ClonePropertyDescriptors(_properties);
 
             public int DefaultIndex { get; }
 
-            private static PropertyDescriptor[] ClonePropertyDescriptors(PropertyDescriptor[] props)
+            private static Com2PropertyDescriptor[] ClonePropertyDescriptors(Com2PropertyDescriptor[] properties)
             {
-                PropertyDescriptor[] retProps = new PropertyDescriptor[props.Length];
-                for (int i = 0; i < props.Length; i++)
+                Com2PropertyDescriptor[] clonedProperties = new Com2PropertyDescriptor[properties.Length];
+                for (int i = 0; i < properties.Length; i++)
                 {
-                    retProps[i] = props[i] is ICloneable cloneable ? (PropertyDescriptor)cloneable.Clone() : props[i];
+                    clonedProperties[i] = properties[i] is ICloneable cloneable
+                        ? (Com2PropertyDescriptor)cloneable.Clone()
+                        : properties[i];
                 }
 
-                return retProps;
+                return clonedProperties;
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2TypeInfoProcessor.PropInfo.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2TypeInfoProcessor.PropInfo.cs
@@ -2,34 +2,33 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Collections;
 using static Interop;
 
 namespace System.Windows.Forms.ComponentModel.Com2Interop
 {
     internal static partial class Com2TypeInfoProcessor
     {
-        private class PropInfo
+        private class PropertyInfo
         {
             public const int ReadOnlyUnknown = 0;
             public const int ReadOnlyTrue = 1;
             public const int ReadOnlyFalse = 2;
 
-            public string Name { get; set; }
+#pragma warning disable IDE0036 // required must come first
+            required public string Name { get; init; }
+#pragma warning restore IDE0036
 
             public Ole32.DispatchID DispId { get; set; } = Ole32.DispatchID.UNKNOWN;
 
-            public Type ValueType { get; set; }
+            public Type? ValueType { get; set; }
 
-            public ArrayList Attributes { get; } = new ArrayList();
+            public List<Attribute> Attributes { get; } = new();
 
             public int ReadOnly { get; set; } = ReadOnlyUnknown;
 
             public bool IsDefault { get; set; }
 
-            public object TypeData { get; set; }
+            public object? TypeData { get; set; }
 
             public bool NonBrowsable { get; set; }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.ComTypeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.ComTypeDescriptor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using static System.TrimmingConstants;
@@ -18,119 +16,52 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         private sealed class ComTypeDescriptor : ICustomTypeDescriptor
         {
             private readonly ComNativeDescriptor _handler;
-            private readonly object _instance;
+            private readonly object? _instance;
 
             /// <summary>
             ///  Creates a new WalkingTypeDescriptor.
             /// </summary>
-            internal ComTypeDescriptor(ComNativeDescriptor handler, object instance)
+            internal ComTypeDescriptor(ComNativeDescriptor handler, object? instance)
             {
                 _handler = handler;
                 _instance = instance;
             }
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
-            AttributeCollection ICustomTypeDescriptor.GetAttributes()
-            {
-                return _handler.GetAttributes(_instance);
-            }
+            AttributeCollection ICustomTypeDescriptor.GetAttributes() => _handler.GetAttributes(_instance);
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
-            string ICustomTypeDescriptor.GetClassName()
-            {
-                return GetClassName(_instance);
-            }
+            string? ICustomTypeDescriptor.GetClassName() => _instance is null ? string.Empty : GetClassName(_instance);
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
-            string ICustomTypeDescriptor.GetComponentName()
-            {
-                return GetName(_instance);
-            }
+            string? ICustomTypeDescriptor.GetComponentName() => _instance is null ? string.Empty : GetName(_instance);
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
             [RequiresUnreferencedCode(AttributesRequiresUnreferencedCodeMessage)]
-            TypeConverter ICustomTypeDescriptor.GetConverter()
-            {
-                return GetConverter();
-            }
+            TypeConverter ICustomTypeDescriptor.GetConverter() => GetConverter();
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
             [RequiresUnreferencedCode(EventDescriptorRequiresUnreferencedCodeMessage)]
-            EventDescriptor ICustomTypeDescriptor.GetDefaultEvent()
-            {
-                return GetDefaultEvent();
-            }
+            EventDescriptor? ICustomTypeDescriptor.GetDefaultEvent() => GetDefaultEvent();
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
             [RequiresUnreferencedCode(PropertyDescriptorPropertyTypeMessage)]
-            PropertyDescriptor ICustomTypeDescriptor.GetDefaultProperty()
-            {
-                return _handler.GetDefaultProperty(_instance);
-            }
+            PropertyDescriptor? ICustomTypeDescriptor.GetDefaultProperty()
+                => _instance is null ? null : _handler.GetDefaultProperty(_instance);
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
             [RequiresUnreferencedCode(EditorRequiresUnreferencedCode)]
-            object ICustomTypeDescriptor.GetEditor(Type editorBaseType)
-            {
-                return GetEditor(_instance, editorBaseType);
-            }
+            object? ICustomTypeDescriptor.GetEditor(Type editorBaseType)
+                => _instance is null ? null : GetEditor(_instance, editorBaseType);
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
-            EventDescriptorCollection ICustomTypeDescriptor.GetEvents()
-            {
-                return GetEvents();
-            }
+            EventDescriptorCollection ICustomTypeDescriptor.GetEvents() => GetEvents();
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
             [RequiresUnreferencedCode(FilterRequiresUnreferencedCodeMessage)]
-            EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[] attributes)
-            {
-                return GetEvents();
-            }
+            EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[]? attributes) => GetEvents();
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
             [RequiresUnreferencedCode(PropertyDescriptorPropertyTypeMessage)]
             PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties()
-            {
-                return _handler.GetProperties(_instance);
-            }
+                => _instance is null ? PropertyDescriptorCollection.Empty : _handler.GetProperties(_instance);
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
             [RequiresUnreferencedCode($"{PropertyDescriptorPropertyTypeMessage} {FilterRequiresUnreferencedCodeMessage}")]
-            PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[] attributes)
-            {
-                return _handler.GetProperties(_instance);
-            }
+            PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[]? attributes)
+                => _instance is null ? PropertyDescriptorCollection.Empty : _handler.GetProperties(_instance);
 
-            /// <summary>
-            ///  ICustomTypeDescriptor implementation.
-            /// </summary>
-            object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor pd)
-            {
-                return _instance;
-            }
+            // Not much we can do here as we don't control the _instance being passed to us from the ComponentModel.
+            object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor? pd) => _instance!;
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/ComNativeDescriptor.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -18,101 +16,71 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
     /// <summary>
     ///  Top level mapping layer between COM Object and TypeDescriptor.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   .NET uses this class for COM object type browsing. <see cref="PropertyGrid"/> is an indirect consumer of this
+    ///   through the <see cref="TypeDescriptor"/> support in .NET.
+    ///  </para>
+    ///  <para>
+    ///   The instance of this type is found via reflection in <see cref="TypeConverter"/> and exposed as
+    ///   <see cref="TypeDescriptor.ComObjectType"/>.
+    ///  </para>
+    /// </remarks>
     internal partial class ComNativeDescriptor : TypeDescriptionProvider
     {
-        private static ComNativeDescriptor handler;
+        private readonly AttributeCollection _staticAttributes = new(new Attribute[] { BrowsableAttribute.Yes, DesignTimeVisibleAttribute.No });
 
-        private readonly AttributeCollection staticAttrs = new AttributeCollection(new Attribute[] { BrowsableAttribute.Yes, DesignTimeVisibleAttribute.No });
+        // Our collection of Object managers (Com2Properties) for native properties
+        private readonly WeakHashtable _nativeProperties = new();
 
-        /// <summary>
-        ///  Our collection of Object managers (Com2Properties) for native properties
-        /// </summary>
-        private readonly WeakHashtable nativeProps = new WeakHashtable();
+        // Our collection of browsing handlers, which are stateless and shared across objects.
+        private readonly Hashtable extendedBrowsingHandlers = new();
 
-        /// <summary>
-        ///  Our collection of browsing handlers, which are stateless and shared across objects.
-        /// </summary>
-        private readonly Hashtable extendedBrowsingHandlers = new Hashtable();
-
-        /// <summary>
-        ///  We increment this every time we look at an Object, at specified
-        ///  intervals, we run through the properties list to see if we should
-        ///  delete any.
-        /// </summary>
-        private int clearCount;
-        private const int CLEAR_INTERVAL = 25;
-
-        internal static ComNativeDescriptor Instance
-        {
-            get
-            {
-                handler ??= new ComNativeDescriptor();
-
-                return handler;
-            }
-        }
+        // We increment this every time we look at an Object, then at specified intervals, we run through the
+        // properties list to see if we should delete any.
+        private int _clearCount;
+        private const int ClearInterval = 25;
 
         // Called via reflection for AutomationExtender stuff. Don't delete!
-        public static object GetNativePropertyValue(object component, string propertyName, ref bool succeeded)
-        {
-            return GetPropertyValue(component, propertyName, ref succeeded);
-        }
+        public static object? GetNativePropertyValue(object component, string propertyName, ref bool succeeded)
+            => GetPropertyValue(component, propertyName, ref succeeded);
 
-        /// <summary>
-        ///  This method returns a custom type descriptor for the given type / object.
-        ///  The objectType parameter is always valid, but the instance parameter may
-        ///  be null if no instance was passed to TypeDescriptor.  The method should
-        ///  return a custom type descriptor for the object.  If the method is not
-        ///  interested in providing type information for the object it should
-        ///  return null.
-        ///
-        ///  This method is prototyped as virtual, and by default returns null
-        ///  if no parent provider was passed.  If a parent provider was passed,
-        ///  this method will invoke the parent provider's GetTypeDescriptor
-        ///  method.
-        /// </summary>
-        public override ICustomTypeDescriptor GetTypeDescriptor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType, object instance)
-        {
-            return new ComTypeDescriptor(this, instance);
-        }
+        public override ICustomTypeDescriptor? GetTypeDescriptor(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type objectType,
+            object? instance)
+            => new ComTypeDescriptor(this, instance);
 
         internal static unsafe string GetClassName(object component)
         {
-            string name = null;
-
-            // does IVsPerPropertyBrowsing supply us a name?
+            // Check IVsPerPropertyBrowsing for a name.
             if (component is VSSDK.IVsPerPropertyBrowsing browsing)
             {
-                HRESULT hr = browsing.GetClassName(ref name);
-                if (hr.Succeeded && name is not null)
+                string? name = null;
+                if (browsing.GetClassName(ref name).Succeeded && name is not null)
                 {
                     return name;
                 }
-
-                // otherwise fall through...
             }
 
-            Oleaut32.ITypeInfo pTypeInfo = Com2TypeInfoProcessor.FindTypeInfo(component, true);
-
-            if (pTypeInfo is null)
+            if (Com2TypeInfoProcessor.FindTypeInfo(component, preferIProvideClassInfo: true) is not Oleaut32.ITypeInfo typeInfo)
             {
                 return string.Empty;
             }
 
-            using BSTR nameBstr = default(BSTR);
-            pTypeInfo.GetDocumentation(DispatchID.MEMBERID_NIL, &nameBstr, null, null, null);
+            using BSTR nameBstr = default;
+            typeInfo.GetDocumentation(
+                DispatchID.MEMBERID_NIL,
+                &nameBstr,
+                pBstrDocString: null,
+                pdwHelpContext: null,
+                pBstrHelpFile: null);
             return nameBstr.AsSpan().TrimStart('_').ToString();
         }
 
-        internal static TypeConverter GetConverter()
-        {
-            return TypeDescriptor.GetConverter(typeof(IComponent));
-        }
+        internal static TypeConverter GetConverter() => TypeDescriptor.GetConverter(typeof(IComponent));
 
-        internal static object GetEditor(object component, Type baseEditorType)
-        {
-            return TypeDescriptor.GetEditor(component.GetType(), baseEditorType);
-        }
+        internal static object? GetEditor(object component, Type baseEditorType)
+            => TypeDescriptor.GetEditor(component.GetType(), baseEditorType);
 
         internal static string GetName(object component)
         {
@@ -125,18 +93,18 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             if (dispid != DispatchID.UNKNOWN)
             {
                 bool success = false;
-                object value = GetPropertyValue(component, dispid, ref success);
+                object? value = GetPropertyValue(component, dispid, ref success);
 
                 if (success && value is not null)
                 {
-                    return value.ToString();
+                    return value.ToString() ?? string.Empty;
                 }
             }
 
             return string.Empty;
         }
 
-        internal static unsafe object GetPropertyValue(object component, string propertyName, ref bool succeeded)
+        internal static unsafe object? GetPropertyValue(object component, string propertyName, ref bool succeeded)
         {
             if (component is not Oleaut32.IDispatch dispatch)
             {
@@ -145,16 +113,12 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             string[] names = new string[] { propertyName };
             DispatchID dispid = DispatchID.UNKNOWN;
-            Guid g = Guid.Empty;
+            Guid guid = Guid.Empty;
             try
             {
-                HRESULT hr = dispatch.GetIDsOfNames(&g, names, 1, PInvoke.GetThreadLocale(), &dispid);
-                if (dispid == DispatchID.UNKNOWN || !hr.Succeeded)
-                {
-                    return null;
-                }
-
-                return GetPropertyValue(component, dispid, ref succeeded);
+                return dispatch.GetIDsOfNames(&guid, names, 1, PInvoke.GetThreadLocale(), &dispid).Failed || dispid == DispatchID.UNKNOWN
+                    ? null
+                    : GetPropertyValue(component, dispid, ref succeeded);
             }
             catch
             {
@@ -162,7 +126,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             }
         }
 
-        internal static object GetPropertyValue(object component, DispatchID dispid, ref bool succeeded)
+        internal static object? GetPropertyValue(object component, DispatchID dispid, ref bool succeeded)
         {
             if (component is not Oleaut32.IDispatch)
             {
@@ -191,14 +155,14 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
 
             try
             {
-                Guid g = Guid.Empty;
-                EXCEPINFO pExcepInfo = default(EXCEPINFO);
-                DISPPARAMS dispParams = default(DISPPARAMS);
+                Guid guid = Guid.Empty;
+                EXCEPINFO pExcepInfo = default;
+                DISPPARAMS dispParams = default;
                 try
                 {
                     HRESULT hr = dispatch.Invoke(
                         dispid,
-                        &g,
+                        &guid,
                         PInvoke.GetThreadLocale(),
                         DISPATCH_FLAGS.DISPATCH_PROPERTYGET,
                         &dispParams,
@@ -206,12 +170,7 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
                         &pExcepInfo,
                         null);
 
-                    if (hr == HRESULT.DISP_E_EXCEPTION)
-                    {
-                        return (HRESULT)pExcepInfo.scode;
-                    }
-
-                    return hr;
+                    return hr == HRESULT.DISP_E_EXCEPTION ? (HRESULT)pExcepInfo.scode : hr;
                 }
                 catch (ExternalException ex)
                 {
@@ -230,62 +189,55 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  as its identification property (Name, ID, etc).
         /// </summary>
         internal static bool IsNameDispId(object obj, DispatchID dispid)
-        {
-            if (obj is null || !obj.GetType().IsCOMObject)
-            {
-                return false;
-            }
-
-            return dispid == Com2TypeInfoProcessor.GetNameDispId((Oleaut32.IDispatch)obj);
-        }
+            => obj is not null
+                && obj.GetType().IsCOMObject
+                && dispid == Com2TypeInfoProcessor.GetNameDispId((Oleaut32.IDispatch)obj);
 
         /// <summary>
         ///  Checks all our property manages to see if any have become invalid.
         /// </summary>
         private void CheckClear()
         {
-            // walk the list every so many calls
-            if ((++clearCount % CLEAR_INTERVAL) == 0)
+            // Walk the list every so many calls.
+            if ((++_clearCount % ClearInterval) != 0)
             {
-                lock (nativeProps)
+                return;
+            }
+
+            lock (_nativeProperties)
+            {
+                _clearCount = 0;
+
+                List<object>? disposeList = null;
+                Com2Properties? entry;
+
+                // First walk the list looking for items that need to be cleaned out.
+                foreach (DictionaryEntry de in _nativeProperties)
                 {
-                    clearCount = 0;
+                    entry = de.Value as Com2Properties;
 
-                    List<object> disposeList = null;
-                    Com2Properties entry;
-
-                    // first walk the list looking for items that need to be
-                    // cleaned out.
-                    //
-                    foreach (DictionaryEntry de in nativeProps)
+                    if (entry is not null && entry.NeedsRefreshed)
                     {
-                        entry = de.Value as Com2Properties;
-
-                        if (entry is not null && entry.NeedsRefreshed)
-                        {
-                            disposeList ??= new List<object>(3);
-
-                            disposeList.Add(de.Key);
-                        }
+                        disposeList ??= new List<object>(3);
+                        disposeList.Add(de.Key);
                     }
+                }
 
-                    // now run through the ones that are dead and dispose them.
-                    // there's going to be a very small number of these.
-                    //
-                    if (disposeList is not null)
+                // Now run through the ones that are dead and dispose them.
+                // There's going to be a very small number of these.
+                if (disposeList is not null)
+                {
+                    object oldKey;
+                    for (int i = disposeList.Count - 1; i >= 0; i--)
                     {
-                        object oldKey;
-                        for (int i = disposeList.Count - 1; i >= 0; i--)
-                        {
-                            oldKey = disposeList[i];
-                            entry = nativeProps[oldKey] as Com2Properties;
+                        oldKey = disposeList[i];
+                        entry = _nativeProperties[oldKey] as Com2Properties;
 
-                            if (entry is not null)
-                            {
-                                entry.Disposed -= new EventHandler(OnPropsInfoDisposed);
-                                entry.Dispose();
-                                nativeProps.Remove(oldKey);
-                            }
+                        if (entry is not null)
+                        {
+                            entry.Disposed -= new EventHandler(OnPropsInfoDisposed);
+                            entry.Dispose();
+                            _nativeProperties.Remove(oldKey);
                         }
                     }
                 }
@@ -295,152 +247,121 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         /// <summary>
         ///  Gets the properties manager for an Object.
         /// </summary>
-        private Com2Properties GetPropsInfo(object component)
+        private Com2Properties? GetPropertiesInfo(object component)
         {
-            // check caches if necessary
-            //
+            // Check caches if necessary.
             CheckClear();
 
-            // Get the property info Object
-            //
-            Com2Properties propsInfo = (Com2Properties)nativeProps[component];
+            // Get the property info Object.
+            Com2Properties? properties = (Com2Properties?)_nativeProperties[component];
 
-            // if we don't have one, create one and set it up
-            //
-            if (propsInfo is null || !propsInfo.CheckValidity())
+            // If we don't have one, create one and set it up.
+            if (properties is null || !properties.CheckValidity())
             {
-                propsInfo = Com2TypeInfoProcessor.GetProperties(component);
-                if (propsInfo is not null)
+                properties = Com2TypeInfoProcessor.GetProperties(component);
+                if (properties is not null)
                 {
-                    propsInfo.Disposed += new EventHandler(OnPropsInfoDisposed);
-                    nativeProps.SetWeak(component, propsInfo);
-                    propsInfo.AddExtendedBrowsingHandlers(extendedBrowsingHandlers);
+                    properties.Disposed += OnPropsInfoDisposed;
+                    _nativeProperties.SetWeak(component, properties);
+                    properties.AddExtendedBrowsingHandlers(extendedBrowsingHandlers);
                 }
             }
 
-            return propsInfo;
+            return properties;
         }
 
-        /// <summary>
-        ///  Got attributes?
-        /// </summary>
-        internal AttributeCollection GetAttributes(object component)
+        internal AttributeCollection GetAttributes(object? component)
         {
-            ArrayList attrs = new ArrayList();
+            if (component is null)
+            {
+                return _staticAttributes;
+            }
+
+            List<Attribute> attributes = new();
 
             if (component is VSSDK.IVSMDPerPropertyBrowsing browsing)
             {
-                object[] temp = Com2IManagedPerPropertyBrowsingHandler.GetComponentAttributes(browsing, DispatchID.MEMBERID_NIL);
-                for (int i = 0; i < temp.Length; ++i)
-                {
-                    attrs.Add(temp[i]);
-                }
+                attributes.AddRange(Com2IManagedPerPropertyBrowsingHandler.GetComponentAttributes(browsing, DispatchID.MEMBERID_NIL));
             }
 
             if (Com2ComponentEditor.NeedsComponentEditor(component))
             {
-                EditorAttribute a = new EditorAttribute(typeof(Com2ComponentEditor), typeof(ComponentEditor));
-                attrs.Add(a);
+                attributes.Add(new EditorAttribute(typeof(Com2ComponentEditor), typeof(ComponentEditor)));
             }
 
-            if (attrs is null || attrs.Count == 0)
-            {
-                return staticAttrs;
-            }
-            else
-            {
-                Attribute[] temp = new Attribute[attrs.Count];
-                attrs.CopyTo(temp, 0);
-                return new AttributeCollection(temp);
-            }
+            return attributes.Count == 0 ? _staticAttributes : new(attributes.ToArray());
         }
 
-        /// <summary>
-        ///  Default Property, please
-        /// </summary>
-        internal PropertyDescriptor GetDefaultProperty(object component)
+        internal PropertyDescriptor? GetDefaultProperty(object component)
         {
             CheckClear();
-
-            Com2Properties propsInfo = GetPropsInfo(component);
-            if (propsInfo is not null)
-            {
-                return propsInfo.DefaultProperty;
-            }
-
-            return null;
+            return GetPropertiesInfo(component)?.DefaultProperty;
         }
 
-        internal static EventDescriptorCollection GetEvents()
-        {
-            return new EventDescriptorCollection(null);
-        }
+        internal static EventDescriptorCollection GetEvents() => new EventDescriptorCollection(null);
 
-        internal static EventDescriptor GetDefaultEvent()
-        {
-            return null;
-        }
+        internal static EventDescriptor? GetDefaultEvent() => null;
 
-        /// <summary>
-        ///  Props!
-        /// </summary>
         internal PropertyDescriptorCollection GetProperties(object component)
         {
-            Com2Properties propsInfo = GetPropsInfo(component);
+            Com2Properties? properties = GetPropertiesInfo(component);
 
-            if (propsInfo is null)
+            if (properties is null)
             {
                 return PropertyDescriptorCollection.Empty;
             }
 
             try
             {
-                propsInfo.AlwaysValid = true;
-                return new PropertyDescriptorCollection(propsInfo.Properties);
+                properties.AlwaysValid = true;
+                return new PropertyDescriptorCollection(properties.Properties);
             }
             finally
             {
-                propsInfo.AlwaysValid = false;
+                properties.AlwaysValid = false;
             }
         }
 
         /// <summary>
         ///  Fired when the property info gets disposed.
         /// </summary>
-        private void OnPropsInfoDisposed(object sender, EventArgs e)
+        private void OnPropsInfoDisposed(object? sender, EventArgs e)
         {
-            if (sender is Com2Properties propsInfo)
+            if (sender is not Com2Properties propsInfo)
             {
-                propsInfo.Disposed -= new EventHandler(OnPropsInfoDisposed);
+                return;
+            }
 
-                lock (nativeProps)
+            propsInfo.Disposed -= OnPropsInfoDisposed;
+
+            lock (_nativeProperties)
+            {
+                // Find the key.
+                object? key = propsInfo.TargetObject;
+
+                if (key is null && _nativeProperties.ContainsValue(propsInfo))
                 {
-                    // find the key
-                    object key = propsInfo.TargetObject;
-
-                    if (key is null && nativeProps.ContainsValue(propsInfo))
+                    // Need to find it - the target object has probably been cleaned out of the Com2Properties object
+                    // already, so we run through the hashtable looking for the value, so we know what key to remove.
+                    foreach (DictionaryEntry de in _nativeProperties)
                     {
-                        // need to find it - the target object has probably been cleaned out
-                        // of the Com2Properties object already, so we run through the
-                        // hashtable looking for the value, so we know what key to remove.
-                        //
-                        foreach (DictionaryEntry de in nativeProps)
+                        if (de.Value == propsInfo)
                         {
-                            if (de.Value == propsInfo)
-                            {
-                                key = de.Key;
-                                break;
-                            }
-                        }
-
-                        if (key is null)
-                        {
-                            Debug.Fail("Failed to find Com2 properties key on dispose.");
-                            return;
+                            key = de.Key;
+                            break;
                         }
                     }
 
-                    nativeProps.Remove(key);
+                    if (key is null)
+                    {
+                        Debug.Fail("Failed to find Com2 properties key on dispose.");
+                        return;
+                    }
+                }
+
+                if (key is not null)
+                {
+                    _nativeProperties.Remove(key);
                 }
             }
         }
@@ -449,19 +370,22 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
         ///  Looks at at value's type and creates an editor based on that.  We use this to decide which editor to use
         ///  for a generic variant.
         /// </summary>
-        internal static void ResolveVariantTypeConverterAndTypeEditor(object propertyValue, ref TypeConverter currentConverter, Type editorType, ref object currentEditor)
+        internal static void ResolveVariantTypeConverterAndTypeEditor(
+            object? propertyValue,
+            ref TypeConverter currentConverter,
+            Type editorType,
+            ref object? currentEditor)
         {
-            object curValue = propertyValue;
-            if (curValue is not null && curValue is not null && !Convert.IsDBNull(curValue))
+            if (propertyValue is not null && !Convert.IsDBNull(propertyValue))
             {
-                Type t = curValue.GetType();
-                TypeConverter subConverter = TypeDescriptor.GetConverter(t);
+                Type type = propertyValue.GetType();
+                TypeConverter subConverter = TypeDescriptor.GetConverter(type);
                 if (subConverter is not null && subConverter.GetType() != typeof(TypeConverter))
                 {
                     currentConverter = subConverter;
                 }
 
-                object subEditor = TypeDescriptor.GetEditor(t, editorType);
+                object? subEditor = TypeDescriptor.GetEditor(type, editorType);
                 if (subEditor is not null)
                 {
                     currentEditor = subEditor;

--- a/src/System.Windows.Forms/src/misc/ImageListUtils.cs
+++ b/src/System.Windows.Forms/src/misc/ImageListUtils.cs
@@ -12,50 +12,53 @@ namespace System.Windows.Forms
     {
         public static PropertyDescriptor? GetImageListProperty(PropertyDescriptor currentComponent, ref object instance)
         {
-            if (instance is object[]) //multiple selection is not supported by this class
+            // Multiple selection is not supported.
+            if (instance is object[])
             {
                 return null;
             }
 
-            PropertyDescriptor? imageListProp = null;
+            if (!currentComponent.TryGetAttribute(out RelatedImageListAttribute? relatedAttribute) || relatedAttribute.RelatedImageList is null)
+            {
+                return null;
+            }
+
+            PropertyDescriptor? imageListProperty = null;
             object? parentInstance = instance;
 
-            if (currentComponent.TryGetAttribute(out RelatedImageListAttribute? relatedAttribute) && relatedAttribute.RelatedImageList is not null)
+            string[] pathInfo = relatedAttribute.RelatedImageList.Split('.');
+            for (int i = 0; i < pathInfo.Length; i++)
             {
-                string[] pathInfo = relatedAttribute.RelatedImageList.Split('.');
-                for (int i = 0; i < pathInfo.Length; i++)
+                if (parentInstance is null)
                 {
-                    if (parentInstance is null)
-                    {
-                        Debug.Fail("A property specified in the path is null or not yet instantiated at this time");
-                        break; // path is wrong
-                    }
+                    Debug.Fail("A property specified in the path is null or not yet instantiated at this time");
+                    break;
+                }
 
-                    PropertyDescriptor? prop = TypeDescriptor.GetProperties(parentInstance)[pathInfo[i]];
-                    if (prop is null)
-                    {
-                        Debug.Fail("The path specified to the property is wrong");
-                        break; // path is wrong
-                    }
+                PropertyDescriptor? property = TypeDescriptor.GetProperties(parentInstance)[pathInfo[i]];
+                if (property is null)
+                {
+                    Debug.Fail("The path specified to the property is wrong");
+                    break;
+                }
 
-                    if (i == pathInfo.Length - 1)
+                if (i == pathInfo.Length - 1)
+                {
+                    // We're on the last one, look if that's our guy
+                    if (typeof(ImageList).IsAssignableFrom(property.PropertyType))
                     {
-                        // we're on the last one, look if that's our guy
-                        if (typeof(ImageList).IsAssignableFrom(prop.PropertyType))
-                        {
-                            instance = parentInstance;
-                            imageListProp = prop;
-                            break;
-                        }
+                        instance = parentInstance;
+                        imageListProperty = property;
+                        break;
                     }
-                    else
-                    {
-                        parentInstance = prop.GetValue(parentInstance);
-                    }
+                }
+                else
+                {
+                    parentInstance = property.GetValue(parentInstance);
                 }
             }
 
-            return imageListProp;
+            return imageListProperty;
         }
     }
 }


### PR DESCRIPTION
This was a bit tricky as we deviate a bit from the base annotations. I've moved a number of the collections to generic ones to facilitate this and cleaned up more to keep null state clearer.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8045)