### PR TITLE
Tweak "Add no recent activity label to issues and pull requests" task

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1,1742 +1,1696 @@
-[
-  {
-    "taskType": "trigger",
-    "capabilityId": "CodeFlowLink",
-    "subCapability": "CodeFlowLink",
-    "version": "1.0",
-    "config": {
-      "taskName": "Add a CodeFlow link to new pull requests"
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestReviewResponder",
-    "version": "1.0",
-    "config": {
-      "taskName": "Add needs author feedback label to pull requests when changes are requested",
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "submitted"
-            }
-          },
-          {
-            "name": "isReviewState",
-            "parameters": {
-              "state": "changes_requested"
-            }
-          }
-        ]
-      },
-      "actions": [
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": ":mailbox_with_no_mail: waiting-author-feedback"
-          }
-        }
-      ],
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request_review"
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestResponder",
-    "version": "1.0",
-    "config": {
-      "taskName": "Remove needs author feedback label when the author responds to a pull request",
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isActivitySender",
-            "parameters": {
-              "user": {
-                "type": "author"
-              }
-            }
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isAction",
-                "parameters": {
-                  "action": "closed"
-                }
-              }
-            ]
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": ":mailbox_with_no_mail: waiting-author-feedback"
-            }
-          }
-        ]
-      },
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": ":mailbox_with_no_mail: waiting-author-feedback"
-          }
-        }
-      ],
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestCommentResponder",
-    "version": "1.0",
-    "config": {
-      "taskName": "Remove needs author feedback label when the author comments on a pull request",
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isActivitySender",
-            "parameters": {
-              "user": {
-                "type": "author"
-              }
-            }
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": ":mailbox_with_no_mail: waiting-author-feedback"
-            }
-          }
-        ]
-      },
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": ":mailbox_with_no_mail: waiting-author-feedback"
-          }
-        }
-      ],
-      "eventType": "pull_request",
-      "eventNames": [
-        "issue_comment"
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestReviewResponder",
-    "version": "1.0",
-    "config": {
-      "taskName": "Remove needs author feedback label when the author responds to a pull request review comment",
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isActivitySender",
-            "parameters": {
-              "user": {
-                "type": "author"
-              }
-            }
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": ":mailbox_with_no_mail: waiting-author-feedback"
-            }
-          }
-        ]
-      },
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": ":mailbox_with_no_mail: waiting-author-feedback"
-          }
-        }
-      ],
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request_review"
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestResponder",
-    "version": "1.0",
-    "config": {
-      "taskName": "Remove no recent activity label from pull requests",
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isAction",
-                "parameters": {
-                  "action": "closed"
-                }
-              }
-            ]
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": ":zzz: no-recent-activity"
-            }
-          }
-        ]
-      },
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": ":zzz: no-recent-activity"
-          }
-        }
-      ],
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestCommentResponder",
-    "version": "1.0",
-    "config": {
-      "taskName": "Remove no recent activity label when a pull request is commented on",
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": ":zzz: no-recent-activity"
-            }
-          }
-        ]
-      },
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": ":zzz: no-recent-activity"
-          }
-        }
-      ],
-      "eventType": "pull_request",
-      "eventNames": [
-        "issue_comment"
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestReviewResponder",
-    "version": "1.0",
-    "config": {
-      "taskName": "Remove no recent activity label when a pull request is reviewed",
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": ":zzz: no-recent-activity"
-            }
-          }
-        ]
-      },
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": ":zzz: no-recent-activity"
-          }
-        }
-      ],
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request_review"
-      ]
-    }
-  },
-  {
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "taskName": "Close stale issues and pull requests",
-      "frequency": [
-        {
-          "weekDay": 0,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": -8
-        },
-        {
-          "weekDay": 1,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": -8
-        },
-        {
-          "weekDay": 2,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": -8
-        },
-        {
-          "weekDay": 3,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": -8
-        },
-        {
-          "weekDay": 4,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": -8
-        },
-        {
-          "weekDay": 5,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": -8
-        },
-        {
-          "weekDay": 6,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": -8
-        }
-      ],
-      "searchTerms": [
-        {
-          "name": "isPr",
-          "parameters": {}
-        },
-        {
-          "name": "isOpen",
-          "parameters": {}
-        },
-        {
-          "name": "hasLabel",
-          "parameters": {
-            "label": ":mailbox_with_no_mail: waiting-author-feedback"
-          }
-        },
-        {
-          "name": "hasLabel",
-          "parameters": {
-            "label": ":zzz: no-recent-activity"
-          }
-        },
-        {
-          "name": "noActivitySince",
-          "parameters": {
-            "days": 7
-          }
-        },
-        {
-          "name": "isIssue",
-          "parameters": {}
-        }
-      ],
-      "actions": [
-        {
-          "name": "closeIssue",
-          "parameters": {}
-        },
-        {
-          "name": "removeMilestone",
-          "parameters": {}
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "taskName": "Add no recent activity label to issues and pull requests",
-      "frequency": [
-        {
-          "weekDay": 0,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 1,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 2,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 3,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 4,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 5,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 6,
-          "hours": [
-            2,
-            5,
-            8,
-            11,
-            14,
-            17,
-            20,
-            23
-          ],
-          "timezoneOffset": 10
-        }
-      ],
-      "searchTerms": [
-        {
-          "name": "isPr",
-          "parameters": {}
-        },
-        {
-          "name": "isOpen",
-          "parameters": {}
-        },
-        {
-          "name": "hasLabel",
-          "parameters": {
-            "label": ":mailbox_with_no_mail: waiting-author-feedback"
-          }
-        },
-        {
-          "name": "noActivitySince",
-          "parameters": {
-            "days": 14
-          }
-        },
-        {
-          "name": "noLabel",
-          "parameters": {
-            "label": ":zzz: no-recent-activity"
-          }
-        },
-        {
-          "name": "isIssue",
-          "parameters": {}
-        }
-      ],
-      "actions": [
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": ":zzz: no-recent-activity"
-          }
-        },
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "This submission has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **14 days**. \n\nIt will be closed if no further activity occurs **within 7 days of this comment**."
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "AutoMerge",
-    "subCapability": "AutoMerge",
-    "version": "1.0",
-    "config": {
-      "taskName": "Automatically merge pull requests",
-      "label": ":octocat:  automerge",
-      "silentMode": false,
-      "minMinutesOpen": "60",
-      "mergeType": "squash",
-      "deleteBranches": true,
-      "requireAllStatuses": false,
-      "removeLabelOnPush": true,
-      "allowAutoMergeInstructionsWithoutLabel": true,
-      "conditionalMergeTypes": [
-        {
-          "mergeType": "squash",
-          "condition": {
-            "placeholder": ""
-          }
-        }
-      ],
-      "usePrDescriptionAsCommitMessage": true
+{
+  "version": "1.0",
+  "tasks": [
+    {
+      "taskType": "trigger",
+      "capabilityId": "CodeFlowLink",
+      "subCapability": "CodeFlowLink",
+      "version": "1.0",
+      "config": {
+        "taskName": "Add a CodeFlow link to new pull requests"
+      }
     },
-    "disabled": false
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "ReleaseAnnouncement",
-    "subCapability": "ReleaseAnnouncement",
-    "version": "1.0",
-    "config": {
-      "taskName": "Release announcement",
-      "prReply": "The fix is included in ${pkgName} ${version}.",
-      "issueReply": "Fixed in ${pkgName} ${version}."
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "InPrLabel",
-    "subCapability": "InPrLabel",
-    "version": "1.0",
-    "config": {
-      "taskName": "In-PR label",
-      "label_inPr": ":construction: work in progress",
-      "fixedLabelEnabled": false,
-      "label_fixed": "tell-mode"
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "prTargetsBranch",
-            "parameters": {
-              "branchName": "main"
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestReviewResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Add needs author feedback label to pull requests when changes are requested",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "submitted"
+              }
+            },
+            {
+              "name": "isReviewState",
+              "parameters": {
+                "state": "changes_requested"
+              }
             }
-          },
+          ]
+        },
+        "actions": [
           {
-            "operator": "and",
-            "operands": [
-              {
-                "name": "isAction",
-                "parameters": {
-                  "action": "merged"
+            "name": "addLabel",
+            "parameters": {
+              "label": ":mailbox_with_no_mail: waiting-author-feedback"
+            }
+          }
+        ],
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request_review"
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove needs author feedback label when the author responds to a pull request",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": {
+                  "type": "author"
                 }
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "titleContains",
-                    "parameters": {
-                      "titlePattern": "[main] Update dependencies"
-                    }
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "closed"
                   }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
-      "actions": [
-        {
-          "name": "addMilestone",
-          "parameters": {
-            "milestoneName": "8.0 Preview1"
-          }
-        }
-      ],
-      "taskName": "Apply milestone '7.0' to PRs on the main branch",
-      "dangerZone": {
-        "respondToBotActions": true,
-        "acceptRespondToBotActions": true
-      }
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isActivitySender",
-            "parameters": {
-              "user": "dotnet-maestro[bot]"
-            }
-          },
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "opened"
-            }
-          }
-        ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
-      "taskName": "Auto-approve maestro PRs",
-      "actions": [
-        {
-          "name": "approvePullRequest",
-          "parameters": {
-            "comment": "Go, you big red fire engine!"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "labelAdded",
-            "parameters": {
-              "label": ":octocat:  automerge"
-            }
-          },
-          {
-            "operator": "or",
-            "operands": [
-              {
-                "name": "activitySenderHasPermissions",
-                "parameters": {
-                  "permissions": "admin"
                 }
-              },
-              {
-                "name": "activitySenderHasPermissions",
-                "parameters": {
-                  "permissions": "write"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
-      "taskName": "Auto-approve auto-merge PRs",
-      "actions": [
-        {
-          "name": "approvePullRequest",
-          "parameters": {
-            "comment": "Happy to oblige"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "EmailCleanser",
-    "subCapability": "EmailCleanser",
-    "version": "1.0",
-    "config": {
-      "taskName": "Cleanse emails"
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": []
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
-      "actions": [
-        {
-          "name": "assignToUser",
-          "parameters": {
-            "user": {
-              "type": "prAuthor"
-            }
-          }
-        }
-      ],
-      "taskName": "Assign PRs to authors"
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssueCommentResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isActivitySender",
-            "parameters": {
-              "user": {
-                "type": "author"
+              ]
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": ":mailbox_with_no_mail: waiting-author-feedback"
               }
             }
-          },
+          ]
+        },
+        "actions": [
           {
-            "name": "hasLabel",
+            "name": "removeLabel",
             "parameters": {
               "label": ":mailbox_with_no_mail: waiting-author-feedback"
             }
           }
+        ],
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
         ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "taskName": "Remove needs author feedback label when the author comments on an issue",
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": ":mailbox_with_no_mail: waiting-author-feedback"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssueCommentResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": ":zzz: no-recent-activity"
-            }
-          }
-        ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "taskName": "Remove no recent activity label when an issue is commented on",
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": ":zzz: no-recent-activity"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssuesOnlyResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isAction",
-                "parameters": {
-                  "action": "closed"
-                }
-              }
-            ]
-          },
-          {
-            "name": "hasLabel",
-            "parameters": {
-              "label": ":zzz: no-recent-activity"
-            }
-          }
-        ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issues",
-        "project_card"
-      ],
-      "taskName": "Remove no recent activity label from issue",
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": ":zzz: no-recent-activity"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssuesOnlyResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "closed"
-            }
-          }
-        ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issues",
-        "project_card"
-      ],
-      "taskName": "Remove closed issues from milestones",
-      "actions": [
-        {
-          "name": "removeMilestone",
-          "parameters": {}
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "dotnet-bot"
-            }
-          },
-          {
-            "name": "titleContains",
-            "parameters": {
-              "titlePattern": "OneLocBuild"
-            }
-          },
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "opened"
-            }
-          }
-        ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
-      "taskName": "Auto-approve OneLocBuild PRs",
-      "actions": [
-        {
-          "name": "approvePullRequest",
-          "parameters": {
-            "comment": "Go, you big red fire engine!"
-          }
-        },
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": ":octocat:  automerge"
-          }
-        }
-      ],
-      "dangerZone": {
-        "respondToBotActions": true,
-        "acceptRespondToBotActions": true
       }
