### PR TITLE
Avoid excessive memory usage and slow `TrackBar` control 

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/LocalAppContextSwitches/LocalAppContextSwitches.cs
@@ -15,15 +15,11 @@ namespace System.Windows.Forms.Primitives
         // for more details on how to enable these switches in the application.
         private const string ScaleTopLevelFormMinMaxSizeForDpiSwitchName = "System.Windows.Forms.ScaleTopLevelFormMinMaxSizeForDpi";
         internal const string AnchorLayoutV2SwitchName = "System.Windows.Forms.AnchorLayoutV2";
+        internal const string TrackBarModernRenderingSwitchName = "System.Windows.Forms.TrackBarModernRendering";
 
-        private static int s_scaleTopLevelFormMinMaxSizeForDpi;
         private static int s_AnchorLayoutV2;
-
-        public static bool ScaleTopLevelFormMinMaxSizeForDpi
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => GetCachedSwitchValue(ScaleTopLevelFormMinMaxSizeForDpiSwitchName, ref s_scaleTopLevelFormMinMaxSizeForDpi);
-        }
+        private static int s_scaleTopLevelFormMinMaxSizeForDpi;
+        private static int s_trackBarModernRendering;
 
         /// <summary>
         ///  Indicates whether AnchorLayoutV2 feature is enabled.
@@ -37,16 +33,6 @@ namespace System.Windows.Forms.Primitives
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => GetCachedSwitchValue(AnchorLayoutV2SwitchName, ref s_AnchorLayoutV2);
-        }
-
-        private static readonly FrameworkName? s_targetFrameworkName = GetTargetFrameworkName();
-
-        private static readonly bool s_isNetCoreApp = (s_targetFrameworkName?.Identifier) == ".NETCoreApp";
-
-        private static FrameworkName? GetTargetFrameworkName()
-        {
-            string? targetFrameworkName = AppContext.TargetFrameworkName;
-            return targetFrameworkName is null ? null : new FrameworkName(targetFrameworkName);
         }
 
         private static bool GetCachedSwitchValue(string switchName, ref int cachedSwitchValue)
@@ -107,8 +93,35 @@ namespace System.Windows.Forms.Primitives
                     }
                 }
 
+                if (switchName == TrackBarModernRenderingSwitchName)
+                {
+                    return true;
+                }
+
                 return false;
             }
+        }
+
+        private static FrameworkName? GetTargetFrameworkName()
+        {
+            string? targetFrameworkName = AppContext.TargetFrameworkName;
+            return targetFrameworkName is null ? null : new FrameworkName(targetFrameworkName);
+        }
+
+        public static bool ScaleTopLevelFormMinMaxSizeForDpi
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetCachedSwitchValue(ScaleTopLevelFormMinMaxSizeForDpiSwitchName, ref s_scaleTopLevelFormMinMaxSizeForDpi);
+        }
+
+        private static readonly bool s_isNetCoreApp = (s_targetFrameworkName?.Identifier) == ".NETCoreApp";
+
+        private static readonly FrameworkName? s_targetFrameworkName = GetTargetFrameworkName();
+
+        public static bool TrackBarModernRendering
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => GetCachedSwitchValue(TrackBarModernRenderingSwitchName, ref s_trackBarModernRendering);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -868,7 +868,7 @@ namespace System.Windows.Forms
             int maxTickCount = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
             int ticksDrawn;
             uint range = (uint)(_maximum - _minimum);
-            if (_tickFrequency > 1)
+            if (_tickFrequency!=1)
             {
                ticksDrawn = (int)(range / _tickFrequency);
                 if(ticksDrawn<maxTickCount)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -29,7 +29,7 @@ namespace System.Windows.Forms
         private static readonly object s_scrollEvent = new object();
         private static readonly object s_valueChangedEvent = new object();
         private static readonly object s_rightToLeftChangedEvent = new object();
-
+        private bool _autoTicks = true;
         private bool _autoSize = true;
         private int _largeChange = 5;
         private int _maximum = 10;
@@ -158,12 +158,27 @@ namespace System.Windows.Forms
                         break;
                     case TickStyle.TopLeft:
                         cp.Style |= (int)(PInvoke.TBS_TOP);
+                        if (_autoTicks)
+                        {
+                            cp.Style |= (int)PInvoke.TBS_AUTOTICKS;
+                        }
+
                         break;
                     case TickStyle.BottomRight:
                         cp.Style |= (int)(PInvoke.TBS_BOTTOM);
+                        if (_autoTicks)
+                        {
+                            cp.Style |= (int)PInvoke.TBS_AUTOTICKS;
+                        }
+
                         break;
                     case TickStyle.Both:
                         cp.Style |= (int)(PInvoke.TBS_BOTH);
+                        if (_autoTicks)
+                        {
+                            cp.Style |= (int)PInvoke.TBS_AUTOTICKS;
+                        }
+
                         break;
                 }
 
@@ -807,9 +822,9 @@ namespace System.Windows.Forms
                 return;
             }
 
-            SetTickFrequency();
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)false, (LPARAM)_maximum);
+            SetTickFrequency();
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETPAGESIZE, (WPARAM)0, (LPARAM)_largeChange);
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETLINESIZE, (WPARAM)0, (LPARAM)_smallChange);
             SetTrackBarPosition();
@@ -828,11 +843,12 @@ namespace System.Windows.Forms
 
             int tickFrequency = _tickFrequency;
             int trackbarSize = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
-            uint maxValue = (uint)(_minimum + _maximum);
+            uint maxValue = (uint)(System.Math.Abs(_minimum) + _maximum);
 
             if (maxValue > trackbarSize && trackbarSize != 0)
             {
                 tickFrequency = ((int)(maxValue / trackbarSize));
+                _autoTicks = false;
             }
 
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_CLEARTICS, (WPARAM)1, (LPARAM)0);
@@ -1018,9 +1034,9 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    SetTickFrequency();
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
+                    SetTickFrequency();
                     Invalidate();
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -147,10 +147,8 @@ namespace System.Windows.Forms
             get
             {
                 _autoDrawTicks = ShouldAutoDrawTicks();
-
                 CreateParams cp = base.CreateParams;
                 cp.ClassName = PInvoke.TRACKBAR_CLASS;
-
                 switch (_tickStyle)
                 {
                     case TickStyle.None:
@@ -568,6 +566,11 @@ namespace System.Windows.Forms
                 }
 
                 _tickFrequency = value;
+                // set the recreateHandle flag to null,
+                // if the _autoDrawTicks flag does not equal what ShouldAutoDrawTicks()
+                // we set the recreateHandle to true,
+                // then we skip sending the messages and,
+                // recreateHandle will be called at the end of the method.
                 bool recreateHandle = false;
                 if (IsHandleCreated && _autoDrawTicks != ShouldAutoDrawTicks())
                 {
@@ -765,6 +768,10 @@ namespace System.Windows.Forms
             base.CreateHandle();
         }
 
+        /// <summary>
+        ///  Check if the value of the max is greater then the taskbar size.
+        ///  If so then we divide the value by size and only that many ticks to be drawn on the screen.
+        /// </summary>
         private void DrawTicks()
         {
             if (_tickStyle == TickStyle.None)
@@ -870,11 +877,6 @@ namespace System.Windows.Forms
             SetTrackBarPosition();
             AdjustSize();
         }
-
-        /// <summary>
-        ///  Check if the value of the max is greater then the taskbar size.
-        ///  If so then we divide the value by size and only that many ticks to be drawn on the screen.
-        /// </summary>
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected virtual void OnRightToLeftLayoutChanged(EventArgs e)
@@ -1049,7 +1051,11 @@ namespace System.Windows.Forms
 
                 _minimum = minValue;
                 _maximum = maxValue;
-
+                // set the recreateHandle flag to null,
+                // if the _autoDrawTicks flag does not equal what ShouldAutoDrawTicks()
+                // we set the recreateHandle to true,
+                // then we skip sending the messages and,
+                // recreateHandle will be called at the end of the method,
                 bool recreateHandle = false;
                 if (_autoDrawTicks != ShouldAutoDrawTicks())
                 {
@@ -1115,6 +1121,9 @@ namespace System.Windows.Forms
             }
         }
 
+        /// <summary>
+        /// This checks all the use cases that we potentially might want to keep `TBS_AUTOTICKS`.
+        /// </summary>
         private bool ShouldAutoDrawTicks()
         {
             if (TickStyle == TickStyle.None)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -856,21 +856,26 @@ namespace System.Windows.Forms
 
         }
 
