### PR TITLE
Fixed disabled ToolStripMenuItem checkmark rendering in HC themes

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -105,21 +105,20 @@ namespace System.Windows.Forms
 
         protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
         {
-            Image? image = e.Image;
-            if (image is not null)
+            if (e.Image is not { } image)
             {
-                if (Image.GetPixelFormatSize(image.PixelFormat) > 16)
-                {
-                    // for 24, 32 bit images, just paint normally - mapping the color table is not
-                    // going to work when you can have full color.
-                    base.OnRenderItemCheck(e);
-                    return;
-                }
-                else
-                {
-                    RenderItemImageOfLowColorDepth(e);
-                }
+                return;
             }
+
+            if (Image.GetPixelFormatSize(image.PixelFormat) > 16)
+            {
+                // For 24, 32 bit images, just paint normally - mapping the color table is not
+                // going to work when you can have full color.
+                base.OnRenderItemCheck(e);
+                return;
+            }
+
+            RenderItemImageOfLowColorDepth(e);
         }
 
         protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
@@ -368,20 +367,20 @@ namespace System.Windows.Forms
 
         protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
         {
-            Image? image = e.Image;
-            if (image is not null)
+            if (e.Image is not { } image)
             {
-                if (Image.GetPixelFormatSize(image.PixelFormat) > 16)
-                {
-                    // for 24, 32 bit images, just paint normally - mapping the color table is not
-                    // going to work when you can have full color.
-                    base.OnRenderItemImage(e);
-                }
-                else
-                {
-                    RenderItemImageOfLowColorDepth(e);
-                }
+                return;
             }
+
+            if (Image.GetPixelFormatSize(image.PixelFormat) > 16)
+            {
+                // For 24, 32 bit images, just paint normally - mapping the color table is not
+                // going to work when you can have full color.
+                base.OnRenderItemImage(e);
+                return;
+            }
+
+            RenderItemImageOfLowColorDepth(e);
         }
 
         protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -466,44 +465,44 @@ namespace System.Windows.Forms
 
         private void RenderItemImageOfLowColorDepth(ToolStripItemImageRenderEventArgs e)
         {
-            Image? image = e.Image;
-
-            if (image is not null)
+            if (e.Image is not { } image)
             {
-                Graphics g = e.Graphics;
+                return;
+            }
 
-                ToolStripItem item = e.Item;
-                Rectangle imageRect = e.ImageRectangle;
-                using (ImageAttributes attrs = new ImageAttributes())
-                {
-                    if (IsHighContrastWhiteOnBlack() && !(FillWhenSelected && (e.Item.Pressed || e.Item.Selected)))
-                    {
-                        // translate white, black and blue to colors visible in high contrast mode.
-                        ColorMap cm1 = new ColorMap();
-                        ColorMap cm2 = new ColorMap();
-                        ColorMap cm3 = new ColorMap();
+            ToolStripItem item = e.Item;
 
-                        cm1.OldColor = Color.Black;
-                        cm1.NewColor = Color.White;
+            using ImageAttributes attrs = new();
 
-                        cm2.OldColor = Color.White;
-                        cm2.NewColor = Color.Black;
+            if (IsHighContrastWhiteOnBlack() && !(FillWhenSelected && (e.Item.Pressed || e.Item.Selected)))
+            {
+                // Translate white, black and blue to colors visible in high contrast mode.
+                ColorMap cm1 = new();
+                ColorMap cm2 = new();
+                ColorMap cm3 = new();
 
-                        cm3.OldColor = Color.FromArgb(0, 0, 128);
-                        cm3.NewColor = Color.White;
+                cm1.OldColor = Color.Black;
+                cm1.NewColor = Color.White;
 
-                        attrs.SetRemapTable(new ColorMap[3] { cm1, cm2, cm3 }, ColorAdjustType.Bitmap);
-                    }
+                cm2.OldColor = Color.White;
+                cm2.NewColor = Color.Black;
 
-                    if (item.ImageScaling == ToolStripItemImageScaling.None)
-                    {
-                        g.DrawImage(image, imageRect, 0, 0, imageRect.Width, imageRect.Height, GraphicsUnit.Pixel, attrs);
-                    }
-                    else
-                    {
-                        g.DrawImage(image, imageRect, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attrs);
-                    }
-                }
+                cm3.OldColor = Color.FromArgb(0, 0, 128);
+                cm3.NewColor = Color.White;
+
+                attrs.SetRemapTable(new ColorMap[3] { cm1, cm2, cm3 }, ColorAdjustType.Bitmap);
+            }
+
+            Graphics g = e.Graphics;
+            Rectangle imageRect = e.ImageRectangle;
+
+            if (item.ImageScaling == ToolStripItemImageScaling.None)
+            {
+                g.DrawImage(image, imageRect, 0, 0, imageRect.Width, imageRect.Height, GraphicsUnit.Pixel, attrs);
+            }
+            else
+            {
+                g.DrawImage(image, imageRect, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attrs);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -474,7 +474,7 @@ namespace System.Windows.Forms
 
             using ImageAttributes attrs = new();
 
-            if (IsHighContrastWhiteOnBlack() && !(FillWhenSelected && (e.Item.Pressed || e.Item.Selected)))
+            if (IsHighContrastWhiteOnBlack() && !(FillWhenSelected && (item.Pressed || item. Selected)))
             {
                 // Translate white, black and blue to colors visible in high contrast mode.
                 ColorMap cm1 = new();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripHighContrastRenderer.cs
@@ -105,30 +105,21 @@ namespace System.Windows.Forms
 
         protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
         {
-            // The ARGB values came directly from the bitmap.
-            // If the bitmap colors change this code will no longer work and will
-            // need to be updated.
-            Color checkColor = Color.FromArgb(255, 4, 2, 4);
-
-            // Create a color map to remap the check color to either the theme
-            // color for highlighted text or menu text, depending on whether
-            // the menu item is selected.
-            ColorMap[] checkColorMap = new ColorMap[1];
-            checkColorMap[0] = new ColorMap
+            Image? image = e.Image;
+            if (image is not null)
             {
-                OldColor = checkColor,
-
-                NewColor = ((e.Item.Selected || e.Item.Pressed) && e.Item.Enabled) ?
-                SystemColors.HighlightText : SystemColors.MenuText
-            };
-
-            // If we already have an image attributes associated with the event,
-            // just add the color map. Otherwise, create a new one.
-            ImageAttributes imageAttr = e.ImageAttributes ?? new ImageAttributes();
-            imageAttr.SetRemapTable(checkColorMap, ColorAdjustType.Bitmap);
-            e.ImageAttributes = imageAttr;
-
-            base.OnRenderItemCheck(e);
+                if (Image.GetPixelFormatSize(image.PixelFormat) > 16)
+                {
+                    // for 24, 32 bit images, just paint normally - mapping the color table is not
+                    // going to work when you can have full color.
+                    base.OnRenderItemCheck(e);
+                    return;
+                }
+                else
+                {
+                    RenderItemImageOfLowColorDepth(e);
+                }
+            }
         }
 
         protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
@@ -385,40 +376,10 @@ namespace System.Windows.Forms
                     // for 24, 32 bit images, just paint normally - mapping the color table is not
                     // going to work when you can have full color.
                     base.OnRenderItemImage(e);
-                    return;
                 }
-
-                Graphics g = e.Graphics;
-
-                ToolStripItem item = e.Item;
-                Rectangle imageRect = e.ImageRectangle;
-                using (ImageAttributes attrs = new ImageAttributes())
+                else
                 {
-                    if (IsHighContrastWhiteOnBlack() && !(FillWhenSelected && (e.Item.Pressed || e.Item.Selected)))
-                    {
-                        // translate white, black and blue to colors visible in high contrast mode.
-                        ColorMap cm1 = new ColorMap();
-                        ColorMap cm2 = new ColorMap();
-                        ColorMap cm3 = new ColorMap();
-
-                        cm1.OldColor = Color.Black;
-                        cm1.NewColor = Color.White;
-                        cm2.OldColor = Color.White;
-                        cm2.NewColor = Color.Black;
-                        cm3.OldColor = Color.FromArgb(0, 0, 128);
-                        cm3.NewColor = Color.White;
-
-                        attrs.SetRemapTable(new ColorMap[] { cm1, cm2, cm3 }, ColorAdjustType.Bitmap);
-                    }
-
-                    if (item.ImageScaling == ToolStripItemImageScaling.None)
-                    {
-                        g.DrawImage(image, imageRect, 0, 0, imageRect.Width, imageRect.Height, GraphicsUnit.Pixel, attrs);
-                    }
-                    else
-                    {
-                        g.DrawImage(image, imageRect, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attrs);
-                    }
+                    RenderItemImageOfLowColorDepth(e);
                 }
             }
         }