-    }
-  },
-  {
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "frequency": [
-        {
-          "weekDay": 0,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 1,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 2,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 3,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 4,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 5,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 6,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        }
-      ],
-      "searchTerms": [
-        {
-          "name": "isDraftPr",
-          "parameters": {
-            "value": "true"
-          }
-        }
-      ],
-      "actions": [
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": "draft"
-          }
-        }
-      ],
-      "taskName": "Add draft label"
-    }
-  },
-  {
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "frequency": [
-        {
-          "weekDay": 0,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 1,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 2,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 3,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 4,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 5,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        },
-        {
-          "weekDay": 6,
-          "hours": [
-            1,
-            5,
-            9,
-            13,
-            17,
-            21
-          ],
-          "timezoneOffset": -7
-        }
-      ],
-      "searchTerms": [
-        {
-          "name": "isDraftPr",
-          "parameters": {
-            "value": "false"
-          }
-        }
-      ],
-      "taskName": "Remove draft label",
-      "actions": [
-        {
-          "name": "removeLabel",
-          "parameters": {
-            "label": "draft"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssueCommentResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isOpen",
-                "parameters": {}
-              }
-            ]
-          },
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "created"
-            }
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isCloseAndComment",
-                "parameters": {}
-              }
-            ]
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "activitySenderHasPermissions",
-                "parameters": {
-                  "permissions": "write"
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestCommentResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove needs author feedback label when the author comments on a pull request",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": {
+                  "type": "author"
                 }
               }
