### PR TITLE
Update backport action environment to Node 16

### DIFF
--- a/eng/actions/backport/action.yml
+++ b/eng/actions/backport/action.yml
@@ -16,5 +16,5 @@ inputs:
       /cc %cc_users%
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
### Problem
<!-- Add the issue number if exists. Describe the problem otherwise. -->
🚨 Node 12 has an end of life on April 30, 2022.

The GitHub Actions workflow gives the following warning while running the action:

> Node.js 12 actions are deprecated. For more information see: github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12.

Similar dep: https://github.com/dotnet/templating/pull/5576

### Solution
<!-- Describe the solution. -->
This PR updates the default runtime to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/) rather then node12. 

This is supported on all Actions Runners v2.285.0 or later.

Signed-off-by: Enes <ahmedenesturan@gmail.com>

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8135)