+
         private void DrawTicks()
         {
             // Check if the value of the max is greater then the taskbar size.
             // If so then we divide the value by size and only that many ticks to be drawn on the screen.
-
+            int ticksDrawnFrequency = _tickFrequency;
             if (_autoDrawTicks)
             {
-                PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)_tickFrequency);
+                PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)ticksDrawnFrequency);
                 return;
             }
 
             int maxTickCount = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
             uint range = (uint)(_maximum - _minimum);
-            int ticksDrawnFrequency = _tickFrequency;
-            int ticksDrawn = (int)(range / ticksDrawnFrequency);
+            int ticksDrawn=1;
+
+            if (ticksDrawnFrequency != 0)
+            {
+                ticksDrawn = (int)(range / ticksDrawnFrequency);
+            }
 
             if (maxTickCount != 0 && ticksDrawn > maxTickCount)
             {
@@ -1061,23 +1066,21 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
-                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
                     bool recreateHandle = false;
                     if (_autoDrawTicks != ShouldAutoDrawTicks())
                     {
                         recreateHandle = true;
                     }
 
-                    if (!recreateHandle && IsHandleCreated)
-                    {
-                        DrawTicks();
-                        Invalidate();
-                    }
-                    else
+                    if (recreateHandle)
                     {
                         RecreateHandle();
                     }
+
+                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
+                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
+                    DrawTicks();
+                    Invalidate();
                 }
 
                 // When we change the range, the comctl32 trackbar's internal position can change

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.Windows.Forms.Layout;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
 using static Interop;
 using static Interop.ComCtl32;
 
@@ -308,7 +307,6 @@ namespace System.Windows.Forms
                 }
 
                 SetRange(_minimum, value);
-                SetTickFrequency();
             }
         }
 
@@ -335,7 +333,6 @@ namespace System.Windows.Forms
                 }
 
                 SetRange(value, _maximum);
-                SetTickFrequency();
             }
         }
 
@@ -539,8 +536,6 @@ namespace System.Windows.Forms
             }
         }
 
-
-
         /// <summary>
         ///  Indicates just how many ticks will be drawn. For a TrackBar with a
         ///  range of 0..100, it might be impractical to draw all 100 ticks for a
@@ -564,7 +559,6 @@ namespace System.Windows.Forms
                 _tickFrequency = value;
                 if (IsHandleCreated)
                 {
-                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)value);
                     SetTickFrequency();
                     Invalidate();
                 }
@@ -826,15 +820,15 @@ namespace System.Windows.Forms
         {
             // check if the value of the max is greater then the taskbar size
             // if so then we divide the value by size and only that many ticks to be drawn on the screen
-                 
+
             if (TickStyle != System.Windows.Forms.TickStyle.None)
             {
                 return;
             }
 
             int tickFrequency = _tickFrequency;
-            Decimal trackbarSize;
-            Decimal maxValue = _minimum + _maximum;
+            int trackbarSize;
+            uint maxValue = (uint)(_minimum + _maximum);
             if (Orientation == Orientation.Horizontal)
             {
                 trackbarSize = Size.Width;
@@ -844,14 +838,12 @@ namespace System.Windows.Forms
                 trackbarSize = Size.Height;
             }
 
-            if ( maxValue > trackbarSize)
+            if (maxValue > trackbarSize)
             {
-                tickFrequency = Convert.ToInt32(Math.Round(Convert.ToDouble(maxValue / trackbarSize)));               
+                tickFrequency = (int)(maxValue / trackbarSize);
             }
 
-   
-            User32.SendMessageW(this, (User32.WM)TBM.SETTICFREQ, tickFrequency);
-
+            PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)tickFrequency);
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -157,13 +157,13 @@ namespace System.Windows.Forms
                         cp.Style |= (int)PInvoke.TBS_NOTICKS;
                         break;
                     case TickStyle.TopLeft:
-                        cp.Style |= (int)(PInvoke.TBS_AUTOTICKS | PInvoke.TBS_TOP);
+                        cp.Style |= (int)(PInvoke.TBS_TOP);
                         break;
                     case TickStyle.BottomRight:
-                        cp.Style |= (int)(PInvoke.TBS_AUTOTICKS | PInvoke.TBS_BOTTOM);
+                        cp.Style |= (int)(PInvoke.TBS_BOTTOM);
                         break;
                     case TickStyle.Both:
-                        cp.Style |= (int)(PInvoke.TBS_AUTOTICKS | PInvoke.TBS_BOTH);
+                        cp.Style |= (int)(PInvoke.TBS_BOTH);
                         break;
                 }
 
@@ -1022,9 +1022,9 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    SetTickFrequency();
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
+                    SetTickFrequency();
                     Invalidate();
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -869,6 +869,7 @@ namespace System.Windows.Forms
             Debug.Assert(_autoDrawTicks == ShouldAutoDrawTicks());
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)false, (LPARAM)_maximum);
+            PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)_tickFrequency);
             DrawTicks();
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETPAGESIZE, (WPARAM)0, (LPARAM)_largeChange);
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETLINESIZE, (WPARAM)0, (LPARAM)_smallChange);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -807,9 +807,9 @@ namespace System.Windows.Forms
                 return;
             }
 
+            SetTickFrequency();
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)false, (LPARAM)_maximum);
-            SetTickFrequency();
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETPAGESIZE, (WPARAM)0, (LPARAM)_largeChange);
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETLINESIZE, (WPARAM)0, (LPARAM)_smallChange);
             SetTrackBarPosition();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -821,7 +821,7 @@ namespace System.Windows.Forms
             // check if the value of the max is greater then the taskbar size
             // if so then we divide the value by size and only that many ticks to be drawn on the screen
 
-            if (TickStyle != System.Windows.Forms.TickStyle.None)
+            if (TickStyle == System.Windows.Forms.TickStyle.None)
             {
                 return;
             }
@@ -838,12 +838,12 @@ namespace System.Windows.Forms
                 trackbarSize = Size.Height;
             }
 
-            if (maxValue > trackbarSize)
+            if (maxValue > trackbarSize && trackbarSize != 0)
             {
-                tickFrequency = (int)(maxValue / trackbarSize);
+              tickFrequency = (int)(maxValue / trackbarSize);
             }
 
-            PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)tickFrequency);
+             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)tickFrequency);
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]
@@ -1022,13 +1022,9 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
-                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
-
-                    // We must repaint the trackbar after changing the range.
-                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
-
                     SetTickFrequency();
-
+                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
+                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
                     Invalidate();
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -570,15 +570,18 @@ namespace System.Windows.Forms
                 // is performed by the native control or the Windows Forms runtime
                 // is still valid. If it's no longer valid, we'll need to recreate the native control.
                 bool recreateHandle = ShouldRecreateHandle();
-                if (recreateHandle && IsHandleCreated)
-                {
-                    RecreateHandle();
-                }
-                else
+                if (IsHandleCreated)
                 {
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)value);
-                    DrawTicks();
-                    Invalidate();
+                    if (recreateHandle)
+                    {
+                        RecreateHandle();
+                    }
+                    else
+                    {
+                        DrawTicks();
+                        Invalidate();
+                    }
                 }
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -827,23 +827,19 @@ namespace System.Windows.Forms
             }
 
             int tickFrequency = _tickFrequency;
-            int trackbarSize;
+            int trackbarSize = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
             uint maxValue = (uint)(_minimum + _maximum);
-            if (Orientation == Orientation.Horizontal)
-            {
-                trackbarSize = Size.Width;
-            }
-            else
-            {
-                trackbarSize = Size.Height;
-            }
 
             if (maxValue > trackbarSize && trackbarSize != 0)
             {
-              tickFrequency = (int)(maxValue / trackbarSize);
+                tickFrequency = ((int)(maxValue / trackbarSize));
             }
 