-            ]
-          }
-        ]
-      },
-      "eventType": "issue",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "actions": [
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "Hi @${contextualAuthor}, it looks like you just commented on a closed issue. The team will most probably miss it. \nIf you have a question - consider opening a new discussion thread. Alternatively, you'd like to bring something important up to their attention, consider filing a new issue and add enough details to build context."
-          }
-        }
-      ],
-      "taskName": "Respond to a comment on closed issue"
-    },
-    "disabled": true
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestCommentResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isOpen",
-                "parameters": {}
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": ":mailbox_with_no_mail: waiting-author-feedback"
               }
-            ]
-          },
-          {
-            "name": "isAction",
-            "parameters": {
-              "action": "created"
             }
-          },
+          ]
+        },
+        "actions": [
           {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "isCloseAndComment",
-                "parameters": {}
-              }
-            ]
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "activitySenderHasPermissions",
-                "parameters": {
-                  "permissions": "write"
+            "name": "removeLabel",
+            "parameters": {
+              "label": ":mailbox_with_no_mail: waiting-author-feedback"
+            }
+          }
+        ],
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestReviewResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove needs author feedback label when the author responds to a pull request review comment",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": {
+                  "type": "author"
                 }
               }
-            ]
-          }
-        ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "issue_comment"
-      ],
-      "taskName": "Respond to a comment on closed PR",
-      "actions": [
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "Hi @${contextualAuthor}, it looks like you just commented on a closed PR. The team will most probably miss it. \nIf you have a question - consider opening a new discussion thread. Alternatively, you'd like to bring something important up to their attention, consider filing a new issue and add enough details to build context."
-          }
-        }
-      ]
-    },
-    "disabled": true
-  },
-  {
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "frequency": [
-        {
-          "weekDay": 0,
-          "hours": [
-            1,
-            7,
-            13,
-            19
-          ],
-          "timezoneOffset": 0
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": ":mailbox_with_no_mail: waiting-author-feedback"
+              }
+            }
+          ]
         },
