### PR TITLE
Refactor MergedAttributeCollection to replace HashTable

### DIFF
--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.MergedAttributeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.MergedAttributeCollection.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable disable
-
-using System.Collections;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
@@ -16,17 +13,17 @@ namespace System.Windows.Forms.PropertyGridInternal
         {
             private readonly MergePropertyDescriptor _owner;
 
-            private AttributeCollection[] _attributeCollections;
-            private IDictionary _foundAttributes;
+            private AttributeCollection[]? _attributeCollections;
+            private Dictionary<Type, Attribute>? _foundAttributes;
 
-            public MergedAttributeCollection(MergePropertyDescriptor owner) : base((Attribute[])null)
+            public MergedAttributeCollection(MergePropertyDescriptor owner) : base(attributes: null)
             {
                 _owner = owner;
             }
 
-            public override Attribute this[[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields)] Type attributeType] => GetCommonAttribute(attributeType);
+            public override Attribute? this[[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields)] Type attributeType] => GetCommonAttribute(attributeType);
 
-            private Attribute GetCommonAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields)]Type attributeType)
+            private Attribute? GetCommonAttribute([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor | DynamicallyAccessedMemberTypes.PublicFields)] Type attributeType)
             {
                 if (_attributeCollections is null)
                 {
@@ -42,14 +39,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                     return GetDefaultAttribute(attributeType);
                 }
 
-                Attribute value;
-                if (_foundAttributes is not null)
+                if (_foundAttributes is not null
+                    && _foundAttributes.TryGetValue(attributeType, out Attribute? value)
+                    && value is not null)
                 {
-                    value = _foundAttributes[attributeType] as Attribute;
-                    if (value is not null)
-                    {
-                        return value;
-                    }
+                    return value;
                 }
 
                 value = _attributeCollections[0][attributeType];
@@ -61,7 +55,7 @@ namespace System.Windows.Forms.PropertyGridInternal
 
                 for (int i = 1; i < _attributeCollections.Length; i++)
                 {
-                    Attribute newValue = _attributeCollections[i][attributeType];
+                    Attribute? newValue = _attributeCollections[i][attributeType];
                     if (!value.Equals(newValue))
                     {
                         value = GetDefaultAttribute(attributeType);
@@ -69,8 +63,11 @@ namespace System.Windows.Forms.PropertyGridInternal
                     }
                 }
 
-                _foundAttributes ??= new Hashtable();
-                _foundAttributes[attributeType] = value;
+                _foundAttributes ??= new();
+                if (value is Attribute)
+                {
+                    _foundAttributes[attributeType] = value;
+                }
                 return value;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.MergedAttributeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.MergedAttributeCollection.cs
@@ -40,8 +40,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 if (_foundAttributes is not null
-                    && _foundAttributes.TryGetValue(attributeType, out Attribute? value)
-                    && value is not null)
+                    && _foundAttributes.TryGetValue(attributeType, out Attribute? value))
                 {
                     return value;
                 }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.MergedAttributeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.MergedAttributeCollection.cs
@@ -68,6 +68,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 {
                     _foundAttributes[attributeType] = value;
                 }
+
                 return value;
             }
         }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.MergedAttributeCollection.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/PropertyGridInternal/MergePropertyDescriptor.MergedAttributeCollection.cs
@@ -64,7 +64,7 @@ namespace System.Windows.Forms.PropertyGridInternal
                 }
 
                 _foundAttributes ??= new();
-                if (value is Attribute)
+                if (value is not null)
                 {
                     _foundAttributes[attributeType] = value;
                 }


### PR DESCRIPTION
Refactor MergedAttributeCollection to replace HashTable and enable nullability.

Related: #8143

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8237)