### PR TITLE
Refactor ComponentDesigner.ShadowPropertyCollection to use Dictionary<TKey, TValue> instead of Hashtable

### DIFF
--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.ShadowPropertyCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.ShadowPropertyCollection.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
-
 namespace System.ComponentModel.Design
 {
     public partial class ComponentDesigner
@@ -14,8 +12,8 @@ namespace System.ComponentModel.Design
         protected sealed class ShadowPropertyCollection
         {
             private readonly ComponentDesigner _designer;
-            private Hashtable _properties;
-            private Hashtable _descriptors;
+            private Dictionary<string, PropertyDescriptor> _properties;
+            private Dictionary<string, PropertyDescriptor> _descriptors;
 
             internal ShadowPropertyCollection(ComponentDesigner designer) => _designer = designer;
 
@@ -30,9 +28,9 @@ namespace System.ComponentModel.Design
                     ArgumentNullException.ThrowIfNull(propertyName);
 
                     // First, check to see if the name is in the given properties table
-                    if (_properties is not null && _properties.ContainsKey(propertyName))
+                    if (_properties is not null && _properties.TryGetValue(propertyName, out PropertyDescriptor property))
                     {
-                        return _properties[propertyName];
+                        return property;
                     }
 
                     // Next, check to see if the name is in the descriptors table.  If it isn't, we will search the
@@ -43,8 +41,8 @@ namespace System.ComponentModel.Design
                 }
                 set
                 {
-                    _properties ??= new Hashtable();
-                    _properties[propertyName] = value;
+                    _properties ??= new();
+                    _properties[propertyName] = (PropertyDescriptor)value;
                 }
             }
 
@@ -58,12 +56,11 @@ namespace System.ComponentModel.Design
             /// </summary>
             private PropertyDescriptor GetShadowedPropertyDescriptor(string propertyName)
             {
-                _descriptors ??= new Hashtable();
+                _descriptors ??= new();
 
-                PropertyDescriptor property = (PropertyDescriptor)_descriptors[propertyName];
-                property ??= TypeDescriptor.GetProperties(_designer.Component.GetType())[propertyName];
-
-                return property;
+                return _descriptors.TryGetValue(propertyName, out PropertyDescriptor property)
+                    ? property
+                    : TypeDescriptor.GetProperties(_designer.Component)[propertyName];
             }
 
             /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.ShadowPropertyCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.ShadowPropertyCollection.cs
@@ -12,7 +12,7 @@ namespace System.ComponentModel.Design
         protected sealed class ShadowPropertyCollection
         {
             private readonly ComponentDesigner _designer;
-            private Dictionary<string, PropertyDescriptor> _properties;
+            private Dictionary<string, object> _properties;
             private Dictionary<string, PropertyDescriptor> _descriptors;
 
             internal ShadowPropertyCollection(ComponentDesigner designer) => _designer = designer;
@@ -28,9 +28,9 @@ namespace System.ComponentModel.Design
                     ArgumentNullException.ThrowIfNull(propertyName);
 
                     // First, check to see if the name is in the given properties table
-                    if (_properties is not null && _properties.TryGetValue(propertyName, out PropertyDescriptor property))
+                    if (_properties is not null && _properties.TryGetValue(propertyName, out object prop))
                     {
-                        return property;
+                        return prop;
                     }
 
                     // Next, check to see if the name is in the descriptors table.  If it isn't, we will search the
@@ -42,7 +42,7 @@ namespace System.ComponentModel.Design
                 set
                 {
                     _properties ??= new();
-                    _properties[propertyName] = (PropertyDescriptor)value;
+                    _properties[propertyName] = value;
                 }
             }
 
@@ -58,9 +58,12 @@ namespace System.ComponentModel.Design
             {
                 _descriptors ??= new();
 
-                return _descriptors.TryGetValue(propertyName, out PropertyDescriptor property)
-                    ? property
-                    : TypeDescriptor.GetProperties(_designer.Component)[propertyName];
+                if (_descriptors.TryGetValue(propertyName, out PropertyDescriptor property))
+                {
+                    return property;
+                }
+
+                return TypeDescriptor.GetProperties(_designer.Component.GetType())[propertyName];
             }
 
             /// <summary>

--- a/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.ShadowPropertyCollection.cs
+++ b/src/System.Windows.Forms.Design/src/System/ComponentModel/Design/ComponentDesigner.ShadowPropertyCollection.cs
@@ -28,9 +28,9 @@ namespace System.ComponentModel.Design
                     ArgumentNullException.ThrowIfNull(propertyName);
 
                     // First, check to see if the name is in the given properties table
-                    if (_properties is not null && _properties.TryGetValue(propertyName, out object prop))
+                    if (_properties is not null && _properties.TryGetValue(propertyName, out object existing))
                     {
-                        return prop;
+                        return existing;
                     }
 
                     // Next, check to see if the name is in the descriptors table.  If it isn't, we will search the


### PR DESCRIPTION
Related: #8143

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8222)