-        {
-          "weekDay": 1,
-          "hours": [
-            1,
-            7,
-            13,
-            19
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 2,
-          "hours": [
-            1,
-            7,
-            13,
-            19
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 3,
-          "hours": [
-            1,
-            7,
-            13,
-            19
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 4,
-          "hours": [
-            1,
-            7,
-            13,
-            19
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 5,
-          "hours": [
-            1,
-            7,
-            13,
-            19
-          ],
-          "timezoneOffset": 0
-        },
-        {
-          "weekDay": 6,
-          "hours": [
-            1,
-            7,
-            13,
-            19
-          ],
-          "timezoneOffset": 0
-        }
-      ],
-      "searchTerms": [
-        {
-          "name": "isClosed",
-          "parameters": {}
-        },
-        {
-          "name": "noActivitySince",
-          "parameters": {
-            "days": 30
-          }
-        },
-        {
-          "name": "isUnlocked",
-          "parameters": {}
-        }
-      ],
-      "actions": [
-        {
-          "name": "lockIssue",
-          "parameters": {
-            "reason": "resolved",
-            "label": "will_lock_this"
-          }
-        }
-      ],
-      "taskName": "Lock stale issues and PRs"
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "PullRequestResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
+        "actions": [
           {
-            "name": "titleContains",
+            "name": "removeLabel",
             "parameters": {
-              "titlePattern": "Enable nullability"
+              "label": ":mailbox_with_no_mail: waiting-author-feedback"
             }
           }
+        ],
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request_review"
         ]
-      },
-      "eventType": "pull_request",
-      "eventNames": [
-        "pull_request",
-        "issues",
-        "project_card"
-      ],
-      "actions": [
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": "area: NRT"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove no recent activity label from pull requests",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "closed"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": ":zzz: no-recent-activity"
+              }
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
           }
