### PR TITLE
Prevent Over Releasing of IStream

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -392,20 +392,7 @@ namespace System.Windows.Forms
                 _storage = null;
             }
 
-            protected virtual unsafe void Dispose(bool disposing)
-            {
-                if (disposing)
-                {
-                    ReleaseResources();
-                }
-                else
-                {
-                    // Unsafe to release COM references from the finalizer thread.
-                    // There is no guarantees whether it has or hasn't been collected.
-                    _iLockBytes = null;
-                    _storage = null;
-                }
-            }
+            protected virtual void Dispose(bool disposing) => ReleaseResources();
 
             public void Dispose()
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.State.cs
@@ -392,7 +392,20 @@ namespace System.Windows.Forms
                 _storage = null;
             }
 
-            protected virtual void Dispose(bool disposing) => ReleaseResources();
+            protected virtual unsafe void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    ReleaseResources();
+                }
+                else
+                {
+                    // Unsafe to release COM references from the finalizer thread.
+                    // There is no guarantees whether it has or hasn't been collected.
+                    _iLockBytes = null;
+                    _storage = null;
+                }
+            }
 
             public void Dispose()
             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.PropertyBagStream.cs
@@ -24,26 +24,27 @@ namespace System.Windows.Forms
                 {
                     // Visual Basic's memory streams don't support seeking, so we have to work around this limitation
                     // here. We do this by copying the contents of the stream into a MemoryStream object.
-                    Stream stream = new DataStreamFromComStream(istream);
                     const int PAGE_SIZE = 0x1000; // one page (4096b)
                     byte[] streamData = new byte[PAGE_SIZE];
-                    int offset = 0;
-
-                    int count = stream.Read(streamData, offset, PAGE_SIZE);
-                    int totalCount = count;
-
-                    while (count == PAGE_SIZE)
+                    using (DataStreamFromComStream comStream = new(istream, ownsHandle: false))
                     {
-                        byte[] newChunk = new byte[streamData.Length + PAGE_SIZE];
-                        Array.Copy(streamData, newChunk, streamData.Length);
-                        streamData = newChunk;
+                        int offset = 0;
+                        int count = comStream.Read(streamData, offset, PAGE_SIZE);
+                        int totalCount = count;
 
-                        offset += PAGE_SIZE;
-                        count = stream.Read(streamData, offset, PAGE_SIZE);
-                        totalCount += count;
+                        while (count == PAGE_SIZE)
+                        {
+                            byte[] newChunk = new byte[streamData.Length + PAGE_SIZE];
+                            Array.Copy(streamData, newChunk, streamData.Length);
+                            streamData = newChunk;
+
+                            offset += PAGE_SIZE;
+                            count = comStream.Read(streamData, offset, PAGE_SIZE);
+                            totalCount += count;
+                        }
                     }
 
-                    stream = new MemoryStream(streamData);
+                    MemoryStream stream = new(streamData);
 
                     BinaryFormatter formatter = new BinaryFormatter();
                     try
@@ -94,8 +95,8 @@ namespace System.Windows.Forms
 
                 internal void Write(IStream* istream)
                 {
-                    Stream stream = new DataStreamFromComStream(istream);
-                    BinaryFormatter formatter = new BinaryFormatter();
+                    using DataStreamFromComStream stream = new(istream, ownsHandle: false);
+                    BinaryFormatter formatter = new();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
                     formatter.Serialize(stream, _bag);
 #pragma warning restore SYSLIB0011 // Type or member is obsolete

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.PropertyBagStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Control.ActiveXImpl.PropertyBagStream.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms
                     // here. We do this by copying the contents of the stream into a MemoryStream object.
                     const int PAGE_SIZE = 0x1000; // one page (4096b)
                     byte[] streamData = new byte[PAGE_SIZE];
-                    using (DataStreamFromComStream comStream = new(istream, ownsHandle: false))
+                    using (DataStreamFromComStream comStream = new(istream))
                     {
                         int offset = 0;
                         int count = comStream.Read(streamData, offset, PAGE_SIZE);
@@ -95,7 +95,7 @@ namespace System.Windows.Forms
 
                 internal void Write(IStream* istream)
                 {
-                    using DataStreamFromComStream stream = new(istream, ownsHandle: false);
+                    using DataStreamFromComStream stream = new(istream);
                     BinaryFormatter formatter = new();
 #pragma warning disable SYSLIB0011 // Type or member is obsolete
                     formatter.Serialize(stream, _bag);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
@@ -147,13 +147,9 @@ namespace System.Windows.Forms
 
         protected override void Dispose(bool disposing)
         {
-            if (_comStream is not null)
+            if (disposing && _comStream is not null)
             {
-                if (disposing)
-                {
-                    _comStream->Commit(STGC.STGC_DEFAULT);
-                }
-
+                _comStream->Commit(STGC.STGC_DEFAULT);
                 // Can't release a COM stream from the finalizer thread.
                 _comStream->Release();
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
@@ -9,12 +9,13 @@ namespace System.Windows.Forms
     internal unsafe class DataStreamFromComStream : Stream
     {
         private IStream* _comStream;
-        private readonly bool _ownsHandle;
 
-        public DataStreamFromComStream(IStream* comStream, bool ownsHandle) : base()
+        /// <summary>
+        ///  Initializes a new instance that does not take ownership of <paramref name="comStream"/>.
+        /// </summary>
+        public DataStreamFromComStream(IStream* comStream) : base()
         {
             _comStream = comStream;
-            _ownsHandle = ownsHandle;
         }
 
         public override long Position
@@ -149,26 +150,13 @@ namespace System.Windows.Forms
 
         protected override void Dispose(bool disposing)
         {
-            if (_comStream is not null)
+            if (disposing && _comStream is not null)
             {
-                if (disposing)
-                {
-                    _comStream->Commit(STGC.STGC_DEFAULT);
-                }
-
-                if (_ownsHandle)
-                {
-                    _comStream->Release();
-                }
+                _comStream->Commit(STGC.STGC_DEFAULT);
             }
 
             _comStream = null;
             base.Dispose(disposing);
-        }
-
-        ~DataStreamFromComStream()
-        {
-            Dispose(false);
         }
     }
 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataStreamFromComStream.cs
@@ -11,7 +11,7 @@ namespace System.Windows.Forms
         private IStream* _comStream;
         private readonly bool _ownsHandle;
 
-        public DataStreamFromComStream(IStream* comStream, bool ownsHandle)
+        public DataStreamFromComStream(IStream* comStream, bool ownsHandle) : base()
         {
             _comStream = comStream;
             _ownsHandle = ownsHandle;

--- a/src/System.Windows.Forms/tests/UnitTests/DataStreamFromComStreamTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/DataStreamFromComStreamTests.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms.Tests
             using MemoryStream memoryStream = new();
             using var stream = ComHelpers.GetComScope<IStream>(new Interop.Ole32.GPStream(memoryStream), out bool result);
             Assert.True(result);
-            DataStreamFromComStream dataStream = new(stream, ownsHandle: false);
+            using DataStreamFromComStream dataStream = new(stream, ownsHandle: false);
             dataStream.Write(new byte[bufferSize], index, count);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/DataStreamFromComStreamTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/DataStreamFromComStreamTests.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms.Tests
             using MemoryStream memoryStream = new();
             using var stream = ComHelpers.GetComScope<IStream>(new Interop.Ole32.GPStream(memoryStream), out bool result);
             Assert.True(result);
-            using DataStreamFromComStream dataStream = new(stream, ownsHandle: false);
+            using DataStreamFromComStream dataStream = new(stream);
             Assert.Throws<IOException>(() => dataStream.Write(new byte[bufferSize], index, count));
         }
 
@@ -32,7 +32,7 @@ namespace System.Windows.Forms.Tests
             using MemoryStream memoryStream = new();
             using var stream = ComHelpers.GetComScope<IStream>(new Interop.Ole32.GPStream(memoryStream), out bool result);
             Assert.True(result);
-            using DataStreamFromComStream dataStream = new(stream, ownsHandle: false);
+            using DataStreamFromComStream dataStream = new(stream);
             dataStream.Write(new byte[bufferSize], index, count);
         }
     }

--- a/src/System.Windows.Forms/tests/UnitTests/DataStreamFromComStreamTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/DataStreamFromComStreamTests.cs
@@ -18,7 +18,7 @@ namespace System.Windows.Forms.Tests
             using MemoryStream memoryStream = new();
             using var stream = ComHelpers.GetComScope<IStream>(new Interop.Ole32.GPStream(memoryStream), out bool result);
             Assert.True(result);
-            var dataStream = new DataStreamFromComStream(stream);
+            using DataStreamFromComStream dataStream = new(stream, ownsHandle: false);
             Assert.Throws<IOException>(() => dataStream.Write(new byte[bufferSize], index, count));
         }
 
@@ -32,7 +32,7 @@ namespace System.Windows.Forms.Tests
             using MemoryStream memoryStream = new();
             using var stream = ComHelpers.GetComScope<IStream>(new Interop.Ole32.GPStream(memoryStream), out bool result);
             Assert.True(result);
-            var dataStream = new DataStreamFromComStream(stream);
+            DataStreamFromComStream dataStream = new(stream, ownsHandle: false);
             dataStream.Write(new byte[bufferSize], index, count);
         }
     }


### PR DESCRIPTION
Addresses https://github.com/dotnet/winforms/pull/8105#discussion_r1017451431
~~Update `Dispose(bool disposing)` methods for `AxHost.State` and `DataStreamFromComStream` to avoid releasing COM references on finalizer thread.~~

Ensure `_comStream` in `DataStreamFromComStream` does not get over released
- ~~Add field indicating whether `DataStreamFromComStream` takes ownership of the stream passed into constructor~~
- ~~Check if `DataStreamFromComStream` owns the stream before releasing~~
- Do not take ownership of `_comStream` in `DataStreamFromComStream` and remove its finalizer


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8148)