### PR TITLE
Fixed comparing  of CultureInfo in unit tests.

### DIFF
--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ListControlTests.cs
@@ -1403,17 +1403,17 @@ namespace System.Windows.Forms.Tests
 
             // Set different.
             control.FormatInfo = CultureInfo.CurrentCulture;
-            Assert.Same(CultureInfo.CurrentCulture, control.FormatInfo);
+            Assert.Equal(CultureInfo.CurrentCulture, control.FormatInfo);
             Assert.Equal(1, callCount);
 
             // Set same.
             control.FormatInfo = CultureInfo.CurrentCulture;
-            Assert.Same(CultureInfo.CurrentCulture, control.FormatInfo);
+            Assert.Equal(CultureInfo.CurrentCulture, control.FormatInfo);
             Assert.Equal(1, callCount);
 
             // Set different.
             control.FormatInfo = CultureInfo.InvariantCulture;
-            Assert.Same(CultureInfo.InvariantCulture, control.FormatInfo);
+            Assert.Equal(CultureInfo.InvariantCulture, control.FormatInfo);
             Assert.Equal(2, callCount);
 
             // Set null.
@@ -1437,17 +1437,17 @@ namespace System.Windows.Forms.Tests
 
             // Set different.
             control.FormatInfo = CultureInfo.CurrentCulture;
-            Assert.Same(CultureInfo.CurrentCulture, control.FormatInfo);
+            Assert.Equal(CultureInfo.CurrentCulture, control.FormatInfo);
             Assert.Equal(1, callCount);
 
             // Set same.
             control.FormatInfo = CultureInfo.CurrentCulture;
-            Assert.Same(CultureInfo.CurrentCulture, control.FormatInfo);
+            Assert.Equal(CultureInfo.CurrentCulture, control.FormatInfo);
             Assert.Equal(1, callCount);
 
             // Set different.
             control.FormatInfo = CultureInfo.InvariantCulture;
-            Assert.Same(CultureInfo.InvariantCulture, control.FormatInfo);
+            Assert.Equal(CultureInfo.InvariantCulture, control.FormatInfo);
             Assert.Equal(2, callCount);
 
             // Set null.
@@ -1458,7 +1458,7 @@ namespace System.Windows.Forms.Tests
             // Remove handler.
             control.FormatInfoChanged -= handler;
             control.FormatInfo = CultureInfo.CurrentCulture;
-            Assert.Same(CultureInfo.CurrentCulture, control.FormatInfo);
+            Assert.Equal(CultureInfo.CurrentCulture, control.FormatInfo);
             Assert.Equal(3, callCount);
         }
 


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #8046


## Proposed changes

- Used `Assert.Same` instead of `Assert.Equal` for `CultureInfo`.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Unit tests shouldn't fail.

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->



## Test methodology <!-- How did you ensure quality? -->

- Unit testing



 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK:
 Version:   8.0.100-alpha.1.22512.5
 Commit:    1b80461e45

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8109)