### PR TITLE
Make currentComponent nullable in ImageListUtils.GetImageListProperty

### DIFF
--- a/src/System.Windows.Forms/src/misc/ImageListUtils.cs
+++ b/src/System.Windows.Forms/src/misc/ImageListUtils.cs
@@ -10,7 +10,7 @@ namespace System.Windows.Forms
     // Miscellaneous utilities
     internal static class ImageListUtils
     {
-        public static PropertyDescriptor? GetImageListProperty(PropertyDescriptor currentComponent, ref object instance)
+        public static PropertyDescriptor? GetImageListProperty(PropertyDescriptor? currentComponent, ref object instance)
         {
             // Multiple selection is not supported.
             if (instance is object[])
@@ -18,7 +18,9 @@ namespace System.Windows.Forms
                 return null;
             }
 
-            if (!currentComponent.TryGetAttribute(out RelatedImageListAttribute? relatedAttribute) || relatedAttribute.RelatedImageList is null)
+            if (currentComponent is null
+                || !currentComponent.TryGetAttribute(out RelatedImageListAttribute? relatedAttribute)
+                || relatedAttribute.RelatedImageList is null)
             {
                 return null;
             }


### PR DESCRIPTION
## Proposed changes

- Make currentComponent nullable in ImageListUtils.GetImageListProperty.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8233)