### PR TITLE
Fix a SaveTabSelection method

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -66,7 +65,7 @@ namespace System.Windows.Forms
         private IDesignerHost _designerHost;
         private IDesignerEventService _designerEventService;
 
-        private Hashtable _designerSelections;
+        private Dictionary<int, int> _designerSelections;
 
         private GridEntry _defaultEntry;
         private GridEntry _rootEntry;
@@ -1106,7 +1105,7 @@ namespace System.Windows.Forms
                     object designerKey = ActiveDesigner;
 
                     // Get the active designer and see if we've stashed away state for it.
-                    if (TryGetSavedTabSelection(out int selectedTab))
+                    if (TryGetSavedTabIndex(out int selectedTab))
                     {
                         if (selectedTab < _tabs.Count && (selectedTab == PropertiesTabIndex || _tabs[selectedTab].Button.Visible))
                         {
@@ -1127,7 +1126,7 @@ namespace System.Windows.Forms
 
                 if (_selectedObjects.Length > 0)
                 {
-                    SaveTabSelection();
+                    SaveSelectedTabIndex();
                 }
             }
         }
@@ -3066,7 +3065,7 @@ namespace System.Windows.Forms
             {
                 SelectViewTabButton((ToolStripButton)sender, true);
                 OnLayoutInternal(dividerOnly: false);
-                SaveTabSelection();
+                SaveSelectedTabIndex();
             }
 
             OnButtonClick(sender, e);
@@ -3541,7 +3540,7 @@ namespace System.Windows.Forms
             }
 
             // Remove this tab from our "last selected" group
-            if (!GetFlag(Flags.ReInitTab) && TryGetSavedTabSelection(out int selectedTab) && selectedTab == tabIndex)
+            if (!GetFlag(Flags.ReInitTab) && TryGetSavedTabIndex(out int selectedTab) && selectedTab == tabIndex)
             {
                 _designerSelections.Remove(ActiveDesigner.GetHashCode());
             }
@@ -3620,18 +3619,18 @@ namespace System.Windows.Forms
 
         public void ResetSelectedProperty() => _gridView.Reset();
 
-        private void SaveTabSelection()
+        private void SaveSelectedTabIndex()
         {
             if (_designerHost is not null)
             {
                 _designerSelections ??= new();
-                _designerSelections[_designerHost.GetHashCode()] = _selectedTab;
+                _designerSelections[_designerHost.GetHashCode()] = _tabs.IndexOf(_selectedTab);
             }
         }
 
-        private bool TryGetSavedTabSelection(out int selectedTab)
+        private bool TryGetSavedTabIndex(out int selectedTabIndex)
         {
-            selectedTab = -1;
+            selectedTabIndex = -1;
             if (_designerSelections is null || ActiveDesigner is null)
             {
                 return false;
@@ -3643,7 +3642,7 @@ namespace System.Windows.Forms
                 return false;
             }
 
-            selectedTab = (int)_designerSelections[hashCode];
+            selectedTabIndex = _designerSelections[hashCode];
             return true;
         }
 

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/TestAccessors.PropertyGridTestAccessor.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridInternal/TestAccessors.PropertyGridTestAccessor.cs
@@ -11,6 +11,12 @@ namespace System
             public PropertyGridTestAccessor(Windows.Forms.PropertyGrid instance) : base(instance) { }
 
             internal Windows.Forms.PropertyGridInternal.PropertyGridView GridView => Dynamic._gridView;
+
+            internal void SaveSelectedTabIndex() { Dynamic.SaveSelectedTabIndex(); }
+
+            internal bool TryGetSavedTabIndex(out int selectedTabIndex) { return Dynamic.TryGetSavedTabIndex(out selectedTabIndex); }
+
+            internal Dictionary<int, int> _designerSelections => Dynamic._designerSelections;
         }
 
         public static PropertyGridTestAccessor TestAccessor(this Windows.Forms.PropertyGrid propertyGrid)

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -2687,6 +2687,80 @@ namespace System.Windows.Forms.Tests
             Assert.Throws<ArgumentException>(() => control.SelectedObjects = new object[] { null });
         }
 
