### PR TITLE
Using GetScaledBitmapFromIcon instead of GetBitmapFromIcon

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/Internals/DpiHelper.cs
@@ -318,15 +318,25 @@ namespace System.Windows.Forms
 
         /// <summary>
         ///  Creates a new bitmap scaled to the closest size from the icon set according to the current DPI mode.
+        ///  Default size for 100% DPI is set to 16x16.
         /// </summary>
-        /// <param name="type">Resource type</param>
-        /// <param name="name">Resource name</param>
-        /// <param name="defaultSize">Default size for 100% DPI</param>
-        /// <returns>New scaled bitmap</returns>
-        internal static Bitmap GetScaledBitmapFromIcon(Type type, string name, Size defaultSize)
+        /// <param name="type">A <see cref="Type"/> that specifies the assembly in which to look for the resource.</param>
+        /// <param name="name">The resource name to load.</param>
+        /// <returns>New scaled bitmap.</returns>
+        internal static Bitmap GetScaledBitmapFromIcon(Type type, string name)
+            => GetScaledBitmapFromIcon(type, name, new(16, 16));
+
+        /// <summary>
+        ///  Creates a new bitmap scaled to the closest size from the icon set according to the current DPI mode.
+        /// </summary>
+        /// <param name="type">A <see cref="Type"/> that specifies the assembly in which to look for the resource.</param>
+        /// <param name="name">The resource name to load.</param>
+        /// <param name="unscaledSize">Default size for 100% DPI</param>
+        /// <returns>New scaled bitmap.</returns>
+        internal static Bitmap GetScaledBitmapFromIcon(Type type, string name, Size unscaledSize)
         {
             using Icon icon = new(type, name);
-            Size scaledSize = LogicalToDeviceUnits(defaultSize);
+            Size scaledSize = LogicalToDeviceUnits(unscaledSize);
             Size deltaSize = icon.Size - scaledSize;
             if (Math.Abs(deltaSize.Height) <= 2 && Math.Abs(deltaSize.Width) <= 2)
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/BindingNavigator.cs
@@ -179,19 +179,12 @@ namespace System.Windows.Forms
             // Set up images
             //
 
-            Bitmap moveFirstImage = DpiHelper.GetBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.MoveFirst");
-            Bitmap movePreviousImage = DpiHelper.GetBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.MovePrevious");
-            Bitmap moveNextImage = DpiHelper.GetBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.MoveNext");
-            Bitmap moveLastImage = DpiHelper.GetBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.MoveLast");
-            Bitmap addNewImage = DpiHelper.GetBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.AddNew");
-            Bitmap deleteImage = DpiHelper.GetBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.Delete");
-
-            MoveFirstItem.Image = moveFirstImage;
-            MovePreviousItem.Image = movePreviousImage;
-            MoveNextItem.Image = moveNextImage;
-            MoveLastItem.Image = moveLastImage;
-            AddNewItem.Image = addNewImage;
-            DeleteItem.Image = deleteImage;
+            MoveFirstItem.Image = DpiHelper.GetScaledBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.MoveFirst");
+            MovePreviousItem.Image = DpiHelper.GetScaledBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.MovePrevious");
+            MoveNextItem.Image = DpiHelper.GetScaledBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.MoveNext");
+            MoveLastItem.Image = DpiHelper.GetScaledBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.MoveLast");
+            AddNewItem.Image = DpiHelper.GetScaledBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.AddNew");
+            DeleteItem.Image = DpiHelper.GetScaledBitmapFromIcon(typeof(BindingNavigator), "BindingNavigator.Delete");
 
             MoveFirstItem.RightToLeftAutoMirrorImage = true;
             MovePreviousItem.RightToLeftAutoMirrorImage = true;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridViewImageCell.cs
@@ -95,7 +95,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                s_errorBitmap ??= DpiHelper.GetBitmapFromIcon(typeof(DataGridView), "ImageInError");
+                s_errorBitmap ??= DpiHelper.GetScaledBitmapFromIcon(typeof(DataGridView), "ImageInError");
 
                 return s_errorBitmap;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PictureBox.cs
@@ -233,7 +233,7 @@ namespace System.Windows.Forms
                     if (_defaultErrorImage is null)
                     {
                         // Can't share images across threads.
-                        t_defaultErrorImageForThread ??= DpiHelper.GetBitmapFromIcon(typeof(PictureBox), "ImageInError");
+                        t_defaultErrorImageForThread ??= DpiHelper.GetScaledBitmapFromIcon(typeof(PictureBox), "ImageInError");
 
                         _defaultErrorImage = t_defaultErrorImageForThread;
                     }
@@ -391,7 +391,7 @@ namespace System.Windows.Forms
                     if (_defaultInitialImage is null)
                     {
                         // Can't share images across threads.
-                        t_defaultInitialImageForThread ??= DpiHelper.GetBitmapFromIcon(typeof(PictureBox), "PictureBox.Loading");
+                        t_defaultInitialImageForThread ??= DpiHelper.GetScaledBitmapFromIcon(typeof(PictureBox), "PictureBox.Loading");
 
                         _defaultInitialImage = t_defaultInitialImageForThread;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Printing/PrintPreviewDialog.cs
@@ -57,7 +57,7 @@ namespace System.Windows.Forms
 
             _previewControl = new PrintPreviewControl();
             _imageList = new ImageList();
-            _imageList.Images.AddStrip(DpiHelper.GetBitmapFromIcon(typeof(PrintPreviewDialog), "PrintPreviewStrip"));
+            _imageList.Images.AddStrip(DpiHelper.GetScaledBitmapFromIcon(typeof(PrintPreviewDialog), "PrintPreviewStrip", new(112, 16)));
             InitForm();
         }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGrid.cs
@@ -3956,7 +3956,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        protected virtual Bitmap SortByPropertyImage => DpiHelper.GetBitmapFromIcon(typeof(PropertyGrid), "PBAlpha");
+        protected virtual Bitmap SortByPropertyImage => DpiHelper.GetScaledBitmapFromIcon(typeof(PropertyGrid), "PBAlpha");
 
         /// <summary>
         ///  This 16x16 Bitmap is applied to the button which displays properties under the assigned categories.
@@ -3964,7 +3964,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        protected virtual Bitmap SortByCategoryImage => DpiHelper.GetBitmapFromIcon(typeof(PropertyGrid), "PBCategory");
+        protected virtual Bitmap SortByCategoryImage => DpiHelper.GetScaledBitmapFromIcon(typeof(PropertyGrid), "PBCategory");
 
         /// <summary>
         ///  This 16x16 Bitmap is applied to the button which displays property page in the designer pane.
@@ -3972,7 +3972,7 @@ namespace System.Windows.Forms
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        protected virtual Bitmap ShowPropertyPageImage => DpiHelper.GetBitmapFromIcon(typeof(PropertyGrid), "PBPPage");
+        protected virtual Bitmap ShowPropertyPageImage => DpiHelper.GetScaledBitmapFromIcon(typeof(PropertyGrid), "PBPPage");
 
         // "Should" methods are used by the designer via reflection.
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridErrorDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridErrorDialog.cs
@@ -43,15 +43,13 @@ namespace System.Windows.Forms.PropertyGridInternal
         public GridErrorDialog(PropertyGrid owner)
         {
             _ownerGrid = owner;
+
             _expandImage = DpiHelper.GetBitmapFromIcon(typeof(ThreadExceptionDialog), "down");
+            _collapseImage = DpiHelper.GetBitmapFromIcon(typeof(ThreadExceptionDialog), "up");
+
             if (DpiHelper.IsScalingRequired)
             {
                 DpiHelper.ScaleBitmapLogicalToDevice(ref _expandImage);
-            }
-
-            _collapseImage = DpiHelper.GetBitmapFromIcon(typeof(ThreadExceptionDialog), "up");
-            if (DpiHelper.IsScalingRequired)
-            {
                 DpiHelper.ScaleBitmapLogicalToDevice(ref _collapseImage);
             }
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripScrollButton.cs
@@ -13,8 +13,6 @@ namespace System.Windows.Forms
     {
         private readonly bool _up = true;
 
-        private static readonly Size defaultBitmapSize = new(16, 16);
-
         [ThreadStatic]
         private static Bitmap? t_upScrollImage;
 
@@ -71,7 +69,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                t_downScrollImage ??= DpiHelper.GetScaledBitmapFromIcon(typeof(ToolStripScrollButton), "ScrollButtonDown", defaultBitmapSize);
+                t_downScrollImage ??= DpiHelper.GetScaledBitmapFromIcon(typeof(ToolStripScrollButton), "ScrollButtonDown");
 
                 return t_downScrollImage;
             }
@@ -84,7 +82,7 @@ namespace System.Windows.Forms
         {
             get
             {
-                t_upScrollImage ??= DpiHelper.GetScaledBitmapFromIcon(typeof(ToolStripScrollButton), "ScrollButtonUp", defaultBitmapSize);
+                t_upScrollImage ??= DpiHelper.GetScaledBitmapFromIcon(typeof(ToolStripScrollButton), "ScrollButtonUp");
 
                 return t_upScrollImage;
             }

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ToolStripTests.cs
@@ -7218,7 +7218,6 @@ namespace System.Windows.Forms.Tests
         {
             Type toolStripScrollButtonType = typeof(ToolStripScrollButton);
             var accessor = typeof(DpiHelper).TestAccessor();
-            Size defaultSize = new(16, 16);
             int oldDeviceDpi = DpiHelper.DeviceDpi;
             DpiTestData dpiTestData = new()
             {
@@ -7230,7 +7229,7 @@ namespace System.Windows.Forms.Tests
             try
             {
                 accessor.Dynamic.DeviceDpi = dpiTestData.Dpi;
-                Bitmap bitmap = DpiHelper.GetScaledBitmapFromIcon(toolStripScrollButtonType, dpiTestData.ResourceName, defaultSize);
+                using Bitmap bitmap = DpiHelper.GetScaledBitmapFromIcon(toolStripScrollButtonType, dpiTestData.ResourceName);
                 Assert.Equal(dpiTestData.ExpectedSide, bitmap.Width);
                 Assert.Equal(dpiTestData.ExpectedSide, bitmap.Height);
             }


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #6137


## Proposed changes

- Added new overload `Bitmap GetScaledBitmapFromIcon(Type type, string name)` with default size 16x16 which uses in most cases.
- Replaced `GetBitmapFromIcon` with `GetScaledBitmapFromIcon` in cases where resize isn't applied and we know the size of the icon precisely. 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- Icons will be more appropriate and their size will be depended on the current DPI.

## Regression? 

- No

## Risk

- Minimal.

<!-- end TELL-MODE -->

## Test methodology <!-- How did you ensure quality? -->

- Manually (using different screen scales 100%-175%)


<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

.NET SDK:
 Version:   8.0.100-alpha.1.22512.5
 Commit:    1b80461e45

Runtime Environment:
 OS Name:     Windows
 OS Version:  10.0.22621



<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8145)