@@ -501,6 +462,49 @@ namespace System.Windows.Forms
 
             graphics.DrawRectangle(focusPen1, bounds);
             graphics.DrawRectangle(focusPen2, bounds);
+        }
+
+        private void RenderItemImageOfLowColorDepth(ToolStripItemImageRenderEventArgs e)
+        {
+            Image? image = e.Image;
+
+            if (image is not null)
+            {
+                Graphics g = e.Graphics;
+
+                ToolStripItem item = e.Item;
+                Rectangle imageRect = e.ImageRectangle;
+                using (ImageAttributes attrs = new ImageAttributes())
+                {
+                    if (IsHighContrastWhiteOnBlack() && !(FillWhenSelected && (e.Item.Pressed || e.Item.Selected)))
+                    {
+                        // translate white, black and blue to colors visible in high contrast mode.
+                        ColorMap cm1 = new ColorMap();
+                        ColorMap cm2 = new ColorMap();
+                        ColorMap cm3 = new ColorMap();
+
+                        cm1.OldColor = Color.Black;
+                        cm1.NewColor = Color.White;
+
+                        cm2.OldColor = Color.White;
+                        cm2.NewColor = Color.Black;
+
+                        cm3.OldColor = Color.FromArgb(0, 0, 128);
+                        cm3.NewColor = Color.White;
+
+                        attrs.SetRemapTable(new ColorMap[3] { cm1, cm2, cm3 }, ColorAdjustType.Bitmap);
+                    }
+
+                    if (item.ImageScaling == ToolStripItemImageScaling.None)
+                    {
+                        g.DrawImage(image, imageRect, 0, 0, imageRect.Width, imageRect.Height, GraphicsUnit.Pixel, attrs);
+                    }
+                    else
+                    {
+                        g.DrawImage(image, imageRect, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, attrs);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #7980


## Proposed changes

- Disabled checkmark is now rendered with the same code as other disabled images on ToolStrip
 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Better visual difference between enabled and disabled menu items

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

Windows 11, .NET 7:
![before_win11](https://user-images.githubusercontent.com/113603457/199568304-87df149f-82fc-4021-94d8-bd109174f86c.png)

Windows 10, .NET 7:
![before_win10](https://user-images.githubusercontent.com/113603457/199568338-00144ff9-ec31-4ebd-ad36-2f2323ca2792.png)

### After

Windows 11, .NET 7:
![after_win11](https://user-images.githubusercontent.com/113603457/199568385-1b4447c8-58bb-44b6-9044-3925c4d416a3.png)

Windows 10, .NET 7:
![after_win10](https://user-images.githubusercontent.com/113603457/199568463-1ce9c54f-0296-4052-945c-2e4c591fe951.png)

## Test environment(s) <!-- Remove any that don't apply -->

- .NET SDK 7.0.100-rc.2.22477.23
- Windows 11



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8102)