### PR TITLE
Prevent OpenFileDialog From Throwing When Opening With Non-Existing Initial Directory

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/FileDialog.Vista.cs
@@ -73,12 +73,11 @@ namespace System.Windows.Forms
 
             if (!string.IsNullOrEmpty(InitialDirectory))
             {
-                IShellItem* initialDirectory = PInvoke.SHCreateShellItem(InitialDirectory);
-                if (initialDirectory is null)
+                using ComScope<IShellItem> initialDirectory = new(PInvoke.SHCreateShellItem(InitialDirectory));
+                if (!initialDirectory.IsNull)
                 {
                     dialog->SetDefaultFolder(initialDirectory).ThrowOnFailure();
                     dialog->SetFolder(initialDirectory).ThrowOnFailure();
-                    initialDirectory->Release();
                 }
             }
 

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/OpenFileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/OpenFileDialogTests.cs
@@ -15,6 +15,7 @@ namespace System.Windows.Forms.UITests
         {
         }
 
+        // Regression test for https://github.com/dotnet/winforms/issues/8108
         [WinFormsFact]
         public void OpenFileDialogTests_OpenWithNonExistingInitDirectory_Success()
         {
@@ -35,11 +36,9 @@ namespace System.Windows.Forms.UITests
 
         private class TestDialogForm : Form
         {
-            private const int MSGF_DIALOGBOX = 0;
-
             protected override void WndProc(ref Message m)
             {
-                if (m.MsgInternal == User32.WM.ENTERIDLE && m.WParamInternal == MSGF_DIALOGBOX)
+                if (m.MsgInternal == User32.WM.ENTERIDLE && m.WParamInternal == (uint)MSGF.DIALOGBOX)
                 {
                     HWND dialogHandle = (HWND)m.LParamInternal;
                     PInvoke.PostMessage(dialogHandle, User32.WM.CLOSE);

--- a/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/OpenFileDialogTests.cs
+++ b/src/System.Windows.Forms/tests/IntegrationTests/UIIntegrationTests/OpenFileDialogTests.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using Xunit.Abstractions;
+using static Interop;
+
+namespace System.Windows.Forms.UITests
+{
+    public class OpenFileDialogTests : ControlTestBase
+    {
+        public OpenFileDialogTests(ITestOutputHelper testOutputHelper)
+            : base(testOutputHelper)
+        {
+        }
+
+        [WinFormsFact]
+        public void OpenFileDialogTests_OpenWithNonExistingInitDirectory_Success()
+        {
+            using TestDialogForm dialogOwnerForm = new();
+            using OpenFileDialog dialog = new();
+            dialog.InitialDirectory = Guid.NewGuid().ToString();
+            Assert.Equal(DialogResult.Cancel, dialog.ShowDialog(dialogOwnerForm));
+        }
+
+        [WinFormsFact]
+        public void OpenFileDialogTests_OpenWithExistingInitDirectory_Success()
+        {
+            using TestDialogForm dialogOwnerForm = new();
+            using OpenFileDialog dialog = new();
+            dialog.InitialDirectory = Path.GetTempPath();
+            Assert.Equal(DialogResult.Cancel, dialog.ShowDialog(dialogOwnerForm));
+        }
+
+        private class TestDialogForm : Form
+        {
+            private const int MSGF_DIALOGBOX = 0;
+
+            protected override void WndProc(ref Message m)
+            {
+                if (m.MsgInternal == User32.WM.ENTERIDLE && m.WParamInternal == MSGF_DIALOGBOX)
+                {
+                    HWND dialogHandle = (HWND)m.LParamInternal;
+                    PInvoke.PostMessage(dialogHandle, User32.WM.CLOSE);
+                }
+
+                base.WndProc(ref m);
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/tests/TestUtilities/MSGF.cs
+++ b/src/System.Windows.Forms/tests/TestUtilities/MSGF.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System;
+
+internal enum MSGF : uint
+{
+    DIALOGBOX = 0,
+}


### PR DESCRIPTION
Fixes #8108 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8115)