### PR TITLE
Refactor ComponentDesigner to use Dictionary<TKey, TValue> instead of Hashtable

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.cs
@@ -654,7 +654,7 @@ namespace System.ComponentModel.Design
             }
 
             // otherwise apply our inherited properties to the actual property list.
-            foreach (var de in _inheritedProps)
+            foreach (KeyValuePair<string, InheritedPropertyDescriptor> de in _inheritedProps)
             {
                 // replace the property descriptor it was created with with the new one in case we're shadowing
                 PropertyDescriptor newInnerProp = (PropertyDescriptor)properties[de.Key];


### PR DESCRIPTION
Related: #8143

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8221)