### PR TITLE
Enable nullability in ToolStripNumericUpDownControl

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripNumericUpDown.ToolStripNumericUpDownControl.ToolStripNumericUpDownAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripNumericUpDown.ToolStripNumericUpDownControl.ToolStripNumericUpDownAccessibleObject.cs
@@ -12,7 +12,8 @@ namespace System.Windows.Forms
         {
             private class ToolStripNumericUpDownAccessibleObject : ToolStripHostedControlAccessibleObject
             {
-                public ToolStripNumericUpDownAccessibleObject(Control toolStripHostedControl, ToolStripControlHost toolStripControlHost) : base(toolStripHostedControl, toolStripControlHost)
+                public ToolStripNumericUpDownAccessibleObject(Control toolStripHostedControl, ToolStripControlHost? toolStripControlHost)
+                    : base(toolStripHostedControl, toolStripControlHost)
                 {
                 }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripNumericUpDown.ToolStripNumericUpDownControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripNumericUpDown.ToolStripNumericUpDownControl.cs
@@ -2,17 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Windows.Forms
 {
     internal partial class ToolStripNumericUpDown
     {
         internal partial class ToolStripNumericUpDownControl : NumericUpDown
         {
-            public ToolStrip ParentToolStrip { get; private set; }
+            public ToolStrip? ParentToolStrip { get; private set; }
 
-            public ToolStripNumericUpDown Owner { get; set; }
+            public ToolStripNumericUpDown? Owner { get; set; }
 
             internal override bool SupportsUiaProviders => true;
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripNumericUpDownControl.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8068)