### PR TITLE
Clean up and null annotate Resx code

### DIFF
--- a/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
+++ b/src/System.Windows.Forms/src/PublicAPI.Shipped.txt
@@ -1,11 +1,11 @@
 #nullable enable
-~override System.Resources.ResXFileRef.Converter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Type sourceType) -> bool
-~override System.Resources.ResXFileRef.Converter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Type destinationType) -> bool
-~override System.Resources.ResXFileRef.Converter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value) -> object
-~override System.Resources.ResXFileRef.Converter.ConvertTo(System.ComponentModel.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, System.Type destinationType) -> object
-~override System.Resources.ResXFileRef.ToString() -> string
-~override System.Resources.ResXResourceSet.GetDefaultReader() -> System.Type
-~override System.Resources.ResXResourceSet.GetDefaultWriter() -> System.Type
+override System.Resources.ResXFileRef.Converter.CanConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Type! sourceType) -> bool
+override System.Resources.ResXFileRef.Converter.CanConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Type? destinationType) -> bool
+override System.Resources.ResXFileRef.Converter.ConvertFrom(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object! value) -> object?
+override System.Resources.ResXFileRef.Converter.ConvertTo(System.ComponentModel.ITypeDescriptorContext? context, System.Globalization.CultureInfo? culture, object? value, System.Type! destinationType) -> object?
+override System.Resources.ResXFileRef.ToString() -> string!
+override System.Resources.ResXResourceSet.GetDefaultReader() -> System.Type!
+override System.Resources.ResXResourceSet.GetDefaultWriter() -> System.Type!
 ~override System.Windows.Forms.AxHost.BackgroundImage.get -> System.Drawing.Image
 ~override System.Windows.Forms.AxHost.BackgroundImage.set -> void
 ~override System.Windows.Forms.AxHost.CreateParams.get -> System.Windows.Forms.CreateParams
