### PR TITLE
Enable nullability in MultiSelectRootGridEntry

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MultiSelectRootGridEntry.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -38,7 +36,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     foreach (object target in (Array)Target)
                     {
-                        if ((TypeDescriptorHelper.TryGetAttribute(target, out ReadOnlyAttribute readOnlyAttribute)
+                        if ((TypeDescriptorHelper.TryGetAttribute(target, out ReadOnlyAttribute? readOnlyAttribute)
                             && !readOnlyAttribute.IsDefaultAttribute())
                             || TypeDescriptor.GetAttributes(target).Contains(InheritanceAttribute.InheritedReadOnly))
                         {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in MultiSelectRootGridEntry.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8071)