-             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)tickFrequency);
+            PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_CLEARTICS, (WPARAM)1, (LPARAM)0);
+            for (int i = tickFrequency; i < maxValue; i += tickFrequency)
+            {
+                PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTIC, lParam: (LPARAM)i);
+            }
         }
 
         [EditorBrowsable(EditorBrowsableState.Advanced)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -843,7 +843,7 @@ namespace System.Windows.Forms
 
             int tickFrequency = _tickFrequency;
             int trackbarSize = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
-            uint maxValue = (uint)(System.Math.Abs(_minimum) + _maximum);
+            uint maxValue = (uint)(-_minimum+_maximum);
 
             if (maxValue > trackbarSize && trackbarSize != 0)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -1018,9 +1018,9 @@ namespace System.Windows.Forms
 
                 if (IsHandleCreated)
                 {
+                    SetTickFrequency();
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
-                    SetTickFrequency();
                     Invalidate();
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -29,7 +29,6 @@ namespace System.Windows.Forms
         private static readonly object s_scrollEvent = new object();
         private static readonly object s_valueChangedEvent = new object();
         private static readonly object s_rightToLeftChangedEvent = new object();
-        private bool _autoTicks = true;
         private bool _autoSize = true;
         private int _largeChange = 5;
         private int _maximum = 10;
@@ -187,7 +186,7 @@ namespace System.Windows.Forms
 
                 void EnableAutoTicksIfRequired()
                 {
-                     if (_autoTicks)
+                     if (AutoDrawTicks)
                      {
                         cp.Style |= (int)PInvoke.TBS_AUTOTICKS;
                      }
@@ -838,7 +837,7 @@ namespace System.Windows.Forms
 
                 int tickFrequency = _tickFrequency;
                 int maxTickCount = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
-                int range = _maximum - _minimum;
+                uint range = (uint)(_maximum - _minimum);
 
                 return range <= maxTickCount || maxTickCount == 0;
             }
@@ -856,15 +855,14 @@ namespace System.Windows.Forms
 
             int tickFrequency = _tickFrequency;
             int maxTickCount = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
-            int range = _maximum - _minimum;
-
+            uint range = (uint)(_maximum - _minimum);
             if (range > maxTickCount && maxTickCount != 0)
             {
-                tickFrequency = range / maxTickCount;
+                tickFrequency = (int)(range / maxTickCount);
             }
 
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_CLEARTICS, (WPARAM)1, (LPARAM)0);
-            for (int i = _minimum + tickFrequency; i < _maximum - tickFrequency; i += tickFrequency)
+            for (int i = (_minimum + tickFrequency); i < _maximum - tickFrequency; i += tickFrequency)
             {
                 LRESULT lresult = PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTIC, lParam: (IntPtr)i);
                 Debug.Assert((bool)(BOOL)lresult);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -870,7 +870,7 @@ namespace System.Windows.Forms
 
             int maxTickCount = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
             uint range = (uint)(_maximum - _minimum);
-            int ticksDrawn=1;
+            int ticksDrawn = 1;
 
             if (ticksDrawnFrequency != 0)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -842,23 +842,6 @@ namespace System.Windows.Forms
             AdjustSize();
         }
 
-        private bool ShouldAutoDrawTicks()
-        {
-        if (TickStyle == TickStyle.None)
-        {
-            return true;
-        }
-
-        int size = Orientation == Orientation.Horizontal ? Size.Width : Size.Height;
-        if (size == 0)
-        {
-            return true;
-        }
-
-        uint range = (uint)(_maximum - _minimum);
-        return range <= (size / 2);
-        }
-
         /// <summary>
         ///  Check if the value of the max is greater then the taskbar size.
         ///  If so then we divide the value by size and only that many ticks to be drawn on the screen.
@@ -870,28 +853,28 @@ namespace System.Windows.Forms
                 return;
             }
 
-            int ticksDrawnFrequency = _tickFrequency;
+            int drawnTickFrequency = _tickFrequency;
             if (_autoDrawTicks)
             {
-                PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)ticksDrawnFrequency);
+                PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)drawnTickFrequency);
                 return;
             }
 
             int maxTickCount = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
             uint range = (uint)(_maximum - _minimum);
             int ticksDrawn = 1;
-            if (ticksDrawnFrequency != 0)
+            if (drawnTickFrequency != 0)
             {
-                ticksDrawn = (int)(range / ticksDrawnFrequency);
+                ticksDrawn = (int)(range / drawnTickFrequency);
             }
 
             if (maxTickCount != 0 && ticksDrawn > maxTickCount)
             {
-                ticksDrawnFrequency = (int)(range / maxTickCount);
+                drawnTickFrequency = (int)(range / maxTickCount);
             }
 
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_CLEARTICS, (WPARAM)1, (LPARAM)0);
-            for (int i = _minimum + ticksDrawnFrequency; i < _maximum - ticksDrawnFrequency; i += ticksDrawnFrequency)
+            for (int i = _minimum + drawnTickFrequency; i < _maximum - drawnTickFrequency; i += drawnTickFrequency)
             {
                 LRESULT lresult = PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTIC, lParam: (IntPtr)i);
                 Debug.Assert((bool)(BOOL)lresult);
@@ -1135,6 +1118,23 @@ namespace System.Windows.Forms
 
                 PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETPOS, (WPARAM)(BOOL)true, (LPARAM)reflectedValue);
             }
+        }
+
+        private bool ShouldAutoDrawTicks()
+        {
+            if (TickStyle == TickStyle.None)
+            {
+                return true;
+            }
+
+            int size = Orientation == Orientation.Horizontal ? Size.Width : Size.Height;
+            if (size == 0)
+            {
+                return true;
+            }
+
+            uint range = (uint)(_maximum - _minimum);
+            return range <= (size / 2);
         }
 
         public override string ToString() => $"{base.ToString()}, Minimum: {Minimum}, Maximum: {Maximum}, Value: {_value}";

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -776,19 +776,13 @@ namespace System.Windows.Forms
         /// </summary>
         private void DrawTicks()
         {
-            if (_tickStyle == TickStyle.None)
+            // Will be true if they opt out TrackBarModernRendering.
+            if (_tickStyle == TickStyle.None || _autoDrawTicks)
             {
                 return;
             }
 
             int drawnTickFrequency = _tickFrequency;
-            // Will be true if they opt out TrackBarModernRendering.
-            if (_autoDrawTicks)
-            {
-                PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)drawnTickFrequency);
-                return;
-            }
-
             // Divide by 2 because otherwise the ticks appear as a solid line.
             int maxTickCount = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
             uint range = (uint)(_maximum - _minimum);
@@ -1065,7 +1059,11 @@ namespace System.Windows.Forms
                 {
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
-                    DrawTicks();
+                    if (!_autoDrawTicks)
+                    {
+                        DrawTicks();
+                    }
+
                     Invalidate();
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TrackBar.cs
@@ -186,7 +186,7 @@ namespace System.Windows.Forms
                 void EnableAutoTicksIfRequired()
                 {
                     _autoDrawTicks = false;
-                    if (ShouldAutoDrawTicks)
+                    if (ShouldAutoDrawTicks())
                      {
                         _autoDrawTicks = true;
                         cp.Style |= (int)PInvoke.TBS_AUTOTICKS;
@@ -569,7 +569,7 @@ namespace System.Windows.Forms
 
                 _tickFrequency = value;
                 bool recreateHandle = false;
-                if (IsHandleCreated && _autoDrawTicks != ShouldAutoDrawTicks)
+                if (IsHandleCreated && _autoDrawTicks != ShouldAutoDrawTicks())
                 {
                     recreateHandle = true;
                 }
@@ -828,7 +828,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            Debug.Assert(_autoDrawTicks == ShouldAutoDrawTicks);
+            Debug.Assert(_autoDrawTicks == ShouldAutoDrawTicks());
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
             PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)false, (LPARAM)_maximum);
             DrawTicks();
@@ -838,24 +838,22 @@ namespace System.Windows.Forms
             AdjustSize();
         }
 
-        private bool ShouldAutoDrawTicks
+        private bool ShouldAutoDrawTicks()
         {
-            get
-            {
-                if (TickStyle == TickStyle.None)
-                {
-                    return true;
-                }
+        if (TickStyle == TickStyle.None)
+        {
+            return true;
+        }
 
-                int size = Orientation == Orientation.Horizontal ? Size.Width : Size.Height;
-                if (size == 0)
-                {
-                    return true;
-                }
+        int size = Orientation == Orientation.Horizontal ? Size.Width : Size.Height;
+        if (size == 0)
+        {
+            return true;
+        }
 
-                uint range = (uint)(_maximum - _minimum);
-                return range <= (size / 2);
-            }
+        uint range = (uint)(_maximum - _minimum);
+        return range <= (size / 2);
+
         }
 
         private void DrawTicks()
@@ -1066,7 +1064,7 @@ namespace System.Windows.Forms
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
                     PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
                     bool recreateHandle = false;
-                    if (_autoDrawTicks != ShouldAutoDrawTicks)
+                    if (_autoDrawTicks != ShouldAutoDrawTicks())
                     {
                         recreateHandle = true;
                     }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.Designer.cs
@@ -39,35 +39,41 @@ namespace WinformsControlsTest
             this.chbRightToLeft = new System.Windows.Forms.CheckBox();
             this.chbRightToLeftLayout = new System.Windows.Forms.CheckBox();
             this.tickstyleNone = new System.Windows.Forms.CheckBox();