@@ -583,20 +583,20 @@ override System.Windows.Forms.ToolStripTextBox.OnUnsubscribeControlEvents(System
 ~override System.Windows.Forms.WindowsFormsSynchronizationContext.CreateCopy() -> System.Threading.SynchronizationContext
 ~override System.Windows.Forms.WindowsFormsSynchronizationContext.Post(System.Threading.SendOrPostCallback d, object state) -> void
 ~override System.Windows.Forms.WindowsFormsSynchronizationContext.Send(System.Threading.SendOrPostCallback d, object state) -> void
-~static readonly System.Resources.ResXResourceWriter.BinSerializedObjectMimeType -> string
-~static readonly System.Resources.ResXResourceWriter.ByteArraySerializedObjectMimeType -> string
-~static readonly System.Resources.ResXResourceWriter.DefaultSerializedObjectMimeType -> string
-~static readonly System.Resources.ResXResourceWriter.ResMimeType -> string
-~static readonly System.Resources.ResXResourceWriter.ResourceSchema -> string
-~static readonly System.Resources.ResXResourceWriter.SoapSerializedObjectMimeType -> string
-~static readonly System.Resources.ResXResourceWriter.Version -> string
+static readonly System.Resources.ResXResourceWriter.BinSerializedObjectMimeType -> string!
+static readonly System.Resources.ResXResourceWriter.ByteArraySerializedObjectMimeType -> string!
+static readonly System.Resources.ResXResourceWriter.DefaultSerializedObjectMimeType -> string!
+static readonly System.Resources.ResXResourceWriter.ResMimeType -> string!
+static readonly System.Resources.ResXResourceWriter.ResourceSchema -> string!
+static readonly System.Resources.ResXResourceWriter.SoapSerializedObjectMimeType -> string!
+static readonly System.Resources.ResXResourceWriter.Version -> string!
 ~static readonly System.Windows.Forms.DataGridView.HitTestInfo.Nowhere -> System.Windows.Forms.DataGridView.HitTestInfo
 ~static readonly System.Windows.Forms.DataGridViewColumnDesignTimeVisibleAttribute.Default -> System.Windows.Forms.DataGridViewColumnDesignTimeVisibleAttribute
 ~static readonly System.Windows.Forms.DataGridViewColumnDesignTimeVisibleAttribute.No -> System.Windows.Forms.DataGridViewColumnDesignTimeVisibleAttribute
 ~static readonly System.Windows.Forms.DataGridViewColumnDesignTimeVisibleAttribute.Yes -> System.Windows.Forms.DataGridViewColumnDesignTimeVisibleAttribute
-~static System.Resources.ResXResourceReader.FromFileContents(string fileContents) -> System.Resources.ResXResourceReader
-~static System.Resources.ResXResourceReader.FromFileContents(string fileContents, System.ComponentModel.Design.ITypeResolutionService typeResolver) -> System.Resources.ResXResourceReader
-~static System.Resources.ResXResourceReader.FromFileContents(string fileContents, System.Reflection.AssemblyName[] assemblyNames) -> System.Resources.ResXResourceReader
+static System.Resources.ResXResourceReader.FromFileContents(string! fileContents) -> System.Resources.ResXResourceReader!
+static System.Resources.ResXResourceReader.FromFileContents(string! fileContents, System.ComponentModel.Design.ITypeResolutionService? typeResolver) -> System.Resources.ResXResourceReader!
+static System.Resources.ResXResourceReader.FromFileContents(string! fileContents, System.Reflection.AssemblyName![]! assemblyNames) -> System.Resources.ResXResourceReader!
 ~static System.Windows.Forms.Application.AddMessageFilter(System.Windows.Forms.IMessageFilter value) -> void
 ~static System.Windows.Forms.Application.CommonAppDataPath.get -> string
 ~static System.Windows.Forms.Application.CommonAppDataRegistry.get -> Microsoft.Win32.RegistryKey
@@ -699,54 +699,54 @@ static System.Windows.Forms.Help.ShowPopup(System.Windows.Forms.Control? parent,
 ~System.Drawing.Design.IPropertyValueUIService.GetPropertyUIValueItems(System.ComponentModel.ITypeDescriptorContext context, System.ComponentModel.PropertyDescriptor propDesc) -> System.Drawing.Design.PropertyValueUIItem[]
 ~System.Drawing.Design.IPropertyValueUIService.RemovePropertyValueUIHandler(System.Drawing.Design.PropertyValueUIHandler newHandler) -> void
 ~System.Drawing.Design.PropertyValueUIItem.PropertyValueUIItem(System.Drawing.Image uiItemImage, System.Drawing.Design.PropertyValueUIItemInvokeHandler handler, string tooltip) -> void
-~System.Resources.ResXDataNode.Comment.get -> string
-~System.Resources.ResXDataNode.Comment.set -> void
-~System.Resources.ResXDataNode.FileRef.get -> System.Resources.ResXFileRef
-~System.Resources.ResXDataNode.GetValue(System.ComponentModel.Design.ITypeResolutionService typeResolver) -> object
-~System.Resources.ResXDataNode.GetValue(System.Reflection.AssemblyName[] names) -> object
-~System.Resources.ResXDataNode.GetValueTypeName(System.ComponentModel.Design.ITypeResolutionService typeResolver) -> string
-~System.Resources.ResXDataNode.GetValueTypeName(System.Reflection.AssemblyName[] names) -> string
-~System.Resources.ResXDataNode.Name.get -> string
-~System.Resources.ResXDataNode.Name.set -> void
-~System.Resources.ResXDataNode.ResXDataNode(string name, object value) -> void
-~System.Resources.ResXDataNode.ResXDataNode(string name, object value, System.Func<System.Type, string> typeNameConverter) -> void
-~System.Resources.ResXDataNode.ResXDataNode(string name, System.Resources.ResXFileRef fileRef) -> void
-~System.Resources.ResXDataNode.ResXDataNode(string name, System.Resources.ResXFileRef fileRef, System.Func<System.Type, string> typeNameConverter) -> void
-~System.Resources.ResXFileRef.FileName.get -> string
-~System.Resources.ResXFileRef.ResXFileRef(string fileName, string typeName) -> void
-~System.Resources.ResXFileRef.ResXFileRef(string fileName, string typeName, System.Text.Encoding textFileEncoding) -> void
-~System.Resources.ResXFileRef.TextFileEncoding.get -> System.Text.Encoding
-~System.Resources.ResXFileRef.TypeName.get -> string
-~System.Resources.ResXResourceReader.BasePath.get -> string
-~System.Resources.ResXResourceReader.BasePath.set -> void
-~System.Resources.ResXResourceReader.GetEnumerator() -> System.Collections.IDictionaryEnumerator
-~System.Resources.ResXResourceReader.GetMetadataEnumerator() -> System.Collections.IDictionaryEnumerator
-~System.Resources.ResXResourceReader.ResXResourceReader(string fileName) -> void
-~System.Resources.ResXResourceReader.ResXResourceReader(string fileName, System.ComponentModel.Design.ITypeResolutionService typeResolver) -> void
-~System.Resources.ResXResourceReader.ResXResourceReader(string fileName, System.Reflection.AssemblyName[] assemblyNames) -> void
-~System.Resources.ResXResourceReader.ResXResourceReader(System.IO.Stream stream) -> void
-~System.Resources.ResXResourceReader.ResXResourceReader(System.IO.Stream stream, System.ComponentModel.Design.ITypeResolutionService typeResolver) -> void
-~System.Resources.ResXResourceReader.ResXResourceReader(System.IO.Stream stream, System.Reflection.AssemblyName[] assemblyNames) -> void
-~System.Resources.ResXResourceReader.ResXResourceReader(System.IO.TextReader reader) -> void
-~System.Resources.ResXResourceReader.ResXResourceReader(System.IO.TextReader reader, System.ComponentModel.Design.ITypeResolutionService typeResolver) -> void
-~System.Resources.ResXResourceReader.ResXResourceReader(System.IO.TextReader reader, System.Reflection.AssemblyName[] assemblyNames) -> void
-~System.Resources.ResXResourceSet.ResXResourceSet(string fileName) -> void
-~System.Resources.ResXResourceSet.ResXResourceSet(System.IO.Stream stream) -> void
-~System.Resources.ResXResourceWriter.AddMetadata(string name, byte[] value) -> void
-~System.Resources.ResXResourceWriter.AddMetadata(string name, object value) -> void
-~System.Resources.ResXResourceWriter.AddMetadata(string name, string value) -> void
-~System.Resources.ResXResourceWriter.AddResource(string name, byte[] value) -> void
-~System.Resources.ResXResourceWriter.AddResource(string name, object value) -> void
-~System.Resources.ResXResourceWriter.AddResource(string name, string value) -> void
-~System.Resources.ResXResourceWriter.AddResource(System.Resources.ResXDataNode node) -> void
-~System.Resources.ResXResourceWriter.BasePath.get -> string
-~System.Resources.ResXResourceWriter.BasePath.set -> void
-~System.Resources.ResXResourceWriter.ResXResourceWriter(string fileName) -> void
-~System.Resources.ResXResourceWriter.ResXResourceWriter(string fileName, System.Func<System.Type, string> typeNameConverter) -> void
-~System.Resources.ResXResourceWriter.ResXResourceWriter(System.IO.Stream stream) -> void
-~System.Resources.ResXResourceWriter.ResXResourceWriter(System.IO.Stream stream, System.Func<System.Type, string> typeNameConverter) -> void
-~System.Resources.ResXResourceWriter.ResXResourceWriter(System.IO.TextWriter textWriter) -> void
-~System.Resources.ResXResourceWriter.ResXResourceWriter(System.IO.TextWriter textWriter, System.Func<System.Type, string> typeNameConverter) -> void
+System.Resources.ResXDataNode.Comment.get -> string!
+System.Resources.ResXDataNode.Comment.set -> void
+System.Resources.ResXDataNode.FileRef.get -> System.Resources.ResXFileRef?
+System.Resources.ResXDataNode.GetValue(System.ComponentModel.Design.ITypeResolutionService? typeResolver) -> object?
+System.Resources.ResXDataNode.GetValue(System.Reflection.AssemblyName![]! names) -> object?
+System.Resources.ResXDataNode.GetValueTypeName(System.ComponentModel.Design.ITypeResolutionService? typeResolver) -> string?
+System.Resources.ResXDataNode.GetValueTypeName(System.Reflection.AssemblyName![]! names) -> string?
+System.Resources.ResXDataNode.Name.get -> string!
+System.Resources.ResXDataNode.Name.set -> void
+System.Resources.ResXDataNode.ResXDataNode(string! name, object? value) -> void
+System.Resources.ResXDataNode.ResXDataNode(string! name, object? value, System.Func<System.Type?, string!>? typeNameConverter) -> void
+System.Resources.ResXDataNode.ResXDataNode(string! name, System.Resources.ResXFileRef! fileRef) -> void
+System.Resources.ResXDataNode.ResXDataNode(string! name, System.Resources.ResXFileRef! fileRef, System.Func<System.Type?, string!>? typeNameConverter) -> void
+System.Resources.ResXFileRef.FileName.get -> string!
+System.Resources.ResXFileRef.ResXFileRef(string! fileName, string! typeName) -> void
+System.Resources.ResXFileRef.ResXFileRef(string! fileName, string! typeName, System.Text.Encoding! textFileEncoding) -> void
+System.Resources.ResXFileRef.TextFileEncoding.get -> System.Text.Encoding?
+System.Resources.ResXFileRef.TypeName.get -> string!
+System.Resources.ResXResourceReader.BasePath.get -> string?
+System.Resources.ResXResourceReader.BasePath.set -> void
+System.Resources.ResXResourceReader.GetEnumerator() -> System.Collections.IDictionaryEnumerator!
+System.Resources.ResXResourceReader.GetMetadataEnumerator() -> System.Collections.IDictionaryEnumerator!
+System.Resources.ResXResourceReader.ResXResourceReader(string! fileName) -> void
+System.Resources.ResXResourceReader.ResXResourceReader(string! fileName, System.ComponentModel.Design.ITypeResolutionService? typeResolver) -> void
+System.Resources.ResXResourceReader.ResXResourceReader(string! fileName, System.Reflection.AssemblyName![]! assemblyNames) -> void
+System.Resources.ResXResourceReader.ResXResourceReader(System.IO.Stream! stream) -> void
+System.Resources.ResXResourceReader.ResXResourceReader(System.IO.Stream! stream, System.ComponentModel.Design.ITypeResolutionService! typeResolver) -> void
+System.Resources.ResXResourceReader.ResXResourceReader(System.IO.Stream! stream, System.Reflection.AssemblyName![]! assemblyNames) -> void
+System.Resources.ResXResourceReader.ResXResourceReader(System.IO.TextReader! reader) -> void
+System.Resources.ResXResourceReader.ResXResourceReader(System.IO.TextReader! reader, System.ComponentModel.Design.ITypeResolutionService! typeResolver) -> void
+System.Resources.ResXResourceReader.ResXResourceReader(System.IO.TextReader! reader, System.Reflection.AssemblyName![]! assemblyNames) -> void
+System.Resources.ResXResourceSet.ResXResourceSet(string! fileName) -> void
+System.Resources.ResXResourceSet.ResXResourceSet(System.IO.Stream! stream) -> void
+System.Resources.ResXResourceWriter.AddMetadata(string! name, byte[]! value) -> void
+System.Resources.ResXResourceWriter.AddMetadata(string! name, object? value) -> void
+System.Resources.ResXResourceWriter.AddMetadata(string! name, string? value) -> void
+System.Resources.ResXResourceWriter.AddResource(string! name, byte[]? value) -> void
+System.Resources.ResXResourceWriter.AddResource(string! name, object? value) -> void
+System.Resources.ResXResourceWriter.AddResource(string! name, string? value) -> void
+System.Resources.ResXResourceWriter.AddResource(System.Resources.ResXDataNode! node) -> void
+System.Resources.ResXResourceWriter.BasePath.get -> string?
+System.Resources.ResXResourceWriter.BasePath.set -> void
+System.Resources.ResXResourceWriter.ResXResourceWriter(string! fileName) -> void
+System.Resources.ResXResourceWriter.ResXResourceWriter(string! fileName, System.Func<System.Type?, string!>! typeNameConverter) -> void
+System.Resources.ResXResourceWriter.ResXResourceWriter(System.IO.Stream! stream) -> void
+System.Resources.ResXResourceWriter.ResXResourceWriter(System.IO.Stream! stream, System.Func<System.Type?, string!>! typeNameConverter) -> void
+System.Resources.ResXResourceWriter.ResXResourceWriter(System.IO.TextWriter! textWriter) -> void
+System.Resources.ResXResourceWriter.ResXResourceWriter(System.IO.TextWriter! textWriter, System.Func<System.Type?, string!>! typeNameConverter) -> void
 ~System.Windows.Forms.AutoCompleteStringCollection.Add(string value) -> int
 ~System.Windows.Forms.AutoCompleteStringCollection.AddRange(string[] value) -> void
 ~System.Windows.Forms.AutoCompleteStringCollection.Contains(string value) -> bool
@@ -1658,7 +1658,7 @@ System.Windows.Forms.ToolStripTextBox.ToolStripTextBox(System.Windows.Forms.Cont
 ~virtual System.Drawing.Design.PropertyValueUIItem.Image.get -> System.Drawing.Image
 ~virtual System.Drawing.Design.PropertyValueUIItem.InvokeHandler.get -> System.Drawing.Design.PropertyValueUIItemInvokeHandler
 ~virtual System.Drawing.Design.PropertyValueUIItem.ToolTip.get -> string
-~virtual System.Resources.ResXResourceWriter.AddAlias(string aliasName, System.Reflection.AssemblyName assemblyName) -> void
+virtual System.Resources.ResXResourceWriter.AddAlias(string? aliasName, System.Reflection.AssemblyName! assemblyName) -> void
 ~virtual System.Windows.Forms.AxHost.CreateInstanceCore(System.Guid clsid) -> object
 ~virtual System.Windows.Forms.BaseCollection.List.get -> System.Collections.ArrayList
 ~virtual System.Windows.Forms.Binding.OnBindingComplete(System.Windows.Forms.BindingCompleteEventArgs e) -> void

--- a/src/System.Windows.Forms/src/System/Resources/DataNodeInfo.cs
+++ b/src/System.Windows.Forms/src/System/Resources/DataNodeInfo.cs
@@ -2,19 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Drawing;
 
 namespace System.Resources
 {
     internal class DataNodeInfo
     {
-        public string Name;
-        public string Comment;
-        public string TypeName;
-        public string MimeType;
-        public string ValueData;
+        public required string Name { get; set; }
+        public string? Comment { get; set; }
+        public string? TypeName { get; set; }
+        public string? MimeType { get; set; }
+        public string ValueData { get; set; } = string.Empty;
         public Point ReaderPosition; // Only used to track position in the reader
 
         internal DataNodeInfo Clone() => new()

--- a/src/System.Windows.Forms/src/System/Resources/DataNodeInfo.cs
+++ b/src/System.Windows.Forms/src/System/Resources/DataNodeInfo.cs
@@ -15,19 +15,16 @@ namespace System.Resources
         public string TypeName;
         public string MimeType;
         public string ValueData;
-        public Point ReaderPosition; //only used to track position in the reader
+        public Point ReaderPosition; // Only used to track position in the reader
 
-        internal DataNodeInfo Clone()
+        internal DataNodeInfo Clone() => new()
         {
-            return new DataNodeInfo
-            {
-                Name = Name,
-                Comment = Comment,
-                TypeName = TypeName,
-                MimeType = MimeType,
-                ValueData = ValueData,
-                ReaderPosition = new Point(ReaderPosition.X, ReaderPosition.Y)
-            };
-        }
+            Name = Name,
+            Comment = Comment,
+            TypeName = TypeName,
+            MimeType = MimeType,
+            ValueData = ValueData,
+            ReaderPosition = ReaderPosition
+        };
     }
 }

--- a/src/System.Windows.Forms/src/System/Resources/IAliasResolver.cs
+++ b/src/System.Windows.Forms/src/System/Resources/IAliasResolver.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.Reflection;
 
 namespace System.Resources
 {
     internal interface IAliasResolver
     {
-        AssemblyName ResolveAlias(string alias);
-        void PushAlias(string alias, AssemblyName name);
+        AssemblyName? ResolveAlias(string alias);
+        void PushAlias(string? alias, AssemblyName name);
     }
 }

--- a/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXDataNode.cs
@@ -442,7 +442,7 @@ namespace System.Resources
                 }
                 else
                 {
-                    // Serialize to string inside the nodeInfo.
+                    // Serialize to string inside the _nodeInfo.
                     FillDataNodeInfoFromObject(_nodeInfo, _value);
                 }
             }

