### PR TITLE
Refactor `ThreadContext` to use `Dictionary<uint, ThreadContext>` instead of `Hashtable`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -32,7 +32,7 @@ namespace System.Windows.Forms
 
             private static readonly UIntPtr s_invalidId = (UIntPtr)0xFFFFFFFF;
 
-            private static readonly Hashtable s_contextHash = new();
+            private static readonly Dictionary<uint, ThreadContext> s_contextHash = new();
 
             // When this gets to zero, we'll invoke a full garbage
             // collect and check for root/window leaks.
@@ -748,7 +748,7 @@ namespace System.Windows.Forms
             /// </summary>
             internal static ThreadContext FromId(uint id)
             {
-                ThreadContext context = (ThreadContext)s_contextHash[id];
+                ThreadContext context = s_contextHash[id];
                 if (context is null && id == PInvoke.GetCurrentThreadId())
                 {
                     context = new ThreadContext();

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Application.ThreadContext.cs
@@ -747,8 +747,7 @@ namespace System.Windows.Forms
             /// </summary>
             internal static ThreadContext FromId(uint id)
             {
-                ThreadContext context = s_contextHash[id];
-                if (context is null && id == PInvoke.GetCurrentThreadId())
+                if (!s_contextHash.TryGetValue(id, out ThreadContext context) && id == PInvoke.GetCurrentThreadId())
                 {
                     context = new ThreadContext();
                 }


### PR DESCRIPTION
Related: #8143

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8161)