+        private ISite CreateISiteObject()
+        {
+            var mockComponentChangeService = new Mock<IComponentChangeService>(MockBehavior.Strict);
+            var mockPropertyValueUIService = new Mock<IPropertyValueUIService>(MockBehavior.Strict);
+            var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
+            mockDesignerHost
+               .Setup(h => h.Container)
+               .Returns((IContainer)null);
+            mockDesignerHost
+                .Setup(h => h.GetService(typeof(IComponentChangeService)))
+                .Returns(mockComponentChangeService.Object);
+            mockDesignerHost
+                .Setup(h => h.GetService(typeof(IPropertyValueUIService)))
+                .Returns(mockPropertyValueUIService.Object);
+            var mockSite = new Mock<ISite>(MockBehavior.Strict);
+            mockSite
+                .Setup(s => s.Container)
+                .Returns((IContainer)null);
+            mockSite
+                .Setup(s => s.GetService(typeof(AmbientProperties)))
+                .Returns(new AmbientProperties());
+            mockSite
+                .Setup(s => s.GetService(typeof(IDesignerHost)))
+                .Returns(mockDesignerHost.Object);
+            return mockSite.Object;
+        }
+
+        [WinFormsFact]
+        public void PropertyGrid_Site_ShouldSaveSelectedTabIndex()
+        {
+            using PropertyGrid propertyGrid = new();
+            var propertyGridTestAccessor = propertyGrid.TestAccessor();
+
+            propertyGrid.Site = CreateISiteObject();
+            Assert.NotNull(propertyGrid.ActiveDesigner);
+
+            propertyGridTestAccessor.SaveSelectedTabIndex();
+            Dictionary<int, int> _designerSelections = propertyGridTestAccessor._designerSelections;
+            Assert.NotNull(_designerSelections);
+            Assert.True(_designerSelections.ContainsKey(propertyGrid.ActiveDesigner.GetHashCode()));
+
+            int savedTabIndex = _designerSelections[propertyGrid.ActiveDesigner.GetHashCode()];
+            int selectedTabIndex = -1;
+            Assert.NotEqual(savedTabIndex, selectedTabIndex);
+
+            bool isInvokeMethodSuccessful = propertyGridTestAccessor.TryGetSavedTabIndex(out selectedTabIndex);
+            Assert.True(isInvokeMethodSuccessful);
+            Assert.Equal(savedTabIndex, selectedTabIndex);
+        }
+
+        [WinFormsFact]
+        public void PropertyGrid_SiteChange_ShouldNotSaveSelectedTabIndex()
+        {
+            using PropertyGrid propertyGrid = new();
+            var propertyGridTestAccessor = propertyGrid.TestAccessor();
+            propertyGrid.Site = CreateISiteObject();
+            var previousActiveDesigner = propertyGrid.ActiveDesigner;
+            propertyGridTestAccessor.SaveSelectedTabIndex();
+
+            //Set other Site
+            propertyGrid.Site = CreateISiteObject();
+            Assert.NotNull(propertyGrid.ActiveDesigner);
+            Assert.NotEqual(previousActiveDesigner, propertyGrid.ActiveDesigner);
+
+            int selectedTabIndex = -1;
+            bool isInvokeMethodSuccessful = propertyGridTestAccessor.TryGetSavedTabIndex(out selectedTabIndex);
+            Assert.False(isInvokeMethodSuccessful);
+            Assert.Equal(-1, selectedTabIndex);
+
+            Dictionary<int, int> _designerSelections = propertyGridTestAccessor._designerSelections;
+            Assert.NotNull(_designerSelections);
+            Assert.True(_designerSelections.ContainsKey(previousActiveDesigner.GetHashCode()));
+        }
+
         public static IEnumerable<object[]> Site_Set_TestData()
         {
             yield return new object[] { null };
@@ -2762,51 +2836,6 @@ namespace System.Windows.Forms.Tests
                 .Setup(s => s.GetService(typeof(IDesignerHost)))
                 .Returns(mockDesignerHost.Object);
             yield return new object[] { mockSite2.Object };
-        }
-
-        [WinFormsFact]
-        public void PropertyGrid_Site_ShouldSaveSelectedTabIndex()
-        {
-            var mockComponentChangeService = new Mock<IComponentChangeService>(MockBehavior.Strict);
-            var mockPropertyValueUIService = new Mock<IPropertyValueUIService>(MockBehavior.Strict);
-            var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
-            mockDesignerHost
-               .Setup(h => h.Container)
-               .Returns((IContainer)null);
-            mockDesignerHost
-                .Setup(h => h.GetService(typeof(IComponentChangeService)))
-                .Returns(mockComponentChangeService.Object);
-            mockDesignerHost
-                .Setup(h => h.GetService(typeof(IPropertyValueUIService)))
-                .Returns(mockPropertyValueUIService.Object);
-            var mockSite = new Mock<ISite>(MockBehavior.Strict);
-            mockSite
-                .Setup(s => s.Container)
-                .Returns((IContainer)null);
-            mockSite
-                .Setup(s => s.GetService(typeof(AmbientProperties)))
-                .Returns(new AmbientProperties());
-            mockSite
-                .Setup(s => s.GetService(typeof(IDesignerHost)))
-                .Returns(mockDesignerHost.Object);
-
-            using PropertyGrid propertyGrid = new();
-            propertyGrid.Site = mockSite.Object;
-            Assert.NotNull(propertyGrid.ActiveDesigner);
-
-            propertyGrid.TestAccessor().Dynamic.SaveSelectedTabIndex();
-            Assert.NotNull(propertyGrid.TestAccessor().Dynamic._designerSelections);
-
-            Dictionary<int,int> _designerSelections = propertyGrid.TestAccessor().Dynamic._designerSelections;
-            Assert.True(_designerSelections.ContainsKey(propertyGrid.ActiveDesigner.GetHashCode()));
-
-            int savedTabIndex = _designerSelections[propertyGrid.ActiveDesigner.GetHashCode()];
-            int selectedTabIndex = -1;
-            Assert.NotEqual(savedTabIndex, selectedTabIndex);
-
-            bool isInvokeMethodSuccessful = propertyGrid.TestAccessor().Dynamic.TryGetSavedTabIndex(out selectedTabIndex);
-            Assert.True(isInvokeMethodSuccessful);
-            Assert.Equal(savedTabIndex, selectedTabIndex);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -2793,13 +2793,17 @@ namespace System.Windows.Forms.Tests
             using PropertyGrid propertyGrid = new();
             propertyGrid.Site = mockSite.Object;
             Assert.NotNull(propertyGrid.ActiveDesigner);
+
             propertyGrid.TestAccessor().Dynamic.SaveSelectedTabIndex();
             Assert.NotNull(propertyGrid.TestAccessor().Dynamic._designerSelections);
+
             Dictionary<int,int> _designerSelections = propertyGrid.TestAccessor().Dynamic._designerSelections;
             Assert.True(_designerSelections.ContainsKey(propertyGrid.ActiveDesigner.GetHashCode()));
+
             int savedTabIndex = _designerSelections[propertyGrid.ActiveDesigner.GetHashCode()];
             int selectedTabIndex = -1;
             Assert.NotEqual(savedTabIndex, selectedTabIndex);
+
             bool isInvokeMethodSuccessful = propertyGrid.TestAccessor().Dynamic.TryGetSavedTabIndex(out selectedTabIndex);
             Assert.True(isInvokeMethodSuccessful);
             Assert.Equal(savedTabIndex, selectedTabIndex);

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/PropertyGridTests.cs
@@ -2764,6 +2764,47 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { mockSite2.Object };
         }
 