-            this.lblTrackBarValue = new System.Windows.Forms.Label();
             this.numericMinimum = new System.Windows.Forms.NumericUpDown();
             this.numericMaximum = new System.Windows.Forms.NumericUpDown();
+            this.numericFrequency = new System.Windows.Forms.NumericUpDown();
             this.lblMinimum = new System.Windows.Forms.Label();
             this.lblMaximum = new System.Windows.Forms.Label();
+            this.lblTickFrequency = new System.Windows.Forms.Label();
+            this.lblTrackBarSize = new System.Windows.Forms.Label();
+            this.lblTrackBarValue = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.trackBar1)).BeginInit();
             this.gbOrientation.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericMinimum)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericMaximum)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericFrequency)).BeginInit();
             this.SuspendLayout();
             // 
             // trackBar1
             // 
-            this.trackBar1.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            this.trackBar1.Location = new System.Drawing.Point(413, 67);
+            this.trackBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.trackBar1.Location = new System.Drawing.Point(10, 30);
+            this.trackBar1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.trackBar1.Name = "trackBar1";
-            this.trackBar1.Size = new System.Drawing.Size(350, 350);
-            this.trackBar1.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
+            this.trackBar1.Size = new System.Drawing.Size(457, 45);
             this.trackBar1.TabIndex = 0;
-            this.trackBar1.Value = 5;
             this.trackBar1.Scroll += new System.EventHandler(this.trackBar1_Scroll);
+            this.trackBar1.SizeChanged += new System.EventHandler(this.trackBar1_SizeChanged);
             // 
             // rbHorizontal
             // 
             this.rbHorizontal.AutoSize = true;
             this.rbHorizontal.Checked = true;
-            this.rbHorizontal.Location = new System.Drawing.Point(20, 35);
+            this.rbHorizontal.Location = new System.Drawing.Point(18, 26);
+            this.rbHorizontal.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.rbHorizontal.Name = "rbHorizontal";
-            this.rbHorizontal.Size = new System.Drawing.Size(100, 24);
+            this.rbHorizontal.Size = new System.Drawing.Size(80, 19);
             this.rbHorizontal.TabIndex = 1;
             this.rbHorizontal.TabStop = true;
             this.rbHorizontal.Text = "Horizontal";
@@ -77,9 +83,10 @@ namespace WinformsControlsTest
             // rbVertical
             // 
             this.rbVertical.AutoSize = true;
-            this.rbVertical.Location = new System.Drawing.Point(20, 74);
+            this.rbVertical.Location = new System.Drawing.Point(18, 56);
+            this.rbVertical.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.rbVertical.Name = "rbVertical";
-            this.rbVertical.Size = new System.Drawing.Size(79, 24);
+            this.rbVertical.Size = new System.Drawing.Size(63, 19);
             this.rbVertical.TabIndex = 2;
             this.rbVertical.Text = "Vertical";
             this.rbVertical.UseVisualStyleBackColor = true;
@@ -89,9 +96,11 @@ namespace WinformsControlsTest
             // 
             this.gbOrientation.Controls.Add(this.rbHorizontal);
             this.gbOrientation.Controls.Add(this.rbVertical);
-            this.gbOrientation.Location = new System.Drawing.Point(56, 67);
+            this.gbOrientation.Location = new System.Drawing.Point(65, 78);
+            this.gbOrientation.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.gbOrientation.Name = "gbOrientation";
-            this.gbOrientation.Size = new System.Drawing.Size(250, 125);
+            this.gbOrientation.Padding = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.gbOrientation.Size = new System.Drawing.Size(168, 84);
             this.gbOrientation.TabIndex = 3;
             this.gbOrientation.TabStop = false;
             this.gbOrientation.Text = "Orientation";
@@ -99,101 +108,160 @@ namespace WinformsControlsTest
             // chbRightToLeft
             // 
             this.chbRightToLeft.AutoSize = true;
-            this.chbRightToLeft.Location = new System.Drawing.Point(56, 220);
+            this.chbRightToLeft.Location = new System.Drawing.Point(83, 176);
+            this.chbRightToLeft.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.chbRightToLeft.Name = "chbRightToLeft";
-            this.chbRightToLeft.Size = new System.Drawing.Size(100, 24);
+            this.chbRightToLeft.Size = new System.Drawing.Size(86, 19);
             this.chbRightToLeft.TabIndex = 4;
             this.chbRightToLeft.Text = "RightToLeft";
             this.chbRightToLeft.UseVisualStyleBackColor = true;
-            this.chbRightToLeft.CheckedChanged += new System.EventHandler(this.chbRightToLeft_CheckedChanged);       
+            this.chbRightToLeft.CheckedChanged += new System.EventHandler(this.chbRightToLeft_CheckedChanged);
             // 
             // chbRightToLeftLayout
-            //
+            // 
             this.chbRightToLeftLayout.AutoSize = true;
-            this.chbRightToLeftLayout.Location = new System.Drawing.Point(56, 260);
+            this.chbRightToLeftLayout.Location = new System.Drawing.Point(83, 199);
+            this.chbRightToLeftLayout.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.chbRightToLeftLayout.Name = "chbRightToLeftLayout";
-            this.chbRightToLeftLayout.Size = new System.Drawing.Size(100, 24);
+            this.chbRightToLeftLayout.Size = new System.Drawing.Size(122, 19);
             this.chbRightToLeftLayout.TabIndex = 5;
             this.chbRightToLeftLayout.Text = "RightToLeftLayout";
             this.chbRightToLeftLayout.UseVisualStyleBackColor = true;
             this.chbRightToLeftLayout.CheckedChanged += new System.EventHandler(this.chbRightToLeftLayout_CheckedChanged);
             // 
             // tickstyleNone
-            //
+            // 
             this.tickstyleNone.AutoSize = true;
-            this.tickstyleNone.Location = new System.Drawing.Point(56, 300);
+            this.tickstyleNone.Location = new System.Drawing.Point(83, 222);
+            this.tickstyleNone.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tickstyleNone.Name = "tickstyleNone";
-            this.tickstyleNone.Size = new System.Drawing.Size(100, 24);
+            this.tickstyleNone.Size = new System.Drawing.Size(100, 19);
             this.tickstyleNone.TabIndex = 11;
             this.tickstyleNone.Text = "TickstyleNone";
             this.tickstyleNone.UseVisualStyleBackColor = true;
             this.tickstyleNone.CheckedChanged += new System.EventHandler(this.tickstyleNone_CheckedChanged);
             // 
-            // lblTrackBarValue
-            // 
-            this.lblTrackBarValue.AutoSize = true;
-            this.lblTrackBarValue.Location = new System.Drawing.Point(422, 26);
-            this.lblTrackBarValue.Name = "lblTrackBarValue";
-            this.lblTrackBarValue.Size = new System.Drawing.Size(50, 20);
-            this.lblTrackBarValue.TabIndex = 6;
-            this.lblTrackBarValue.Text = "label1";
-            // 
             // numericMinimum
             // 
-            this.numericMinimum.Location = new System.Drawing.Point(56, 359);
+            this.numericMinimum.Location = new System.Drawing.Point(260, 104);
+            this.numericMinimum.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.numericMinimum.Minimum = new decimal(new int[] {
+            -1,
+            -1,
+            -1,
+            -2147483648});
             this.numericMinimum.Name = "numericMinimum";
-            this.numericMinimum.Size = new System.Drawing.Size(150, 27);
+            this.numericMinimum.Size = new System.Drawing.Size(131, 23);
             this.numericMinimum.TabIndex = 7;
+            this.numericMinimum.Value = new decimal(new int[] {
+            100,
+            0,
+            0,
+            -2147483648});
             this.numericMinimum.ValueChanged += new System.EventHandler(this.numericMinimum_ValueChanged);
-            this.numericMinimum.Minimum = int.MinValue;
             // 
             // numericMaximum
             // 
-            this.numericMaximum.Location = new System.Drawing.Point(56, 418);
-            this.numericMaximum.Maximum = decimal.MaxValue;
+            this.numericMaximum.Location = new System.Drawing.Point(260, 149);
+            this.numericMaximum.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.numericMaximum.Maximum = new decimal(new int[] {
+            -1,
+            -1,
+            -1,
+            0});
             this.numericMaximum.Name = "numericMaximum";
