### PR TITLE
Fix Anchors in PermonitorV2 mode applications.

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -48,8 +48,10 @@ namespace System.Windows.Forms
         /// </summary>
         private bool _isScaledByDpiChangedEvent;
 
-        // Indicates scaling, due to DPI changed event, of the container control is in progress.
-        internal bool ContainersDpiScalingInProgress;
+        /// <summary>
+        ///  Indicates scaling, due to DPI changed event, of the container control is in progress.
+        /// </summary>
+        internal bool _dpiScalingInProgress;
 
         private BitVector32 _state;
 
@@ -1444,7 +1446,7 @@ namespace System.Windows.Forms
             SuspendAllLayout(this);
             try
             {
-                ContainersDpiScalingInProgress = true;
+                _dpiScalingInProgress = true;
 
                 if (LocalAppContextSwitches.ScaleTopLevelFormMinMaxSizeForDpi)
                 {
@@ -1498,7 +1500,7 @@ namespace System.Windows.Forms
                 _isScaledByDpiChangedEvent = false;
 
                 // Scaling and ResumeLayout, due to DPI changed event, should be finished by now for this container.
-                ContainersDpiScalingInProgress = false;
+                _dpiScalingInProgress = false;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ContainerControl.cs
@@ -48,6 +48,9 @@ namespace System.Windows.Forms
         /// </summary>
         private bool _isScaledByDpiChangedEvent;
 
+        // Indicates scaling, due to DPI changed event, of the container control is in progress.
+        internal bool ContainersDpiScalingInProgress;
+
         private BitVector32 _state;
 
         /// <summary>
@@ -1441,6 +1444,8 @@ namespace System.Windows.Forms
             SuspendAllLayout(this);
             try
             {
+                ContainersDpiScalingInProgress = true;
+
                 if (LocalAppContextSwitches.ScaleTopLevelFormMinMaxSizeForDpi)
                 {
                     // The suggested rectangle comes from Windows, and it does not match with our calculations for scaling controls by AutoscaleFactor.
@@ -1491,6 +1496,9 @@ namespace System.Windows.Forms
                 // We want to perform layout for dpi-changed high Dpi improvements - setting the second parameter to 'true'
                 ResumeAllLayout(this, true);
                 _isScaledByDpiChangedEvent = false;
+
+                // Scaling and ResumeLayout, due to DPI changed event, should be finished by now for this container.
+                ContainersDpiScalingInProgress = false;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -1713,10 +1713,10 @@ namespace System.Windows.Forms
         }
 
         /// <summary>
-        ///  returns bool indicating whether the control is currently being scaled.
+        ///  Returns bool indicating whether the control is currently being scaled.
         ///  This property is set in ScaleControl method to allow method being called to condition code that should not run for scaling.
         /// </summary>
-        internal bool IsCurrentlyBeingScaled
+        internal bool ScalingInProgress
         {
             get => GetExtendedState(ExtendedStates.CurrentlyBeingScaled);
             private set => SetExtendedState(ExtendedStates.CurrentlyBeingScaled, value);
@@ -10450,7 +10450,7 @@ namespace System.Windows.Forms
         {
             try
             {
-                IsCurrentlyBeingScaled = true;
+                ScalingInProgress = true;
 
                 BoundsSpecified includedSpecified = BoundsSpecified.None;
                 BoundsSpecified excludedSpecified = BoundsSpecified.None;
@@ -10489,7 +10489,7 @@ namespace System.Windows.Forms
             }
             finally
             {
-                IsCurrentlyBeingScaled = false;
+                ScalingInProgress = false;
             }
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.cs
@@ -10589,9 +10589,6 @@ namespace System.Windows.Forms
             scaledSize = LayoutUtils.UnionSizes(scaledSize, minSize);
 
             if (DpiHelper.IsScalingRequirementMet
-                // In the v2 layout, anchors are updated/computed after the controls bounds changed
-                // and, thus, don't need scaling.
-                && !DefaultLayout.UseAnchorLayoutV2(this)
                 && ParentInternal is { } parent
                 && (parent.LayoutEngine == DefaultLayout.Instance))
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -896,6 +896,12 @@ namespace System.Windows.Forms.Layout
                 return;
             }
 
+            // Anchors are scaled for the new DPI and doesn't need to be recalculated.
+            if (IsDPIScalingInProgress(control, parent))
+            {
+                return;
+            }
+
             AnchorInfo anchorInfo = GetAnchorInfo(control);
             if (anchorInfo is null)
             {
@@ -913,6 +919,27 @@ namespace System.Windows.Forms.Layout
 
             anchorInfo.Right = displayRect.Width - (x + elementBounds.Width);
             anchorInfo.Bottom = displayRect.Height - (y + elementBounds.Height);
+
+            // Walk through parent heirarchy and check if scaling due to DPI change is in progress.
+            static bool IsDPIScalingInProgress(Control control, Control parent)
+            {
+                if (control.IsCurrentlyBeingScaled)
+                {
+                    return true;
+                }
+
+                while (parent is not null)
+                {
+                    if (parent is ContainerControl container && container.ContainersDpiScalingInProgress)
+                    {
+                        return true;
+                    }
+
+                    parent = parent.Parent;
+                }
+
+                return false;
+            }
         }
 
         public static AnchorStyles GetAnchor(IArrangedElement element) => CommonProperties.xGetAnchor(element);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -920,7 +920,7 @@ namespace System.Windows.Forms.Layout
             anchorInfo.Right = displayRect.Width - (x + elementBounds.Width);
             anchorInfo.Bottom = displayRect.Height - (y + elementBounds.Height);
 
-            // Walk through parent heirarchy and check if scaling due to DPI change is in progress.
+            // Walk through parent hierarchy and check if scaling due to DPI change is in progress.
             static bool IsDPIScalingInProgress(Control control, Control parent)
             {
                 if (control.IsCurrentlyBeingScaled)

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/DefaultLayout.cs
@@ -896,8 +896,8 @@ namespace System.Windows.Forms.Layout
                 return;
             }
 
-            // Anchors are scaled for the new DPI and doesn't need to be recalculated.
-            if (IsDPIScalingInProgress(control, parent))
+            // Anchors are already scaled for the new DPI.
+            if (DpiScalingInProgress(control, parent))
             {
                 return;
             }
@@ -921,16 +921,17 @@ namespace System.Windows.Forms.Layout
             anchorInfo.Bottom = displayRect.Height - (y + elementBounds.Height);
 
             // Walk through parent hierarchy and check if scaling due to DPI change is in progress.
-            static bool IsDPIScalingInProgress(Control control, Control parent)
+            static bool DpiScalingInProgress(Control control, Control parent)
             {
-                if (control.IsCurrentlyBeingScaled)
+                if (control.ScalingInProgress
+                    || (control is ContainerControl container && container._dpiScalingInProgress))
                 {
                     return true;
                 }
 
                 while (parent is not null)
                 {
-                    if (parent is ContainerControl container && container.ContainersDpiScalingInProgress)
+                    if (parent is ContainerControl parentContainer && parentContainer._dpiScalingInProgress)
                     {
                         return true;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/MonthCalendar.cs
@@ -1756,7 +1756,7 @@ namespace System.Windows.Forms
 
             // Second argument to GetPreferredWidth and GetPreferredHeight is a boolean specifying if we should update the number of rows/columns.
             // We only want to update the number of rows/columns if we are not currently being scaled.
-            bool updateRowsAndColumns = !DpiHelper.IsScalingRequirementMet || !IsCurrentlyBeingScaled;
+            bool updateRowsAndColumns = !DpiHelper.IsScalingRequirementMet || !ScalingInProgress;
 
             if (width != oldBounds.Width)
             {


### PR DESCRIPTION
fixes: #8087

In PermonitorV2 mode applications, when moving the Form from one monitor to the other, Form gets an invalid display rectangle for a brief period during the scaling of its child controls. Updating anchors, because of layout, during this period would end up invalid anchor calculations. For all scaling scenarios due to DPI changed event, we will be scaling anchors and avoid/skip recalculation of anchors to prevent using this invalid display rect.

Following is the snippet where we see invalid DisplayRect of the Form for a brief period while moving from one monitor to the other.

**Invalid state:**
![image](https://user-images.githubusercontent.com/36968667/199293490-967c0fe3-324f-47b0-89ec-8340890dd834.png)

**Final state:**

![image](https://user-images.githubusercontent.com/36968667/199293757-999100ae-cef0-4083-8e53-f50148fb6cf4.png)


Amending #7956 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8086)