### PR TITLE
`System.Windows.Forms` Refactor `!= null` to `is not null`

### DIFF
--- a/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/Generators/ProjectFileReader.FontConverter.cs
+++ b/src/System.Windows.Forms.Analyzers.CSharp/src/System/Windows/Forms/Generators/ProjectFileReader.FontConverter.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Forms.Generators
                     // Parse size.
                     (string? size, string? unit) unitTokens = ParseSizeTokens(sizeStr, separator);
 
-                    if (unitTokens.size != null)
+                    if (unitTokens.size is not null)
                     {
                         try
                         {
@@ -84,13 +84,13 @@ namespace System.Windows.Forms.Generators
                         }
                     }
 
-                    if (unitTokens.unit != null)
+                    if (unitTokens.unit is not null)
                     {
                         // ParseGraphicsUnits throws an ArgumentException if format is invalid.
                         units = ParseGraphicsUnits(unitTokens.unit);
                     }
 
-                    if (style != null)
+                    if (style is not null)
                     {
                         // Parse FontStyle
                         style = style.Substring(6); // style string always starts with style=

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.Methods.cs
@@ -3158,7 +3158,7 @@ namespace System.Windows.Forms
                 int oldCurrentCellX = _ptCurrentCell.X;
                 DataGridViewDataErrorEventArgs dgvdee = CancelEditPrivate(/*ref dataGridViewCurrentCell, context*/);
 
-                if (null != dgvdee)
+                if (dgvdee is not null)
                 {
                     if (dgvdee.ThrowException)
                     {
@@ -3866,7 +3866,7 @@ namespace System.Windows.Forms
                     false /*fireRowLeave*/,
                     false /*fireRowEnter*/,
                     false /*fireLeave*/);
-                if (null != dgvdee)
+                if (dgvdee is not null)
                 {
                     if (dgvdee.ThrowException)
                     {
@@ -4120,7 +4120,7 @@ namespace System.Windows.Forms
                 forCurrentRowChange /*fireRowLeave*/,
                 forCurrentRowChange /*fireRowEnter*/,
                 false /*fireLeave*/);
-            if (null != dgvdee)
+            if (dgvdee is not null)
             {
                 if (dgvdee.ThrowException)
                 {
@@ -4134,7 +4134,7 @@ namespace System.Windows.Forms
 
                 // Restore old value
                 dgvdee = CancelEditPrivate();
-                if (null != dgvdee)
+                if (dgvdee is not null)
                 {
                     if (dgvdee.ThrowException)
                     {
@@ -6319,7 +6319,7 @@ namespace System.Windows.Forms
 
                     // Restore old value
                     dgvdee = CancelEditPrivate();
-                    if (null != dgvdee)
+                    if (dgvdee is not null)
                     {
                         if (dgvdee.ThrowException)
                         {
@@ -22033,7 +22033,7 @@ namespace System.Windows.Forms
                             false /*fireRowLeave*/,
                             false /*fireRowEnter*/,
                             false /*fireLeave*/);
-                        if (null != dgvdee)
+                        if (dgvdee is not null)
                         {
                             if (dgvdee.ThrowException)
                             {

--- a/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/DataGridView.cs
@@ -1904,7 +1904,7 @@ namespace System.Windows.Forms
 
                 Debug.Assert(_ptCurrentCell.Y != -1);
 
-                bool previousVisibleColumnExists = (null != Columns.GetPreviousColumn(Columns[_ptCurrentCell.X], DataGridViewElementStates.Visible, DataGridViewElementStates.None));
+                bool previousVisibleColumnExists = (Columns.GetPreviousColumn(Columns[_ptCurrentCell.X], DataGridViewElementStates.Visible, DataGridViewElementStates.None) is not null);
                 bool previousVisibleRowExists = (-1 != Rows.GetPreviousRow(_ptCurrentCell.Y, DataGridViewElementStates.Visible));
 
                 return !previousVisibleColumnExists && !previousVisibleRowExists;
@@ -1922,7 +1922,7 @@ namespace System.Windows.Forms
 
                 Debug.Assert(_ptCurrentCell.Y != -1);
 
-                bool nextVisibleColumnExists = (null != Columns.GetNextColumn(Columns[_ptCurrentCell.X], DataGridViewElementStates.Visible, DataGridViewElementStates.None));
+                bool nextVisibleColumnExists = (Columns.GetNextColumn(Columns[_ptCurrentCell.X], DataGridViewElementStates.Visible, DataGridViewElementStates.None) is not null);
                 bool nextVisibleRowExists = (-1 != Rows.GetNextRow(_ptCurrentCell.Y, DataGridViewElementStates.Visible));
 
                 return !nextVisibleColumnExists && !nextVisibleRowExists;

--- a/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/Design/ComponentEditorForm.cs
@@ -415,7 +415,7 @@ namespace System.Windows.Forms.Design
         /// </summary>
         public override bool PreProcessMessage(ref Message msg)
         {
-            if (null != _pageSites && _pageSites[_activePage].GetPageControl().IsPageMessage(ref msg))
+            if (_pageSites is not null && _pageSites[_activePage].GetPageControl().IsPageMessage(ref msg))
             {
                 return true;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/ListView.cs
@@ -3222,7 +3222,7 @@ namespace System.Windows.Forms
         {
             // On the final EndUpdate, check to see if we've got any cached items.
             // If we do, insert them as normal, then turn off the painting freeze.
-            if (--_updateCounter == 0 && null != Properties.GetObject(PropDelayedUpdateItems))
+            if (--_updateCounter == 0 && Properties.GetObject(PropDelayedUpdateItems) is not null)
             {
                 ApplyUpdateCachedItems();
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TextBoxBase.TextBoxBaseAccessibleObject.cs
@@ -69,7 +69,7 @@ namespace System.Windows.Forms
                 get
                 {
                     var name = base.Name;
-                    return name != null || !_owningTextBoxBase.PasswordProtect ? name : string.Empty;
+                    return name is not null || !_owningTextBoxBase.PasswordProtect ? name : string.Empty;
                 }
                 set => base.Name = value;
             }

--- a/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
+++ b/src/System.Windows.Forms/src/System/Windows/Forms/TreeView.cs
@@ -1830,7 +1830,7 @@ namespace System.Windows.Forms
 
         private void ImageListChangedHandle(object sender, EventArgs e)
         {
-            if ((null != sender) && (sender == imageList) && IsHandleCreated)
+            if ((sender is not null) && (sender == imageList) && IsHandleCreated)
             {
                 BeginUpdate();
                 foreach (TreeNode node in Nodes)
@@ -1874,7 +1874,7 @@ namespace System.Windows.Forms
 
         private void StateImageListChangedHandle(object sender, EventArgs e)
         {
-            if ((null != sender) && (sender == stateImageList) && IsHandleCreated)
+            if ((sender is not null) && (sender == stateImageList) && IsHandleCreated)
             {
                 // Since the native treeview requires the state imagelist to be 1-indexed we need to
                 // re add the images if the original collection had changed.


### PR DESCRIPTION
Refactors `System.Windows.Forms` to use `is not null` instead of `!= null` using [CSharpIsNull](https://github.com/AArnott/CSharpIsNull) analyzer code fix.

Related: #3459

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/winforms/pull/8238)