### PR TITLE
Enable nullability in HostedWindowsFormsMessageHook

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.ModalMenuFilter.HostedWindowsFormsMessageHook.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripManager.ModalMenuFilter.HostedWindowsFormsMessageHook.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using static Interop;
@@ -18,7 +16,7 @@ namespace System.Windows.Forms
             {
                 private HHOOK _messageHookHandle;
                 private bool _isHooked;
-                private HOOKPROC _callBack;
+                private HOOKPROC? _callBack;
 
                 public HostedWindowsFormsMessageHook()
                 {


### PR DESCRIPTION
## Proposed changes

- Enable nullability in HostedWindowsFormsMessageHook.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8097)