-            this.numericMaximum.Size = new System.Drawing.Size(150, 27);
+            this.numericMaximum.Size = new System.Drawing.Size(131, 23);
             this.numericMaximum.TabIndex = 8;
             this.numericMaximum.Value = new decimal(new int[] {
-            10,
+            100,
             0,
             0,
             0});
             this.numericMaximum.ValueChanged += new System.EventHandler(this.numericMaximum_ValueChanged);
             // 
+            // numericFrequency
+            // 
+            this.numericFrequency.Location = new System.Drawing.Point(260, 193);
+            this.numericFrequency.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.numericFrequency.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numericFrequency.Name = "numericFrequency";
+            this.numericFrequency.Size = new System.Drawing.Size(131, 23);
+            this.numericFrequency.TabIndex = 11;
+            this.numericFrequency.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numericFrequency.ValueChanged += new System.EventHandler(this.numericFrequency_ValueChanged);
+            // 
             // lblMinimum
             // 
             this.lblMinimum.AutoSize = true;
-            this.lblMinimum.Location = new System.Drawing.Point(56, 336);
+            this.lblMinimum.Location = new System.Drawing.Point(260, 87);
             this.lblMinimum.Name = "lblMinimum";
-            this.lblMinimum.Size = new System.Drawing.Size(72, 20);
+            this.lblMinimum.Size = new System.Drawing.Size(60, 15);
             this.lblMinimum.TabIndex = 9;
             this.lblMinimum.Text = "Minimum";
             // 
             // lblMaximum
             // 
             this.lblMaximum.AutoSize = true;
-            this.lblMaximum.Location = new System.Drawing.Point(56, 395);
+            this.lblMaximum.Location = new System.Drawing.Point(260, 131);
             this.lblMaximum.Name = "lblMaximum";
-            this.lblMaximum.Size = new System.Drawing.Size(75, 20);
+            this.lblMaximum.Size = new System.Drawing.Size(62, 15);
             this.lblMaximum.TabIndex = 10;
             this.lblMaximum.Text = "Maximum";
             // 
-            // Form1
+            // lblTickFrequency
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+            this.lblTickFrequency.AutoSize = true;
+            this.lblTickFrequency.Location = new System.Drawing.Point(260, 176);
+            this.lblTickFrequency.Name = "lblTickFrequency";
+            this.lblTickFrequency.Size = new System.Drawing.Size(86, 15);
+            this.lblTickFrequency.TabIndex = 12;
+            this.lblTickFrequency.Text = "Tick Frequency";
+            // 
+            // lblTrackBarSize
+            // 
+            this.lblTrackBarSize.AutoSize = true;
+            this.lblTrackBarSize.Location = new System.Drawing.Point(166, 9);
+            this.lblTrackBarSize.Name = "lblTrackBarSize";
+            this.lblTrackBarSize.Size = new System.Drawing.Size(39, 15);
+            this.lblTrackBarSize.TabIndex = 13;
+            this.lblTrackBarSize.Text = "Size: 0";
+            // 
+            // lblTrackBarValue
+            // 
+            this.lblTrackBarValue.AutoSize = true;
+            this.lblTrackBarValue.Location = new System.Drawing.Point(12, 9);
+            this.lblTrackBarValue.Name = "lblTrackBarValue";
+            this.lblTrackBarValue.Size = new System.Drawing.Size(47, 15);
+            this.lblTrackBarValue.TabIndex = 14;
+            this.lblTrackBarValue.Text = "Value: 0";
+            // 
+            // TrackBars
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(826, 468);
+            this.ClientSize = new System.Drawing.Size(479, 308);
+            this.Controls.Add(this.lblTrackBarValue);
+            this.Controls.Add(this.lblTrackBarSize);
+            this.Controls.Add(this.lblTickFrequency);
             this.Controls.Add(this.lblMaximum);
             this.Controls.Add(this.lblMinimum);
+            this.Controls.Add(this.numericFrequency);
             this.Controls.Add(this.numericMaximum);
             this.Controls.Add(this.numericMinimum);
-            this.Controls.Add(this.lblTrackBarValue);
             this.Controls.Add(this.chbRightToLeftLayout);
             this.Controls.Add(this.chbRightToLeft);
             this.Controls.Add(this.gbOrientation);
             this.Controls.Add(this.trackBar1);
             this.Controls.Add(this.tickstyleNone);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "TrackBars";
             this.Text = "TrackBars";
             ((System.ComponentModel.ISupportInitialize)(this.trackBar1)).EndInit();
@@ -201,6 +269,7 @@ namespace WinformsControlsTest
             this.gbOrientation.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericMinimum)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericMaximum)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericFrequency)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -215,11 +284,14 @@ namespace WinformsControlsTest
         private System.Windows.Forms.CheckBox chbRightToLeft;
         private System.Windows.Forms.CheckBox tickstyleNone;
         private System.Windows.Forms.CheckBox chbRightToLeftLayout;
-        private System.Windows.Forms.Label lblTrackBarValue;
         private System.Windows.Forms.NumericUpDown numericMinimum;
         private System.Windows.Forms.NumericUpDown numericMaximum;
+        private System.Windows.Forms.NumericUpDown numericFrequency;
         private System.Windows.Forms.Label lblMinimum;
         private System.Windows.Forms.Label lblMaximum;
+        private System.Windows.Forms.Label lblTickFrequency;
+        private System.Windows.Forms.Label lblTrackBarSize;
+        private System.Windows.Forms.Label lblTrackBarValue;
     }
 }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.Designer.cs
@@ -38,6 +38,7 @@ namespace WinformsControlsTest
             this.gbOrientation = new System.Windows.Forms.GroupBox();
             this.chbRightToLeft = new System.Windows.Forms.CheckBox();
             this.chbRightToLeftLayout = new System.Windows.Forms.CheckBox();
+            this.tickstyleNone = new System.Windows.Forms.CheckBox();
             this.lblTrackBarValue = new System.Windows.Forms.Label();
             this.numericMinimum = new System.Windows.Forms.NumericUpDown();
             this.numericMaximum = new System.Windows.Forms.NumericUpDown();
@@ -51,9 +52,11 @@ namespace WinformsControlsTest
             // 
             // trackBar1
             // 
+            this.trackBar1.Anchor = System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
             this.trackBar1.Location = new System.Drawing.Point(413, 67);
             this.trackBar1.Name = "trackBar1";
             this.trackBar1.Size = new System.Drawing.Size(350, 350);
+            this.trackBar1.TickStyle = System.Windows.Forms.TickStyle.BottomRight;
             this.trackBar1.TabIndex = 0;
             this.trackBar1.Value = 5;
             this.trackBar1.Scroll += new System.EventHandler(this.trackBar1_Scroll);
@@ -96,24 +99,35 @@ namespace WinformsControlsTest
             // chbRightToLeft
             // 
             this.chbRightToLeft.AutoSize = true;
-            this.chbRightToLeft.Location = new System.Drawing.Point(56, 223);
+            this.chbRightToLeft.Location = new System.Drawing.Point(56, 220);
             this.chbRightToLeft.Name = "chbRightToLeft";
-            this.chbRightToLeft.Size = new System.Drawing.Size(107, 24);
+            this.chbRightToLeft.Size = new System.Drawing.Size(100, 24);
             this.chbRightToLeft.TabIndex = 4;
             this.chbRightToLeft.Text = "RightToLeft";
             this.chbRightToLeft.UseVisualStyleBackColor = true;
-            this.chbRightToLeft.CheckedChanged += new System.EventHandler(this.chbRightToLeft_CheckedChanged);
+            this.chbRightToLeft.CheckedChanged += new System.EventHandler(this.chbRightToLeft_CheckedChanged);       
             // 
             // chbRightToLeftLayout
-            // 
+            //
             this.chbRightToLeftLayout.AutoSize = true;
-            this.chbRightToLeftLayout.Location = new System.Drawing.Point(56, 279);
+            this.chbRightToLeftLayout.Location = new System.Drawing.Point(56, 260);
             this.chbRightToLeftLayout.Name = "chbRightToLeftLayout";
-            this.chbRightToLeftLayout.Size = new System.Drawing.Size(151, 24);
+            this.chbRightToLeftLayout.Size = new System.Drawing.Size(100, 24);
             this.chbRightToLeftLayout.TabIndex = 5;
             this.chbRightToLeftLayout.Text = "RightToLeftLayout";
             this.chbRightToLeftLayout.UseVisualStyleBackColor = true;
             this.chbRightToLeftLayout.CheckedChanged += new System.EventHandler(this.chbRightToLeftLayout_CheckedChanged);