--- a/src/System.Windows.Forms/src/System/Resources/ResXFileRef.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXFileRef.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
@@ -40,13 +38,14 @@ namespace System.Resources
             TextFileEncoding = textFileEncoding;
         }
 
-        internal ResXFileRef Clone() => new ResXFileRef(FileName, TypeName, TextFileEncoding);
+        internal ResXFileRef Clone()
+            => TextFileEncoding is null ? new(FileName, TypeName) : new(FileName, TypeName, TextFileEncoding);
 
         public string FileName { get; private set; }
 
         public string TypeName { get; }
 
-        public Encoding TextFileEncoding { get; }
+        public Encoding? TextFileEncoding { get; }
 
         /// <summary>
         ///  path1+result = path2

--- a/src/System.Windows.Forms/src/System/Resources/ResXFileRef.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXFileRef.cs
@@ -40,10 +40,7 @@ namespace System.Resources
             TextFileEncoding = textFileEncoding;
         }
 
-        internal ResXFileRef Clone()
-        {
-            return new ResXFileRef(FileName, TypeName, TextFileEncoding);
-        }
+        internal ResXFileRef Clone() => new ResXFileRef(FileName, TypeName, TextFileEncoding);
 
         public string FileName { get; private set; }
 
@@ -64,7 +61,8 @@ namespace System.Resources
 
             for (i = 0; (i < path1.Length) && (i < path2.Length); ++i)
             {
-                if ((path1[i] != path2[i]) && (compareCase || (char.ToLower(path1[i], CultureInfo.InvariantCulture) != char.ToLower(path2[i], CultureInfo.InvariantCulture))))
+                if ((path1[i] != path2[i])
+                    && (compareCase || (char.ToLower(path1[i], CultureInfo.InvariantCulture) != char.ToLower(path2[i], CultureInfo.InvariantCulture))))
                 {
                     break;
                 }
@@ -91,7 +89,7 @@ namespace System.Resources
             {
                 if (path1[i] == Path.DirectorySeparatorChar)
                 {
-                    relPath.Append(".." + Path.DirectorySeparatorChar);
+                    relPath.Append($"..{Path.DirectorySeparatorChar}");
                 }
             }
 
@@ -114,17 +112,17 @@ namespace System.Resources
 
             if (FileName.IndexOf(';') != -1 || FileName.IndexOf('\"') != -1)
             {
-                result += ("\"" + FileName + "\";");
+                result += $"\"{FileName}\";";
             }
             else
             {
-                result += (FileName + ";");
+                result += $"{FileName};";
             }
 
             result += TypeName;
             if (TextFileEncoding is not null)
             {
-                result += (";" + TextFileEncoding.WebName);
+                result += $";{TextFileEncoding.WebName}";
             }
 
             return result;

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.ReaderAliasResolver.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.ReaderAliasResolver.cs
@@ -20,7 +20,6 @@ namespace System.Resources
             public AssemblyName? ResolveAlias(string alias)
             {
                 _cachedAliases.TryGetValue(alias, out AssemblyName? result);
-
                 return result;
             }
 

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceReader.cs
@@ -53,11 +53,12 @@ namespace System.Resources
             _aliasResolver = new ReaderAliasResolver();
         }
 