-        }
-      ],
-      "taskName": "Apply \"area: NRT\" label"
-    }
-  },
-  {
-    "taskType": "trigger",
-    "capabilityId": "IssueResponder",
-    "subCapability": "IssuesOnlyResponder",
-    "version": "1.0",
-    "config": {
-      "conditions": {
-        "operator": "and",
-        "operands": [
+        ],
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestCommentResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove no recent activity label when a pull request is commented on",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": ":zzz: no-recent-activity"
+              }
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          }
+        ],
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestReviewResponder",
+      "version": "1.0",
+      "config": {
+        "taskName": "Remove no recent activity label when a pull request is reviewed",
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": ":zzz: no-recent-activity"
+              }
+            }
+          ]
+        },
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          }
+        ],
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request_review"
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "taskName": "Close stale issues and pull requests",
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              2,
+              14
+            ],
+            "timezoneOffset": 11
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              2,
+              14
+            ],
+            "timezoneOffset": 11
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              2,
+              14
+            ],
+            "timezoneOffset": 11
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              2,
+              14
+            ],
+            "timezoneOffset": 11
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              2,
+              14
+            ],
+            "timezoneOffset": 11
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              2,
+              14
+            ],
+            "timezoneOffset": 11
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              2,
+              14
+            ],
+            "timezoneOffset": 11
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isPr",
+            "parameters": {}
+          },
           {
             "name": "isOpen",
             "parameters": {}
           },
           {
-            "name": "labelAdded",
+            "name": "hasLabel",
             "parameters": {
-              "label": "help wanted"
+              "label": ":mailbox_with_no_mail: waiting-author-feedback"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 7
+            }
+          },
+          {
+            "name": "isIssue",
+            "parameters": {}
+          }
+        ],
+        "actions": [
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          },
+          {
+            "name": "removeMilestone",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "taskName": "Add no recent activity label to issues and pull requests",
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              2,
+              5,
+              8,
+              11,
+              14,
+              17,
+              20,
+              23
+            ],
+            "timezoneOffset": 10
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":mailbox_with_no_mail: waiting-author-feedback"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 14
+            }
+          },
+          {
+            "name": "noLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This submission has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **14 days**. \n\nIt will be closed if no further activity occurs **within 7 days of this comment**."
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "AutoMerge",
+      "subCapability": "AutoMerge",
+      "version": "1.0",
+      "config": {
+        "taskName": "Automatically merge pull requests",
+        "label": ":octocat:  automerge",
+        "silentMode": false,
+        "minMinutesOpen": "60",
+        "mergeType": "squash",
+        "deleteBranches": true,
+        "requireAllStatuses": false,
+        "removeLabelOnPush": true,
+        "allowAutoMergeInstructionsWithoutLabel": true,
+        "conditionalMergeTypes": [
+          {
+            "mergeType": "squash",
+            "condition": {
+              "placeholder": ""
+            }
+          }
+        ],
+        "usePrDescriptionAsCommitMessage": true
+      },
+      "disabled": false
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "ReleaseAnnouncement",
+      "subCapability": "ReleaseAnnouncement",
+      "version": "1.0",
+      "config": {
+        "taskName": "Release announcement",
+        "prReply": "The fix is included in ${pkgName} ${version}.",
+        "issueReply": "Fixed in ${pkgName} ${version}."
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "InPrLabel",
+      "subCapability": "InPrLabel",
+      "version": "1.0",
+      "config": {
+        "taskName": "In-PR label",
+        "label_inPr": ":construction: work in progress",
+        "fixedLabelEnabled": false,
+        "label_fixed": "tell-mode"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "prTargetsBranch",
+              "parameters": {
+                "branchName": "main"
+              }
+            },
+            {
+              "operator": "and",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "merged"
+                  }
+                },
+                {
+                  "operator": "not",
+                  "operands": [
+                    {
+                      "name": "titleContains",
+                      "parameters": {
+                        "titlePattern": "[main] Update dependencies"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "8.0 Preview1"
+            }
+          }
+        ],
+        "taskName": "Apply milestone '7.0' to PRs on the main branch",
+        "dangerZone": {
+          "respondToBotActions": true,
+          "acceptRespondToBotActions": true
+        }
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": "dotnet-maestro[bot]"
+              }
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Auto-approve maestro PRs",
+        "actions": [
+          {
+            "name": "approvePullRequest",
+            "parameters": {
+              "comment": "Go, you big red fire engine!"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": ":octocat:  automerge"
+              }
+            },
+            {
+              "operator": "or",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "admin"
+                  }
+                },
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Auto-approve auto-merge PRs",
+        "actions": [
+          {
+            "name": "approvePullRequest",
+            "parameters": {
+              "comment": "Happy to oblige"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "EmailCleanser",
+      "subCapability": "EmailCleanser",
+      "version": "1.0",
+      "config": {
+        "taskName": "Cleanse emails"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": []
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "assignToUser",
+            "parameters": {
+              "user": {
+                "type": "prAuthor"
+              }
+            }
+          }
+        ],
+        "taskName": "Assign PRs to authors"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isActivitySender",
+              "parameters": {
+                "user": {
+                  "type": "author"
+                }
+              }
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": ":mailbox_with_no_mail: waiting-author-feedback"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Remove needs author feedback label when the author comments on an issue",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": ":mailbox_with_no_mail: waiting-author-feedback"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": ":zzz: no-recent-activity"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Remove no recent activity label when an issue is commented on",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "closed"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "hasLabel",
+              "parameters": {
+                "label": ":zzz: no-recent-activity"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Remove no recent activity label from issue",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "closed"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Remove closed issues from milestones",
+        "actions": [
+          {
+            "name": "removeMilestone",
+            "parameters": {}
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAssignedToUser",
+              "parameters": {
+                "user": "dotnet-bot"
+              }
+            },
+            {
+              "name": "titleContains",
+              "parameters": {
+                "titlePattern": "OneLocBuild"
+              }
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "opened"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "Auto-approve OneLocBuild PRs",
+        "actions": [
+          {
+            "name": "approvePullRequest",
+            "parameters": {
+              "comment": "Go, you big red fire engine!"
+            }
+          },
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": ":octocat:  automerge"
+            }
+          }
+        ],
+        "dangerZone": {
+          "respondToBotActions": true,
+          "acceptRespondToBotActions": true
+        }
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isDraftPr",
+            "parameters": {
+              "value": "true"
+            }
+          }
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "draft"
+            }
+          }
+        ],
+        "taskName": "Add draft label"
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              1,
+              5,
+              9,
+              13,
+              17,
+              21
+            ],
+            "timezoneOffset": -7
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isDraftPr",
+            "parameters": {
+              "value": "false"
+            }
+          }
+        ],
+        "taskName": "Remove draft label",
+        "actions": [
+          {
+            "name": "removeLabel",
+            "parameters": {
+              "label": "draft"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssueCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isOpen",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isCloseAndComment",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi @${contextualAuthor}, it looks like you just commented on a closed issue. The team will most probably miss it. \nIf you have a question - consider opening a new discussion thread. Alternatively, you'd like to bring something important up to their attention, consider filing a new issue and add enough details to build context."
+            }
+          }
+        ],
+        "taskName": "Respond to a comment on closed issue"
+      },
+      "disabled": true
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestCommentResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isOpen",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "created"
+              }
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "isCloseAndComment",
+                  "parameters": {}
+                }
+              ]
+            },
+            {
+              "operator": "not",
+              "operands": [
+                {
+                  "name": "activitySenderHasPermissions",
+                  "parameters": {
+                    "permissions": "write"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "issue_comment"
+        ],
+        "taskName": "Respond to a comment on closed PR",
+        "actions": [
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "Hi @${contextualAuthor}, it looks like you just commented on a closed PR. The team will most probably miss it. \nIf you have a question - consider opening a new discussion thread. Alternatively, you'd like to bring something important up to their attention, consider filing a new issue and add enough details to build context."
             }
           }
         ]
       },
