### PR TITLE
Enable nullability in PostAssignedPositionComparer, PreAssignedPositionComparer and SpanComparer

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.PostAssignedPositionComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.PostAssignedPositionComparer.cs
@@ -2,15 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Collections;
-
 namespace System.Windows.Forms.Layout
 {
     internal partial class TableLayout
     {
-        private class PostAssignedPositionComparer : IComparer
+        private class PostAssignedPositionComparer : IComparer<LayoutInfo>
         {
             private static readonly PostAssignedPositionComparer instance = new PostAssignedPositionComparer();
 
@@ -19,26 +15,39 @@ namespace System.Windows.Forms.Layout
                 get { return instance; }
             }
 
-            public int Compare(object x, object y)
+            public int Compare(LayoutInfo? x, LayoutInfo? y)
             {
-                LayoutInfo xInfo = (LayoutInfo)x;
-                LayoutInfo yInfo = (LayoutInfo)y;
-                if (xInfo.RowStart < yInfo.RowStart)
+                if (x is null && y is null)
+                {
+                    return 0;
+                }
+
+                if (x is null)
                 {
                     return -1;
                 }
 
-                if (xInfo.RowStart > yInfo.RowStart)
+                if (y is null)
                 {
                     return 1;
                 }
 
-                if (xInfo.ColumnStart < yInfo.ColumnStart)
+                if (x.RowStart < y.RowStart)
                 {
                     return -1;
                 }
 
-                if (xInfo.ColumnStart > yInfo.ColumnStart)
+                if (x.RowStart > y.RowStart)
+                {
+                    return 1;
+                }
+
+                if (x.ColumnStart < y.ColumnStart)
+                {
+                    return -1;
+                }
+
+                if (x.ColumnStart > y.ColumnStart)
                 {
                     return 1;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.PreAssignedPositionComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.PreAssignedPositionComparer.cs
@@ -2,15 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Collections;
-
 namespace System.Windows.Forms.Layout
 {
     internal partial class TableLayout
     {
-        private class PreAssignedPositionComparer : IComparer
+        private class PreAssignedPositionComparer : IComparer<LayoutInfo>
         {
             private static readonly PreAssignedPositionComparer instance = new PreAssignedPositionComparer();
 
@@ -19,26 +15,39 @@ namespace System.Windows.Forms.Layout
                 get { return instance; }
             }
 
-            public int Compare(object x, object y)
+            public int Compare(LayoutInfo? x, LayoutInfo? y)
             {
-                LayoutInfo xInfo = (LayoutInfo)x;
-                LayoutInfo yInfo = (LayoutInfo)y;
-                if (xInfo.RowPosition < yInfo.RowPosition)
+                if (x is null && y is null)
+                {
+                    return 0;
+                }
+
+                if (x is null)
                 {
                     return -1;
                 }
 
-                if (xInfo.RowPosition > yInfo.RowPosition)
+                if (y is null)
                 {
                     return 1;
                 }
 
-                if (xInfo.ColumnPosition < yInfo.ColumnPosition)
+                if (x.RowPosition < y.RowPosition)
                 {
                     return -1;
                 }
 
-                if (xInfo.ColumnPosition > yInfo.ColumnPosition)
+                if (x.RowPosition > y.RowPosition)
+                {
+                    return 1;
+                }
+
+                if (x.ColumnPosition < y.ColumnPosition)
+                {
+                    return -1;
+                }
+
+                if (x.ColumnPosition > y.ColumnPosition)
                 {
                     return 1;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.SorterObjectArray.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.SorterObjectArray.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
-
 namespace System.Windows.Forms.Layout
 {
     internal partial class TableLayout
@@ -11,12 +9,12 @@ namespace System.Windows.Forms.Layout
         // Private value type used by the Sort methods.
         private struct SorterObjectArray
         {
-            private readonly object[] keys;
-            private readonly IComparer comparer;
+            private readonly LayoutInfo[] keys;
+            private readonly IComparer<LayoutInfo> comparer;
 
-            internal SorterObjectArray(object[] keys, IComparer comparer)
+            internal SorterObjectArray(LayoutInfo[] keys, IComparer<LayoutInfo> comparer)
             {
-                comparer ??= Comparer.Default;
+                comparer ??= Comparer<LayoutInfo>.Default;
 
                 this.keys = keys;
                 this.comparer = comparer;
@@ -30,9 +28,7 @@ namespace System.Windows.Forms.Layout
                     {
                         if (comparer.Compare(keys[a], keys[b]) > 0)
                         {
-                            object temp = keys[a];
-                            keys[a] = keys[b];
-                            keys[b] = temp;
+                            (keys[a], keys[b]) = (keys[b], keys[a]);
                         }
                     }
                     catch (IndexOutOfRangeException)
@@ -62,7 +58,7 @@ namespace System.Windows.Forms.Layout
                     SwapIfGreaterWithItems(i, j);      // swap the low with the high
                     SwapIfGreaterWithItems(middle, j); // swap the middle with the high
 
-                    object x = keys[middle];
+                    LayoutInfo x = keys[middle];
                     do
                     {
                         // Add a try block here to detect IComparers (or their
@@ -95,9 +91,7 @@ namespace System.Windows.Forms.Layout
 
                         if (i < j)
                         {
-                            object key = keys[i];
-                            keys[i] = keys[j];
-                            keys[j] = key;
+                            (keys[i], keys[j]) = (keys[j], keys[i]);
                         }
 
                         i++;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.SpanComparer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.SpanComparer.cs
@@ -2,23 +2,32 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Collections;
-
 namespace System.Windows.Forms.Layout
 {
     internal partial class TableLayout
     {
-        private abstract class SpanComparer : IComparer
+        private abstract class SpanComparer : IComparer<LayoutInfo>
         {
             public abstract int GetSpan(LayoutInfo layoutInfo);
 
-            public int Compare(object x, object y)
+            public int Compare(LayoutInfo? x, LayoutInfo? y)
             {
-                LayoutInfo xInfo = (LayoutInfo)x;
-                LayoutInfo yInfo = (LayoutInfo)y;
-                return GetSpan(xInfo) - GetSpan(yInfo);
+                if (x is null && y is null)
+                {
+                    return 0;
+                }
+
+                if (x is null)
+                {
+                    return -1;
+                }
+
+                if (y is null)
+                {
+                    return 1;
+                }
+
+                return GetSpan(x) - GetSpan(y);
             }
         }
     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Layout/TableLayout.cs
@@ -25,7 +25,7 @@ namespace System.Windows.Forms.Layout
             return low + ((hi - low) >> 1);
         }
 
-        private static void Sort(object[] array, IComparer comparer)
+        private static void Sort(LayoutInfo[] array, IComparer<LayoutInfo> comparer)
         {
             ArgumentNullException.ThrowIfNull(array);
 


### PR DESCRIPTION
## Proposed changes

- Enable nullability in PostAssignedPositionComparer, PreAssignedPositionComparer and SpanComparer.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8127)