### PR TITLE
Refactor `AxHost` to use `Dictionary<VSSDK.PROPCAT, CategoryAttribute>` instead of `Hastable`

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/AxHost.cs
@@ -2509,8 +2509,8 @@ namespace System.Windows.Forms
                 return s_categoryNames[index];
             }
 
-            if (_objectDefinedCategoryNames?.TryGetValue(propcat, out CategoryAttribute category)
-                ?? false && category is not null)
+            if (_objectDefinedCategoryNames?.TryGetValue(propcat, out CategoryAttribute category) ?? false
+                && category is not null)
             {
                 return category;
             }


### PR DESCRIPTION
Related: #8143

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8163)