+            // 
+            // tickstyleNone
+            //
+            this.tickstyleNone.AutoSize = true;
+            this.tickstyleNone.Location = new System.Drawing.Point(56, 300);
+            this.tickstyleNone.Name = "tickstyleNone";
+            this.tickstyleNone.Size = new System.Drawing.Size(100, 24);
+            this.tickstyleNone.TabIndex = 11;
+            this.tickstyleNone.Text = "TickstyleNone";
+            this.tickstyleNone.UseVisualStyleBackColor = true;
+            this.tickstyleNone.CheckedChanged += new System.EventHandler(this.tickstyleNone_CheckedChanged);
             // 
             // lblTrackBarValue
             // 
@@ -135,6 +149,7 @@ namespace WinformsControlsTest
             // numericMaximum
             // 
             this.numericMaximum.Location = new System.Drawing.Point(56, 418);
+            this.numericMaximum.Maximum = decimal.MaxValue;
             this.numericMaximum.Name = "numericMaximum";
             this.numericMaximum.Size = new System.Drawing.Size(150, 27);
             this.numericMaximum.TabIndex = 8;
@@ -177,6 +192,7 @@ namespace WinformsControlsTest
             this.Controls.Add(this.chbRightToLeft);
             this.Controls.Add(this.gbOrientation);
             this.Controls.Add(this.trackBar1);
+            this.Controls.Add(this.tickstyleNone);
             this.Name = "TrackBars";
             this.Text = "TrackBars";
             ((System.ComponentModel.ISupportInitialize)(this.trackBar1)).EndInit();
@@ -196,6 +212,7 @@ namespace WinformsControlsTest
         private System.Windows.Forms.RadioButton rbVertical;
         private System.Windows.Forms.GroupBox gbOrientation;
         private System.Windows.Forms.CheckBox chbRightToLeft;
+        private System.Windows.Forms.CheckBox tickstyleNone;
         private System.Windows.Forms.CheckBox chbRightToLeftLayout;
         private System.Windows.Forms.Label lblTrackBarValue;
         private System.Windows.Forms.NumericUpDown numericMinimum;

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.Designer.cs
@@ -145,6 +145,7 @@ namespace WinformsControlsTest
             this.numericMinimum.Size = new System.Drawing.Size(150, 27);
             this.numericMinimum.TabIndex = 7;
             this.numericMinimum.ValueChanged += new System.EventHandler(this.numericMinimum_ValueChanged);
+            this.numericMinimum.Minimum = -1000000000;
             // 
             // numericMaximum
             // 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.Designer.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.Designer.cs
@@ -145,7 +145,7 @@ namespace WinformsControlsTest
             this.numericMinimum.Size = new System.Drawing.Size(150, 27);
             this.numericMinimum.TabIndex = 7;
             this.numericMinimum.ValueChanged += new System.EventHandler(this.numericMinimum_ValueChanged);
-            this.numericMinimum.Minimum = -1000000000;
+            this.numericMinimum.Minimum = int.MinValue;
             // 
             // numericMaximum
             // 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
@@ -3,11 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows.Forms;
+using static Interop.ComCtl32;
+using static Interop;
+using static System.Windows.Forms.VisualStyles.VisualStyleElement;
+using Newtonsoft.Json.Linq;
 
 namespace WinformsControlsTest
 {
     public partial class TrackBars : Form
     {
+        private int V;
+
         public TrackBars()
         {
             InitializeComponent();
@@ -29,7 +35,18 @@ namespace WinformsControlsTest
             trackBar1.RightToLeft = chbRightToLeft.Checked ? RightToLeft.Yes : RightToLeft.No;
         }
 
-        private void numericMinimum_ValueChanged(object sender, EventArgs e)
+        private void tickstyleNone_CheckedChanged(object sender, EventArgs e)
+        {
+            if (trackBar1.TickStyle.Equals(System.Windows.Forms.TickStyle.BottomRight))
+            {
+                trackBar1.TickStyle = System.Windows.Forms.TickStyle.None;
+            }
+            else
+            { trackBar1.TickStyle = System.Windows.Forms.TickStyle.BottomRight; }
+        }
+    
+
+    private void numericMinimum_ValueChanged(object sender, EventArgs e)
         {
             trackBar1.Minimum = Decimal.ToInt32(numericMinimum.Value);
             numericMaximum.Minimum = numericMinimum.Value;
@@ -38,9 +55,11 @@ namespace WinformsControlsTest
 
         private void numericMaximum_ValueChanged(object sender, EventArgs e)
         {
+
             trackBar1.Maximum = Decimal.ToInt32(numericMaximum.Value);
             numericMinimum.Maximum = numericMaximum.Value;
             UpdateValueLabel();
+
         }
 
         private void trackBar1_Scroll(object sender, EventArgs e)

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -11,17 +11,47 @@ namespace WinformsControlsTest
         public TrackBars()
         {
             InitializeComponent();
+
+            trackBar1.Minimum = -100;
+            trackBar1.Maximum = 100;
+
+            numericMinimum.Value = trackBar1.Minimum;
+            numericMaximum.Value = trackBar1.Maximum;
+            numericFrequency.Value = trackBar1.TickFrequency;
+
+            UpdateSizeLabel();
             UpdateValueLabel();
+        }
+
+        private void UpdateSizeLabel()
+        {
+            if (trackBar1.Orientation == Orientation.Horizontal)
+            {
+                lblTrackBarSize.Text = $"Trackbar width: {trackBar1.Width}";
+            }
+            else
+            {
+                lblTrackBarSize.Text = $"Trackbar height: {trackBar1.Height}";
+            }
+        }
+
+        private void UpdateValueLabel()
+        {
+            lblTrackBarValue.Text = $"Value {trackBar1.Value}";
         }
 
         private void rbHorizontal_CheckedChanged(object sender, EventArgs e)
         {
             trackBar1.Orientation = Orientation.Horizontal;
+            trackBar1.Width = ClientRectangle.Width - trackBar1.Left * 2;
+            trackBar1.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
         }
 
         private void rbVertical_CheckedChanged(object sender, EventArgs e)
         {
             trackBar1.Orientation = Orientation.Vertical;
+            trackBar1.Height = ClientRectangle.Height - trackBar1.Top * 2;
+            trackBar1.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Bottom;
         }
 
         private void chbRightToLeft_CheckedChanged(object sender, EventArgs e)
@@ -39,20 +69,27 @@ namespace WinformsControlsTest
             {
                 trackBar1.TickStyle = TickStyle.BottomRight;
             }
-        }    
+        }
 
-    private void numericMinimum_ValueChanged(object sender, EventArgs e)
+        private void numericMinimum_ValueChanged(object sender, EventArgs e)
         {
-            trackBar1.Minimum = Decimal.ToInt32(numericMinimum.Value);
+            trackBar1.Minimum = (int)Math.Max(numericMinimum.Value, int.MinValue);
             numericMaximum.Minimum = numericMinimum.Value;
+            numericFrequency.Maximum = (int)Math.Min(numericMaximum.Value - numericMaximum.Minimum, int.MaxValue);
             UpdateValueLabel();
         }
 
         private void numericMaximum_ValueChanged(object sender, EventArgs e)
         {
-            trackBar1.Maximum = Decimal.ToInt32(numericMaximum.Value);
+            trackBar1.Maximum = (int)Math.Min(numericMaximum.Value, int.MaxValue);
             numericMinimum.Maximum = numericMaximum.Value;
+            numericFrequency.Maximum = (int)Math.Min(numericMaximum.Value - numericMaximum.Minimum, int.MaxValue);
             UpdateValueLabel();
+        }
+
+        private void numericFrequency_ValueChanged(object sender, EventArgs e)
+        {
+            trackBar1.TickFrequency = (int)numericFrequency.Value;
         }
 
         private void trackBar1_Scroll(object sender, EventArgs e)
@@ -65,9 +102,9 @@ namespace WinformsControlsTest
             trackBar1.RightToLeftLayout = chbRightToLeftLayout.Checked;
         }
 
-        private void UpdateValueLabel()
+        private void trackBar1_SizeChanged(object sender, EventArgs e)
         {
-            lblTrackBarValue.Text = $"Value {trackBar1.Value}";
+            UpdateSizeLabel();
         }
     }
 }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