-        public ResXResourceReader(string fileName) : this(fileName, (ITypeResolutionService?)null, null)
+        public ResXResourceReader(string fileName) : this(fileName, typeResolver: null, aliasResolver: null)
         {
         }
 
-        public ResXResourceReader(string fileName, ITypeResolutionService? typeResolver) : this(fileName, typeResolver, null)
+        public ResXResourceReader(string fileName, ITypeResolutionService? typeResolver)
+            : this(fileName, typeResolver, aliasResolver: null)
         {
         }
 
@@ -68,11 +69,12 @@ namespace System.Resources
             _aliasResolver = aliasResolver ?? new ReaderAliasResolver();
         }
 
-        public ResXResourceReader(TextReader reader) : this(reader, (ITypeResolutionService?)null, null)
+        public ResXResourceReader(TextReader reader) : this(reader, typeResolver: null, aliasResolver: null)
         {
         }
 
-        public ResXResourceReader(TextReader reader, ITypeResolutionService typeResolver) : this(reader, typeResolver, null)
+        public ResXResourceReader(TextReader reader, ITypeResolutionService typeResolver)
+            : this(reader, typeResolver, aliasResolver: null)
         {
         }
 
@@ -83,11 +85,12 @@ namespace System.Resources
             _aliasResolver = aliasResolver ?? new ReaderAliasResolver();
         }
 