-      "eventType": "issue",
-      "eventNames": [
-        "issues",
-        "project_card"
-      ],
-      "actions": [
-        {
-          "name": "addMilestone",
-          "parameters": {
-            "milestoneName": "Help wanted"
+      "disabled": true
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": 0
+          },
+          {
+            "weekDay": 1,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": 0
+          },
+          {
+            "weekDay": 2,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": 0
+          },
+          {
+            "weekDay": 3,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": 0
+          },
+          {
+            "weekDay": 4,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": 0
+          },
+          {
+            "weekDay": 5,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": 0
+          },
+          {
+            "weekDay": 6,
+            "hours": [
+              1,
+              7,
+              13,
+              19
+            ],
+            "timezoneOffset": 0
           }
+        ],
+        "searchTerms": [
+          {
+            "name": "isClosed",
+            "parameters": {}
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 30
+            }
+          },
+          {
+            "name": "isUnlocked",
+            "parameters": {}
+          }
+        ],
+        "actions": [
+          {
+            "name": "lockIssue",
+            "parameters": {
+              "reason": "resolved",
+              "label": "will_lock_this"
+            }
+          }
+        ],
+        "taskName": "Lock stale issues and PRs"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "titleContains",
+              "parameters": {
+                "titlePattern": "Enable nullability"
+              }
+            }
+          ]
         },
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "This issue is now marked as \"help wanted\", and we’re looking for a community volunteer to work on this issue. If we receive no interest in 180 days, we will close the issue. To learn more about how we handle feature requests, please see our [documentation](https://aka.ms/winforms/issue-lifecycle).\n\nHappy Coding!"
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": "area: NRT"
+            }
           }
