### PR TITLE
GridError dialog missing AutoScaleDimensions property

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridErrorDialog.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/GridErrorDialog.cs
@@ -272,6 +272,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
             AcceptButton = _okButton;
             AutoSize = true;
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             AutoSizeMode = AutoSizeMode.GrowAndShrink;
             CancelButton = _cancelButton;


### PR DESCRIPTION
GridError dialog is missing `AutoScaleDimension` property resulting in default scale factor `1`. Thus, not scaled according to the DPI of the primary monitor. This property is auto generated if dialog was designed in the designer.

Fixes #5111 .
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8171)