-        public ResXResourceReader(Stream stream) : this(stream, (ITypeResolutionService?)null, null)
+        public ResXResourceReader(Stream stream) : this(stream, typeResolver: null, aliasResolver: null)
         {
         }
 
-        public ResXResourceReader(Stream stream, ITypeResolutionService typeResolver) : this(stream, typeResolver, null)
+        public ResXResourceReader(Stream stream, ITypeResolutionService typeResolver)
+            : this(stream, typeResolver, aliasResolver: null)
         {
         }
 
@@ -98,7 +101,8 @@ namespace System.Resources
             _aliasResolver = aliasResolver ?? new ReaderAliasResolver();
         }
 
-        public ResXResourceReader(Stream stream, AssemblyName[] assemblyNames) : this(stream, assemblyNames, null)
+        public ResXResourceReader(Stream stream, AssemblyName[] assemblyNames)
+            : this(stream, assemblyNames, aliasResolver: null)
         {
         }
 
@@ -120,7 +124,8 @@ namespace System.Resources
             _aliasResolver = aliasResolver ?? new ReaderAliasResolver();
         }
 
-        public ResXResourceReader(string fileName, AssemblyName[] assemblyNames) : this(fileName, assemblyNames, null)
+        public ResXResourceReader(string fileName, AssemblyName[] assemblyNames)
+            : this(fileName, assemblyNames, aliasResolver: null)
         {
         }
 