@@ -31,7 +31,7 @@ namespace WinformsControlsTest
 
         private void tickstyleNone_CheckedChanged(object sender, EventArgs e)
         {
-            if (trackBar1.TickStyle.Equals(System.Windows.Forms.TickStyle.BottomRight))
+            if (trackBar1.TickStyle == TickStyle.BottomRight)
             {
                 trackBar1.TickStyle = System.Windows.Forms.TickStyle.None;
             }

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
@@ -33,10 +33,12 @@ namespace WinformsControlsTest
         {
             if (trackBar1.TickStyle == TickStyle.BottomRight)
             {
-                trackBar1.TickStyle = System.Windows.Forms.TickStyle.None;
+                trackBar1.TickStyle = TickStyle.None;
             }
             else
-            { trackBar1.TickStyle = System.Windows.Forms.TickStyle.BottomRight; }
+            {
+                trackBar1.TickStyle = TickStyle.BottomRight;
+            }
         }    
 
     private void numericMinimum_ValueChanged(object sender, EventArgs e)

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
@@ -12,8 +12,6 @@ namespace WinformsControlsTest
 {
     public partial class TrackBars : Form
     {
-        private int V;
-
         public TrackBars()
         {
             InitializeComponent();

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -14,7 +14,6 @@ namespace WinformsControlsTest
 
             trackBar1.Minimum = -100;
             trackBar1.Maximum = 100;
-
             numericMinimum.Value = trackBar1.Minimum;
             numericMaximum.Value = trackBar1.Maximum;
             numericFrequency.Value = trackBar1.TickFrequency;
@@ -74,8 +73,13 @@ namespace WinformsControlsTest
         private void numericMinimum_ValueChanged(object sender, EventArgs e)
         {
             trackBar1.Minimum = (int)Math.Max(numericMinimum.Value, int.MinValue);
-            numericMaximum.Minimum = numericMinimum.Value;
+            numericMaximum.Minimum = numericMinimum.Value;        
             numericFrequency.Maximum = (int)Math.Min(numericMaximum.Value - numericMaximum.Minimum, int.MaxValue);
+            if (numericFrequency.Maximum == 0)
+            {
+                numericFrequency.Minimum = 1;
+            }
+
             UpdateValueLabel();
         }
 
@@ -84,6 +88,11 @@ namespace WinformsControlsTest
             trackBar1.Maximum = (int)Math.Min(numericMaximum.Value, int.MaxValue);
             numericMinimum.Maximum = numericMaximum.Value;
             numericFrequency.Maximum = (int)Math.Min(numericMaximum.Value - numericMaximum.Minimum, int.MaxValue);
+            if (numericFrequency.Maximum == 0)
+            {
+                numericFrequency.Minimum = 1;
+            }
+
             UpdateValueLabel();
         }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/WinformsControlsTest/TrackBars.cs
@@ -3,10 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Windows.Forms;
-using static Interop.ComCtl32;
-using static Interop;
-using static System.Windows.Forms.VisualStyles.VisualStyleElement;
-using Newtonsoft.Json.Linq;
 
 namespace WinformsControlsTest
 {
@@ -41,8 +37,7 @@ namespace WinformsControlsTest
             }
             else
             { trackBar1.TickStyle = System.Windows.Forms.TickStyle.BottomRight; }
-        }
-    
+        }    
 
     private void numericMinimum_ValueChanged(object sender, EventArgs e)
         {
@@ -53,11 +48,9 @@ namespace WinformsControlsTest
 
         private void numericMaximum_ValueChanged(object sender, EventArgs e)
         {
-
             trackBar1.Maximum = Decimal.ToInt32(numericMaximum.Value);
             numericMinimum.Maximum = numericMaximum.Value;
             UpdateValueLabel();
-
         }
 
         private void trackBar1_Scroll(object sender, EventArgs e)


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Allow users to set large a range of values on the trackbar without excessive memory consumption.

Fixes #329

## Proposed changes
- Solving the issue of Memory consumption for the trackbar for large range of values on trackbar.
- Turning `TBS_AUTOTICKS` off when the the tick range is larger then the physical limitations of the trackbar by checking this with the Boolean method `ShouldAutoDrawTicks()`. This sets the flag `_autoDrawTicks` in `CreateParams`.
- The fix will be put behind a feature switch called `TrackBarModernRendering` in `LocalAppContextSwitches ` because of the significant risk - primarily due to the use of `RecreateHandle()` method. If they opt out of the feature the `ShouldAutoDrawTicks()` then it will always return true. This means that the way of rendering ticks will be reverted back to the old way e.g. using `TBS_AUTOTICKS` and setting tick frequency with the `TBM_SETTICFREQ` message.

   ```C#
        /// <summary>
        /// This checks all the use cases that we potentially might want to keep `TBS_AUTOTICKS`.
        /// </summary>
        private bool ShouldAutoDrawTicks()
        {
            // If the user decides to opt out of TrackBarModernRendering for drawing ticks,
            // by returning true autoticks will be set to true which will
            // use the old way of rendering ticks on the trackbar.
            // TBS_AUTOTICKS will be enabled and sending
            // the TBM_SETTICFREQ message to set tick frequency.
            if (!LocalAppContextSwitches.TrackBarModernRendering)
            {
                return true;
            }

            if (TickStyle == TickStyle.None)
            {
                return true;
            }

            int size = Orientation == Orientation.Horizontal ? Size.Width : Size.Height;
            if (size == 0)
            {
                return true;
            }

            uint range = (uint)(_maximum - _minimum);
            return range <= (size / 2);
        }
    ```
- The method   `DrawTicks()` replaces the message `TBM_SETTICFREQ` It gets called everywhere  `TBM_SETTICFREQ`  would have been used.
- It checks whether the tickstyle is None (return) or `_autoDrawTicks` is true which sets the `_tickFrequency` using the  `TBM_SETTICFREQ` message then return .
- When the tick range is greater then physical limitaions of the size of the trackbar it calculates if the users set `_tickFrequency` will fit on the trackbar.
- If the value is greater then the physical limiations we have then we set `drawnTickFrequency ` to `range / maxTickCount`.
- Using a for loop we maually draw the ticks based on the  `drawnTickFrequency ` set.
 ```C#
        private void DrawTicks()
        {
            if (_tickStyle == TickStyle.None)
            {
                return;
            }

            int drawnTickFrequency = _tickFrequency;
            // Will be true if they opt out TrackBarModernRendering.
            if (_autoDrawTicks)
            {
                PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)drawnTickFrequency);
                return;
            }

            // Divide by 2 because otherwise the ticks appear as a solid line.
            int maxTickCount = (Orientation == Orientation.Horizontal ? Size.Width : Size.Height) / 2;
            uint range = (uint)(_maximum - _minimum);
            if (range > maxTickCount && maxTickCount != 0)
            {
                int calculatedTickFrequency = (int)(range / maxTickCount);
                if (calculatedTickFrequency > drawnTickFrequency)
                {
                    drawnTickFrequency = calculatedTickFrequency;
                }
            }

            PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_CLEARTICS, (WPARAM)1, (LPARAM)0);
            for (int i = _minimum + drawnTickFrequency; i < _maximum - drawnTickFrequency; i += drawnTickFrequency)
            {
                LRESULT lresult = PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTIC, lParam: (IntPtr)i);
                Debug.Assert((bool)(BOOL)lresult);
            }
        }
```

- Before Recreating Handle check to see If it needs to be recreated by using `ShouldRecreateHandle()` to set the `recreateHandle` flag in places where  `DrawTicks()` gets called

 ```C#
        /// <summary>
        /// Determine if the decision of whether the ticks drawing,
        /// is performed by the native control or the Windows Forms runtime
        /// is still valid. If it's no longer valid, we'll need to recreate the native control.
        /// If user opts out of TrackBarModernRendering then this will always return false.
        /// </summary>
        private bool ShouldRecreateHandle() => IsHandleCreated && _autoDrawTicks != ShouldAutoDrawTicks();
 ```

- `DrawTicks()` Is refrenced in three places first is when the user wants to change the `TickFrequency` and the second place is `SetRange()` when max or min is changed and `OnHandleCreated()` .
- If `recreateHandle` is true then  `DrawTicks()` will not be called in either of the first two places it will be called in  `OnHandleCreated()`

 ```C#
        /// <summary>
        ///  Indicates just how many ticks will be drawn. For a TrackBar with a
        ///  range of 0..100, it might be impractical to draw all 100 ticks for a
        ///  very small control. Passing in a value of 5 here would only draw
        ///  20 ticks -- i.e. each tick would represent 5 units in the TrackBars
        ///  range of values.
        /// </summary>
       public int TickFrequency
        {
            ....

                // Determine if the decision of whether the ticks drawing,
                // is performed by the native control or the Windows Forms runtime
                // is still valid. If it's no longer valid, we'll need to recreate the native control.
                bool recreateHandle = ShouldRecreateHandle();
                if (IsHandleCreated)
                {
                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETTICFREQ, (WPARAM)value);
                    // If user opts out of TrackBarModernRendering then recreateHandle
                    // will always be false.
                    if (recreateHandle)
                    {
                        RecreateHandle();
                    }
                    else
                    {
                        DrawTicks();
                        Invalidate();
                    }
                }
            }
        }
```

 ```C#
        /// <summary>
        ///  Lets you set the entire range for the TrackBar control at once.
        ///  The values passed are both the lower and upper limits to the range
        ///  with which the control will work.
        /// </summary>
        public void SetRange(int minValue, int maxValue)
        {
            ....

                // Determine if the decision of whether the ticks drawing,
                // is performed by the native control or the Windows Forms runtime
                // is still valid. If it's no longer valid, we'll need to recreate the native control.
                bool recreateHandle = ShouldRecreateHandle();
                // If user opts out of TrackBarModernRendering then recreateHandle
                // will always be false.
                if (IsHandleCreated && !recreateHandle)
                {
                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
                    PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)true, (LPARAM)_maximum);
                    DrawTicks();
                    Invalidate();
                }

               ....

                // If user opts out of TrackBarModernRendering then recreateHandle
                // will always be false.
                if (recreateHandle)
                {
                    RecreateHandle();
                }
                else
                {
                    SetTrackBarPosition();
                }
            }
        }
```

- If the trackbar has been created or `RecreateHandle()` is excuted then we excute `DrawTicks();` here

```C#
    protected override void OnHandleCreated(EventArgs e)
        {
            base.OnHandleCreated(e);

            if (!IsHandleCreated)
            {
                return;
            }

            Debug.Assert(_autoDrawTicks == ShouldAutoDrawTicks());
            PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMIN, (WPARAM)(BOOL)false, (LPARAM)_minimum);
            PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETRANGEMAX, (WPARAM)(BOOL)false, (LPARAM)_maximum);
            DrawTicks();
            PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETPAGESIZE, (WPARAM)0, (LPARAM)_largeChange);
            PInvoke.SendMessage(this, (User32.WM)PInvoke.TBM_SETLINESIZE, (WPARAM)0, (LPARAM)_smallChange);
            SetTrackBarPosition();
            AdjustSize();
        }
```
<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Solves the issue of ticks slowing down performance via large memory consumption.

## Regression? 

-  No.

## Risk

- Significant risk - primarily due to the use of `RecreateHandle()` method.

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

![image](https://user-images.githubusercontent.com/57994682/205930842-a1fd72c7-08a9-4865-98aa-c0eaacfd1d3d.png)

### After

![image](https://user-images.githubusercontent.com/57994682/205931679-e2d16b24-3b4a-41bc-b98c-d3df45288085.png)


## Test methodology <!-- How did you ensure quality? -->
### Test Feature Switch 
- With `TrackBarModernRendering` set to false

![image](https://user-images.githubusercontent.com/57994682/207367778-63fa0bed-449e-411c-8ad7-d7135995e119.png)

- With `TrackBarModernRendering` set to true

![image](https://user-images.githubusercontent.com/57994682/207368461-619f3cb5-454e-4e73-9f83-983fecf966c5.png)


### Test  int.MinValue 

- For min int value – trackbar breaks and is unuseable seems to be issue with the trackbar range cannot be greater then the positive value for an integer e.g. -2,147,483,648 would create a range larger then 2,147,483,647 . 
-  This is for both horizontal and vertical orientation
- set a trackbar width to 588px, orientation horizontal, min=int.MinValue, max=0, tick freq=1 -> expect memory consumption to be low. 0  ticks drawn on trackbar. Autoticks disabled

![image](https://user-images.githubusercontent.com/57994682/205937822-9f101bf4-9af5-4441-8565-ca36150f2c13.png)

![image](https://user-images.githubusercontent.com/57994682/205938542-818a03c3-dbef-4a41-9575-51ba5e7a84b4.png)

- set a trackbar width to 364px, orientation vertical, min=-int.MinValue, max=0, tick freq=1 -> expect memory consumption to be low. 0 ticks drawn on trackbar. Autoticks disabled

![image](https://user-images.githubusercontent.com/57994682/205941282-e21e45e6-8622-433c-b537-207e3f808f57.png)
### Test int.MaxValue
-  For max int value – trackbar works for both horizontal and vertical orientation
- set a trackbar width to 588px, orientation horizontal, min=0, max=int.MaxValue, tick freq=1 -> expect memory consumption to be low. 294 ticks drawn on trackbar. Autoticks disabled

![image](https://user-images.githubusercontent.com/57994682/205939062-30e8463c-c497-407c-b498-610c9fea2c96.png)

- set a trackbar width to 364px, orientation vertical, min=0, max=int.MaxValue, tick freq=1 -> expect memory consumption to be low. 182 ticks drawn on trackbar. Autoticks disabled

![image](https://user-images.githubusercontent.com/57994682/205939683-6ce1de5e-51b5-4bcf-8939-1dae5de94387.png)

### Basic Tests
- Testing for a large value range to turn off  `TBS_AUTOTICKS`  then setting to a small range for  `TBS_AUTOTICKS`  to be turned on , works for both `horizontal `and `vertical `orientation.

- set a trackbar width to 588px, orientation horizontal, min=-100, max=1000, tick freq=1 -> expect memory consumption to be low e.g 20mb. expect 294 ticks, autoTicks disabled ticks manually drawn 

![image](https://user-images.githubusercontent.com/57994682/205962250-b4f4c8a1-8809-461f-8fe4-b6bfd4ae2b4f.png)

- set a trackbar width to 588px, orientation horizontal, min=-100, max=100, tick freq=1 -> expect memory consumption to be low e.g 20mb. expect 200 ticks, autoTicks enabled 

![image](https://user-images.githubusercontent.com/57994682/205962444-7e2d7ce0-52a0-4fb6-8f71-9897feb62b93.png)

- set a trackbar width to 588px, orientation horizontal, min=-100, max=100, tick freq=1 , Tickstyle set to none, -> expect memory consumption to be low e.g 20mb. expect 0 ticks, autoTicks disabled

![image](https://user-images.githubusercontent.com/57994682/205968364-ae6a3114-fb87-4526-8af9-6287400f7e8f.png)

### Trackbar Size tests
- works the same for both `horizontal `and `vertical `orientation.
- set a trackbar width to 0px, orientation vertical, min=-100, max=100, tick freq=10 -> expect memory consumption to be low e.g 20mb.expect 0 ticks, autoTicks disabled
![image](https://user-images.githubusercontent.com/57994682/205966207-c119c549-60bf-482a-b67f-580777782f6f.png) 
- set a trackbar width to 1,000px, orientation horizontal, min=-100, max=100, tick freq=1 -> expect memory consumption to be low e.g 20mb. expect 200 ticks, autoTicks enabled

![image](https://user-images.githubusercontent.com/57994682/205966954-c5a2e0a9-e75e-4684-9f52-e8696aacd9cd.png)

- set a trackbar width to 1,000px, orientation horizontal, min=-1000, max=1000, tick freq=1 -> expect memory consumption to be low e.g 20mb. expect 500 ticks, autoTicks disabled
![image](https://user-images.githubusercontent.com/57994682/205967136-08d88924-1687-4b7b-9952-9f89c23644c6.png)


- set a trackbar width to 1,000px, orientation horizontal, min=-1000, max=1000, tick freq=100 -> expect memory consumption to be low e.g 20mb. expect 20 ticks, autoTicks disabled
![image](https://user-images.githubusercontent.com/57994682/205967459-e37054e0-6d6a-4d80-a25e-e16760fafef1.png)

### Tickfrequency tests
- works the same for both `horizontal `and `vertical `orientation.

- set a trackbar width to 588px, orientation horizontal, min=-100, max=100, tick freq=100 -> expect memory consumption to be low e.g 20mb. expect 3 ticks, autoTicks enabled

![image](https://user-images.githubusercontent.com/57994682/205972781-83275173-9fe2-4085-b3a9-f6ad27626461.png)

- set a trackbar width to 364px, orientation vertical, min=-10000, max=10000, tick freq=1000 -> expect memory consumption to be low e.g 20mb. expect 20 ticks, autoTicks disabled 

![image](https://user-images.githubusercontent.com/57994682/205973883-85cc2bb4-e226-4c0f-beeb-d8a33fe45ac2.png)


- TODO: Add unit tests.
- TODO: Add UIIntegration tests.

## Accessibility testing  <!-- Remove this section if PR does not change UI -->
TODO
<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->




<!-- Mention language, UI scaling, or anything else that might be relevant -->
.NET 8.0.0 - alpha.1.22605.1

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8060)