### PR TITLE
Refactor `AxPropertyDescriptor` to replace `ArrayList`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
@@ -26,7 +26,7 @@ namespace System.Windows.Forms
 
             private TypeConverter _converter;
             private UITypeEditor _editor;
-            private readonly ArrayList _updateAttributes = new();
+            private readonly List<Attribute> _updateAttributes = new();
             private int _flags;
 
             private const int FlagUpdatedEditorAndConverter = 0x00000001;
@@ -268,7 +268,7 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                ArrayList attributes = new ArrayList(AttributeArray);
+                List<Attribute> attributes = new List<Attribute>(AttributeArray);
                 foreach (Attribute attr in _updateAttributes)
                 {
                     attributes.Add(attr);

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.AxPropertyDescriptor.cs
@@ -267,16 +267,13 @@ namespace System.Windows.Forms
                     return;
                 }
 
-                List<Attribute> attributes = new List<Attribute>(AttributeArray);
+                List<Attribute> attributes = new(AttributeArray);
                 foreach (Attribute attr in _updateAttributes)
                 {
                     attributes.Add(attr);
                 }
 
-                Attribute[] temp = new Attribute[attributes.Count];
-                attributes.CopyTo(temp, 0);
-                AttributeArray = temp;
-
+                AttributeArray = attributes.ToArray();
                 _updateAttributes.Clear();
             }
 


### PR DESCRIPTION
Refactored `AxPropertyDescriptor` to replace `ArrayList` with `List<T>`

Related: #8140

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8152)