### PR TITLE
Enable nullability in ToolStripPanelCellToControlEnumerator

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.ToolStripPanelCellToControlEnumerator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.ToolStripPanelCellToControlEnumerator.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Collections;
 using System.Diagnostics;
 
@@ -11,7 +9,7 @@ namespace System.Windows.Forms
 {
     public partial class ToolStripPanelRow
     {
-internal partial class ToolStripPanelRowControlCollection
+        internal partial class ToolStripPanelRowControlCollection
         {
             ///  We want to pretend like we're only holding controls... so everywhere we've returned controls.
             ///  but the problem is if you do a foreach, you'll get the cells not the controls.  So we've got
@@ -25,11 +23,11 @@ internal partial class ToolStripPanelRowControlCollection
                     _arrayListEnumerator = ((IEnumerable)list).GetEnumerator();
                 }
 
-                public virtual object Current
+                public virtual object? Current
                 {
                     get
                     {
-                        ToolStripPanelCell cell = _arrayListEnumerator.Current as ToolStripPanelCell;
+                        ToolStripPanelCell? cell = _arrayListEnumerator.Current as ToolStripPanelCell;
                         Debug.Assert(cell is not null, "Expected ToolStripPanel cells only!!!" + _arrayListEnumerator.Current.GetType().ToString());
                         return cell?.Control;
                     }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.ToolStripPanelCellToControlEnumerator.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.ToolStripPanelCellToControlEnumerator.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable disable
+
+using System.Collections;
+using System.Diagnostics;
+
+namespace System.Windows.Forms
+{
+    public partial class ToolStripPanelRow
+    {
+internal partial class ToolStripPanelRowControlCollection
+        {
+            ///  We want to pretend like we're only holding controls... so everywhere we've returned controls.
+            ///  but the problem is if you do a foreach, you'll get the cells not the controls.  So we've got
+            ///  to sort of write a wrapper class around the ArrayList enumerator.
+            private class ToolStripPanelCellToControlEnumerator : IEnumerator, ICloneable
+            {
+                private readonly IEnumerator _arrayListEnumerator;
+
+                internal ToolStripPanelCellToControlEnumerator(ArrayList list)
+                {
+                    _arrayListEnumerator = ((IEnumerable)list).GetEnumerator();
+                }
+
+                public virtual object Current
+                {
+                    get
+                    {
+                        ToolStripPanelCell cell = _arrayListEnumerator.Current as ToolStripPanelCell;
+                        Debug.Assert(cell is not null, "Expected ToolStripPanel cells only!!!" + _arrayListEnumerator.Current.GetType().ToString());
+                        return cell?.Control;
+                    }
+                }
+
+                public object Clone()
+                {
+                    return MemberwiseClone();
+                }
+
+                public virtual bool MoveNext()
+                {
+                    return _arrayListEnumerator.MoveNext();
+                }
+
+                public virtual void Reset()
+                {
+                    _arrayListEnumerator.Reset();
+                }
+            }
+        }
+    }
+}

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ToolStripPanelRow.ToolStripPanelRowControlCollection.cs
@@ -6,7 +6,6 @@
 
 using System.Collections;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Windows.Forms.Layout;
 
 namespace System.Windows.Forms
@@ -30,7 +29,7 @@ namespace System.Windows.Forms
         ///  is responsible for parenting and unparenting the controls (ToolStripPanelRows do NOT derive from
         ///  Control and thus are NOT hwnd backed).
         /// </summary>
-        internal class ToolStripPanelRowControlCollection : ArrangedElementCollection, IList, IEnumerable
+        internal partial class ToolStripPanelRowControlCollection : ArrangedElementCollection, IList, IEnumerable
         {
             private readonly ToolStripPanelRow _owner;
             private ArrangedElementCollection _cellCollection;
@@ -306,44 +305,6 @@ namespace System.Windows.Forms
                 for (int i = 0; i < InnerList.Count; i++)
                 {
                     array[index++] = GetControl(i);
-                }
-            }
-
-            ///  We want to pretend like we're only holding controls... so everywhere we've returned controls.
-            ///  but the problem is if you do a foreach, you'll get the cells not the controls.  So we've got
-            ///  to sort of write a wrapper class around the ArrayList enumerator.
-            private class ToolStripPanelCellToControlEnumerator : IEnumerator, ICloneable
-            {
-                private readonly IEnumerator _arrayListEnumerator;
-
-                internal ToolStripPanelCellToControlEnumerator(ArrayList list)
-                {
-                    _arrayListEnumerator = ((IEnumerable)list).GetEnumerator();
-                }
-
-                public virtual object Current
-                {
-                    get
-                    {
-                        ToolStripPanelCell cell = _arrayListEnumerator.Current as ToolStripPanelCell;
-                        Debug.Assert(cell is not null, "Expected ToolStripPanel cells only!!!" + _arrayListEnumerator.Current.GetType().ToString());
-                        return cell?.Control;
-                    }
-                }
-
-                public object Clone()
-                {
-                    return MemberwiseClone();
-                }
-
-                public virtual bool MoveNext()
-                {
-                    return _arrayListEnumerator.MoveNext();
-                }
-
-                public virtual void Reset()
-                {
-                    _arrayListEnumerator.Reset();
                 }
             }
         }


### PR DESCRIPTION
## Proposed changes

- Enable nullability in ToolStripPanelCellToControlEnumerator.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8175)