### PR TITLE
Replace Hashtable with generic dictionary in ToolStrip

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStrip.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design.Serialization;
 using System.Diagnostics;
@@ -53,7 +52,7 @@ namespace System.Windows.Forms
         private byte _mouseDownID;  // NEVER use this directly from another class, 0 should never be returned to another class.
         private ToolStripRenderer? _renderer;
         private Type _currentRendererType = typeof(Type);
-        private Hashtable? _shortcuts;
+        private Dictionary<Keys, ToolStripMenuItem>? _shortcuts;
         private Stack<MergeHistory>? _mergeHistoryStack;
         private ToolStripDropDownDirection _toolStripDropDownDirection = ToolStripDropDownDirection.Default;
         private Size _largestDisplayedItemSize = Size.Empty;
@@ -1742,11 +1741,11 @@ namespace System.Windows.Forms
         }
 
         /// <summary> internal lookup table for shortcuts... intended to speed search time </summary>
-        internal Hashtable Shortcuts
+        internal Dictionary<Keys, ToolStripMenuItem> Shortcuts
         {
             get
             {
-                _shortcuts ??= new Hashtable(1);
+                _shortcuts ??= new Dictionary<Keys, ToolStripMenuItem>(1);
 
                 return _shortcuts;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.cs
@@ -774,7 +774,7 @@ namespace System.Windows.Forms
         {
             for (int i = 0; i < ToolStrips.Count; i++)
             {
-                if (ToolStrips[i] is ToolStrip t && t.Shortcuts.Contains(shortcut))
+                if (ToolStrips[i] is ToolStrip t && t.Shortcuts.ContainsKey(shortcut))
                 {
                     return true;
                 }
@@ -836,9 +836,8 @@ namespace System.Windows.Forms
                     // Check the context menu strip first.
                     if (activeControlInChain.ContextMenuStrip is not null)
                     {
-                        if (activeControlInChain.ContextMenuStrip.Shortcuts.ContainsKey(shortcut))
+                        if (activeControlInChain.ContextMenuStrip.Shortcuts.TryGetValue(shortcut, out ToolStripMenuItem item))
                         {
-                            ToolStripMenuItem item = activeControlInChain.ContextMenuStrip.Shortcuts[shortcut] as ToolStripMenuItem;
                             if (item.ProcessCmdKey(ref m, shortcut))
                             {
                                 Debug.WriteLineIf(Control.s_controlKeyboardRouting.TraceVerbose, "ToolStripManager.ProcessShortcut - found item on context menu: [" + item.ToString() + "]");
@@ -941,7 +940,7 @@ namespace System.Windows.Forms
 
                         if (isAssociatedContextMenu || rootWindowsMatch || isDoublyAssignedContextMenuStrip)
                         {
-                            if (toolStrip.Shortcuts[shortcut] is ToolStripMenuItem item)
+                            if (toolStrip.Shortcuts.TryGetValue(shortcut, out ToolStripMenuItem item))
                             {
                                 if (item.ProcessCmdKey(ref m, shortcut))
                                 {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripMenuItem.cs
@@ -503,7 +503,7 @@ namespace System.Windows.Forms
                             owner.Shortcuts.Remove(originalShortcut);
                         }
 
-                        if (owner.Shortcuts.Contains(value))
+                        if (owner.Shortcuts.ContainsKey(value))
                         {
                             // last one in wins.
                             owner.Shortcuts[value] = this;
@@ -686,7 +686,7 @@ namespace System.Windows.Forms
             {
                 if (_lastOwner is not null)
                 {
-                    Keys shortcut = this.ShortcutKeys;
+                    Keys shortcut = ShortcutKeys;
                     if (shortcut != Keys.None && _lastOwner.Shortcuts.ContainsKey(shortcut))
                     {
                         _lastOwner.Shortcuts.Remove(shortcut);
@@ -1063,7 +1063,7 @@ namespace System.Windows.Forms
 
                 if (Owner is not null)
                 {
-                    if (Owner.Shortcuts.Contains(shortcut))
+                    if (Owner.Shortcuts.ContainsKey(shortcut))
                     {
                         // last one in wins
                         Owner.Shortcuts[shortcut] = this;


### PR DESCRIPTION
## Proposed changes

- Replace Hashtable with generic dictionary in ToolStrip.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8096)