-        }
-      ],
-      "taskName": "help wanted: labelled"
+        ],
+        "taskName": "Apply \"area: NRT\" label"
+      }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "IssuesOnlyResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isOpen",
+              "parameters": {}
+            },
+            {
+              "name": "labelAdded",
+              "parameters": {
+                "label": "help wanted"
+              }
+            }
+          ]
+        },
+        "eventType": "issue",
+        "eventNames": [
+          "issues",
+          "project_card"
+        ],
+        "actions": [
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Help wanted"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This issue is now marked as \"help wanted\", and we’re looking for a community volunteer to work on this issue. If we receive no interest in 180 days, we will close the issue. To learn more about how we handle feature requests, please see our [documentation](https://aka.ms/winforms/issue-lifecycle).\n\nHappy Coding!"
+            }
+          }
+        ],
+        "taskName": "help wanted: labelled"
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 1,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 2,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 3,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 4,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 5,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 6,
+            "hours": [],
+            "timezoneOffset": 10
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "noAssignees",
+            "parameters": {}
+          },
+          {
+            "name": "isPartOfMilestone",
+            "parameters": {
+              "milestone": "Up-for-grabs"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 90
+            }
+          }
+        ],
+        "taskName": "Up-for-grabs: mark as \"no activity\"",
+        "actions": [
+          {
+            "name": "addLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          },
+          {
+            "name": "addReply",
+            "parameters": {
+              "comment": "This issue has not yet received the community interest. 30 days to go. To learn more about how we handle feature requests, please see our [documentation](https://aka.ms/winforms/issue-lifecycle).\n\nHappy Coding!"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "taskType": "scheduled",
+      "capabilityId": "ScheduledSearch",
+      "subCapability": "ScheduledSearch",
+      "version": "1.1",
+      "config": {
+        "frequency": [
+          {
+            "weekDay": 0,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 1,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 2,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 3,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 4,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 5,
+            "hours": [],
+            "timezoneOffset": 10
+          },
+          {
+            "weekDay": 6,
+            "hours": [],
+            "timezoneOffset": 10
+          }
+        ],
+        "searchTerms": [
+          {
+            "name": "isIssue",
+            "parameters": {}
+          },
+          {
+            "name": "isOpen",
+            "parameters": {}
+          },
+          {
+            "name": "noAssignees",
+            "parameters": {}
+          },
+          {
+            "name": "isPartOfMilestone",
+            "parameters": {
+              "milestone": "Up-for-grabs"
+            }
+          },
+          {
+            "name": "hasLabel",
+            "parameters": {
+              "label": ":zzz: no-recent-activity"
+            }
+          },
+          {
+            "name": "noActivitySince",
+            "parameters": {
+              "days": 30
+            }
+          }
+        ],
+        "taskName": "Up-for-grabs: close stale",
+        "actions": [
+          {
+            "name": "closeIssue",
+            "parameters": {}
+          },
+          {
+            "name": "removeMilestone",
+            "parameters": {}
+          }
+        ]
+      }
     }
-  },
-  {
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "frequency": [
-        {
-          "weekDay": 0,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 1,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 2,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 3,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 4,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 5,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 6,
-          "hours": [],
-          "timezoneOffset": 10
-        }
-      ],
-      "searchTerms": [
-        {
-          "name": "isIssue",
-          "parameters": {}
-        },
-        {
-          "name": "isOpen",
-          "parameters": {}
-        },
-        {
-          "name": "noAssignees",
-          "parameters": {}
-        },
-        {
-          "name": "isPartOfMilestone",
-          "parameters": {
-            "milestone": "Up-for-grabs"
-          }
-        },
-        {
-          "name": "noActivitySince",
-          "parameters": {
-            "days": 90
-          }
-        }
-      ],
-      "taskName": "Up-for-grabs: mark as \"no activity\"",
-      "actions": [
-        {
-          "name": "addLabel",
-          "parameters": {
-            "label": ":zzz: no-recent-activity"
-          }
-        },
-        {
-          "name": "addReply",
-          "parameters": {
-            "comment": "This issue has not yet received the community interest. 30 days to go. To learn more about how we handle feature requests, please see our [documentation](https://aka.ms/winforms/issue-lifecycle).\n\nHappy Coding!"
-          }
-        }
-      ]
-    }
-  },
-  {
-    "taskType": "scheduled",
-    "capabilityId": "ScheduledSearch",
-    "subCapability": "ScheduledSearch",
-    "version": "1.1",
-    "config": {
-      "frequency": [
-        {
-          "weekDay": 0,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 1,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 2,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 3,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 4,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 5,
-          "hours": [],
-          "timezoneOffset": 10
-        },
-        {
-          "weekDay": 6,
-          "hours": [],
-          "timezoneOffset": 10
-        }
-      ],
-      "searchTerms": [
-        {
-          "name": "isIssue",
-          "parameters": {}
-        },
-        {
-          "name": "isOpen",
-          "parameters": {}
-        },
-        {
-          "name": "noAssignees",
-          "parameters": {}
-        },
-        {
-          "name": "isPartOfMilestone",
-          "parameters": {
-            "milestone": "Up-for-grabs"
-          }
-        },
-        {
-          "name": "hasLabel",
-          "parameters": {
-            "label": ":zzz: no-recent-activity"
-          }
-        },
-        {
-          "name": "noActivitySince",
-          "parameters": {
-            "days": 30
-          }
-        }
-      ],
-      "taskName": "Up-for-grabs: close stale",
-      "actions": [
-        {
-          "name": "closeIssue",
-          "parameters": {}
-        },
-        {
-          "name": "removeMilestone",
-          "parameters": {}
-        }
-      ]
-    }
-  }
-]
+  ],
+  "userGroups": []
+}


### PR DESCRIPTION
The task appears to have not been run for awhile, tweak the settings in hope to revive the task.
![image](https://user-images.githubusercontent.com/4403806/201817886-dd075aa4-44da-435f-9ba5-027440189b3c.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8197)