### PR TITLE
Removed a duplicate WIN32_ERROR from  NativeMethods.txt 

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
+++ b/src/System.Windows.Forms.Primitives/src/NativeMethods.txt
@@ -120,7 +120,6 @@ EndDialog
 EndPaint
 EnumDisplaySettings
 EnumEnhMetaFile
-WIN32_ERROR
 EVENTMSG
 ExtTextOut
 FDAP


### PR DESCRIPTION
 Removed a duplicate instance of WIN32_ERROR line in NativeMethods.txt file.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8081)