@@ -245,7 +250,7 @@ namespace System.Resources
 
             try
             {
-                // Read data
+                // Create the reader and parse the XML
                 if (_fileContents is not null)
                 {
                     contentReader = new XmlTextReader(new StringReader(_fileContents));
@@ -578,7 +583,7 @@ namespace System.Resources
                 WhitespaceHandling oldValue = reader.WhitespaceHandling;
                 try
                 {
-                    // Based on the documentation at https://docs.microsoft.com/dotnet/api/system.xml.xmltextreader.whitespacehandling
+                    // Based on the documentation at https://learn.microsoft.com/dotnet/api/system.xml.xmltextreader.whitespacehandling
                     // this is ok because:
                     //
                     //  "Because the XmlTextReader does not have DTD information available to it,

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceSet.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceSet.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 namespace System.Resources
 {
     /// <summary>

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
@@ -13,8 +13,7 @@ using System.Xml;
 namespace System.Resources
 {
     /// <summary>
-    ///  ResX resource writer. See the text in "ResourceSchema" for more
-    ///  information.
+    ///  ResX resource writer. See the text in "ResourceSchema" for more information.
     /// </summary>
     public class ResXResourceWriter : IResourceWriter
     {
@@ -45,54 +44,54 @@ namespace System.Resources
         public static readonly string ResMimeType = "text/microsoft-resx";
         public static readonly string Version = "2.0";
 
-        public static readonly string ResourceSchema = @"
-    <xsd:schema id=""root"" xmlns="""" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:msdata=""urn:schemas-microsoft-com:xml-msdata"">
-        <xsd:import namespace=""http://www.w3.org/XML/1998/namespace""/>
-        <xsd:element name=""root"" msdata:IsDataSet=""true"">
-            <xsd:complexType>
-                <xsd:choice maxOccurs=""unbounded"">
-                    <xsd:element name=""metadata"">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                            <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0""/>
-                            </xsd:sequence>
-                            <xsd:attribute name=""name"" use=""required"" type=""xsd:string""/>
-                            <xsd:attribute name=""type"" type=""xsd:string""/>
-                            <xsd:attribute name=""mimetype"" type=""xsd:string""/>
-                            <xsd:attribute ref=""xml:space""/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name=""assembly"">
-                      <xsd:complexType>
-                        <xsd:attribute name=""alias"" type=""xsd:string""/>
-                        <xsd:attribute name=""name"" type=""xsd:string""/>
-                      </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name=""data"">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1"" />
-                                <xsd:element name=""comment"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""2"" />
-                            </xsd:sequence>
-                            <xsd:attribute name=""name"" type=""xsd:string"" use=""required"" msdata:Ordinal=""1"" />
-                            <xsd:attribute name=""type"" type=""xsd:string"" msdata:Ordinal=""3"" />
-                            <xsd:attribute name=""mimetype"" type=""xsd:string"" msdata:Ordinal=""4"" />
-                            <xsd:attribute ref=""xml:space""/>
-                        </xsd:complexType>
-                    </xsd:element>
-                    <xsd:element name=""resheader"">
-                        <xsd:complexType>
-                            <xsd:sequence>
-                                <xsd:element name=""value"" type=""xsd:string"" minOccurs=""0"" msdata:Ordinal=""1"" />
-                            </xsd:sequence>
-                            <xsd:attribute name=""name"" type=""xsd:string"" use=""required"" />
-                        </xsd:complexType>
-                    </xsd:element>
-                </xsd:choice>
-            </xsd:complexType>
-        </xsd:element>
-        </xsd:schema>
-        ";
+        public static readonly string ResourceSchema = """
+            <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+                <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+                <xsd:element name="root" msdata:IsDataSet="true">
+                    <xsd:complexType>
+                        <xsd:choice maxOccurs="unbounded">
+                            <xsd:element name="metadata">
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+                                    </xsd:sequence>
+                                    <xsd:attribute name="name" use="required" type="xsd:string"/>
+                                    <xsd:attribute name="type" type="xsd:string"/>
+                                    <xsd:attribute name="mimetype" type="xsd:string"/>
+                                    <xsd:attribute ref="xml:space"/>
+                                </xsd:complexType>
+                            </xsd:element>
+                            <xsd:element name="assembly">
+                                <xsd:complexType>
+                                    <xsd:attribute name="alias" type="xsd:string"/>
+                                    <xsd:attribute name="name" type="xsd:string"/>
+                                </xsd:complexType>
+                            </xsd:element>
+                            <xsd:element name="data">
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                                        <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+                                    </xsd:sequence>
+                                    <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+                                    <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+                                    <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+                                    <xsd:attribute ref="xml:space"/>
+                                </xsd:complexType>
+                            </xsd:element>
+                            <xsd:element name="resheader">
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                                    </xsd:sequence>
+                                    <xsd:attribute name="name" type="xsd:string" use="required" />
+                                </xsd:complexType>
+                            </xsd:element>
+                        </xsd:choice>
+                    </xsd:complexType>
+                </xsd:element>
+            </xsd:schema>
+            """;
 #pragma warning restore IDE1006 // Naming Styles
 
         private readonly string _fileName;
@@ -163,12 +162,12 @@ namespace System.Resources
                 }
                 else if (_stream is not null)
                 {
-                    _xmlTextWriter = new XmlTextWriter(_stream, System.Text.Encoding.UTF8);
+                    _xmlTextWriter = new XmlTextWriter(_stream, Encoding.UTF8);
                 }
                 else
                 {
                     Debug.Assert(_fileName is not null, "Nothing to output to");
-                    _xmlTextWriter = new XmlTextWriter(_fileName, System.Text.Encoding.UTF8);
+                    _xmlTextWriter = new XmlTextWriter(_fileName, Encoding.UTF8);
                 }
 
                 _xmlTextWriter.Formatting = Formatting.Indented;
@@ -260,7 +259,7 @@ namespace System.Resources
         }
 
         /// <summary>
-        ///  Adds aliases to the resource file...
+        ///  Adds aliases to the resource file.
         /// </summary>
         public virtual void AddAlias(string aliasName, AssemblyName assemblyName)
         {
@@ -293,9 +292,8 @@ namespace System.Resources
         public void AddResource(string name, byte[] value) => AddDataRow(DataStr, name, value);
 
         /// <summary>
-        ///  Adds a resource to the resources. If the resource is a string,
-        ///  it will be saved that way, otherwise it will be serialized
-        ///  and stored as in binary.
+        ///  Adds a resource to the resources. If the resource is a string, it will be saved that way, otherwise it
+        ///  will be serialized and stored as in binary.
         /// </summary>
         public void AddResource(string name, object value)
         {
@@ -319,17 +317,14 @@ namespace System.Resources
         /// </summary>
         public void AddResource(ResXDataNode node)
         {
-            // we're modifying the node as we're adding it to the resxwriter
-            // this is BAD, so we clone it. adding it to a writer doesnt change it
-            // we're messing with a copy
+            // Clone the node to work on a copy.
             ResXDataNode nodeClone = node.DeepClone();
-
             ResXFileRef fileRef = nodeClone.FileRef;
             string modifiedBasePath = BasePath;
 
             if (!string.IsNullOrEmpty(modifiedBasePath))
             {
-                if (!modifiedBasePath.EndsWith("\\"))
+                if (!modifiedBasePath.EndsWith('\\'))
                 {
                     modifiedBasePath += "\\";
                 }
@@ -345,9 +340,7 @@ namespace System.Resources
         ///  Adds a blob resource to the resources.
         /// </summary>
         private void AddDataRow(string elementName, string name, byte[] value)
-        {
-            AddDataRow(elementName, name, ToBase64WrappedString(value), TypeNameWithAssembly(typeof(byte[])), null, null);
-        }
+            => AddDataRow(elementName, name, ToBase64WrappedString(value), TypeNameWithAssembly(typeof(byte[])), null, null);
 
         /// <summary>
         ///  Adds a resource to the resources. If the resource is a string,
@@ -442,11 +435,8 @@ namespace System.Resources
 
                 if (!string.IsNullOrEmpty(alias) && !string.IsNullOrEmpty(type) && elementName == DataStr)
                 {
-                    // CHANGE: we still output version information. This might have
-                    // to change in 3.2
-                    string typeName = GetTypeName(type);
-                    string typeValue = typeName + ", " + alias;
-                    Writer.WriteAttributeString(TypeStr, typeValue);
+                    // CHANGE: we still output version information. This might have to change in 3.2
+                    Writer.WriteAttributeString(TypeStr, $"{GetTypeName(type)}, {alias}");
                 }
                 else
                 {
@@ -524,10 +514,7 @@ namespace System.Resources
         /// <summary>
         ///  Closes any files or streams locked by the writer.
         /// </summary>
-        public void Close()
-        {
-            Dispose();
-        }
+        public void Close() => Dispose();
 
         public virtual void Dispose()
         {
@@ -544,44 +531,30 @@ namespace System.Resources
                     Generate();
                 }
 
-                if (_xmlTextWriter is not null)
-                {
-                    _xmlTextWriter.Close();
-                    _xmlTextWriter = null;
-                }
+                _xmlTextWriter?.Close();
+                _xmlTextWriter = null;
 
-                if (_stream is not null)
-                {
-                    _stream.Close();
-                    _stream = null;
-                }
+                _stream?.Close();
+                _stream = null;
 
-                if (_textWriter is not null)
-                {
-                    _textWriter.Close();
-                    _textWriter = null;
-                }
+                _textWriter?.Close();
+                _textWriter = null;
             }
         }
 
         private static string GetTypeName(string typeName)
         {
             int indexStart = typeName.IndexOf(',');
-            return ((indexStart == -1) ? typeName : typeName.Substring(0, indexStart));
+            return (indexStart == -1) ? typeName : typeName[..indexStart];
         }
 
         private static string GetFullName(string typeName)
         {
             int indexStart = typeName.IndexOf(',');
-            if (indexStart == -1)
-            {
-                return null;
-            }
-
-            return typeName.Substring(indexStart + 2);
+            return indexStart == -1 ? null : typeName[(indexStart + 2)..];
         }
 
-        static string ToBase64WrappedString(byte[] data)
+        private static string ToBase64WrappedString(byte[] data)
         {
             const int lineWrap = 80;
             const string crlf = "\r\n";
@@ -589,8 +562,10 @@ namespace System.Resources
             string raw = Convert.ToBase64String(data);
             if (raw.Length > lineWrap)
             {
-                StringBuilder output = new StringBuilder(raw.Length + (raw.Length / lineWrap) * 3); // word wrap on lineWrap chars, \r\n
+                // Word wrap on lineWrap chars, \r\n.
+                StringBuilder output = new(raw.Length + (raw.Length / lineWrap) * 3);
                 int current = 0;
+
                 for (; current < raw.Length - lineWrap; current += lineWrap)
                 {
                     output.Append(crlf);

--- a/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXResourceWriter.cs
@@ -103,7 +103,8 @@ namespace System.Resources
         private readonly Func<Type?, string>? _typeNameConverter; // no public property to be consistent with ResXDataNode class.
 
         /// <summary>
-        ///  Base Path for ResXFileRefs.
+        ///  A path that, if prepended to the relative file path specified in a <see cref="ResXFileRef"/> object,
+        ///  yields an absolute path to an XML resource file.
         /// </summary>
         public string? BasePath { get; set; }
 
@@ -130,7 +131,8 @@ namespace System.Resources
         }
 
         /// <summary>
-        ///  Creates a new ResXResourceWriter that will write to the specified TextWriter.
+        ///  Initializes a new instance of the <see cref="ResXResourceWriter"/> class that writes to the specified
+        ///  <see cref="TextWriter"/> object.
         /// </summary>
         public ResXResourceWriter(TextWriter textWriter) => _textWriter = textWriter;
 
@@ -315,9 +317,9 @@ namespace System.Resources
 
             if (!string.IsNullOrEmpty(modifiedBasePath))
             {
-                if (!modifiedBasePath.EndsWith('\\'))
+                if (!Path.EndsInDirectorySeparator(modifiedBasePath))
                 {
-                    modifiedBasePath += "\\";
+                    modifiedBasePath += Path.DirectorySeparatorChar;
                 }
 
                 fileRef?.MakeFilePathRelative(modifiedBasePath);
@@ -437,7 +439,6 @@ namespace System.Resources
 
                 if (!string.IsNullOrEmpty(alias) && !string.IsNullOrEmpty(type) && elementName == DataStr)
                 {
-                    // CHANGE: we still output version information. This might have to change in 3.2
                     Writer.WriteAttributeString(TypeStr, $"{GetTypeName(type)}, {alias}");
                 }
                 else

--- a/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
 using System.ComponentModel.Design;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
@@ -16,20 +14,22 @@ namespace System.Resources
 
     internal class ResXSerializationBinder : SerializationBinder
     {
-        private readonly ITypeResolutionService _typeResolver;
-        private readonly Func<Type, string> _typeNameConverter;
+        private readonly ITypeResolutionService? _typeResolver;
+        private readonly Func<Type?, string>? _typeNameConverter;
 
-        internal ResXSerializationBinder(ITypeResolutionService typeResolver)
+        internal ResXSerializationBinder(ITypeResolutionService? typeResolver)
         {
             _typeResolver = typeResolver;
         }
 
-        internal ResXSerializationBinder(Func<Type, string> typeNameConverter)
+        internal ResXSerializationBinder(Func<Type?, string>? typeNameConverter)
         {
             _typeNameConverter = typeNameConverter;
         }
 
-        public override Type BindToType(string assemblyName, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]string typeName)
+        public override Type? BindToType(
+            string assemblyName,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] string typeName)
         {
             if (_typeResolver is null)
             {
@@ -38,7 +38,7 @@ namespace System.Resources
 
             typeName = $"{typeName}, {assemblyName}";
 
-            Type type = _typeResolver.GetType(typeName);
+            Type? type = _typeResolver.GetType(typeName);
             if (type is null)
             {
                 string[] typeParts = typeName.Split(',');
@@ -69,7 +69,7 @@ namespace System.Resources
         }
 
         // Get the multitarget-aware string representation for the give type.
-        public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
+        public override void BindToName(Type serializedType, out string? assemblyName, out string? typeName)
         {
             // Normally we don't change typeName when changing the target framework,
             // only assembly version or assembly name might change, thus we are setting
@@ -87,13 +87,13 @@ namespace System.Resources
             typeName = null;
             if (_typeNameConverter is not null)
             {
-                string assemblyQualifiedTypeName = MultitargetUtil.GetAssemblyQualifiedName(serializedType, _typeNameConverter);
+                string? assemblyQualifiedTypeName = MultitargetUtil.GetAssemblyQualifiedName(serializedType, _typeNameConverter);
                 if (!string.IsNullOrEmpty(assemblyQualifiedTypeName))
                 {
                     int pos = assemblyQualifiedTypeName.IndexOf(',');
                     if (pos > 0 && pos < assemblyQualifiedTypeName.Length - 1)
                     {
-                        assemblyName = assemblyQualifiedTypeName.Substring(pos + 1).TrimStart();
+                        assemblyName = assemblyQualifiedTypeName[(pos + 1)..].TrimStart();
                         string newTypeName = assemblyQualifiedTypeName.Substring(0, pos);
                         if (!string.Equals(newTypeName, serializedType.FullName, StringComparison.InvariantCulture))
                         {

--- a/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResXSerializationBinder.cs
@@ -36,7 +36,7 @@ namespace System.Resources
                 return null;
             }
 
-            typeName = typeName + ", " + assemblyName;
+            typeName = $"{typeName}, {assemblyName}";
 
             Type type = _typeResolver.GetType(typeName);
             if (type is null)
@@ -44,7 +44,7 @@ namespace System.Resources
                 string[] typeParts = typeName.Split(',');
 
                 // Break up the assembly name from the rest of the assembly strong name.
-                // we try 1) FQN 2) FQN without a version 3) just the short name
+                // we try 1) FQN 2) FQN without a version 3) just the short name.
                 if (typeParts is not null && typeParts.Length > 2)
                 {
                     string partialName = typeParts[0].Trim();
@@ -52,9 +52,10 @@ namespace System.Resources
                     for (int i = 1; i < typeParts.Length; ++i)
                     {
                         string typePart = typeParts[i].Trim();
-                        if (!typePart.StartsWith("Version=") && !typePart.StartsWith("version="))
+                        if (!typePart.StartsWith("Version=", StringComparison.Ordinal)
+                            && !typePart.StartsWith("version=", StringComparison.Ordinal))
                         {
-                            partialName = partialName + ", " + typePart;
+                            partialName = $"{partialName}, {typePart}";
                         }
                     }
 

--- a/src/System.Windows.Forms/src/System/Resources/ResxFileRef.Converter.cs
+++ b/src/System.Windows.Forms/src/System/Resources/ResxFileRef.Converter.cs
@@ -121,7 +121,7 @@ namespace System.Resources
                     }
                 }
 
-                // This is a regular file, we call it's constructor with a stream as a parameter
+                // This is a regular file, we call its constructor with a stream as a parameter
                 // or if it's a byte array we just return that.
                 byte[]? temp = null;
 


### PR DESCRIPTION
There are two commits here. The first cleans up the code, with particular attention to reducing the nesting by inverting if statements and returning out early.

The second null annotates all of types that weren't already annotated.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8232)