### PR TITLE
Make component nullable in AboutBoxUITypeEditor

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2AboutBoxPropertyDescriptor.AboutBoxUITypeEditor.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ComponentModel/COM2Interop/Com2AboutBoxPropertyDescriptor.AboutBoxUITypeEditor.cs
@@ -18,9 +18,11 @@ namespace System.Windows.Forms.ComponentModel.Com2Interop
             public override unsafe object? EditValue(ITypeDescriptorContext? context, IServiceProvider provider, object? value)
             {
                 ArgumentNullException.ThrowIfNull(context);
-                object component = context.Instance;
+                object? component = context.Instance;
 
-                if (Marshal.IsComObject(component) && component is Oleaut32.IDispatch pDisp)
+                if (component is not null
+                    && Marshal.IsComObject(component)
+                    && component is Oleaut32.IDispatch pDisp)
                 {
                     EXCEPINFO pExcepInfo = default(EXCEPINFO);
                     DISPPARAMS dispParams = default(DISPPARAMS);


### PR DESCRIPTION
## Proposed changes

- Make component nullable in AboutBoxUITypeEditor.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8234)