### PR TITLE
Refactor PropertyGridView to use List<GridEntryCollection> instead of ArrayList

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridPositionData.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridPositionData.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-
 namespace System.Windows.Forms.PropertyGridInternal
 {
     internal partial class PropertyGridView

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridPositionData.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.GridPositionData.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 
 namespace System.Windows.Forms.PropertyGridInternal
 {
@@ -12,7 +11,7 @@ namespace System.Windows.Forms.PropertyGridInternal
     {
         internal class GridPositionData
         {
-            private readonly ArrayList _expandedState;
+            private readonly List<GridEntryCollection> _expandedState;
             private readonly GridEntryCollection _selectedItemTree;
             private readonly int _itemRow;
 

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/PropertyGridView.cs
@@ -4,7 +4,6 @@
 
 #nullable disable
 
-using System.Collections;
 using System.ComponentModel;
 using System.ComponentModel.Design;
 using System.Diagnostics;
@@ -4226,7 +4225,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
         private static void ResetOrigin(Graphics g) => g.ResetTransform();
 
-        internal void RestoreHierarchyState(ArrayList expandedItems)
+        internal void RestoreHierarchyState(List<GridEntryCollection> expandedItems)
         {
             if (expandedItems is null)
             {
@@ -4239,14 +4238,14 @@ namespace System.Windows.Forms.PropertyGridInternal
             }
         }
 
-        internal ArrayList SaveHierarchyState(GridEntryCollection entries, ArrayList expandedItems = null)
+        internal List<GridEntryCollection> SaveHierarchyState(GridEntryCollection entries, List<GridEntryCollection> expandedItems = null)
         {
             if (entries is null)
             {
-                return new ArrayList();
+                return new();
             }
 
-            expandedItems ??= new ArrayList();
+            expandedItems ??= new();
 
             for (int i = 0; i < entries.Count; i++)
             {


### PR DESCRIPTION
Related: #8140

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8210)