### PR TITLE
Refactor `ResXResourceWriter` to use `Dictionary<string, string>` instead of `Hashtable`

### DIFF
--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
@@ -511,7 +511,7 @@ namespace System.Resources
         private string GetAliasFromName(AssemblyName assemblyName)
         {
             _cachedAliases ??= new();
-            if (!_cachedAliases.TryGetValue(assemblyName.FullName, out string alias))
+            if (!_cachedAliases.TryGetValue(assemblyName.FullName, out string alias) || string.IsNullOrEmpty(alias))
             {
                 alias = assemblyName.Name;
                 AddAlias(alias, assemblyName);

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
@@ -34,7 +34,7 @@ namespace System.Resources
         internal const string AssemblyStr = "assembly";
         internal const string AliasStr = "alias";
 
-        private Hashtable _cachedAliases;
+        private Dictionary<string, string> _cachedAliases;
 
         private static readonly TraceSwitch s_resValueProviderSwitch = new TraceSwitch("ResX", "Debug the resource value provider");
 
@@ -266,9 +266,7 @@ namespace System.Resources
         public virtual void AddAlias(string aliasName, AssemblyName assemblyName)
         {
             ArgumentNullException.ThrowIfNull(assemblyName);
-
-            _cachedAliases ??= new Hashtable();
-
+            _cachedAliases ??= new();
             _cachedAliases[assemblyName.FullName] = aliasName;
         }
 
@@ -513,10 +511,8 @@ namespace System.Resources
 
         private string GetAliasFromName(AssemblyName assemblyName)
         {
-            _cachedAliases ??= new Hashtable();
-
-            string alias = (string)_cachedAliases[assemblyName.FullName];
-
+            _cachedAliases ??= new();
+            string alias = _cachedAliases[assemblyName.FullName];
             if (string.IsNullOrEmpty(alias))
             {
                 alias = assemblyName.Name;

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
@@ -511,8 +511,7 @@ namespace System.Resources
         private string GetAliasFromName(AssemblyName assemblyName)
         {
             _cachedAliases ??= new();
-            string alias = _cachedAliases[assemblyName.FullName];
-            if (string.IsNullOrEmpty(alias))
+            if (!_cachedAliases.TryGetValue(assemblyName.FullName, out string alias))
             {
                 alias = assemblyName.Name;
                 AddAlias(alias, assemblyName);


### PR DESCRIPTION
Refactor `ResXResourceWriter` to use `Dictionary<string, string>` instead of `Hashtable`.

Related: #8143

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8160)