### PR TITLE
Add MSAA focus event on ComboBox dropdown close

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3060,7 +3060,7 @@ namespace System.Windows.Forms
 
                 // Some accessibility tools (e.g., NVDA) could recognize ComboBox as IAccessible object
                 // and ignore UIA focus change event. For such cases we need to additionaly raise MSAA focus event.
-                // childID = CHILDID_SELF - 1 (the -1 is because WinForms always adds 1 to the value)
+                // childID = CHILDID_SELF - 1 (the -1 will resolve to CHILDID_SELF when we call NotifyWinEvent)
                 AccessibilityNotifyClients(AccessibleEvents.Focus, childID: -1);
 
                 // Notify Collapsed/expanded property change.

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComboBox.cs
@@ -3058,6 +3058,11 @@ namespace System.Windows.Forms
                     AccessibilityObject.RaiseAutomationEvent(UiaCore.UIA.AutomationFocusChangedEventId);
                 }
 
+                // Some accessibility tools (e.g., NVDA) could recognize ComboBox as IAccessible object
+                // and ignore UIA focus change event. For such cases we need to additionaly raise MSAA focus event.
+                // childID = CHILDID_SELF - 1 (the -1 is because WinForms always adds 1 to the value)
+                AccessibilityNotifyClients(AccessibleEvents.Focus, childID: -1);
+
                 // Notify Collapsed/expanded property change.
                 AccessibilityObject.RaiseAutomationPropertyChangedEvent(
                     UiaCore.UIA.ExpandCollapseExpandCollapseStatePropertyId,


### PR DESCRIPTION
Fixes #8218

## Proposed changes

- Add MSAA focus event on ComboBox dropdown close. This event lets NVDA correctly switch focus from dropdown to ComboBox edit field when the dropdown is closed. NVDA recognizes ComboBox as IAccessible object, therefore it ignores existing UIA focus events.

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- NVDA will announce value change by arrows after the dropdown was closed

## Regression? 

- No

## Risk

- Minimal

<!-- end TELL-MODE -->




## Test methodology <!-- How did you ensure quality? -->

- Manual testing


## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->

Test using NVDA screen reader. Scenario: a form with a ComboBox having items "1", "2" and "3", focus is set to ComboBox.

Steps:
1. Press Alt + Down: expand ComboBox
2. Press Down: select item "1"
3. Press Enter: close dropdown
4. Press Down: change selection to item "2"
5. Press Down: change selection to item "3"

### Before

NVDA speech output:

> combo box  collapsed
> expanded
> 1
> list
> 1

No announcement of value change by arrows.

NVDA event log: [nvda-log-before.log](https://github.com/dotnet/winforms/files/10034358/nvda-log-before.log), main point — NVDA `loseFocus` event for list item and `gainFocus` event for ComboBox are **not** present after closing dropdown.

NVDA focus highlight behavior:

![A gif showing that NVDA highlight rectangle stays on the dropdown list item even after it was closed](https://user-images.githubusercontent.com/102954094/202523917-cfd5a8a6-84d5-450b-9055-6dfeb7d4a788.gif)

### After

NVDA speech output:

> combo box  collapsed
> expanded
> 1
> list
> 1
> combo box  1  collapsed
> 2
> 3

There is additional announcement of ComboBox content on close, including "collapsed" state, and when value is changed by arrows it is also announced.

NVDA event log: [nvda-log-after.log](https://github.com/dotnet/winforms/files/10034395/nvda-log-after.log), main point — NVDA `loseFocus` event for list item and `gainFocus` event for ComboBox are present after closing dropdown.

NVDA focus highlight behavior:

![A gif showing that NVDA highlight rectangle is correctly switched back to ComboBox after dropdown was closed](https://user-images.githubusercontent.com/102954094/202526245-fbf93211-1063-4755-a15a-99303f53340b.gif)

Also tested with Narrator — everything works as expected before and after the changes.

## Test environment(s) <!-- Remove any that don't apply -->

- .NET 8.0.100-alpha.1.22565.7
- Windows 11

<!-- Mention language, UI scaling, or anything else that might be relevant -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8220)