### PR TITLE
Reorder Message fields

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Message.cs
@@ -20,16 +20,20 @@ namespace System.Windows.Forms
         private static readonly TraceSwitch s_allWinMessages = new("AllWinMessages", "Output every received message");
 #endif
 
-        // Using prefixed variants of the property names for easier diffing.
-#pragma warning disable IDE1006 // Naming Styles
-        internal LRESULT ResultInternal;
-        internal LPARAM LParamInternal;
-        internal WPARAM WParamInternal;
-        internal User32.WM MsgInternal;
-        internal HWND HWND => (HWND)HWnd;
-#pragma warning restore IDE1006 // Naming Styles
+        // Keep HWND, WM, WPARAM, and LPARAM in this order so that they match the MSG struct.
+        // This struct shouldn't be used as a direct mapping against MSG, but if someone does already do this
+        // it will allow their code to continue to work.
 
         public IntPtr HWnd { get; set; }
+
+        // Using prefixed variants of the property names for easier diffing.
+#pragma warning disable IDE1006 // Naming Styles
+        internal User32.WM MsgInternal;
+        internal WPARAM WParamInternal;
+        internal LPARAM LParamInternal;
+        internal LRESULT ResultInternal;
+        internal HWND HWND => (HWND)HWnd;
+#pragma warning restore IDE1006 // Naming Styles
 
         public int Msg
         {


### PR DESCRIPTION
Historically our first four fields matched the layout of MSG. Keeping it that way for better back compat.

As Message doesn't match MSG, they shouldn't be blitted over each other, but for those that might be doing this we can keep the order. Note that other future changes to the struct could break doing this sort of thing even if the first four fields stay the same.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8063)