### PR TITLE
Refactor WebBrowserContainer to replace HashTable and Enable Nullability

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
@@ -392,7 +392,7 @@ namespace System.Windows.Forms
         }
 
         internal static string GetNameForControl(Control ctl)
-            => ctl.Site is not null ? ctl.Site.Name ?? string.Empty : ctl.Name;
+            => ctl.Site is not null ? ctl.Site.Name ?? string.Empty : ctl.Name ?? string.Empty;
 
         internal void OnUIActivate(WebBrowserBase site)
         {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/WebBrowserContainer.cs
@@ -198,7 +198,7 @@ namespace System.Windows.Forms
                 return;
             }
 
-            foreach (Control ctl in components)
+            foreach (Control ctl in components.ToArray())
             {
                 if (ctl is WebBrowserBase webBrowserBase)
                 {


### PR DESCRIPTION
Refactored WebBrowserContainer to replace HashTable and Enable Nullability.

Related to #8143

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8226)