### PR TITLE
Scrollbar scaling according to Dpi is controllable via public property in Framework

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -26,7 +26,6 @@ namespace System.Windows.Forms
         private int _value;
         private readonly ScrollOrientation _scrollOrientation;
         private int _wheelDelta;
-        private bool _scaleScrollBarForDpiChange = true;
 
         /// <summary>
         ///  Initializes a new instance of the <see cref="ScrollBar"/> class.
@@ -136,7 +135,7 @@ namespace System.Windows.Forms
         {
             base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
 
-            if (_scaleScrollBarForDpiChange)
+            if (ScaleScrollBarForDpiChange)
             {
                 Scale((float)deviceDpiNew / deviceDpiOld);
             }
@@ -381,11 +380,7 @@ namespace System.Windows.Forms
         [Browsable(true)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [SRDescription(nameof(SR.ControlDpiChangeScale))]
-        public bool ScaleScrollBarForDpiChange
-        {
-            get => _scaleScrollBarForDpiChange;
-            set => _scaleScrollBarForDpiChange = value;
-        }
+        public bool ScaleScrollBarForDpiChange { get; set; } = true;
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ScrollBar.cs
@@ -135,7 +135,11 @@ namespace System.Windows.Forms
         protected override void RescaleConstantsForDpi(int deviceDpiOld, int deviceDpiNew)
         {
             base.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
-            Scale((float)deviceDpiNew / deviceDpiOld);
+
+            if (_scaleScrollBarForDpiChange)
+            {
+                Scale((float)deviceDpiNew / deviceDpiOld);
+            }
         }
 
         /// <summary>

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
@@ -2623,11 +2623,6 @@ namespace System.Windows.Forms.Tests
             control.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
             Assert.Equal(expected, control.Size);
             Assert.False(control.IsHandleCreated);
-
-            // Call again.
-            control.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
-            Assert.Equal(expected, control.Size);
-            Assert.False(control.IsHandleCreated);
         }
 
         [WinFormsTheory]

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
@@ -2580,6 +2580,7 @@ namespace System.Windows.Forms.Tests
             {
                 yield return new object[] { scaleScrollBarForDpiChange, 100, 200 };
                 yield return new object[] { scaleScrollBarForDpiChange, 100, 100 };
+                yield return new object[] { scaleScrollBarForDpiChange, 0, 0 };
             }
         }
 
@@ -2606,6 +2607,11 @@ namespace System.Windows.Forms.Tests
             yield return new object[] { true, 100, 200, new Size(10, 20), new Size(20, 40) };
             yield return new object[] { true, 200, 100, new Size(10, 20), new Size(5, 10) };
             yield return new object[] { true, 100, 100, new Size(10, 20), new Size(10, 20) };
+
+            // Invalid DPI values. Given we do not check the input explicitly for validity and
+            // simply try to calculate factor, passing invalid values like -100, -200 are equivalent
+            // to 100, 200 (factor = newDpi/oldDpi).
+            yield return new object[] { true, 0, 0, new Size(10, 20), Size.Empty };
 
             yield return new object[] { false, 100, 200, new Size(10, 20), new Size(10, 20) };
             yield return new object[] { false, 100, 100, new Size(10, 20), new Size(10, 20) };

--- a/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
+++ b/src/System.Windows.Forms/tests/UnitTests/System/Windows/Forms/ScrollBarTests.cs
@@ -2578,10 +2578,8 @@ namespace System.Windows.Forms.Tests
         {
             foreach (bool scaleScrollBarForDpiChange in new bool[] { true, false })
             {
-                yield return new object[] { scaleScrollBarForDpiChange, 1, 2 };
-                yield return new object[] { scaleScrollBarForDpiChange, 1, 1 };
-                yield return new object[] { scaleScrollBarForDpiChange, 0, 0 };
-                yield return new object[] { scaleScrollBarForDpiChange, -1, -2 };
+                yield return new object[] { scaleScrollBarForDpiChange, 100, 200 };
+                yield return new object[] { scaleScrollBarForDpiChange, 100, 100 };
             }
         }
 
@@ -2605,33 +2603,30 @@ namespace System.Windows.Forms.Tests
 
         public static IEnumerable<object[]> RescaleConstantsForDpi_WithSize_TestData()
         {
-            yield return new object[] { true, 1, 2, new Size(20, 40), new Size(40, 80) };
-            yield return new object[] { true, 1, 1, new Size(10, 20), new Size(10, 20) };
-            yield return new object[] { true, 0, 0, Size.Empty, Size.Empty };
-            yield return new object[] { true, -1, -2, new Size(20, 40), new Size(40, 80) };
+            yield return new object[] { true, 100, 200, new Size(10, 20), new Size(20, 40) };
+            yield return new object[] { true, 200, 100, new Size(10, 20), new Size(5, 10) };
+            yield return new object[] { true, 100, 100, new Size(10, 20), new Size(10, 20) };
 
-            yield return new object[] { false, 1, 2, new Size(20, 40), new Size(40, 80) };
-            yield return new object[] { false, 1, 1, new Size(10, 20), new Size(10, 20) };
-            yield return new object[] { false, 0, 0, Size.Empty, Size.Empty };
-            yield return new object[] { false, -1, -2, new Size(20, 40), new Size(40, 80) };
+            yield return new object[] { false, 100, 200, new Size(10, 20), new Size(10, 20) };
+            yield return new object[] { false, 100, 100, new Size(10, 20), new Size(10, 20) };
         }
 
         [WinFormsTheory]
         [MemberData(nameof(RescaleConstantsForDpi_WithSize_TestData))]
-        public void ScrollBar_RescaleConstantsForDpi_InvokeWithSize_Nop(bool scaleScrollBarForDpiChange, int deviceDpiOld, int deviceDpiNew, Size expected1, Size expected2)
+        public void ScrollBar_RescaleConstantsForDpi_InvokeWithSize_Nop(bool scaleScrollBarForDpiChange, int deviceDpiOld, int deviceDpiNew, Size controlSize, Size expected)
         {
             using var control = new SubScrollBar
             {
                 ScaleScrollBarForDpiChange = scaleScrollBarForDpiChange,
-                Size = new Size(10, 20)
+                Size = controlSize
             };
             control.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
-            Assert.Equal(expected1, control.Size);
+            Assert.Equal(expected, control.Size);
             Assert.False(control.IsHandleCreated);
 
             // Call again.
             control.RescaleConstantsForDpi(deviceDpiOld, deviceDpiNew);
-            Assert.Equal(expected2, control.Size);
+            Assert.Equal(expected, control.Size);
             Assert.False(control.IsHandleCreated);
         }
 


### PR DESCRIPTION
When original fix to scale scrollbars was introduced, we hide change under a switch and introduced public property to help developers control the scaling. In .NET, we removed all switches and accidentally removed developer control via public property `ScaleScrollBarForDpiChange`.

Bringing parity with Framework here.

Fixes #2742

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8149)