+        [WinFormsFact]
+        public void PropertyGrid_Site_ShouldSaveSelectedTabIndex()
+        {
+            var mockComponentChangeService = new Mock<IComponentChangeService>(MockBehavior.Strict);
+            var mockPropertyValueUIService = new Mock<IPropertyValueUIService>(MockBehavior.Strict);
+            var mockDesignerHost = new Mock<IDesignerHost>(MockBehavior.Strict);
+            mockDesignerHost
+               .Setup(h => h.Container)
+               .Returns((IContainer)null);
+            mockDesignerHost
+                .Setup(h => h.GetService(typeof(IComponentChangeService)))
+                .Returns(mockComponentChangeService.Object);
+            mockDesignerHost
+                .Setup(h => h.GetService(typeof(IPropertyValueUIService)))
+                .Returns(mockPropertyValueUIService.Object);
+            var mockSite = new Mock<ISite>(MockBehavior.Strict);
+            mockSite
+                .Setup(s => s.Container)
+                .Returns((IContainer)null);
+            mockSite
+                .Setup(s => s.GetService(typeof(AmbientProperties)))
+                .Returns(new AmbientProperties());
+            mockSite
+                .Setup(s => s.GetService(typeof(IDesignerHost)))
+                .Returns(mockDesignerHost.Object);
+
+            using PropertyGrid propertyGrid = new();
+            propertyGrid.Site = mockSite.Object;
+            Assert.NotNull(propertyGrid.ActiveDesigner);
+            propertyGrid.TestAccessor().Dynamic.SaveSelectedTabIndex();
+            Assert.NotNull(propertyGrid.TestAccessor().Dynamic._designerSelections);
+            Dictionary<int,int> _designerSelections = propertyGrid.TestAccessor().Dynamic._designerSelections;
+            Assert.True(_designerSelections.ContainsKey(propertyGrid.ActiveDesigner.GetHashCode()));
+            int savedTabIndex = _designerSelections[propertyGrid.ActiveDesigner.GetHashCode()];
+            int selectedTabIndex = -1;
+            Assert.NotEqual(savedTabIndex, selectedTabIndex);
+            bool isInvokeMethodSuccessful = propertyGrid.TestAccessor().Dynamic.TryGetSavedTabIndex(out selectedTabIndex);
+            Assert.True(isInvokeMethodSuccessful);
+            Assert.Equal(savedTabIndex, selectedTabIndex);
+        }
+
         [WinFormsTheory]
         [MemberData(nameof(Site_Set_TestData))]
         public void PropertyGrid_Site_Set_GetReturnsExpected(ISite value)


### PR DESCRIPTION

<!-- Please read CONTRIBUTING.md before submitting a pull request -->



Hi,



My name is Alex M. I am a software developer at DevExpress WinForms Team.



I created a pull request that fixes the following issue. It's related only for .NET 7 after this PR - [Combine PropertyGrid tab information.](https://github.com/dotnet/winforms/pull/6108).




### Fixes
"Invalid cast error" in the TryGetSavedTabSelection method. PropertyGrid saves information about selectedTab in a [SaveTabSelection ](https://github.com/dotnet/winforms/blob/7ef35233ec820db47dce981b9ba403850b98d7ec/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs#L3628) method. After change the _selectedTab field from int to a TabInfo record we should use a _tabs.IndexOf(_selectedTab) method. In a [TryGetSavedTabSelection ](https://github.com/dotnet/winforms/blob/7ef35233ec820db47dce981b9ba403850b98d7ec/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs#L3646) method we restore information and we expect int value in a _designerSelections Hashtable. 





## Proposed changes



-Changed the type of value added to the _designerSelections dictionary in the SaveTabSelection method.



-Before
TabInfo 



-After
int




<!-- We are in TELL-MODE the following section must be completed -->
## Customer Impact



The error occurs when an end-user modify somthing in Visual Studio designer.



## Regression?



Yes



## Risk



Medium



<!-- end TELL-MODE -->




## Test methodology <!-- How did you ensure quality? -->



* Manually




## Test environment(s) <!-- Remove any that don't apply -->

VisualStudio 2022 Preview 4
.NET 7 RC2


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8055)